### PR TITLE
feat(auth): align admin sensitive user gating

### DIFF
--- a/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
@@ -12,6 +12,12 @@ import {
   getAdminUserDetail,
   type AdminUserDetail,
 } from "@/lib/api/admin-users";
+import { ApiError } from "@/lib/api/client";
+import {
+  canManageAdministrativeCompletion,
+  canReadSensitiveUserData,
+  canViewAdministrativeCompletion,
+} from "@/lib/auth/permission-utils";
 import { requireAdminUser } from "@/lib/auth/session";
 
 type Params = Promise<{ userId: string }>;
@@ -99,16 +105,34 @@ function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
 }
 
 export default async function UserDetailPage({ params }: { params: Params }) {
-  await requireAdminUser();
+  const currentUser = await requireAdminUser();
   const { userId } = await params;
 
   let user: AdminUserDetail;
   try {
     user = await getAdminUserDetail(userId);
-  } catch {
+  } catch (error) {
+    if (error instanceof ApiError && [401, 403].includes(error.status)) {
+      return (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Acceso restringido</CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            Necesitas autorizacion global resuelta para consultar datos de terceros.
+          </CardContent>
+        </Card>
+      );
+    }
+
     notFound();
   }
 
+  const canSeeSensitiveData = canReadSensitiveUserData(currentUser);
+  const canSeeAdministrativeCompletion =
+    canViewAdministrativeCompletion(currentUser);
+  const canUpdateAdministrativeCompletion =
+    canManageAdministrativeCompletion(currentUser);
   const fullName =
     [user.name, user.paternal_last_name, user.maternal_last_name]
       .filter(Boolean)
@@ -150,10 +174,12 @@ export default async function UserDetailPage({ params }: { params: Params }) {
               ))}
             </div>
             <div className="mt-2">
-              <UserApprovalActions
-                userId={user.user_id}
-                currentApproval={user.approval}
-              />
+              {canUpdateAdministrativeCompletion ? (
+                <UserApprovalActions
+                  userId={user.user_id}
+                  currentApproval={user.approval}
+                />
+              ) : null}
             </div>
           </div>
         </CardContent>
@@ -169,22 +195,31 @@ export default async function UserDetailPage({ params }: { params: Params }) {
             <InfoRow label="Apellido paterno" value={user.paternal_last_name} />
             <InfoRow label="Apellido materno" value={user.maternal_last_name} />
             <InfoRow label="Email" value={user.email} />
-            <InfoRow
-              label="Fecha de nacimiento"
-              value={formatDate(user.birthday)}
-            />
-            <InfoRow label="Género" value={user.gender} />
-            <InfoRow label="Tipo de sangre" value={user.blood} />
-            <InfoRow
-              label="Bautismo"
-              value={
-                user.baptism !== null && user.baptism !== undefined
-                  ? user.baptism
-                    ? `Sí${user.baptism_date ? ` (${formatDate(user.baptism_date)})` : ""}`
-                    : "No"
-                  : "—"
-              }
-            />
+            {canSeeSensitiveData ? (
+              <>
+                <InfoRow
+                  label="Fecha de nacimiento"
+                  value={formatDate(user.birthday)}
+                />
+                <InfoRow label="Género" value={user.gender} />
+                <InfoRow label="Tipo de sangre" value={user.blood} />
+                <InfoRow
+                  label="Bautismo"
+                  value={
+                    user.baptism !== null && user.baptism !== undefined
+                      ? user.baptism
+                        ? `Sí${user.baptism_date ? ` (${formatDate(user.baptism_date)})` : ""}`
+                        : "No"
+                      : "—"
+                  }
+                />
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                Los datos sensibles enviados por el usuario solo se muestran con
+                autorizacion global de lectura resuelta.
+              </p>
+            )}
           </CardContent>
         </Card>
 
@@ -226,43 +261,45 @@ export default async function UserDetailPage({ params }: { params: Params }) {
           </CardContent>
         </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-base">Post-registro</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            <InfoRow
-              label="Completado"
-              value={
-                <Badge
-                  variant={
-                    user.post_registration?.complete ? "default" : "outline"
-                  }
-                >
-                  {user.post_registration?.complete ? "Completo" : "Pendiente"}
-                </Badge>
-              }
-            />
-            <InfoRow
-              label="Foto de perfil"
-              value={
-                user.post_registration?.profile_picture_complete ? "Sí" : "No"
-              }
-            />
-            <InfoRow
-              label="Info personal"
-              value={
-                user.post_registration?.personal_info_complete ? "Sí" : "No"
-              }
-            />
-            <InfoRow
-              label="Selección de club"
-              value={
-                user.post_registration?.club_selection_complete ? "Sí" : "No"
-              }
-            />
-          </CardContent>
-        </Card>
+        {canSeeAdministrativeCompletion ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Post-registro</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <InfoRow
+                label="Completado"
+                value={
+                  <Badge
+                    variant={
+                      user.post_registration?.complete ? "default" : "outline"
+                    }
+                  >
+                    {user.post_registration?.complete ? "Completo" : "Pendiente"}
+                  </Badge>
+                }
+              />
+              <InfoRow
+                label="Foto de perfil"
+                value={
+                  user.post_registration?.profile_picture_complete ? "Sí" : "No"
+                }
+              />
+              <InfoRow
+                label="Info personal"
+                value={
+                  user.post_registration?.personal_info_complete ? "Sí" : "No"
+                }
+              />
+              <InfoRow
+                label="Selección de club"
+                value={
+                  user.post_registration?.club_selection_complete ? "Sí" : "No"
+                }
+              />
+            </CardContent>
+          </Card>
+        ) : null}
 
         <Card>
           <CardHeader>

--- a/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
@@ -15,7 +15,7 @@ import {
 import { ApiError } from "@/lib/api/client";
 import {
   canManageAdministrativeCompletion,
-  canReadSensitiveUserData,
+  canReadSensitiveUserFamily,
   canViewAdministrativeCompletion,
 } from "@/lib/auth/permission-utils";
 import { requireAdminUser } from "@/lib/auth/session";
@@ -80,6 +80,18 @@ type ClubAssignment = {
   [key: string]: unknown;
 };
 
+type HealthItem = {
+  name?: string | null;
+};
+
+type LegalRepresentative = {
+  name?: string | null;
+  paternal_last_name?: string | null;
+  maternal_last_name?: string | null;
+  phone?: string | null;
+  relationship_type_id?: number | null;
+};
+
 function formatDate(dateStr?: string | null): string {
   if (!dateStr) return "—";
   try {
@@ -102,6 +114,39 @@ function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
       <span className="text-sm">{value ?? "—"}</span>
     </div>
   );
+}
+
+function formatNames(items: unknown[] | undefined) {
+  if (!Array.isArray(items) || items.length === 0) {
+    return "—";
+  }
+
+  const names = items
+    .map((item) => (item as HealthItem | null)?.name?.trim())
+    .filter((value): value is string => Boolean(value));
+
+  return names.length > 0 ? names.join(", ") : "—";
+}
+
+function formatLegalRepresentative(value: Record<string, unknown> | null | undefined) {
+  if (!value) {
+    return null;
+  }
+
+  const representative = value as LegalRepresentative;
+  const fullName = [
+    representative.name,
+    representative.paternal_last_name,
+    representative.maternal_last_name,
+  ]
+    .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+    .join(" ");
+
+  return {
+    fullName: fullName || "—",
+    phone: representative.phone ?? "—",
+    relationshipTypeId: representative.relationship_type_id ?? "—",
+  };
 }
 
 export default async function UserDetailPage({ params }: { params: Params }) {
@@ -128,7 +173,19 @@ export default async function UserDetailPage({ params }: { params: Params }) {
     notFound();
   }
 
-  const canSeeSensitiveData = canReadSensitiveUserData(currentUser);
+  const canSeeHealthData = canReadSensitiveUserFamily(currentUser, "health");
+  const canSeeEmergencyContacts = canReadSensitiveUserFamily(
+    currentUser,
+    "emergency_contacts",
+  );
+  const canSeeLegalRepresentative = canReadSensitiveUserFamily(
+    currentUser,
+    "legal_representative",
+  );
+  const canSeePostRegistrationDetail = canReadSensitiveUserFamily(
+    currentUser,
+    "post_registration",
+  );
   const canSeeAdministrativeCompletion =
     canViewAdministrativeCompletion(currentUser);
   const canUpdateAdministrativeCompletion =
@@ -140,6 +197,7 @@ export default async function UserDetailPage({ params }: { params: Params }) {
     user.email ||
     "Usuario";
   const roleNames = extractRoleNames(user);
+  const legalRepresentative = formatLegalRepresentative(user.legal_representative);
 
   return (
     <div className="space-y-6">
@@ -195,31 +253,21 @@ export default async function UserDetailPage({ params }: { params: Params }) {
             <InfoRow label="Apellido paterno" value={user.paternal_last_name} />
             <InfoRow label="Apellido materno" value={user.maternal_last_name} />
             <InfoRow label="Email" value={user.email} />
-            {canSeeSensitiveData ? (
-              <>
-                <InfoRow
-                  label="Fecha de nacimiento"
-                  value={formatDate(user.birthday)}
-                />
-                <InfoRow label="Género" value={user.gender} />
-                <InfoRow label="Tipo de sangre" value={user.blood} />
-                <InfoRow
-                  label="Bautismo"
-                  value={
-                    user.baptism !== null && user.baptism !== undefined
-                      ? user.baptism
-                        ? `Sí${user.baptism_date ? ` (${formatDate(user.baptism_date)})` : ""}`
-                        : "No"
-                      : "—"
-                  }
-                />
-              </>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                Los datos sensibles enviados por el usuario solo se muestran con
-                autorizacion global de lectura resuelta.
-              </p>
-            )}
+            <InfoRow
+              label="Fecha de nacimiento"
+              value={formatDate(user.birthday)}
+            />
+            <InfoRow label="Género" value={user.gender} />
+            <InfoRow
+              label="Bautismo"
+              value={
+                user.baptism !== null && user.baptism !== undefined
+                  ? user.baptism
+                    ? `Sí${user.baptism_date ? ` (${formatDate(user.baptism_date)})` : ""}`
+                    : "No"
+                  : "—"
+              }
+            />
           </CardContent>
         </Card>
 
@@ -261,42 +309,134 @@ export default async function UserDetailPage({ params }: { params: Params }) {
           </CardContent>
         </Card>
 
+        {canSeeHealthData ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Salud</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {user.health ? (
+                <>
+                  <InfoRow label="Tipo de sangre" value={user.health.blood} />
+                  <InfoRow
+                    label="Alergias"
+                    value={formatNames(user.health.allergies)}
+                  />
+                  <InfoRow
+                    label="Enfermedades"
+                    value={formatNames(user.health.diseases)}
+                  />
+                  <InfoRow
+                    label="Medicamentos"
+                    value={formatNames(user.health.medicines)}
+                  />
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Este payload no incluyó el bloque sensible de salud.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {canSeeEmergencyContacts ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Contactos de emergencia</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {user.emergency_contacts ? (
+                user.emergency_contacts.length > 0 ? (
+                  user.emergency_contacts.map((contact, index) => (
+                    <div key={index} className="rounded-md border p-3 text-sm">
+                      <pre className="whitespace-pre-wrap font-sans text-sm">
+                        {JSON.stringify(contact, null, 2)}
+                      </pre>
+                    </div>
+                  ))
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    Sin contactos de emergencia registrados.
+                  </p>
+                )
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Este payload no incluyó el bloque de contactos de emergencia.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        ) : null}
+
+        {canSeeLegalRepresentative ? (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">Representante legal</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {legalRepresentative ? (
+                <>
+                  <InfoRow label="Nombre" value={legalRepresentative.fullName} />
+                  <InfoRow label="Teléfono" value={legalRepresentative.phone} />
+                  <InfoRow
+                    label="Tipo de relación"
+                    value={legalRepresentative.relationshipTypeId}
+                  />
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Este payload no incluyó el bloque de representante legal.
+                </p>
+              )}
+            </CardContent>
+          </Card>
+        ) : null}
+
         {canSeeAdministrativeCompletion ? (
           <Card>
             <CardHeader>
               <CardTitle className="text-base">Post-registro</CardTitle>
             </CardHeader>
             <CardContent className="space-y-3">
-              <InfoRow
-                label="Completado"
-                value={
-                  <Badge
-                    variant={
-                      user.post_registration?.complete ? "default" : "outline"
+              {canSeePostRegistrationDetail && user.post_registration ? (
+                <>
+                  <InfoRow
+                    label="Completado"
+                    value={
+                      <Badge
+                        variant={
+                          user.post_registration.complete ? "default" : "outline"
+                        }
+                      >
+                        {user.post_registration.complete ? "Completo" : "Pendiente"}
+                      </Badge>
                     }
-                  >
-                    {user.post_registration?.complete ? "Completo" : "Pendiente"}
-                  </Badge>
-                }
-              />
-              <InfoRow
-                label="Foto de perfil"
-                value={
-                  user.post_registration?.profile_picture_complete ? "Sí" : "No"
-                }
-              />
-              <InfoRow
-                label="Info personal"
-                value={
-                  user.post_registration?.personal_info_complete ? "Sí" : "No"
-                }
-              />
-              <InfoRow
-                label="Selección de club"
-                value={
-                  user.post_registration?.club_selection_complete ? "Sí" : "No"
-                }
-              />
+                  />
+                  <InfoRow
+                    label="Foto de perfil"
+                    value={
+                      user.post_registration.profile_picture_complete ? "Sí" : "No"
+                    }
+                  />
+                  <InfoRow
+                    label="Info personal"
+                    value={
+                      user.post_registration.personal_info_complete ? "Sí" : "No"
+                    }
+                  />
+                  <InfoRow
+                    label="Selección de club"
+                    value={
+                      user.post_registration.club_selection_complete ? "Sí" : "No"
+                    }
+                  />
+                </>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Tu acceso actual solo permite completion administrativa mínima.
+                </p>
+              )}
             </CardContent>
           </Card>
         ) : null}

--- a/src/app/(dashboard)/dashboard/users/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/page.tsx
@@ -9,6 +9,8 @@ import { UsersFilters } from "@/components/users/users-filters";
 import { UsersTable } from "@/components/users/users-table";
 import { listAdminUsers, type AdminUsersQuery } from "@/lib/api/admin-users";
 import { requireAdminUser } from "@/lib/auth/session";
+import { canViewAdministrativeCompletion } from "@/lib/auth/permission-utils";
+import type { AuthUser } from "@/lib/auth/types";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 
@@ -33,8 +35,15 @@ function parseSearchParams(raw: Record<string, string | string[] | undefined>): 
   };
 }
 
-async function UsersContent({ query }: { query: AdminUsersQuery }) {
+async function UsersContent({
+  query,
+  currentUser,
+}: {
+  query: AdminUsersQuery;
+  currentUser: AuthUser;
+}) {
   const result = await listAdminUsers(query);
+  const showAdministrativeCompletion = canViewAdministrativeCompletion(currentUser);
 
   if (!result.endpointAvailable) {
     return (
@@ -67,7 +76,10 @@ async function UsersContent({ query }: { query: AdminUsersQuery }) {
 
   return (
     <div className="space-y-4">
-      <UsersTable users={result.items} />
+      <UsersTable
+        users={result.items}
+        showAdministrativeCompletion={showAdministrativeCompletion}
+      />
       {meta && (
         <DataTablePagination
           page={meta.page}
@@ -110,7 +122,7 @@ export default async function UsersPage({
 }: {
   searchParams: SearchParams;
 }) {
-  await requireAdminUser();
+  const currentUser = await requireAdminUser();
   const rawParams = await searchParams;
   const query = parseSearchParams(rawParams);
 
@@ -123,7 +135,7 @@ export default async function UsersPage({
 
       <Suspense fallback={<UsersListSkeleton />}>
         <UsersFilters />
-        <UsersContent query={query} />
+        <UsersContent query={query} currentUser={currentUser} />
       </Suspense>
     </div>
   );

--- a/src/components/users/users-table.tsx
+++ b/src/components/users/users-table.tsx
@@ -11,11 +11,6 @@ import {
 } from "@/components/ui/table";
 import type { AdminUser } from "@/lib/api/admin-users";
 
-function getInitials(name?: string | null, email?: string | null): string {
-  if (name) return name.split(" ").map((n) => n[0]).join("").toUpperCase().slice(0, 2);
-  return (email?.[0] ?? "?").toUpperCase();
-}
-
 function extractRoleNames(user: AdminUser): string[] {
   const roles: string[] = [];
   if (user.roles) roles.push(...user.roles);
@@ -51,9 +46,13 @@ function formatDate(dateStr?: string | null): string {
 
 interface UsersTableProps {
   users: AdminUser[];
+  showAdministrativeCompletion?: boolean;
 }
 
-export function UsersTable({ users }: UsersTableProps) {
+export function UsersTable({
+  users,
+  showAdministrativeCompletion = false,
+}: UsersTableProps) {
   return (
     <div className="rounded-md border">
       <Table>
@@ -64,7 +63,9 @@ export function UsersTable({ users }: UsersTableProps) {
             <TableHead className="hidden lg:table-cell">Ubicación</TableHead>
             <TableHead>Estado</TableHead>
             <TableHead className="hidden sm:table-cell">Accesos</TableHead>
-            <TableHead className="hidden lg:table-cell">Post-registro</TableHead>
+            {showAdministrativeCompletion ? (
+              <TableHead className="hidden lg:table-cell">Post-registro</TableHead>
+            ) : null}
             <TableHead className="hidden md:table-cell">Fecha de alta</TableHead>
           </TableRow>
         </TableHeader>
@@ -138,14 +139,16 @@ export function UsersTable({ users }: UsersTableProps) {
                     </Badge>
                   </div>
                 </TableCell>
-                <TableCell className="hidden lg:table-cell">
-                  <Badge
-                    variant={user.post_registration?.complete ? "default" : "outline"}
-                    className="text-xs"
-                  >
-                    {user.post_registration?.complete ? "Completo" : "Pendiente"}
-                  </Badge>
-                </TableCell>
+                {showAdministrativeCompletion ? (
+                  <TableCell className="hidden lg:table-cell">
+                    <Badge
+                      variant={user.post_registration?.complete ? "default" : "outline"}
+                      className="text-xs"
+                    >
+                      {user.post_registration?.complete ? "Completo" : "Pendiente"}
+                    </Badge>
+                  </TableCell>
+                ) : null}
                 <TableCell className="hidden text-xs text-muted-foreground md:table-cell">
                   {formatDate(user.created_at)}
                 </TableCell>

--- a/src/lib/api/admin-users.ts
+++ b/src/lib/api/admin-users.ts
@@ -75,7 +75,13 @@ export type AdminUserDetail = AdminUser & {
   modified_at?: string | null;
   classes?: unknown[];
   club_assignments?: unknown[];
-  emergency_contacts?: unknown[];
+  health?: {
+    blood?: string | null;
+    allergies?: unknown[];
+    diseases?: unknown[];
+    medicines?: unknown[];
+  } | null;
+  emergency_contacts?: unknown[] | null;
   legal_representative?: Record<string, unknown> | null;
   scope?: ScopeMeta | null;
 };
@@ -337,6 +343,20 @@ function normalizePostRegistration(value: unknown): AdminUser["post_registration
   };
 }
 
+function normalizeHealthBlock(value: unknown): AdminUserDetail["health"] {
+  const record = asRecord(value);
+  if (!record) {
+    return null;
+  }
+
+  return {
+    blood: pickString(record.blood),
+    allergies: Array.isArray(record.allergies) ? record.allergies : [],
+    diseases: Array.isArray(record.diseases) ? record.diseases : [],
+    medicines: Array.isArray(record.medicines) ? record.medicines : [],
+  };
+}
+
 function normalizeActive(item: Record<string, unknown>) {
   if (typeof item.active === "boolean") {
     return item.active;
@@ -534,7 +554,14 @@ function normalizeDetailPayload(payload: unknown): AdminUserDetail | null {
     modified_at: pickString(record.modified_at),
     classes: Array.isArray(record.classes) ? record.classes : [],
     club_assignments: Array.isArray(record.club_assignments) ? record.club_assignments : [],
-    emergency_contacts: Array.isArray(record.emergency_contacts) ? record.emergency_contacts : [],
+    health:
+      record.health === null ? null : normalizeHealthBlock(record.health),
+    emergency_contacts:
+      record.emergency_contacts === null
+        ? null
+        : Array.isArray(record.emergency_contacts)
+          ? record.emergency_contacts
+          : undefined,
     legal_representative: asRecord(record.legal_representative),
     scope: normalizeScope(record.scope),
   };

--- a/src/lib/auth/permission-utils.test.ts
+++ b/src/lib/auth/permission-utils.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { before } from "node:test";
+import test from "node:test";
+import type { AuthUser } from "./types";
+
+process.env.NEXT_PUBLIC_RBAC_LEGACY_FALLBACK = "true";
+
+let permissionUtils: typeof import("./permission-utils");
+
+before(async () => {
+  permissionUtils = await import("./permission-utils");
+});
+
+function buildUser(permissions: string[]): AuthUser {
+  return {
+    id: "actor",
+    email: "actor@example.com",
+    authorization: {
+      effective: {
+        permissions,
+      },
+    },
+  };
+}
+
+test("grants sensitive family read access with fine permissions", () => {
+  const user = buildUser(["health:read", "emergency_contacts:read"]);
+
+  assert.equal(permissionUtils.canReadSensitiveUserFamily(user, "health"), true);
+  assert.equal(
+    permissionUtils.canReadSensitiveUserFamily(user, "emergency_contacts"),
+    true,
+  );
+  assert.equal(
+    permissionUtils.canReadSensitiveUserFamily(user, "legal_representative"),
+    false,
+  );
+});
+
+test("keeps legacy users:read_detail fallback for sensitive family reads", () => {
+  const user = buildUser(["users:read_detail"]);
+
+  assert.equal(permissionUtils.canReadSensitiveUserFamily(user, "health"), true);
+  assert.equal(
+    permissionUtils.canReadSensitiveUserFamily(user, "post_registration"),
+    true,
+  );
+});
+
+test("grants sensitive family updates with fine permission or legacy fallback", () => {
+  const fineGrainedUser = buildUser(["legal_representative:update"]);
+  const legacyUser = buildUser(["users:update"]);
+
+  assert.equal(
+    permissionUtils.canUpdateSensitiveUserFamily(
+      fineGrainedUser,
+      "legal_representative",
+    ),
+    true,
+  );
+  assert.equal(
+    permissionUtils.canUpdateSensitiveUserFamily(legacyUser, "health"),
+    true,
+  );
+});
+
+test("separates post-registration administrative completion from sensitive reads", () => {
+  const user = buildUser(["users:update"]);
+
+  assert.equal(
+    permissionUtils.canReadSensitiveUserFamily(user, "post_registration"),
+    false,
+  );
+  assert.equal(permissionUtils.canViewAdministrativeCompletion(user), true);
+  assert.equal(permissionUtils.canManageAdministrativeCompletion(user), true);
+});

--- a/src/lib/auth/permission-utils.ts
+++ b/src/lib/auth/permission-utils.ts
@@ -8,6 +8,8 @@ import {
   CLUB_INSTANCES_CREATE,
   CLUB_INSTANCES_READ,
   CLUB_INSTANCES_UPDATE,
+  USERS_READ_DETAIL,
+  USERS_UPDATE,
 } from "@/lib/auth/permissions";
 import { ALLOWED_ADMIN_ROLES, extractRoles } from "@/lib/auth/roles";
 import type { AuthUser } from "@/lib/auth/types";
@@ -126,7 +128,6 @@ function emitRbacEvent(
   }
 
   // Simple telemetry sink until analytics provider is wired.
-  // eslint-disable-next-line no-console
   console.info(`[rbac] ${event}`, payload);
 }
 
@@ -229,6 +230,22 @@ export function hasAnyPermission(
   return permissionKeys.some((permissionKey) =>
     permissions.has(normalizePermission(permissionKey)),
   );
+}
+
+export function canReadSensitiveUserData(user: AuthUser | null | undefined) {
+  return hasPermission(user, USERS_READ_DETAIL);
+}
+
+export function canViewAdministrativeCompletion(
+  user: AuthUser | null | undefined,
+) {
+  return hasAnyPermission(user, [USERS_READ_DETAIL, USERS_UPDATE]);
+}
+
+export function canManageAdministrativeCompletion(
+  user: AuthUser | null | undefined,
+) {
+  return hasPermission(user, USERS_UPDATE);
 }
 
 export function hasAnyRole(

--- a/src/lib/auth/permission-utils.ts
+++ b/src/lib/auth/permission-utils.ts
@@ -8,6 +8,14 @@ import {
   CLUB_INSTANCES_CREATE,
   CLUB_INSTANCES_READ,
   CLUB_INSTANCES_UPDATE,
+  EMERGENCY_CONTACTS_READ,
+  EMERGENCY_CONTACTS_UPDATE,
+  HEALTH_READ,
+  HEALTH_UPDATE,
+  LEGAL_REPRESENTATIVE_READ,
+  LEGAL_REPRESENTATIVE_UPDATE,
+  POST_REGISTRATION_READ,
+  POST_REGISTRATION_UPDATE,
   USERS_READ_DETAIL,
   USERS_UPDATE,
 } from "@/lib/auth/permissions";
@@ -38,6 +46,26 @@ export const CLUBS_INSTANCES_UPDATE_KEYS = [
   CLUBS_INSTANCES_UPDATE,
   CLUB_INSTANCES_UPDATE,
 ];
+
+export type SensitiveUserFamily =
+  | "health"
+  | "emergency_contacts"
+  | "legal_representative"
+  | "post_registration";
+
+const SENSITIVE_USER_READ_KEYS: Record<SensitiveUserFamily, string[]> = {
+  health: [HEALTH_READ, USERS_READ_DETAIL],
+  emergency_contacts: [EMERGENCY_CONTACTS_READ, USERS_READ_DETAIL],
+  legal_representative: [LEGAL_REPRESENTATIVE_READ, USERS_READ_DETAIL],
+  post_registration: [POST_REGISTRATION_READ, USERS_READ_DETAIL],
+};
+
+const SENSITIVE_USER_UPDATE_KEYS: Record<SensitiveUserFamily, string[]> = {
+  health: [HEALTH_UPDATE, USERS_UPDATE],
+  emergency_contacts: [EMERGENCY_CONTACTS_UPDATE, USERS_UPDATE],
+  legal_representative: [LEGAL_REPRESENTATIVE_UPDATE, USERS_UPDATE],
+  post_registration: [POST_REGISTRATION_UPDATE, USERS_UPDATE],
+};
 
 function isRecord(value: unknown): value is UnknownRecord {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -233,19 +261,39 @@ export function hasAnyPermission(
 }
 
 export function canReadSensitiveUserData(user: AuthUser | null | undefined) {
-  return hasPermission(user, USERS_READ_DETAIL);
+  return ["health", "emergency_contacts", "legal_representative"]
+    .some((family) =>
+      canReadSensitiveUserFamily(user, family as SensitiveUserFamily),
+    );
+}
+
+export function canReadSensitiveUserFamily(
+  user: AuthUser | null | undefined,
+  family: SensitiveUserFamily,
+) {
+  return hasAnyPermission(user, SENSITIVE_USER_READ_KEYS[family]);
+}
+
+export function canUpdateSensitiveUserFamily(
+  user: AuthUser | null | undefined,
+  family: SensitiveUserFamily,
+) {
+  return hasAnyPermission(user, SENSITIVE_USER_UPDATE_KEYS[family]);
 }
 
 export function canViewAdministrativeCompletion(
   user: AuthUser | null | undefined,
 ) {
-  return hasAnyPermission(user, [USERS_READ_DETAIL, USERS_UPDATE]);
+  return hasAnyPermission(user, [
+    ...SENSITIVE_USER_READ_KEYS.post_registration,
+    ...SENSITIVE_USER_UPDATE_KEYS.post_registration,
+  ]);
 }
 
 export function canManageAdministrativeCompletion(
   user: AuthUser | null | undefined,
 ) {
-  return hasPermission(user, USERS_UPDATE);
+  return canUpdateSensitiveUserFamily(user, "post_registration");
 }
 
 export function hasAnyRole(

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -20,6 +20,14 @@ export const USERS_CREATE = "users:create";
 export const USERS_UPDATE = "users:update";
 export const USERS_DELETE = "users:delete";
 export const USERS_EXPORT = "users:export";
+export const HEALTH_READ = "health:read";
+export const HEALTH_UPDATE = "health:update";
+export const EMERGENCY_CONTACTS_READ = "emergency_contacts:read";
+export const EMERGENCY_CONTACTS_UPDATE = "emergency_contacts:update";
+export const LEGAL_REPRESENTATIVE_READ = "legal_representative:read";
+export const LEGAL_REPRESENTATIVE_UPDATE = "legal_representative:update";
+export const POST_REGISTRATION_READ = "post_registration:read";
+export const POST_REGISTRATION_UPDATE = "post_registration:update";
 
 // --- Roles y Permisos ---
 export const ROLES_READ = "roles:read";


### PR DESCRIPTION
## Summary
- align admin authorization helpers with fine-grained sensitive user families plus transitional legacy fallback behavior
- update the admin user detail screen to consume pruned sensitive payloads without collapsing omitted blocks into false empty states
- keep administrative post-registration completion gating distinct from sensitive data reads

## Test Plan
- `pnpm dlx tsx --test src/lib/auth/permission-utils.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/lib/auth/permission-utils.ts src/lib/auth/permission-utils.test.ts \"src/app/(dashboard)/dashboard/users/[userId]/page.tsx\"`