### PR TITLE
feat(8.4-C): extended rankings admin UI

### DIFF
--- a/src/app/(dashboard)/dashboard/annual-folders/rankings/[enrollmentId]/breakdown/page.tsx
+++ b/src/app/(dashboard)/dashboard/annual-folders/rankings/[enrollmentId]/breakdown/page.tsx
@@ -1,0 +1,63 @@
+import { BreakdownView } from "@/components/rankings/breakdown-view";
+import { PageHeader } from "@/components/shared/page-header";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { requireAdminUser } from "@/lib/auth/session";
+import { fetchRankingBreakdown } from "@/lib/api/annual-folders";
+import { ApiError } from "@/lib/api/client";
+import type { RankingBreakdown } from "@/lib/api/annual-folders";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface PageProps {
+  params: Promise<{ enrollmentId: string }>;
+  searchParams: Promise<{ year_id?: string }>;
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function BreakdownPage({
+  params,
+  searchParams,
+}: PageProps) {
+  await requireAdminUser();
+
+  const { enrollmentId } = await params;
+  const { year_id } = await searchParams;
+  const yearId = Number(year_id);
+
+  if (!enrollmentId || !Number.isFinite(yearId) || yearId <= 0) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">
+        Los parámetros <code>enrollmentId</code> y <code>year_id</code> son
+        requeridos.
+      </div>
+    );
+  }
+
+  const [result] = await Promise.allSettled([
+    fetchRankingBreakdown(enrollmentId, yearId),
+  ]);
+
+  const data: RankingBreakdown | null =
+    result.status === "fulfilled" ? result.value : null;
+
+  const loadError: string | null =
+    result.status === "rejected"
+      ? result.reason instanceof ApiError
+        ? result.reason.message
+        : "No se pudo cargar el breakdown de ranking. Verificá la conexión con el servidor."
+      : null;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Breakdown de ranking"
+        description={`Detalle por componente para la inscripción ${enrollmentId}`}
+      />
+
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+
+      {data && <BreakdownView data={data} />}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/ranking-weights/page.tsx
+++ b/src/app/(dashboard)/dashboard/ranking-weights/page.tsx
@@ -1,0 +1,55 @@
+import { Settings2 } from "lucide-react";
+import { PageHeader } from "@/components/shared/page-header";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { EmptyState } from "@/components/shared/empty-state";
+import { RankingWeightsClientPage } from "@/components/ranking-weights/ranking-weights-client-page";
+import { requireAdminUser } from "@/lib/auth/session";
+import { ApiError } from "@/lib/api/client";
+import { fetchRankingWeights } from "@/lib/api/ranking-weights";
+import type { RankingWeights } from "@/lib/api/ranking-weights";
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function RankingWeightsPage() {
+  await requireAdminUser();
+
+  let weights: RankingWeights[] = [];
+  let loadError: string | null = null;
+
+  try {
+    const result = await fetchRankingWeights();
+    weights = Array.isArray(result) ? result : [];
+  } catch (err) {
+    if (err instanceof ApiError) {
+      loadError = err.message;
+    } else {
+      loadError =
+        "No se pudieron cargar los pesos de ranking. Verificá la conexión con el servidor.";
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Pesos de ranking"
+        description="Configurá la ponderación de cada dimensión (folder, finance, camporee, evidence) para el cálculo del ranking anual. La suma de los 4 pesos debe ser exactamente 100."
+      />
+
+      {loadError && (
+        <EndpointErrorBanner state="missing" detail={loadError} />
+      )}
+
+      {!loadError && weights.length === 0 && (
+        <EmptyState
+          icon={Settings2}
+          title="Sin configuración"
+          description="No se encontraron configuraciones de pesos. El backend debería haber creado un default global al iniciarse."
+        />
+      )}
+
+      {!loadError && weights.length > 0 && (
+        <RankingWeightsClientPage initial={weights} />
+      )}
+    </div>
+  );
+}

--- a/src/components/annual-folders/award-categories-client-page.tsx
+++ b/src/components/annual-folders/award-categories-client-page.tsx
@@ -6,6 +6,7 @@ import { Plus, RefreshCw, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
   Table,
   TableBody,
@@ -42,6 +43,8 @@ interface AwardCategoriesClientPageProps {
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
+type FilterTab = "active" | "legacy";
+
 function extractCategories(payload: unknown): AwardCategory[] {
   if (Array.isArray(payload)) return payload as AwardCategory[];
   if (payload && typeof payload === "object") {
@@ -60,6 +63,11 @@ function clubTypeLabel(
   return found?.name ?? `Tipo ${clubTypeId}`;
 }
 
+function formatPct(value: number | null): string {
+  if (value === null) return "—";
+  return `${value}%`;
+}
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function AwardCategoriesClientPage({
@@ -70,6 +78,7 @@ export function AwardCategoriesClientPage({
   const [categories, setCategories] =
     useState<AwardCategory[]>(initialCategories);
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [filter, setFilter] = useState<FilterTab>("active");
 
   // Form dialog state
   const [formOpen, setFormOpen] = useState(false);
@@ -84,21 +93,37 @@ export function AwardCategoriesClientPage({
 
   // ─── Refresh ──────────────────────────────────────────────────────────────
 
-  const refreshCategories = useCallback(async () => {
-    setIsRefreshing(true);
-    try {
-      const payload = await getAwardCategoriesFromClient();
-      setCategories(extractCategories(payload));
-    } catch (err) {
-      const message =
-        err instanceof ApiError
-          ? err.message
-          : "No se pudieron actualizar las categorias";
-      toast.error(message);
-    } finally {
-      setIsRefreshing(false);
-    }
-  }, []);
+  const refreshCategories = useCallback(
+    async (tab: FilterTab = filter) => {
+      setIsRefreshing(true);
+      try {
+        const includeLegacy = tab === "legacy" ? true : undefined;
+        const payload = await getAwardCategoriesFromClient(
+          undefined,
+          undefined,
+          includeLegacy,
+        );
+        setCategories(extractCategories(payload));
+      } catch (err) {
+        const message =
+          err instanceof ApiError
+            ? err.message
+            : "No se pudieron actualizar las categorias";
+        toast.error(message);
+      } finally {
+        setIsRefreshing(false);
+      }
+    },
+    [filter],
+  );
+
+  // ─── Tab change ───────────────────────────────────────────────────────────
+
+  function handleFilterChange(value: string) {
+    const tab = value as FilterTab;
+    setFilter(tab);
+    void refreshCategories(tab);
+  }
 
   // ─── Create ───────────────────────────────────────────────────────────────
 
@@ -141,9 +166,13 @@ export function AwardCategoriesClientPage({
     }
   }
 
-  // ─── Sorted by order ──────────────────────────────────────────────────────
+  // ─── Derived list ─────────────────────────────────────────────────────────
 
-  const sortedCategories = [...categories].sort((a, b) => a.order - b.order);
+  const filteredCategories = [...categories]
+    .filter((cat) =>
+      filter === "legacy" ? cat.is_legacy === true : cat.is_legacy !== true,
+    )
+    .sort((a, b) => a.order - b.order);
 
   // ─── Render ───────────────────────────────────────────────────────────────
 
@@ -154,14 +183,14 @@ export function AwardCategoriesClientPage({
         <div className="flex items-center gap-2">
           <p className="text-sm text-muted-foreground">
             <span className="font-medium text-foreground">
-              {categories.length}
+              {filteredCategories.length}
             </span>{" "}
-            {categories.length === 1 ? "categoria" : "categorias"}
+            {filteredCategories.length === 1 ? "categoria" : "categorias"}
           </p>
           <Button
             variant="outline"
             size="icon-sm"
-            onClick={refreshCategories}
+            onClick={() => refreshCategories()}
             disabled={isRefreshing}
             title="Actualizar"
           >
@@ -177,23 +206,36 @@ export function AwardCategoriesClientPage({
         </Button>
       </div>
 
+      {/* Tabs filter */}
+      <Tabs value={filter} onValueChange={handleFilterChange}>
+        <TabsList>
+          <TabsTrigger value="active">Activas</TabsTrigger>
+          <TabsTrigger value="legacy">Legacy</TabsTrigger>
+        </TabsList>
+      </Tabs>
+
       {/* List */}
-      {sortedCategories.length === 0 ? (
+      {filteredCategories.length === 0 ? (
         <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center">
           <div className="flex size-12 items-center justify-center rounded-full bg-muted">
             <Plus className="size-6 text-muted-foreground" />
           </div>
           <h3 className="mt-4 text-base font-semibold">
-            Sin categorias de premio
+            {filter === "legacy"
+              ? "Sin categorias legacy"
+              : "Sin categorias de premio"}
           </h3>
           <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-            Crea categorias para clasificar los clubes segun sus puntos obtenidos
-            en la carpeta anual.
+            {filter === "legacy"
+              ? "No hay categorias marcadas como legacy en este momento."
+              : "Crea categorias para clasificar los clubes segun sus puntos obtenidos en la carpeta anual."}
           </p>
-          <Button size="sm" className="mt-4" onClick={handleCreate}>
-            <Plus className="size-4" />
-            Nueva categoria
-          </Button>
+          {filter === "active" && (
+            <Button size="sm" className="mt-4" onClick={handleCreate}>
+              <Plus className="size-4" />
+              Nueva categoria
+            </Button>
+          )}
         </div>
       ) : (
         <div className="rounded-lg border border-border">
@@ -209,13 +251,22 @@ export function AwardCategoriesClientPage({
                 <TableHead className="hidden w-24 text-center md:table-cell">
                   Pts Max
                 </TableHead>
+                <TableHead className="hidden w-24 text-center lg:table-cell">
+                  % Min
+                </TableHead>
+                <TableHead className="hidden w-24 text-center lg:table-cell">
+                  % Max
+                </TableHead>
                 <TableHead className="w-20 text-center">Estado</TableHead>
                 <TableHead className="w-20 text-right">Acciones</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {sortedCategories.map((cat) => (
-                <TableRow key={cat.award_category_id}>
+              {filteredCategories.map((cat) => (
+                <TableRow
+                  key={cat.award_category_id}
+                  className={cat.is_legacy ? "opacity-60" : ""}
+                >
                   <TableCell className="text-center">
                     <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-xs font-medium">
                       {cat.order}
@@ -223,7 +274,14 @@ export function AwardCategoriesClientPage({
                   </TableCell>
                   <TableCell>
                     <div className="flex flex-col gap-0.5">
-                      <span className="font-medium">{cat.name}</span>
+                      <div className="flex items-center gap-2">
+                        <span className="font-medium">{cat.name}</span>
+                        {cat.is_legacy && (
+                          <Badge variant="outline" className="text-xs">
+                            Legacy
+                          </Badge>
+                        )}
+                      </div>
                       {cat.description && (
                         <span className="line-clamp-1 text-xs text-muted-foreground">
                           {cat.description}
@@ -244,6 +302,12 @@ export function AwardCategoriesClientPage({
                       </span>
                     )}
                   </TableCell>
+                  <TableCell className="hidden text-center text-sm text-muted-foreground lg:table-cell">
+                    {formatPct(cat.min_composite_pct)}
+                  </TableCell>
+                  <TableCell className="hidden text-center text-sm text-muted-foreground lg:table-cell">
+                    {formatPct(cat.max_composite_pct)}
+                  </TableCell>
                   <TableCell className="text-center">
                     <Badge
                       variant={cat.active ? "success" : "secondary"}
@@ -259,6 +323,7 @@ export function AwardCategoriesClientPage({
                         size="icon-xs"
                         onClick={() => handleEdit(cat)}
                         title="Editar categoria"
+                        disabled={cat.is_legacy}
                       >
                         <Pencil className="size-3.5" />
                         <span className="sr-only">Editar</span>

--- a/src/components/annual-folders/award-category-form-dialog.tsx
+++ b/src/components/annual-folders/award-category-form-dialog.tsx
@@ -34,29 +34,54 @@ import type { ClubType } from "@/lib/api/catalogs";
 
 // ─── Schema ───────────────────────────────────────────────────────────────────
 
-const formSchema = z.object({
-  name: z
-    .string()
-    .min(2, "El nombre debe tener al menos 2 caracteres")
-    .max(200, "El nombre no puede superar 200 caracteres"),
-  description: z
-    .string()
-    .max(500, "La descripción no puede superar 500 caracteres")
-    .optional(),
-  club_type_id: z.string(), // "all" | stringified number
-  min_points: z.coerce.number().int().min(0, "Debe ser 0 o mayor"),
-  max_points: z.coerce
-    .number()
-    .int()
-    .min(0, "Debe ser 0 o mayor")
-    .optional()
-    .nullable(),
-  icon: z
-    .string()
-    .max(100, "El ícono no puede superar 100 caracteres")
-    .optional(),
-  order: z.coerce.number().int().min(0, "El orden debe ser 0 o mayor"),
-});
+const formSchema = z
+  .object({
+    name: z
+      .string()
+      .min(2, "El nombre debe tener al menos 2 caracteres")
+      .max(200, "El nombre no puede superar 200 caracteres"),
+    description: z
+      .string()
+      .max(500, "La descripción no puede superar 500 caracteres")
+      .optional(),
+    club_type_id: z.string(), // "all" | stringified number
+    min_points: z.coerce.number().int().min(0, "Debe ser 0 o mayor"),
+    max_points: z.coerce
+      .number()
+      .int()
+      .min(0, "Debe ser 0 o mayor")
+      .optional()
+      .nullable(),
+    icon: z
+      .string()
+      .max(100, "El ícono no puede superar 100 caracteres")
+      .optional(),
+    order: z.coerce.number().int().min(0, "El orden debe ser 0 o mayor"),
+    // ── 8.4-C composite scoring ──────────────────────────────────────────────
+    min_composite_pct: z.coerce
+      .number()
+      .min(0, "Debe ser 0 o mayor")
+      .max(100, "No puede superar 100")
+      .optional()
+      .nullable(),
+    max_composite_pct: z.coerce
+      .number()
+      .min(0, "Debe ser 0 o mayor")
+      .max(100, "No puede superar 100")
+      .optional()
+      .nullable(),
+  })
+  .superRefine((data, ctx) => {
+    const min = data.min_composite_pct;
+    const max = data.max_composite_pct;
+    if (min != null && max != null && min >= max) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "El min_composite_pct debe ser menor que el max_composite_pct.",
+        path: ["min_composite_pct"],
+      });
+    }
+  });
 
 type FormValues = z.infer<typeof formSchema>;
 
@@ -100,6 +125,8 @@ export function AwardCategoryFormDialog({
       max_points: null,
       icon: "",
       order: 0,
+      min_composite_pct: null,
+      max_composite_pct: null,
     },
   });
 
@@ -119,6 +146,8 @@ export function AwardCategoryFormDialog({
           max_points: category.max_points ?? null,
           icon: category.icon ?? "",
           order: category.order,
+          min_composite_pct: category.min_composite_pct ?? null,
+          max_composite_pct: category.max_composite_pct ?? null,
         });
       } else {
         reset({
@@ -129,6 +158,8 @@ export function AwardCategoryFormDialog({
           max_points: null,
           icon: "",
           order: 0,
+          min_composite_pct: null,
+          max_composite_pct: null,
         });
       }
     }
@@ -149,6 +180,16 @@ export function AwardCategoryFormDialog({
             : null,
         icon: values.icon || null,
         order: values.order,
+        min_composite_pct:
+          values.min_composite_pct !== null &&
+          values.min_composite_pct !== undefined
+            ? values.min_composite_pct
+            : null,
+        max_composite_pct:
+          values.max_composite_pct !== null &&
+          values.max_composite_pct !== undefined
+            ? values.max_composite_pct
+            : null,
       };
 
       if (isEdit && category) {
@@ -270,6 +311,45 @@ export function AwardCategoryFormDialog({
               {errors.max_points && (
                 <p className="text-xs text-destructive">
                   {errors.max_points.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Composite % min / max */}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="cat-min-composite-pct">Min composite %</Label>
+              <Input
+                id="cat-min-composite-pct"
+                type="number"
+                min={0}
+                max={100}
+                step="0.01"
+                {...register("min_composite_pct")}
+                placeholder="Ej. 60"
+              />
+              {errors.min_composite_pct && (
+                <p className="text-xs text-destructive">
+                  {errors.min_composite_pct.message}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="cat-max-composite-pct">Max composite %</Label>
+              <Input
+                id="cat-max-composite-pct"
+                type="number"
+                min={0}
+                max={100}
+                step="0.01"
+                {...register("max_composite_pct")}
+                placeholder="Ej. 80"
+              />
+              {errors.max_composite_pct && (
+                <p className="text-xs text-destructive">
+                  {errors.max_composite_pct.message}
                 </p>
               )}
             </div>

--- a/src/components/annual-folders/rankings-client-page.tsx
+++ b/src/components/annual-folders/rankings-client-page.tsx
@@ -4,15 +4,17 @@ import { useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import {
   Search,
-  RefreshCw,
   Medal,
   Trophy,
   TrendingUp,
   BarChart3,
+  ArrowRight,
 } from "lucide-react";
+import Link from "next/link";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { RankingScoreBadge } from "@/components/rankings/ranking-score-badge";
 import {
   Select,
   SelectContent,
@@ -366,6 +368,21 @@ export function RankingsClientPage({
               <TableRow>
                 <TableHead className="w-16 text-center">Posicion</TableHead>
                 <TableHead>Club</TableHead>
+                <TableHead className="w-28 text-center">
+                  Composite
+                </TableHead>
+                <TableHead className="hidden w-24 text-center lg:table-cell">
+                  Carpeta
+                </TableHead>
+                <TableHead className="hidden w-24 text-center lg:table-cell">
+                  Finanzas
+                </TableHead>
+                <TableHead className="hidden w-24 text-center lg:table-cell">
+                  Camporees
+                </TableHead>
+                <TableHead className="hidden w-24 text-center lg:table-cell">
+                  Evidencias
+                </TableHead>
                 <TableHead className="hidden w-32 text-center md:table-cell">
                   Pts Obtenidos
                 </TableHead>
@@ -376,6 +393,7 @@ export function RankingsClientPage({
                 <TableHead className="hidden w-32 sm:table-cell">
                   Categoria
                 </TableHead>
+                <TableHead className="w-24 text-center">Acciones</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -397,6 +415,21 @@ export function RankingsClientPage({
                     >
                       {item.club_name}
                     </span>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <RankingScoreBadge value={item.composite_score_pct} />
+                  </TableCell>
+                  <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
+                    {item.folder_score_pct.toFixed(1)}%
+                  </TableCell>
+                  <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
+                    {item.finance_score_pct.toFixed(1)}%
+                  </TableCell>
+                  <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
+                    {item.camporee_score_pct.toFixed(1)}%
+                  </TableCell>
+                  <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
+                    {item.evidence_score_pct.toFixed(1)}%
                   </TableCell>
                   <TableCell className="hidden text-center text-sm font-medium md:table-cell">
                     {item.total_earned_points}
@@ -425,6 +458,15 @@ export function RankingsClientPage({
                         Sin categoria
                       </span>
                     )}
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <Link
+                      href={`/dashboard/annual-folders/rankings/${item.club_enrollment_id}/breakdown?year_id=${item.ecclesiastical_year_id ?? selectedYearId}`}
+                      className="inline-flex items-center gap-1 text-xs text-primary underline-offset-4 hover:underline"
+                    >
+                      Ver detalle
+                      <ArrowRight className="size-3" />
+                    </Link>
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/components/ranking-weights/new-override-form.tsx
+++ b/src/components/ranking-weights/new-override-form.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { WeightsForm } from "./weights-form";
+import { createRankingWeights } from "@/lib/api/ranking-weights";
+import { listClubTypes } from "@/lib/api/catalogs";
+import type { ClubType } from "@/lib/api/catalogs";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface NewOverrideFormProps {
+  existingClubTypeIds: number[];
+  onCreated: () => Promise<void>;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function NewOverrideForm({
+  existingClubTypeIds,
+  onCreated,
+}: NewOverrideFormProps) {
+  const [types, setTypes] = useState<ClubType[]>([]);
+  const [selected, setSelected] = useState<number | null>(null);
+
+  useEffect(() => {
+    listClubTypes()
+      .then((rows) => {
+        setTypes(Array.isArray(rows) ? rows : []);
+      })
+      .catch(() => setTypes([]));
+  }, []);
+
+  const available = types.filter(
+    (t) => !existingClubTypeIds.includes(t.club_type_id),
+  );
+
+  return (
+    <div className="space-y-4">
+      <Select
+        onValueChange={(v) => setSelected(parseInt(v, 10))}
+      >
+        <SelectTrigger>
+          <SelectValue placeholder="Seleccionar tipo de club" />
+        </SelectTrigger>
+        <SelectContent>
+          {available.length === 0 ? (
+            <SelectItem value="__none" disabled>
+              Sin tipos disponibles
+            </SelectItem>
+          ) : (
+            available.map((t) => (
+              <SelectItem
+                key={t.club_type_id}
+                value={String(t.club_type_id)}
+              >
+                {t.name}
+              </SelectItem>
+            ))
+          )}
+        </SelectContent>
+      </Select>
+
+      {selected != null && (
+        <WeightsForm
+          initial={{
+            folder_weight: 60,
+            finance_weight: 15,
+            camporee_weight: 15,
+            evidence_weight: 10,
+          }}
+          submitLabel="Crear override"
+          onSubmit={async (values) => {
+            await createRankingWeights({
+              club_type_id: selected,
+              ...values,
+            });
+            await onCreated();
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/ranking-weights/ranking-weights-client-page.tsx
+++ b/src/components/ranking-weights/ranking-weights-client-page.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableHead,
+  TableRow,
+  TableCell,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { WeightsForm } from "./weights-form";
+import { NewOverrideForm } from "./new-override-form";
+import {
+  deleteRankingWeights,
+  updateRankingWeights,
+  type RankingWeights,
+} from "@/lib/api/ranking-weights";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface RankingWeightsClientPageProps {
+  initial: RankingWeights[];
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function weightSum(r: RankingWeights): number {
+  return (
+    r.folder_weight +
+    r.finance_weight +
+    r.camporee_weight +
+    r.evidence_weight
+  );
+}
+
+// ─── Override row actions ─────────────────────────────────────────────────────
+
+interface OverrideRowActionsProps {
+  row: RankingWeights;
+  onUpdate: (updated: RankingWeights) => void;
+  onDelete: (id: string) => void;
+}
+
+function OverrideRowActions({
+  row,
+  onUpdate,
+  onDelete,
+}: OverrideRowActionsProps) {
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  async function handleDelete() {
+    setIsDeleting(true);
+    try {
+      await deleteRankingWeights(row.ranking_weight_config_id);
+      toast.success("Override eliminado");
+      onDelete(row.ranking_weight_config_id);
+      setDeleteOpen(false);
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : "Error al eliminar el override";
+      toast.error(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {/* Edit */}
+      <Dialog open={editOpen} onOpenChange={setEditOpen}>
+        <DialogTrigger asChild>
+          <Button size="xs" variant="outline">
+            Editar
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Editar override</DialogTitle>
+          </DialogHeader>
+          <WeightsForm
+            initial={{
+              folder_weight: row.folder_weight,
+              finance_weight: row.finance_weight,
+              camporee_weight: row.camporee_weight,
+              evidence_weight: row.evidence_weight,
+            }}
+            onSubmit={async (values) => {
+              try {
+                const updated = await updateRankingWeights(
+                  row.ranking_weight_config_id,
+                  values,
+                );
+                toast.success("Override actualizado");
+                onUpdate(updated);
+                setEditOpen(false);
+              } catch (err: unknown) {
+                const message =
+                  err instanceof Error
+                    ? err.message
+                    : "Error al actualizar el override";
+                toast.error(message);
+                throw err;
+              }
+            }}
+          />
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <Button
+          size="xs"
+          variant="destructive"
+          onClick={() => setDeleteOpen(true)}
+        >
+          Eliminar
+        </Button>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Eliminar override?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta acción no se puede deshacer. El tipo de club volverá a usar
+              los pesos del default global.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>
+              Cancelar
+            </AlertDialogCancel>
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              {isDeleting ? (
+                <>
+                  <Loader2 className="animate-spin" />
+                  Eliminando...
+                </>
+              ) : (
+                "Eliminar"
+              )}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export function RankingWeightsClientPage({
+  initial,
+}: RankingWeightsClientPageProps) {
+  const [rows, setRows] = useState<RankingWeights[]>(initial);
+  const [newOverrideOpen, setNewOverrideOpen] = useState(false);
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+
+  const def = rows.find((r) => r.club_type_id === null);
+  const overrides = rows.filter((r) => r.club_type_id !== null);
+
+  async function handleRefresh() {
+    startTransition(() => router.refresh());
+    setNewOverrideOpen(false);
+  }
+
+  function handleUpdate(updated: RankingWeights) {
+    setRows((rs) =>
+      rs.map((r) =>
+        r.ranking_weight_config_id === updated.ranking_weight_config_id
+          ? updated
+          : r,
+      ),
+    );
+  }
+
+  function handleDelete(id: string) {
+    setRows((rs) => rs.filter((r) => r.ranking_weight_config_id !== id));
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Default global */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Default global</CardTitle>
+          <CardDescription>
+            Pesos aplicados a todos los tipos de club que no tienen un override
+            configurado. La suma debe ser exactamente 100.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {def ? (
+            <WeightsForm
+              initial={{
+                folder_weight: def.folder_weight,
+                finance_weight: def.finance_weight,
+                camporee_weight: def.camporee_weight,
+                evidence_weight: def.evidence_weight,
+              }}
+              onSubmit={async (values) => {
+                try {
+                  const updated = await updateRankingWeights(
+                    def.ranking_weight_config_id,
+                    values,
+                  );
+                  toast.success("Default global actualizado");
+                  handleUpdate(updated);
+                } catch (err: unknown) {
+                  const message =
+                    err instanceof Error
+                      ? err.message
+                      : "Error al actualizar el default";
+                  toast.error(message);
+                  throw err;
+                }
+              }}
+            />
+          ) : (
+            <p className="text-sm text-muted-foreground">
+              Default global no encontrado. Contacta al administrador del
+              sistema.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Overrides table */}
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between gap-4">
+          <div className="space-y-1">
+            <CardTitle>Overrides por tipo de club</CardTitle>
+            <CardDescription>
+              Pesos específicos que reemplazan el default para un tipo de club
+              determinado.
+            </CardDescription>
+          </div>
+          <Dialog open={newOverrideOpen} onOpenChange={setNewOverrideOpen}>
+            <DialogTrigger asChild>
+              <Button>
+                <Plus />
+                Agregar override
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Nuevo override</DialogTitle>
+              </DialogHeader>
+              <NewOverrideForm
+                existingClubTypeIds={overrides
+                  .map((o) => o.club_type_id)
+                  .filter((n): n is number => n != null)}
+                onCreated={handleRefresh}
+              />
+            </DialogContent>
+          </Dialog>
+        </CardHeader>
+        <CardContent>
+          {overrides.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No hay overrides configurados. Todos los tipos de club usan el
+              default global.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Tipo de club</TableHead>
+                  <TableHead>Folder</TableHead>
+                  <TableHead>Finance</TableHead>
+                  <TableHead>Camporee</TableHead>
+                  <TableHead>Evidence</TableHead>
+                  <TableHead>Suma</TableHead>
+                  <TableHead>Acciones</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {overrides.map((r) => {
+                  const sum = weightSum(r);
+                  return (
+                    <TableRow key={r.ranking_weight_config_id}>
+                      <TableCell className="font-medium">
+                        {r.club_type_id}
+                      </TableCell>
+                      <TableCell className="font-mono tabular-nums">
+                        {r.folder_weight}
+                      </TableCell>
+                      <TableCell className="font-mono tabular-nums">
+                        {r.finance_weight}
+                      </TableCell>
+                      <TableCell className="font-mono tabular-nums">
+                        {r.camporee_weight}
+                      </TableCell>
+                      <TableCell className="font-mono tabular-nums">
+                        {r.evidence_weight}
+                      </TableCell>
+                      <TableCell>
+                        <Badge
+                          variant={sum === 100 ? "soft-success" : "destructive"}
+                          className="font-mono tabular-nums"
+                        >
+                          {sum}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <OverrideRowActions
+                          row={r}
+                          onUpdate={handleUpdate}
+                          onDelete={handleDelete}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/ranking-weights/weight-input.tsx
+++ b/src/components/ranking-weights/weight-input.tsx
@@ -1,0 +1,33 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface WeightInputProps {
+  id: string;
+  label: string;
+  value: number;
+  onChange: (n: number) => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function WeightInput({ id, label, value, onChange }: WeightInputProps) {
+  return (
+    <div className="space-y-1">
+      <Label htmlFor={id}>{label}</Label>
+      <Input
+        id={id}
+        type="number"
+        min={0}
+        max={100}
+        value={value}
+        onChange={(e) => {
+          const v = parseInt(e.target.value, 10);
+          onChange(Number.isFinite(v) ? Math.max(0, Math.min(100, v)) : 0);
+        }}
+        className="font-mono tabular-nums w-24"
+      />
+    </div>
+  );
+}

--- a/src/components/ranking-weights/weight-sum-indicator.tsx
+++ b/src/components/ranking-weights/weight-sum-indicator.tsx
@@ -1,0 +1,21 @@
+import { Badge } from "@/components/ui/badge";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface WeightSumIndicatorProps {
+  sum: number;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function WeightSumIndicator({ sum }: WeightSumIndicatorProps) {
+  const ok = sum === 100;
+  return (
+    <Badge
+      variant={ok ? "soft-success" : "destructive"}
+      className="font-mono tabular-nums"
+    >
+      Suma: {sum} {ok ? "✓" : "✗"}
+    </Badge>
+  );
+}

--- a/src/components/ranking-weights/weights-form.tsx
+++ b/src/components/ranking-weights/weights-form.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { WeightInput } from "./weight-input";
+import { WeightSumIndicator } from "./weight-sum-indicator";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface WeightsValues {
+  folder_weight: number;
+  finance_weight: number;
+  camporee_weight: number;
+  evidence_weight: number;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface WeightsFormProps {
+  initial: WeightsValues;
+  submitLabel?: string;
+  onSubmit: (values: WeightsValues) => Promise<void>;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function WeightsForm({
+  initial,
+  submitLabel = "Guardar",
+  onSubmit,
+}: WeightsFormProps) {
+  const [v, setV] = useState<WeightsValues>(initial);
+  const [busy, setBusy] = useState(false);
+
+  const sum =
+    v.folder_weight + v.finance_weight + v.camporee_weight + v.evidence_weight;
+  const ok = sum === 100;
+
+  return (
+    <form
+      className="space-y-4"
+      onSubmit={async (e) => {
+        e.preventDefault();
+        if (!ok || busy) return;
+        try {
+          setBusy(true);
+          await onSubmit(v);
+        } finally {
+          setBusy(false);
+        }
+      }}
+    >
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <WeightInput
+          id="folder"
+          label="Folder"
+          value={v.folder_weight}
+          onChange={(n) => setV({ ...v, folder_weight: n })}
+        />
+        <WeightInput
+          id="finance"
+          label="Finance"
+          value={v.finance_weight}
+          onChange={(n) => setV({ ...v, finance_weight: n })}
+        />
+        <WeightInput
+          id="camporee"
+          label="Camporee"
+          value={v.camporee_weight}
+          onChange={(n) => setV({ ...v, camporee_weight: n })}
+        />
+        <WeightInput
+          id="evidence"
+          label="Evidence"
+          value={v.evidence_weight}
+          onChange={(n) => setV({ ...v, evidence_weight: n })}
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-4">
+        <WeightSumIndicator sum={sum} />
+        <Button type="submit" disabled={!ok || busy}>
+          {busy ? (
+            <>
+              <Loader2 className="animate-spin" />
+              Guardando...
+            </>
+          ) : (
+            submitLabel
+          )}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/rankings/breakdown-view.tsx
+++ b/src/components/rankings/breakdown-view.tsx
@@ -1,0 +1,168 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { RankingScoreBadge } from "@/components/rankings/ranking-score-badge";
+import type {
+  RankingBreakdown,
+  RankingBreakdownCamporeeEvent,
+} from "@/lib/api/annual-folders";
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+function WeightsCard({
+  weights,
+}: {
+  weights: RankingBreakdown["weights_applied"];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Pesos aplicados</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-1 text-sm">
+        <div className="text-muted-foreground">
+          Fuente:{" "}
+          <span className="text-foreground font-medium">
+            {weights.source === "default"
+              ? "Default global"
+              : "Override por tipo de club"}
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-x-4 gap-y-1">
+          <span>Carpetas: {weights.folder}%</span>
+          <span>Finanzas: {weights.finance}%</span>
+          <span>Camporees: {weights.camporee}%</span>
+          <span>Evidencias: {weights.evidence}%</span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function CamporeeEventList({
+  events,
+}: {
+  events: RankingBreakdownCamporeeEvent[];
+}) {
+  if (events.length === 0) return null;
+  return (
+    <ul className="mt-2 space-y-0.5 text-xs text-muted-foreground">
+      {events.map((e) => (
+        <li key={e.id} className="flex items-center gap-1.5">
+          <span
+            className={
+              e.status === "approved" ? "text-success" : "text-muted-foreground"
+            }
+          >
+            {e.status === "approved" ? "✓" : "—"}
+          </span>
+          {e.name}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface Props {
+  data: RankingBreakdown;
+}
+
+export function BreakdownView({ data }: Props) {
+  const { components: c, weights_applied } = data;
+
+  return (
+    <div className="space-y-6">
+      {/* Composite header */}
+      <div className="flex items-center gap-3">
+        <RankingScoreBadge value={data.composite_score_pct} className="text-lg px-3 py-1" />
+        <span className="text-sm text-muted-foreground">
+          Puntaje compuesto institucional
+        </span>
+      </div>
+
+      {/* Four component cards */}
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* Carpetas */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between text-base">
+              Carpetas
+              <RankingScoreBadge value={c.folder.score_pct} />
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <div>
+              {c.folder.earned_points} / {c.folder.max_points} puntos
+            </div>
+            <div className="text-muted-foreground">
+              {c.folder.sections_evaluated} secciones evaluadas
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Finanzas */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between text-base">
+              Finanzas
+              <RankingScoreBadge value={c.finance.score_pct} />
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <div>
+              {c.finance.months_closed_on_time} / {c.finance.months_total}{" "}
+              meses cerrados a tiempo
+            </div>
+            <div className="text-muted-foreground">
+              Deadline: día {c.finance.deadline_day} del mes siguiente
+            </div>
+            {c.finance.missed_months.length > 0 && (
+              <div className="text-destructive text-xs">
+                Meses faltantes: {c.finance.missed_months.join(", ")}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Camporees */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between text-base">
+              Camporees
+              <RankingScoreBadge value={c.camporee.score_pct} />
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="text-sm">
+            <div>
+              {c.camporee.attended} / {c.camporee.available_in_scope} eventos
+              del scope
+            </div>
+            <CamporeeEventList events={c.camporee.events} />
+          </CardContent>
+        </Card>
+
+        {/* Evidencias */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between text-base">
+              Evidencias
+              <RankingScoreBadge value={c.evidence.score_pct} />
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <div>
+              {c.evidence.validated} validadas / {c.evidence.rejected}{" "}
+              rechazadas
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {c.evidence.pending_excluded} pendientes (excluidas del cálculo)
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Weights */}
+      <WeightsCard weights={weights_applied} />
+    </div>
+  );
+}

--- a/src/components/rankings/ranking-score-badge.tsx
+++ b/src/components/rankings/ranking-score-badge.tsx
@@ -1,0 +1,27 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export interface RankingScoreBadgeProps {
+  value: number; // 0..100 expected
+  className?: string;
+}
+
+/**
+ * Displays a percentage score with a color-coded Badge variant:
+ *   >= 80  → success (green)
+ *   >= 60  → soft-warning (amber)
+ *    < 60  → destructive (red)
+ */
+export function RankingScoreBadge({ value, className }: RankingScoreBadgeProps) {
+  const variant =
+    value >= 80 ? "success" : value >= 60 ? "soft-warning" : "destructive";
+
+  return (
+    <Badge
+      variant={variant}
+      className={cn("font-mono tabular-nums", className)}
+    >
+      {value.toFixed(1)}%
+    </Badge>
+  );
+}

--- a/src/lib/api/annual-folders.ts
+++ b/src/lib/api/annual-folders.ts
@@ -390,6 +390,10 @@ export type AwardCategory = {
   icon: string | null;
   order: number;
   active: boolean;
+  // ── 8.4-C extended institutional rankings ─────────────────────────────────
+  min_composite_pct: number | null;
+  max_composite_pct: number | null;
+  is_legacy: boolean;
 };
 
 export type ClubRanking = {
@@ -415,8 +419,13 @@ export type RecalculateResult = {
   rankings_updated: number;
 };
 
-export type CreateAwardCategoryPayload = Omit<AwardCategory, "award_category_id" | "active">;
-export type UpdateAwardCategoryPayload = Partial<AwardCategory>;
+export type CreateAwardCategoryPayload = Omit<
+  AwardCategory,
+  "award_category_id" | "active" | "is_legacy"
+>;
+export type UpdateAwardCategoryPayload = Partial<
+  Omit<AwardCategory, "is_legacy">
+>;
 
 // ─── Rankings — Server-side ───────────────────────────────────────────────────
 
@@ -477,17 +486,19 @@ export async function recalculateRankings(
 // ─── Award Categories — Server-side ──────────────────────────────────────────
 
 /**
- * GET /api/v1/award-categories?club_type_id=X&active=true
+ * GET /api/v1/award-categories?club_type_id=X&active=true&include_legacy=true
  * Returns the list of award categories.
  */
 export async function getAwardCategories(
   clubTypeId?: number,
   active?: boolean,
+  includeLegacy?: boolean,
 ): Promise<AwardCategory[]> {
   return apiRequest<AwardCategory[]>("/award-categories", {
     params: {
       ...(clubTypeId !== undefined ? { club_type_id: clubTypeId } : {}),
       ...(active !== undefined ? { active } : {}),
+      ...(includeLegacy !== undefined ? { include_legacy: includeLegacy } : {}),
     },
   });
 }
@@ -504,16 +515,18 @@ export async function getAwardCategory(categoryId: string): Promise<AwardCategor
 
 /**
  * GET /api/v1/award-categories (client-side)
- * For re-fetching.
+ * For re-fetching. Pass includeLegacy=true to include legacy rows.
  */
 export async function getAwardCategoriesFromClient(
   clubTypeId?: number,
   active?: boolean,
+  includeLegacy?: boolean,
 ): Promise<AwardCategory[]> {
   return apiRequestFromClient<AwardCategory[]>("/award-categories", {
     params: {
       ...(clubTypeId !== undefined ? { club_type_id: clubTypeId } : {}),
       ...(active !== undefined ? { active } : {}),
+      ...(includeLegacy !== undefined ? { include_legacy: includeLegacy } : {}),
     },
   });
 }

--- a/src/lib/api/annual-folders.ts
+++ b/src/lib/api/annual-folders.ts
@@ -396,10 +396,18 @@ export type ClubRanking = {
   rank_position: number | null;
   club_name: string;
   club_enrollment_id: string;
+  ecclesiastical_year_id: number;
   total_earned_points: number;
   total_max_points: number;
   progress_percentage: number;
   award_category_name: string | null;
+  // ── Composite scoring (8.4-C extended institutional rankings) ──────────────
+  folder_score_pct: number;
+  finance_score_pct: number;
+  camporee_score_pct: number;
+  evidence_score_pct: number;
+  composite_score_pct: number;
+  composite_calculated_at: string | null;
 };
 
 export type RecalculateResult = {

--- a/src/lib/api/annual-folders.ts
+++ b/src/lib/api/annual-folders.ts
@@ -554,3 +554,89 @@ export async function deleteAwardCategory(categoryId: string): Promise<void> {
     method: "DELETE",
   });
 }
+
+// ─── Ranking Breakdown ────────────────────────────────────────────────────────
+
+export interface RankingBreakdownComponentFolder {
+  score_pct: number;
+  earned_points: number;
+  max_points: number;
+  sections_evaluated: number;
+}
+
+export interface RankingBreakdownComponentFinance {
+  score_pct: number;
+  months_closed_on_time: number;
+  months_total: number;
+  deadline_day: number;
+  missed_months: number[];
+}
+
+export interface RankingBreakdownCamporeeEvent {
+  id: string;
+  name: string;
+  status: "approved" | null;
+}
+
+export interface RankingBreakdownComponentCamporee {
+  score_pct: number;
+  attended: number;
+  available_in_scope: number;
+  events: RankingBreakdownCamporeeEvent[];
+}
+
+export interface RankingBreakdownComponentEvidence {
+  score_pct: number;
+  validated: number;
+  rejected: number;
+  pending_excluded: number;
+}
+
+export interface RankingBreakdownWeightsApplied {
+  folder: number;
+  finance: number;
+  camporee: number;
+  evidence: number;
+  source: "default" | "club_type_override";
+}
+
+export interface RankingBreakdown {
+  enrollment_id: string;
+  year_id: number;
+  composite_score_pct: number;
+  weights_applied: RankingBreakdownWeightsApplied;
+  components: {
+    folder: RankingBreakdownComponentFolder;
+    finance: RankingBreakdownComponentFinance;
+    camporee: RankingBreakdownComponentCamporee;
+    evidence: RankingBreakdownComponentEvidence;
+  };
+}
+
+/**
+ * GET /api/v1/annual-folders/rankings/:enrollmentId/breakdown?year_id=Y
+ * Returns the per-component breakdown for a single enrollment's ranking.
+ */
+export async function fetchRankingBreakdown(
+  enrollmentId: string,
+  yearId: number,
+): Promise<RankingBreakdown> {
+  return apiRequest<RankingBreakdown>(
+    `/annual-folders/rankings/${enrollmentId}/breakdown`,
+    { params: { year_id: yearId } },
+  );
+}
+
+/**
+ * GET /api/v1/annual-folders/rankings/:enrollmentId/breakdown?year_id=Y (client-side)
+ * For use in client components.
+ */
+export async function fetchRankingBreakdownFromClient(
+  enrollmentId: string,
+  yearId: number,
+): Promise<RankingBreakdown> {
+  return apiRequestFromClient<RankingBreakdown>(
+    `/annual-folders/rankings/${enrollmentId}/breakdown`,
+    { params: { year_id: yearId } },
+  );
+}

--- a/src/lib/api/ranking-weights.ts
+++ b/src/lib/api/ranking-weights.ts
@@ -1,0 +1,66 @@
+import { apiRequest, apiRequestFromClient } from "@/lib/api/client";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface RankingWeights {
+  ranking_weight_config_id: string;
+  /** null for the default global row — cannot be deleted. */
+  club_type_id: number | null;
+  folder_weight: number;
+  finance_weight: number;
+  camporee_weight: number;
+  evidence_weight: number;
+  created_at: string;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+export interface CreateRankingWeightsPayload {
+  club_type_id: number;
+  folder_weight: number;
+  finance_weight: number;
+  camporee_weight: number;
+  evidence_weight: number;
+}
+
+export interface UpdateRankingWeightsPayload {
+  folder_weight?: number;
+  finance_weight?: number;
+  camporee_weight?: number;
+  evidence_weight?: number;
+}
+
+// ─── Server-side API functions (use apiRequest — reads cookie server-side) ────
+
+export async function fetchRankingWeights(): Promise<RankingWeights[]> {
+  return apiRequest<RankingWeights[]>("/ranking-weights");
+}
+
+// ─── Client-side API functions (use apiRequestFromClient — uses withCredentials axios) ─
+
+export async function fetchRankingWeightsFromClient(): Promise<RankingWeights[]> {
+  return apiRequestFromClient<RankingWeights[]>("/ranking-weights");
+}
+
+export async function createRankingWeights(
+  payload: CreateRankingWeightsPayload,
+): Promise<RankingWeights> {
+  return apiRequestFromClient<RankingWeights>("/ranking-weights", {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export async function updateRankingWeights(
+  id: string,
+  patch: UpdateRankingWeightsPayload,
+): Promise<RankingWeights> {
+  return apiRequestFromClient<RankingWeights>(`/ranking-weights/${id}`, {
+    method: "PATCH",
+    body: patch,
+  });
+}
+
+export async function deleteRankingWeights(id: string): Promise<void> {
+  await apiRequestFromClient(`/ranking-weights/${id}`, { method: "DELETE" });
+}


### PR DESCRIPTION
## Summary

Admin UI for **8.4-C — Clasificación institucional ampliada**. Surfaces composite + component scores across rankings, breakdown drill-down, weights CRUD, and award categories extension.

Companion PRs:
- **Docs**: https://github.com/abn-r/sacdia/pull/9
- **Backend**: https://github.com/abn-r/sacdia-backend/pull/new/feat/extended-rankings-8-4-c

### Changes

- `/dashboard/annual-folders/rankings` — 5 new columns (Composite badge + Folder/Finance/Camporees/Evidencias %), drill-down link per row.
- `/dashboard/annual-folders/rankings/[enrollmentId]/breakdown` — new server route showing 4 component cards (folder, finance, camporee, evidence) with badges + detail metrics + the weights applied (default vs club_type_override).
- `/dashboard/ranking-weights` — new CRUD page. Default global card with live sum-to-100 validation; overrides table with edit (Dialog) + delete (AlertDialog with confirmation). New override Dialog combines a club-type select (filtered to types without an override) with the WeightsForm.
- `/dashboard/annual-folders/categories` — form gains optional `min_composite_pct` + `max_composite_pct` (0-100, client-side `min < max` validation via zod superRefine); list gets a Legacy badge per row, an Activas/Legacy tabs filter that toggles `?include_legacy=true`, and disables Edit on legacy rows.
- New `<RankingScoreBadge>` component — color-coded by 80 / 60 thresholds (success / soft-warning / destructive Badge variants, no hardcoded Tailwind colors).
- New `<WeightInput>` + `<WeightSumIndicator>` + `<WeightsForm>` + `<NewOverrideForm>` components under `src/components/ranking-weights/`.
- `src/lib/api/annual-folders.ts` extended with `RankingBreakdown` type hierarchy + `fetchRankingBreakdown` (server + client variants).
- `src/lib/api/ranking-weights.ts` — new types + 5 API functions.

## Test plan

- [ ] `pnpm tsc --noEmit` — currently **clean**.
- [ ] `pnpm lint` — no new errors/warnings introduced (4 errors + 49 warnings in unrelated pre-existing files remain).
- [ ] Smoke: `pnpm dev`, navigate to `/dashboard/annual-folders/rankings` and verify the 5 new columns render.
- [ ] Smoke: click "Ver detalle" on a row → breakdown page renders 4 cards + weights card.
- [ ] Smoke: navigate to `/dashboard/ranking-weights`. Edit default global, save. Add an override for a club type. Delete the override. Verify default global delete button is disabled / rejected.
- [ ] Smoke: navigate to `/dashboard/annual-folders/categories`. Switch to "Legacy" tab and verify legacy rows show with the Legacy badge + disabled Edit. Create a new active category with `min_composite_pct=70`, `max_composite_pct=80`.
- [ ] Smoke: try saving a category with `min_composite_pct >= max_composite_pct` and verify the inline validation prevents submit.