### PR TITLE
feat(rankings): 8.4-A admin — 5 dashboard pages (rankings + weights + scope tabs)

### DIFF
--- a/src/app/(dashboard)/dashboard/annual-folders/categories/page.tsx
+++ b/src/app/(dashboard)/dashboard/annual-folders/categories/page.tsx
@@ -31,7 +31,7 @@ export default async function AwardCategoriesPage() {
   let loadError: string | null = null;
 
   const [categoriesResult, clubTypesResult] = await Promise.allSettled([
-    getAwardCategories(),
+    getAwardCategories(undefined, true, "club"),
     listClubTypes(),
   ]);
 
@@ -44,7 +44,7 @@ export default async function AwardCategoriesPage() {
     loadError =
       err instanceof ApiError
         ? err.message
-        : "No se pudieron cargar las categorias de premio.";
+        : "No se pudieron cargar las categorías de premio.";
   }
 
   if (clubTypesResult.status === "fulfilled") {
@@ -56,8 +56,8 @@ export default async function AwardCategoriesPage() {
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Categorias de premios"
-        description="Gestiona las categorias que clasifican a los clubes segun sus puntos obtenidos."
+        title="Categorías de premios"
+        description="Gestión de categorías de premio por alcance: Club, Sección y Miembro."
       />
 
       {loadError && (

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weight-sum-indicator.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weight-sum-indicator.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+
+interface WeightSumIndicatorProps {
+  values: number[];
+}
+
+/**
+ * Live percentage-sum badge used inside the weights form dialog.
+ * Renders green (success) when sum is within ±0.01 of 100, red (destructive)
+ * otherwise — matching the backend IEEE float tolerance:
+ *   Math.abs(sum - 100) <= 0.01
+ */
+export function WeightSumIndicator({ values }: WeightSumIndicatorProps) {
+  const sum = values.reduce(
+    (acc, v) => acc + (Number.isFinite(v) ? v : 0),
+    0,
+  );
+  const isValid = Math.abs(sum - 100) <= 0.01;
+
+  return (
+    <Badge variant={isValid ? "success" : "destructive"}>
+      Suma: {sum.toFixed(2)}% {isValid ? "✓" : "— debe ser 100"}
+    </Badge>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-client-page.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-client-page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { WeightsTable } from "./weights-table";
+import { WeightsFormDialog } from "./weights-form-dialog";
+import {
+  deleteMemberRankingWeights,
+  mapWeightsErrorMessage,
+} from "@/lib/api/member-ranking-weights";
+import type { EnrollmentRankingWeight } from "@/lib/api/member-ranking-weights";
+import type { ClubType, EcclesiasticalYear } from "@/lib/api/catalogs";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface WeightsClientPageProps {
+  initialData: EnrollmentRankingWeight[];
+  clubTypes: ClubType[];
+  ecclesiasticalYears: EcclesiasticalYear[];
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function WeightsClientPage({
+  initialData,
+  clubTypes,
+  ecclesiasticalYears,
+}: WeightsClientPageProps) {
+  const router = useRouter();
+
+  // ── Form dialog state ─────────────────────────────────────────────────────
+  const [formOpen, setFormOpen] = useState(false);
+  const [editingRow, setEditingRow] = useState<EnrollmentRankingWeight | null>(null);
+
+  // ── Delete dialog state ───────────────────────────────────────────────────
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deletingRow, setDeletingRow] = useState<EnrollmentRankingWeight | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  // ── Refresh after mutations ───────────────────────────────────────────────
+  const refresh = useCallback(() => {
+    router.refresh();
+  }, [router]);
+
+  // ── Create ────────────────────────────────────────────────────────────────
+  function handleCreate() {
+    setEditingRow(null);
+    setFormOpen(true);
+  }
+
+  // ── Edit ──────────────────────────────────────────────────────────────────
+  function handleEdit(row: EnrollmentRankingWeight) {
+    setEditingRow(row);
+    setFormOpen(true);
+  }
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+  function handleDelete(row: EnrollmentRankingWeight) {
+    setDeletingRow(row);
+    setDeleteOpen(true);
+  }
+
+  async function confirmDelete() {
+    if (!deletingRow) return;
+    setIsDeleting(true);
+    try {
+      await deleteMemberRankingWeights(deletingRow.id);
+      toast.success("Sobreescritura eliminada");
+      setDeleteOpen(false);
+      setDeletingRow(null);
+      refresh();
+    } catch (err: unknown) {
+      toast.error(mapWeightsErrorMessage(err));
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  // ── Render ────────────────────────────────────────────────────────────────
+  return (
+    <div className="space-y-6">
+      <WeightsTable
+        items={initialData}
+        clubTypes={clubTypes}
+        ecclesiasticalYears={ecclesiasticalYears}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onCreate={handleCreate}
+      />
+
+      {/* Form dialog — create & edit */}
+      <WeightsFormDialog
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        editingRow={editingRow}
+        clubTypes={clubTypes}
+        ecclesiasticalYears={ecclesiasticalYears}
+        onSuccess={refresh}
+      />
+
+      {/* Delete confirmation — AlertDialog per design system */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Eliminar sobreescritura de pesos</AlertDialogTitle>
+            <AlertDialogDescription>
+              Los cálculos de ranking que usaban esta configuración volverán a usar
+              la configuración por defecto global. Esta acción no se puede deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isDeleting}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmDelete}
+              disabled={isDeleting}
+              className="bg-destructive text-white hover:bg-destructive/90"
+            >
+              {isDeleting ? "Eliminando..." : "Eliminar"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-form-dialog.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-form-dialog.tsx
@@ -158,7 +158,7 @@ export function WeightsFormDialog({
 
       if (isEdit && editingRow) {
         await updateMemberRankingWeights(editingRow.id, payload);
-        toast.success("Configuracion de pesos actualizada");
+        toast.success("Configuración de pesos actualizada");
       } else {
         await createMemberRankingWeights(payload);
         toast.success("Sobreescritura de pesos creada");
@@ -188,7 +188,7 @@ export function WeightsFormDialog({
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
-            {isEdit ? "Editar configuracion de pesos" : "Nueva sobreescritura de pesos"}
+            {isEdit ? "Editar configuración de pesos" : "Nueva sobreescritura de pesos"}
           </DialogTitle>
         </DialogHeader>
 

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-form-dialog.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-form-dialog.tsx
@@ -1,0 +1,349 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import type { Resolver, SubmitHandler } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { WeightSumIndicator } from "./weight-sum-indicator";
+import {
+  createMemberRankingWeights,
+  updateMemberRankingWeights,
+  mapWeightsErrorMessage,
+} from "@/lib/api/member-ranking-weights";
+import type { EnrollmentRankingWeight } from "@/lib/api/member-ranking-weights";
+import type { ClubType, EcclesiasticalYear } from "@/lib/api/catalogs";
+
+// ─── Schema ───────────────────────────────────────────────────────────────────
+
+const formSchema = z
+  .object({
+    class_pct: z.coerce
+      .number()
+      .min(0, "Minimo 0")
+      .max(100, "Maximo 100"),
+    investiture_pct: z.coerce
+      .number()
+      .min(0, "Minimo 0")
+      .max(100, "Maximo 100"),
+    camporee_pct: z.coerce
+      .number()
+      .min(0, "Minimo 0")
+      .max(100, "Maximo 100"),
+    /** "all" means null (applies to all club types) */
+    club_type_id: z.string(),
+    /** "all" means null (applies to all years) */
+    ecclesiastical_year_id: z.string(),
+  })
+  .refine(
+    (data) =>
+      Math.abs(data.class_pct + data.investiture_pct + data.camporee_pct - 100) <=
+      0.01,
+    {
+      message: "La suma de los porcentajes debe ser exactamente 100",
+      path: ["camporee_pct"],
+    },
+  );
+
+type FormValues = z.infer<typeof formSchema>;
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface WeightsFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** When provided, the dialog operates in edit mode. */
+  editingRow?: EnrollmentRankingWeight | null;
+  clubTypes: ClubType[];
+  ecclesiasticalYears: EcclesiasticalYear[];
+  onSuccess: () => void;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function rowToDefaultValues(row: EnrollmentRankingWeight): FormValues {
+  return {
+    class_pct: row.class_pct,
+    investiture_pct: row.investiture_pct,
+    camporee_pct: row.camporee_pct,
+    club_type_id:
+      row.club_type_id !== null ? String(row.club_type_id) : "all",
+    ecclesiastical_year_id:
+      row.ecclesiastical_year_id !== null
+        ? String(row.ecclesiastical_year_id)
+        : "all",
+  };
+}
+
+const EMPTY_DEFAULTS: FormValues = {
+  class_pct: 0,
+  investiture_pct: 0,
+  camporee_pct: 0,
+  club_type_id: "all",
+  ecclesiastical_year_id: "all",
+};
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function WeightsFormDialog({
+  open,
+  onOpenChange,
+  editingRow,
+  clubTypes,
+  ecclesiasticalYears,
+  onSuccess,
+}: WeightsFormDialogProps) {
+  const isEdit = !!editingRow;
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    setValue,
+    watch,
+    formState: { errors, isDirty },
+  } = useForm<FormValues>({
+    // z.coerce.number() splits Zod's input/output types (string-ish in, number out),
+    // so zodResolver's inferred Resolver type doesn't match useForm<FormValues>'s
+    // unified signature. Cast is safe because runtime behavior is identical.
+    resolver: zodResolver(formSchema) as unknown as Resolver<FormValues>,
+    defaultValues: EMPTY_DEFAULTS,
+  });
+
+  const classPct = watch("class_pct");
+  const investiturePct = watch("investiture_pct");
+  const camporeePct = watch("camporee_pct");
+  const clubTypeValue = watch("club_type_id");
+  const yearValue = watch("ecclesiastical_year_id");
+
+  useEffect(() => {
+    if (open) {
+      reset(editingRow ? rowToDefaultValues(editingRow) : EMPTY_DEFAULTS);
+    }
+  }, [open, editingRow, reset]);
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    setIsSubmitting(true);
+    try {
+      const payload = {
+        class_pct: values.class_pct,
+        investiture_pct: values.investiture_pct,
+        camporee_pct: values.camporee_pct,
+        club_type_id:
+          values.club_type_id === "all" ? null : Number(values.club_type_id),
+        ecclesiastical_year_id:
+          values.ecclesiastical_year_id === "all"
+            ? null
+            : Number(values.ecclesiastical_year_id),
+      };
+
+      if (isEdit && editingRow) {
+        await updateMemberRankingWeights(editingRow.id, payload);
+        toast.success("Configuracion de pesos actualizada");
+      } else {
+        await createMemberRankingWeights(payload);
+        toast.success("Sobreescritura de pesos creada");
+      }
+
+      onSuccess();
+      onOpenChange(false);
+    } catch (err: unknown) {
+      toast.error(mapWeightsErrorMessage(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const sumValues = [
+    Number.isFinite(Number(classPct)) ? Number(classPct) : 0,
+    Number.isFinite(Number(investiturePct)) ? Number(investiturePct) : 0,
+    Number.isFinite(Number(camporeePct)) ? Number(camporeePct) : 0,
+  ];
+  const sumIsValid =
+    Math.abs(sumValues[0] + sumValues[1] + sumValues[2] - 100) <= 0.01;
+  const submitDisabled =
+    isSubmitting || !sumIsValid || (isEdit && !isDirty);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {isEdit ? "Editar configuracion de pesos" : "Nueva sobreescritura de pesos"}
+          </DialogTitle>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+          {/* Porcentajes */}
+          <div className="grid grid-cols-3 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="w-class">Clase (%)</Label>
+              <Input
+                id="w-class"
+                type="number"
+                step="0.01"
+                min={0}
+                max={100}
+                {...register("class_pct")}
+                placeholder="0"
+              />
+              {errors.class_pct && (
+                <p className="text-xs text-destructive">
+                  {errors.class_pct.message}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="w-investiture">Investidura (%)</Label>
+              <Input
+                id="w-investiture"
+                type="number"
+                step="0.01"
+                min={0}
+                max={100}
+                {...register("investiture_pct")}
+                placeholder="0"
+              />
+              {errors.investiture_pct && (
+                <p className="text-xs text-destructive">
+                  {errors.investiture_pct.message}
+                </p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="w-camporee">Campaña (%)</Label>
+              <Input
+                id="w-camporee"
+                type="number"
+                step="0.01"
+                min={0}
+                max={100}
+                {...register("camporee_pct")}
+                placeholder="0"
+              />
+              {errors.camporee_pct && (
+                <p className="text-xs text-destructive">
+                  {errors.camporee_pct.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* Live sum indicator */}
+          <div className="flex items-center gap-2">
+            <WeightSumIndicator values={sumValues} />
+          </div>
+
+          {/* Tipo de club — catalog Select */}
+          <div className="space-y-1.5">
+            <Label>Tipo de club</Label>
+            <Select
+              value={clubTypeValue}
+              onValueChange={(val) => setValue("club_type_id", val, { shouldDirty: true })}
+              disabled={isEdit && editingRow?.is_default}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Seleccionar tipo de club" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos los tipos</SelectItem>
+                {clubTypes.map((ct) => (
+                  <SelectItem
+                    key={ct.club_type_id}
+                    value={String(ct.club_type_id)}
+                  >
+                    {ct.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.club_type_id && (
+              <p className="text-xs text-destructive">
+                {errors.club_type_id.message}
+              </p>
+            )}
+          </div>
+
+          {/* Ano eclesiastico — catalog Select */}
+          <div className="space-y-1.5">
+            <Label>Ano eclesiastico</Label>
+            <Select
+              value={yearValue}
+              onValueChange={(val) =>
+                setValue("ecclesiastical_year_id", val, { shouldDirty: true })
+              }
+              disabled={isEdit && editingRow?.is_default}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Seleccionar ano" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">Todos los anos</SelectItem>
+                {ecclesiasticalYears.map((y) => (
+                  <SelectItem
+                    key={y.ecclesiastical_year_id}
+                    value={String(y.ecclesiastical_year_id)}
+                  >
+                    {y.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {errors.ecclesiastical_year_id && (
+              <p className="text-xs text-destructive">
+                {errors.ecclesiastical_year_id.message}
+              </p>
+            )}
+          </div>
+
+          {isEdit && editingRow?.is_default && (
+            <p className="text-xs text-muted-foreground">
+              La fila por defecto no puede cambiar su tipo de club ni ano eclesiastico.
+            </p>
+          )}
+
+          <DialogFooter className="pt-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={submitDisabled}>
+              {isSubmitting
+                ? isEdit
+                  ? "Guardando..."
+                  : "Creando..."
+                : isEdit
+                  ? "Guardar cambios"
+                  : "Crear sobreescritura"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-table.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-table.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import { Pencil, Trash2, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { WeightSumIndicator } from "./weight-sum-indicator";
+import type { EnrollmentRankingWeight } from "@/lib/api/member-ranking-weights";
+import type { ClubType, EcclesiasticalYear } from "@/lib/api/catalogs";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface WeightsTableProps {
+  items: EnrollmentRankingWeight[];
+  clubTypes: ClubType[];
+  ecclesiasticalYears: EcclesiasticalYear[];
+  onEdit: (row: EnrollmentRankingWeight) => void;
+  onDelete: (row: EnrollmentRankingWeight) => void;
+  onCreate: () => void;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function clubTypeLabel(id: number | null, clubTypes: ClubType[]): string {
+  if (id === null) return "Todos los tipos";
+  return clubTypes.find((ct) => ct.club_type_id === id)?.name ?? `Tipo ${id}`;
+}
+
+function yearLabel(
+  id: number | null,
+  years: EcclesiasticalYear[],
+): string {
+  if (id === null) return "Todos los anos";
+  return years.find((y) => y.ecclesiastical_year_id === id)?.name ?? `Ano ${id}`;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function WeightsTable({
+  items,
+  clubTypes,
+  ecclesiasticalYears,
+  onEdit,
+  onDelete,
+  onCreate,
+}: WeightsTableProps) {
+  const defaultRow = items.find((r) => r.is_default) ?? null;
+  const overrides = items.filter((r) => !r.is_default);
+
+  return (
+    <div className="space-y-6">
+      {/* ── Default global row ─────────────────────────────────────────── */}
+      {defaultRow && (
+        <Card className="border-primary/20 bg-primary/5">
+          <CardHeader className="pb-2">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <CardTitle className="text-base">Configuracion por defecto</CardTitle>
+                <Badge variant="soft">Global</Badge>
+              </div>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => onEdit(defaultRow)}
+                title="Editar configuracion por defecto"
+              >
+                <Pencil className="size-3.5" />
+                Editar
+              </Button>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap items-center gap-4">
+              <div className="space-y-0.5">
+                <p className="text-xs text-muted-foreground">Clase</p>
+                <p className="text-sm font-semibold">{defaultRow.class_pct.toFixed(2)}%</p>
+              </div>
+              <div className="h-6 w-px bg-border" />
+              <div className="space-y-0.5">
+                <p className="text-xs text-muted-foreground">Investidura</p>
+                <p className="text-sm font-semibold">
+                  {defaultRow.investiture_pct.toFixed(2)}%
+                </p>
+              </div>
+              <div className="h-6 w-px bg-border" />
+              <div className="space-y-0.5">
+                <p className="text-xs text-muted-foreground">Campana</p>
+                <p className="text-sm font-semibold">
+                  {defaultRow.camporee_pct.toFixed(2)}%
+                </p>
+              </div>
+              <div className="ml-auto">
+                <WeightSumIndicator
+                  values={[
+                    defaultRow.class_pct,
+                    defaultRow.investiture_pct,
+                    defaultRow.camporee_pct,
+                  ]}
+                />
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Overrides table ────────────────────────────────────────────── */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-medium">Sobreescrituras por tipo de club / ano</h2>
+            <Badge variant="secondary">{overrides.length}</Badge>
+          </div>
+          <Button size="sm" onClick={onCreate}>
+            <Plus className="size-4" />
+            Crear sobreescritura
+          </Button>
+        </div>
+
+        {overrides.length === 0 ? (
+          <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center">
+            <p className="text-sm text-muted-foreground">Sin sobreescrituras</p>
+            <p className="mt-1 max-w-xs text-xs text-muted-foreground">
+              Se aplica la configuracion por defecto a todos los clubes y anos.
+            </p>
+            <Button size="sm" variant="outline" className="mt-4" onClick={onCreate}>
+              <Plus className="size-4" />
+              Crear sobreescritura
+            </Button>
+          </div>
+        ) : (
+          <div className="rounded-lg border border-border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Tipo de club</TableHead>
+                  <TableHead>Ano eclesiastico</TableHead>
+                  <TableHead className="text-right">Clase</TableHead>
+                  <TableHead className="text-right">Investidura</TableHead>
+                  <TableHead className="text-right">Campana</TableHead>
+                  <TableHead className="text-center">Suma</TableHead>
+                  <TableHead className="w-20 text-right">Acciones</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {overrides.map((row) => (
+                  <TableRow key={row.id}>
+                    <TableCell className="text-sm">
+                      {clubTypeLabel(row.club_type_id, clubTypes)}
+                    </TableCell>
+                    <TableCell className="text-sm text-muted-foreground">
+                      {yearLabel(row.ecclesiastical_year_id, ecclesiasticalYears)}
+                    </TableCell>
+                    <TableCell className="text-right text-sm font-medium">
+                      {row.class_pct.toFixed(2)}%
+                    </TableCell>
+                    <TableCell className="text-right text-sm font-medium">
+                      {row.investiture_pct.toFixed(2)}%
+                    </TableCell>
+                    <TableCell className="text-right text-sm font-medium">
+                      {row.camporee_pct.toFixed(2)}%
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <WeightSumIndicator
+                        values={[
+                          row.class_pct,
+                          row.investiture_pct,
+                          row.camporee_pct,
+                        ]}
+                      />
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={() => onEdit(row)}
+                          title="Editar sobreescritura"
+                        >
+                          <Pencil className="size-3.5" />
+                          <span className="sr-only">Editar</span>
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={() => onDelete(row)}
+                          title="Eliminar sobreescritura"
+                          className="text-destructive hover:text-destructive"
+                        >
+                          <Trash2 className="size-3.5" />
+                          <span className="sr-only">Eliminar</span>
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-table.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-table.tsx
@@ -38,8 +38,8 @@ function yearLabel(
   id: number | null,
   years: EcclesiasticalYear[],
 ): string {
-  if (id === null) return "Todos los anos";
-  return years.find((y) => y.ecclesiastical_year_id === id)?.name ?? `Ano ${id}`;
+  if (id === null) return "Todos los años";
+  return years.find((y) => y.ecclesiastical_year_id === id)?.name ?? `Año ${id}`;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -63,14 +63,14 @@ export function WeightsTable({
           <CardHeader className="pb-2">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
-                <CardTitle className="text-base">Configuracion por defecto</CardTitle>
+                <CardTitle className="text-base">Configuración por defecto</CardTitle>
                 <Badge variant="soft">Global</Badge>
               </div>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => onEdit(defaultRow)}
-                title="Editar configuracion por defecto"
+                title="Editar configuración por defecto"
               >
                 <Pencil className="size-3.5" />
                 Editar
@@ -92,7 +92,7 @@ export function WeightsTable({
               </div>
               <div className="h-6 w-px bg-border" />
               <div className="space-y-0.5">
-                <p className="text-xs text-muted-foreground">Campana</p>
+                <p className="text-xs text-muted-foreground">Campaña</p>
                 <p className="text-sm font-semibold">
                   {defaultRow.camporee_pct.toFixed(2)}%
                 </p>
@@ -115,7 +115,7 @@ export function WeightsTable({
       <div className="space-y-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <h2 className="text-sm font-medium">Sobreescrituras por tipo de club / ano</h2>
+            <h2 className="text-sm font-medium">Sobreescrituras por tipo de club / año</h2>
             <Badge variant="secondary">{overrides.length}</Badge>
           </div>
           <Button size="sm" onClick={onCreate}>
@@ -128,7 +128,7 @@ export function WeightsTable({
           <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center">
             <p className="text-sm text-muted-foreground">Sin sobreescrituras</p>
             <p className="mt-1 max-w-xs text-xs text-muted-foreground">
-              Se aplica la configuracion por defecto a todos los clubes y anos.
+              Se aplica la configuración por defecto a todos los clubes y años.
             </p>
             <Button size="sm" variant="outline" className="mt-4" onClick={onCreate}>
               <Plus className="size-4" />
@@ -141,10 +141,10 @@ export function WeightsTable({
               <TableHeader>
                 <TableRow>
                   <TableHead>Tipo de club</TableHead>
-                  <TableHead>Ano eclesiastico</TableHead>
+                  <TableHead>Año eclesiástico</TableHead>
                   <TableHead className="text-right">Clase</TableHead>
                   <TableHead className="text-right">Investidura</TableHead>
-                  <TableHead className="text-right">Campana</TableHead>
+                  <TableHead className="text-right">Campaña</TableHead>
                   <TableHead className="text-center">Suma</TableHead>
                   <TableHead className="w-20 text-right">Acciones</TableHead>
                 </TableRow>

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/page.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/page.tsx
@@ -1,0 +1,96 @@
+import { Suspense } from "react";
+import { Scale } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageHeader } from "@/components/shared/page-header";
+import { EmptyState } from "@/components/shared/empty-state";
+import { WeightsClientPage } from "./_components/weights-client-page";
+import { listMemberRankingWeights } from "@/lib/api/member-ranking-weights";
+import { listClubTypes, listEcclesiasticalYears } from "@/lib/api/catalogs";
+import { requireAdminUser } from "@/lib/auth/session";
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+function WeightsSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* Default card skeleton */}
+      <Skeleton className="h-28 w-full rounded-xl" />
+      {/* Overrides section skeleton */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-5 w-56" />
+          <Skeleton className="h-9 w-44" />
+        </div>
+        <div className="rounded-xl border">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 border-b p-4 last:border-b-0"
+            >
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-4 w-12" />
+              <Skeleton className="h-5 w-20" />
+              <Skeleton className="ml-auto h-7 w-16" />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Content ──────────────────────────────────────────────────────────────────
+
+async function WeightsContent() {
+  const [weightsResult, clubTypes, ecclesiasticalYears] = await Promise.all([
+    listMemberRankingWeights({ limit: 100 }),
+    listClubTypes().catch(() => [] as Awaited<ReturnType<typeof listClubTypes>>),
+    listEcclesiasticalYears().catch(
+      () => [] as Awaited<ReturnType<typeof listEcclesiasticalYears>>,
+    ),
+  ]);
+
+  if (!weightsResult.endpointAvailable) {
+    return (
+      <EmptyState
+        icon={Scale}
+        title="No se pueden mostrar los pesos de ranking"
+        description={weightsResult.endpointDetail}
+      />
+    );
+  }
+
+  return (
+    <WeightsClientPage
+      initialData={weightsResult.items}
+      clubTypes={clubTypes}
+      ecclesiasticalYears={ecclesiasticalYears}
+    />
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function MemberRankingWeightsPage() {
+  await requireAdminUser();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Pesos de ranking"
+        description="Configura los porcentajes de clase, investidura y campaña usados para calcular el composite score de cada miembro."
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Pesos de ranking" },
+        ]}
+      />
+
+      <Suspense fallback={<WeightsSkeleton />}>
+        <WeightsContent />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-rankings/[enrollmentId]/breakdown/_components/member-breakdown-card.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/[enrollmentId]/breakdown/_components/member-breakdown-card.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { MemberRankingScoreBadge } from "@/app/(dashboard)/dashboard/member-rankings/_components/member-ranking-score-badge";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface MemberBreakdownCardProps {
+  title: string;
+  score: number | null;
+  weight: number;
+  breakdown: ReactNode;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Pure server component. Renders a single signal card (class / investiture /
+ * camporee) with a progress bar, score badge, weight pill, and slot for
+ * the signal-specific breakdown detail.
+ */
+export function MemberBreakdownCard({
+  title,
+  score,
+  weight,
+  breakdown,
+}: MemberBreakdownCardProps) {
+  const progressValue = score !== null ? Math.min(100, Math.max(0, score)) : 0;
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <CardTitle className="text-base">{title}</CardTitle>
+          <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+            Peso: {weight}%
+          </span>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-4">
+        {/* Score badge + progress bar */}
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Puntuación</span>
+            <MemberRankingScoreBadge score={score} />
+          </div>
+          <Progress value={progressValue} />
+        </div>
+
+        {/* Signal-specific breakdown slot */}
+        <div className="space-y-1 text-sm text-muted-foreground">
+          {breakdown}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-rankings/[enrollmentId]/breakdown/page.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/[enrollmentId]/breakdown/page.tsx
@@ -1,0 +1,221 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { notFound } from "next/navigation";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/shared/page-header";
+import { ApiError } from "@/lib/api/client";
+import { getMemberBreakdown } from "@/lib/api/member-rankings";
+import { MemberRankingScoreBadge } from "@/app/(dashboard)/dashboard/member-rankings/_components/member-ranking-score-badge";
+import { MemberBreakdownCard } from "./_components/member-breakdown-card";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * TODO: replace with a real year selector once the ecclesiastical year
+ * management feature is built. Same pattern as Task 17 list page.
+ */
+const DEFAULT_YEAR_ID = 2026;
+
+// ─── Route params ─────────────────────────────────────────────────────────────
+
+type Params = Promise<{ enrollmentId: string }>;
+type SearchParams = Promise<{ year_id?: string }>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Maps investiture status raw strings to human-readable Spanish labels.
+ * Falls back to the raw value so unknown statuses are still visible.
+ */
+function investitureStatusLabel(status: string | null): string {
+  if (!status) return "Sin registro";
+
+  const labels: Record<string, string> = {
+    investido: "Investido",
+    completed: "Completada",
+    in_progress: "En proceso",
+    pending: "Pendiente",
+    not_started: "No iniciada",
+  };
+
+  return labels[status.toLowerCase()] ?? status;
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function MemberBreakdownPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: SearchParams;
+}) {
+  const { enrollmentId: enrollmentIdRaw } = await params;
+  const { year_id: yearIdRaw } = await searchParams;
+
+  const enrollmentId = Number(enrollmentIdRaw);
+  if (!Number.isFinite(enrollmentId) || enrollmentId <= 0) {
+    notFound();
+  }
+
+  const parsedYearId = yearIdRaw ? Number(yearIdRaw) : DEFAULT_YEAR_ID;
+  const yearId = Number.isFinite(parsedYearId) && parsedYearId > 0 ? parsedYearId : DEFAULT_YEAR_ID;
+
+  let data: Awaited<ReturnType<typeof getMemberBreakdown>>;
+  try {
+    data = await getMemberBreakdown(enrollmentId, yearId);
+  } catch (error) {
+    if (error instanceof ApiError && (error.status === 404 || error.status === 403)) {
+      notFound();
+    }
+    throw error;
+  }
+
+  const memberName = data.user?.name ?? `Miembro #${enrollmentId}`;
+  const sectionName = data.club_section?.name ?? data.section?.name ?? "sección desconocida";
+
+  const calculatedAt = data.composite_calculated_at
+    ? new Date(data.composite_calculated_at).toLocaleString("es-MX")
+    : null;
+
+  return (
+    <div className="space-y-6">
+      {/* ── Header ── */}
+      <PageHeader
+        title={`Detalle: ${memberName}`}
+        description={`Sección ${sectionName} · Año ${yearId}`}
+        breadcrumbs={[
+          { label: "Rankings de miembros", href: "/dashboard/member-rankings" },
+          { label: memberName },
+        ]}
+      >
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/dashboard/member-rankings">
+            <ArrowLeft className="mr-2 size-4" />
+            Volver a rankings
+          </Link>
+        </Button>
+      </PageHeader>
+
+      {/* ── Composite score summary ── */}
+      <Card>
+        <CardContent className="flex flex-wrap items-center gap-4 pt-6">
+          <div className="space-y-0.5">
+            <p className="text-sm font-medium">Posición</p>
+            <p className="text-2xl font-bold">
+              {data.rank_position !== null ? `#${data.rank_position}` : "—"}
+            </p>
+          </div>
+          <div className="h-10 w-px bg-border" />
+          <div className="space-y-0.5">
+            <p className="text-sm font-medium">Puntaje compuesto</p>
+            <MemberRankingScoreBadge score={data.composite_score_pct} className="text-base" />
+          </div>
+          {data.awarded_category?.name && (
+            <>
+              <div className="h-10 w-px bg-border" />
+              <div className="space-y-0.5">
+                <p className="text-sm font-medium">Categoría</p>
+                <p className="text-sm">{data.awarded_category.name}</p>
+              </div>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Signal breakdown cards ── */}
+      <div className="grid gap-6 md:grid-cols-3">
+        <MemberBreakdownCard
+          title="Clase"
+          score={data.class_score_pct}
+          weight={data.weights.class_pct}
+          breakdown={
+            <>
+              <p>
+                Secciones completadas:{" "}
+                <span className="font-medium text-foreground">
+                  {data.class_breakdown.completed_sections} /{" "}
+                  {data.class_breakdown.required_sections}
+                </span>
+              </p>
+              {data.class_breakdown.folder_status && (
+                <p>
+                  Folder:{" "}
+                  <span className="font-medium text-foreground">
+                    {data.class_breakdown.folder_status}
+                  </span>
+                </p>
+              )}
+            </>
+          }
+        />
+
+        <MemberBreakdownCard
+          title="Investidura"
+          score={data.investiture_score_pct}
+          weight={data.weights.investiture_pct}
+          breakdown={
+            <p>
+              Estado:{" "}
+              <span className="font-medium text-foreground">
+                {investitureStatusLabel(data.investiture_breakdown.status)}
+              </span>
+            </p>
+          }
+        />
+
+        <MemberBreakdownCard
+          title="Camporees"
+          score={data.camporee_score_pct}
+          weight={data.weights.camporee_pct}
+          breakdown={
+            <>
+              <p>
+                Participación:{" "}
+                <span className="font-medium text-foreground">
+                  {data.camporee_breakdown.participated ? "Sí" : "No"}
+                </span>
+              </p>
+              {data.camporee_breakdown.total_camporees !== null && (
+                <p>
+                  Camporees disponibles:{" "}
+                  <span className="font-medium text-foreground">
+                    {data.camporee_breakdown.total_camporees}
+                  </span>
+                </p>
+              )}
+            </>
+          }
+        />
+      </div>
+
+      {/* ── Weights applied ── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Pesos aplicados</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            Fuente:{" "}
+            <span className="font-medium text-foreground">{data.weights.source}</span>
+          </p>
+          <p>
+            Clase{" "}
+            <span className="font-medium text-foreground">{data.weights.class_pct}%</span>
+            {" + "}Investidura{" "}
+            <span className="font-medium text-foreground">{data.weights.investiture_pct}%</span>
+            {" + "}Camporees{" "}
+            <span className="font-medium text-foreground">{data.weights.camporee_pct}%</span>
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* ── Last calculated timestamp ── */}
+      <p className="text-sm text-muted-foreground">
+        Última recalculación:{" "}
+        {calculatedAt ?? <span className="italic">no registrada</span>}
+      </p>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-rankings/_components/member-ranking-score-badge.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/_components/member-ranking-score-badge.tsx
@@ -1,0 +1,54 @@
+import { Badge } from "@/components/ui/badge";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface MemberRankingScoreBadgeProps {
+  score: number | null;
+  className?: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Renders a colored Badge for a composite score percentage.
+ *
+ * Cutoffs (Q3):
+ *   null       → outline "—"
+ *   >= 85%     → success
+ *   >= 65%     → warning
+ *   < 65%      → destructive
+ */
+export function MemberRankingScoreBadge({
+  score,
+  className,
+}: MemberRankingScoreBadgeProps) {
+  if (score === null) {
+    return (
+      <Badge variant="outline" className={className}>
+        —
+      </Badge>
+    );
+  }
+
+  if (score >= 85) {
+    return (
+      <Badge variant="success" className={className}>
+        {score.toFixed(1)}%
+      </Badge>
+    );
+  }
+
+  if (score >= 65) {
+    return (
+      <Badge variant="warning" className={className}>
+        {score.toFixed(1)}%
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="destructive" className={className}>
+      {score.toFixed(1)}%
+    </Badge>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-filters.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-filters.tsx
@@ -1,0 +1,99 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface MemberRankingsFiltersProps {
+  defaultYear?: number;
+  defaultClubId?: number;
+  defaultSectionId?: number;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * GET-form filter bar for the member-rankings list page.
+ *
+ * Uses plain number inputs for year, club, and section.
+ * TODO: Replace with catalog-backed <Select> components once
+ *       catalog hooks / fetch helpers are available for each entity.
+ *
+ * Submitting the form encodes values as query params (bookmarkable URLs).
+ * The reset link navigates to the bare route, clearing all params.
+ */
+export function MemberRankingsFilters({
+  defaultYear,
+  defaultClubId,
+  defaultSectionId,
+}: MemberRankingsFiltersProps) {
+  return (
+    <form className="flex flex-wrap items-end gap-3" method="GET">
+      {/* Year filter */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="filter-year" className="text-xs text-muted-foreground">
+          Año eclesiástico
+        </Label>
+        <Input
+          id="filter-year"
+          name="year_id"
+          type="number"
+          min={2000}
+          max={2100}
+          placeholder="2026"
+          defaultValue={defaultYear}
+          className="h-9 w-32"
+        />
+      </div>
+
+      {/* Club filter */}
+      <div className="flex flex-col gap-1.5">
+        <Label
+          htmlFor="filter-club"
+          className="text-xs text-muted-foreground"
+        >
+          ID de club
+        </Label>
+        <Input
+          id="filter-club"
+          name="club_id"
+          type="number"
+          min={1}
+          placeholder="Todos"
+          defaultValue={defaultClubId}
+          className="h-9 w-32"
+        />
+      </div>
+
+      {/* Section filter */}
+      <div className="flex flex-col gap-1.5">
+        <Label
+          htmlFor="filter-section"
+          className="text-xs text-muted-foreground"
+        >
+          ID de sección
+        </Label>
+        <Input
+          id="filter-section"
+          name="section_id"
+          type="number"
+          min={1}
+          placeholder="Todas"
+          defaultValue={defaultSectionId}
+          className="h-9 w-32"
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        <Button type="submit" size="sm">
+          Filtrar
+        </Button>
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/dashboard/member-rankings">Limpiar</Link>
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-table.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-table.tsx
@@ -1,0 +1,196 @@
+import Link from "next/link";
+import { Trophy } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/shared/empty-state";
+import { DataTablePagination } from "@/components/shared/data-table-pagination";
+import { MemberRankingScoreBadge } from "./member-ranking-score-badge";
+import type { MemberRankingItem } from "@/lib/api/member-rankings";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface MemberRankingsTableProps {
+  data: MemberRankingItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getMemberName(user?: MemberRankingItem["user"]): string {
+  if (!user) return "—";
+  const parts = [
+    user.name ?? user.first_name,
+    user.paternal_last_name,
+    user.maternal_last_name,
+  ].filter(Boolean);
+  if (parts.length > 0) return parts.join(" ");
+  return user.email ?? "—";
+}
+
+function formatScorePct(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—";
+  return `${value.toFixed(1)}%`;
+}
+
+function formatInvestitureScore(value: number | null | undefined): string {
+  if (value === null) return "—";
+  if (value === 100) return "Investido";
+  if (value === 0) return "En progreso";
+  // Partial scores theoretically possible if backend evolves — fallback semantically
+  return "En progreso";
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Pure server component — renders paginated member rankings in a shadcn Table.
+ * Pagination is handled by the shared DataTablePagination (client component).
+ */
+export function MemberRankingsTable({
+  data,
+  total,
+  page,
+  limit,
+  totalPages,
+}: MemberRankingsTableProps) {
+  if (data.length === 0) {
+    return (
+      <EmptyState
+        icon={Trophy}
+        title="Sin rankings disponibles"
+        description="Sin rankings para los filtros seleccionados."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        <span className="font-medium text-foreground">{total}</span>{" "}
+        {total === 1 ? "miembro rankeado" : "miembros rankeados"}
+      </p>
+
+      <div className="overflow-x-auto rounded-xl border border-border bg-card shadow-sm">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="h-9 w-14 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                #
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Miembro
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Sección
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Composite
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Clase
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Investidura
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Camporees
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Categoría
+              </TableHead>
+              <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Acción
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {data.map((item) => (
+              <TableRow key={item.member_ranking_id} className="hover:bg-muted/30">
+                {/* Rank */}
+                <TableCell className="px-3 py-2.5 align-middle">
+                  <span className="tabular-nums text-sm font-medium text-foreground">
+                    #{item.rank_position ?? "—"}
+                  </span>
+                </TableCell>
+
+                {/* Member */}
+                <TableCell className="px-3 py-2.5 align-middle">
+                  <div className="space-y-0.5">
+                    <p className="font-medium leading-none text-sm">
+                      {getMemberName(item.user)}
+                    </p>
+                    {item.user?.email && (
+                      <p className="text-xs text-muted-foreground">
+                        {item.user.email}
+                      </p>
+                    )}
+                  </div>
+                </TableCell>
+
+                {/* Section */}
+                <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                  {item.section?.name ?? "—"}
+                </TableCell>
+
+                {/* Composite score */}
+                <TableCell className="px-3 py-2.5 align-middle">
+                  <MemberRankingScoreBadge score={item.composite_score_pct} />
+                </TableCell>
+
+                {/* Class score */}
+                <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
+                  {formatScorePct(item.class_score_pct)}
+                </TableCell>
+
+                {/* Investiture status derived from score */}
+                <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                  {formatInvestitureScore(item.investiture_score_pct)}
+                </TableCell>
+
+                {/* Camporee score */}
+                <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
+                  {formatScorePct(item.camporee_score_pct)}
+                </TableCell>
+
+                {/* Awarded category */}
+                <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                  {item.awarded_category?.name ?? "—"}
+                </TableCell>
+
+                {/* Action */}
+                <TableCell className="px-3 py-2.5 align-middle text-right">
+                  <Button variant="ghost" size="sm" asChild>
+                    <Link
+                      href={`/dashboard/member-rankings/${item.enrollment_id}/breakdown`}
+                    >
+                      Ver detalle
+                    </Link>
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      <DataTablePagination
+        page={page}
+        totalPages={totalPages}
+        total={total}
+        limit={limit}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-rankings/page.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/page.tsx
@@ -1,0 +1,144 @@
+import { Suspense } from "react";
+import { Trophy } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageHeader } from "@/components/shared/page-header";
+import { EmptyState } from "@/components/shared/empty-state";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { MemberRankingsFilters } from "./_components/member-rankings-filters";
+import { MemberRankingsTable } from "./_components/member-rankings-table";
+import { listMemberRankings, type MemberRankingsQuery } from "@/lib/api/member-rankings";
+import { requireAdminUser } from "@/lib/auth/session";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+// TODO: derive from active ecclesiastical year via API once endpoint is available
+const DEFAULT_YEAR = 2026;
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+function parseSearchParams(
+  raw: Record<string, string | string[] | undefined>,
+): MemberRankingsQuery {
+  const getString = (key: string) => {
+    const v = raw[key];
+    return typeof v === "string" && v.trim().length > 0 ? v.trim() : undefined;
+  };
+  const getNumber = (key: string) => {
+    const v = getString(key);
+    return v ? Number(v) : undefined;
+  };
+
+  return {
+    year_id: getNumber("year_id") ?? DEFAULT_YEAR,
+    club_id: getNumber("club_id"),
+    section_id: getNumber("section_id"),
+    page: getNumber("page") ?? DEFAULT_PAGE,
+    limit: getNumber("limit") ?? DEFAULT_LIMIT,
+  };
+}
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+function MemberRankingsTableSkeleton() {
+  return (
+    <div className="space-y-4">
+      {/* Filter bar skeleton */}
+      <div className="flex gap-3">
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-9 w-20" />
+      </div>
+      {/* Table skeleton */}
+      <div className="rounded-xl border">
+        {Array.from({ length: 8 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b p-4 last:border-b-0"
+          >
+            <Skeleton className="h-4 w-8" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-4 w-36" />
+              <Skeleton className="h-3 w-48" />
+            </div>
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-5 w-16" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-4 w-16" />
+            <Skeleton className="h-4 w-20" />
+            <Skeleton className="h-8 w-24" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Content ──────────────────────────────────────────────────────────────────
+
+async function MemberRankingsContent({ query }: { query: MemberRankingsQuery }) {
+  const result = await listMemberRankings(query);
+
+  if (!result.endpointAvailable) {
+    return (
+      <div className="space-y-4">
+        <EndpointErrorBanner
+          state={result.endpointState as "forbidden" | "missing" | "rate-limited"}
+          detail={result.endpointDetail}
+          showLoginLink={result.endpointState === "forbidden"}
+        />
+        <EmptyState
+          icon={Trophy}
+          title="No se pueden mostrar rankings"
+          description={result.endpointDetail}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <MemberRankingsTable
+      data={result.items}
+      total={result.total}
+      page={result.page}
+      limit={result.limit}
+      totalPages={result.totalPages}
+    />
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function MemberRankingsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  await requireAdminUser();
+  const rawParams = await searchParams;
+  const query = parseSearchParams(rawParams);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Ranking de miembros"
+        description="Clasificación general por categoría con composite calculado."
+      />
+
+      <MemberRankingsFilters
+        defaultYear={query.year_id}
+        defaultClubId={query.club_id}
+        defaultSectionId={query.section_id}
+      />
+
+      <Suspense fallback={<MemberRankingsTableSkeleton />}>
+        <MemberRankingsContent query={query} />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/section-rankings/[sectionId]/members/_components/section-members-table.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/[sectionId]/members/_components/section-members-table.tsx
@@ -1,0 +1,175 @@
+import Link from "next/link";
+import { Users } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/shared/empty-state";
+import { MemberRankingScoreBadge } from "@/app/(dashboard)/dashboard/member-rankings/_components/member-ranking-score-badge";
+import type { MemberRankingItem } from "@/lib/api/section-rankings";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SectionMembersTableProps {
+  data: MemberRankingItem[];
+  /** year_id passed through for the breakdown link */
+  yearId: number;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getMemberName(user?: MemberRankingItem["user"]): string {
+  if (!user) return "—";
+  const parts = [
+    user.name ?? user.first_name,
+    user.paternal_last_name,
+    user.maternal_last_name,
+  ].filter(Boolean);
+  if (parts.length > 0) return parts.join(" ");
+  return user.email ?? "—";
+}
+
+function formatScorePct(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—";
+  return `${value.toFixed(1)}%`;
+}
+
+function formatInvestitureScore(value: number | null | undefined): string {
+  if (value === null || value === undefined) return "—";
+  if (value === 100) return "Investido";
+  return "En progreso";
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Renders a flat (non-paginated) list of members belonging to a section.
+ *
+ * No pagination needed — backend returns a flat array < 100 members per section.
+ *
+ * Columns (7 data + 1 action = 8):
+ *   # | Miembro | Composite | Clase | Investidura | Camporees | Categoría | Acción
+ *
+ * Acción links to the member breakdown page (/dashboard/member-rankings/[id]/breakdown)
+ * because that page already owns the detailed view — reusing it avoids duplication.
+ */
+export function SectionMembersTable({
+  data,
+  yearId,
+}: SectionMembersTableProps) {
+  if (data.length === 0) {
+    return (
+      <EmptyState
+        icon={Users}
+        title="Sin miembros con ranking"
+        description="Esta sección no tiene miembros con ranking calculado."
+      />
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-border bg-card shadow-sm">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="h-9 w-14 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              #
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Miembro
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Composite
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Clase
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Investidura
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Camporees
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Categoría
+            </TableHead>
+            <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Acción
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+
+        <TableBody>
+          {data.map((item) => (
+            <TableRow
+              key={item.member_ranking_id}
+              className="hover:bg-muted/30"
+            >
+              {/* Rank */}
+              <TableCell className="px-3 py-2.5 align-middle">
+                <span className="tabular-nums text-sm font-medium text-foreground">
+                  {item.rank_position !== null ? `#${item.rank_position}` : "—"}
+                </span>
+              </TableCell>
+
+              {/* Member */}
+              <TableCell className="px-3 py-2.5 align-middle">
+                <div className="space-y-0.5">
+                  <p className="font-medium leading-none text-sm">
+                    {getMemberName(item.user)}
+                  </p>
+                  {item.user?.email && (
+                    <p className="text-xs text-muted-foreground">
+                      {item.user.email}
+                    </p>
+                  )}
+                </div>
+              </TableCell>
+
+              {/* Composite score */}
+              <TableCell className="px-3 py-2.5 align-middle">
+                <MemberRankingScoreBadge score={item.composite_score_pct} />
+              </TableCell>
+
+              {/* Class score */}
+              <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
+                {formatScorePct(item.class_score_pct)}
+              </TableCell>
+
+              {/* Investiture derived from score */}
+              <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                {formatInvestitureScore(item.investiture_score_pct)}
+              </TableCell>
+
+              {/* Camporee score */}
+              <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
+                {formatScorePct(item.camporee_score_pct)}
+              </TableCell>
+
+              {/* Awarded category */}
+              <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                {item.awarded_category?.name ?? "—"}
+              </TableCell>
+
+              {/* Action — links to existing member breakdown page */}
+              <TableCell className="px-3 py-2.5 align-middle text-right">
+                <Button variant="ghost" size="sm" asChild>
+                  <Link
+                    href={`/dashboard/member-rankings/${item.enrollment_id}/breakdown?year_id=${yearId}`}
+                  >
+                    Ver detalle
+                  </Link>
+                </Button>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/section-rankings/[sectionId]/members/page.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/[sectionId]/members/page.tsx
@@ -1,0 +1,87 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { notFound } from "next/navigation";
+import { PageHeader } from "@/components/shared/page-header";
+import { Button } from "@/components/ui/button";
+import { ApiError } from "@/lib/api/client";
+import { getSectionMembers } from "@/lib/api/section-rankings";
+import { SectionMembersTable } from "./_components/section-members-table";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * TODO: replace with a real year selector once the ecclesiastical year
+ * management feature is built. Same pattern as Task 17/18 list + breakdown pages.
+ */
+const DEFAULT_YEAR_ID = 2026;
+
+// ─── Route params ─────────────────────────────────────────────────────────────
+
+type Params = Promise<{ sectionId: string }>;
+type SearchParams = Promise<{ year_id?: string }>;
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function SectionMembersPage({
+  params,
+  searchParams,
+}: {
+  params: Params;
+  searchParams: SearchParams;
+}) {
+  const { sectionId: sectionIdRaw } = await params;
+  const { year_id: yearIdRaw } = await searchParams;
+
+  // Validate sectionId
+  const sectionId = Number(sectionIdRaw);
+  if (!Number.isFinite(sectionId) || sectionId <= 0) {
+    notFound();
+  }
+
+  // Validate + fallback yearId
+  const parsedYearId = yearIdRaw ? Number(yearIdRaw) : DEFAULT_YEAR_ID;
+  const yearId =
+    Number.isFinite(parsedYearId) && parsedYearId > 0
+      ? parsedYearId
+      : DEFAULT_YEAR_ID;
+
+  let members: Awaited<ReturnType<typeof getSectionMembers>>;
+  try {
+    members = await getSectionMembers(sectionId, yearId);
+  } catch (error) {
+    if (
+      error instanceof ApiError &&
+      (error.status === 404 || error.status === 403)
+    ) {
+      notFound();
+    }
+    throw error;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* ── Header ── */}
+      <PageHeader
+        title="Miembros de la sección"
+        description={`Sección #${sectionId} · Año ${yearId} · ${members.length} ${members.length === 1 ? "miembro" : "miembros"}`}
+        breadcrumbs={[
+          {
+            label: "Ranking de secciones",
+            href: "/dashboard/section-rankings",
+          },
+          { label: `Sección #${sectionId}` },
+        ]}
+      >
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/dashboard/section-rankings">
+            <ArrowLeft className="mr-2 size-4" />
+            Volver a secciones
+          </Link>
+        </Button>
+      </PageHeader>
+
+      {/* ── Members table ── */}
+      <SectionMembersTable data={members} yearId={yearId} />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-filters.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-filters.tsx
@@ -1,0 +1,77 @@
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SectionRankingsFiltersProps {
+  defaultYear?: number;
+  defaultClubId?: number;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * GET-form filter bar for the section-rankings list page.
+ *
+ * Filters: year_id + club_id only.
+ * section_id is intentionally omitted — sections ARE the rows, not a filter.
+ *
+ * TODO: Replace number inputs with catalog-backed <Select> components once
+ *       fetch helpers for ecclesiastical years and clubs are available.
+ *
+ * Submitting the form encodes values as query params (bookmarkable URLs).
+ * The reset link navigates to the bare route, clearing all params.
+ */
+export function SectionRankingsFilters({
+  defaultYear,
+  defaultClubId,
+}: SectionRankingsFiltersProps) {
+  return (
+    <form className="flex flex-wrap items-end gap-3" method="GET">
+      {/* Year filter */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="filter-year" className="text-xs text-muted-foreground">
+          Año eclesiástico
+        </Label>
+        <Input
+          id="filter-year"
+          name="year_id"
+          type="number"
+          min={2000}
+          max={2100}
+          placeholder="2026"
+          defaultValue={defaultYear}
+          className="h-9 w-32"
+        />
+      </div>
+
+      {/* Club filter */}
+      <div className="flex flex-col gap-1.5">
+        <Label htmlFor="filter-club" className="text-xs text-muted-foreground">
+          ID de club
+        </Label>
+        <Input
+          id="filter-club"
+          name="club_id"
+          type="number"
+          min={1}
+          placeholder="Todos"
+          defaultValue={defaultClubId}
+          className="h-9 w-32"
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        <Button type="submit" size="sm">
+          Filtrar
+        </Button>
+        <Button variant="ghost" size="sm" asChild>
+          <Link href="/dashboard/section-rankings">Limpiar</Link>
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-table.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-table.tsx
@@ -1,0 +1,170 @@
+import Link from "next/link";
+import { BarChart3 } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/shared/empty-state";
+import { DataTablePagination } from "@/components/shared/data-table-pagination";
+import { MemberRankingScoreBadge } from "@/app/(dashboard)/dashboard/member-rankings/_components/member-ranking-score-badge";
+import type { SectionRankingItem } from "@/lib/api/section-rankings";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface SectionRankingsTableProps {
+  data: SectionRankingItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  /** year_id passed through to the drill-down link query string */
+  yearId: number;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+/**
+ * Pure server component — renders paginated section rankings in a shadcn Table.
+ *
+ * Columns (6 data + 1 action = 7):
+ *   # | Sección | Composite | Miembros activos | Categoría | Calculado | Acción
+ *
+ * NOTE: `club_name` is NOT included because `SectionRankingResponseDto` does not
+ * carry a `club` relation at the section level. The club filter on the list page
+ * is sufficient context. If the backend adds a `club` relation to the DTO in
+ * future, add a "Club" column here.
+ *
+ * Pagination is handled by the shared DataTablePagination (client component).
+ */
+export function SectionRankingsTable({
+  data,
+  total,
+  page,
+  limit,
+  totalPages,
+  yearId,
+}: SectionRankingsTableProps) {
+  if (data.length === 0) {
+    return (
+      <EmptyState
+        icon={BarChart3}
+        title="Sin rankings disponibles"
+        description="Sin rankings para los filtros seleccionados."
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        <span className="font-medium text-foreground">{total}</span>{" "}
+        {total === 1 ? "sección rankeada" : "secciones rankeadas"}
+      </p>
+
+      <div className="overflow-x-auto rounded-xl border border-border bg-card shadow-sm">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="h-9 w-14 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                #
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Sección
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Composite
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Miembros activos
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Categoría
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Calculado
+              </TableHead>
+              <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Acción
+              </TableHead>
+            </TableRow>
+          </TableHeader>
+
+          <TableBody>
+            {data.map((item) => {
+              const calculatedAt = item.composite_calculated_at
+                ? new Date(item.composite_calculated_at).toLocaleString("es-MX")
+                : "—";
+
+              return (
+                <TableRow
+                  key={item.club_section_id}
+                  className="hover:bg-muted/30"
+                >
+                  {/* Rank */}
+                  <TableCell className="px-3 py-2.5 align-middle">
+                    <span className="tabular-nums text-sm font-medium text-foreground">
+                      {item.rank_position !== null
+                        ? `#${item.rank_position}`
+                        : "—"}
+                    </span>
+                  </TableCell>
+
+                  {/* Section name */}
+                  <TableCell className="px-3 py-2.5 align-middle">
+                    <p className="font-medium text-sm leading-none">
+                      {item.section_name}
+                    </p>
+                  </TableCell>
+
+                  {/* Composite score */}
+                  <TableCell className="px-3 py-2.5 align-middle">
+                    <MemberRankingScoreBadge score={item.composite_score_pct} />
+                  </TableCell>
+
+                  {/* Active member count */}
+                  <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
+                    {item.active_enrollment_count}
+                  </TableCell>
+
+                  {/* Awarded category (always null for now per backend contract) */}
+                  <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                    {item.awarded_category?.name ?? "—"}
+                  </TableCell>
+
+                  {/* Calculated at */}
+                  <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                    {calculatedAt}
+                  </TableCell>
+
+                  {/* Action */}
+                  <TableCell className="px-3 py-2.5 align-middle text-right">
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link
+                        href={`/dashboard/section-rankings/${item.club_section_id}/members?year_id=${yearId}`}
+                      >
+                        Ver miembros
+                      </Link>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Pagination */}
+      <DataTablePagination
+        page={page}
+        totalPages={totalPages}
+        total={total}
+        limit={limit}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/section-rankings/page.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/page.tsx
@@ -1,0 +1,155 @@
+import { Suspense } from "react";
+import { BarChart3 } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { PageHeader } from "@/components/shared/page-header";
+import { EmptyState } from "@/components/shared/empty-state";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { SectionRankingsFilters } from "./_components/section-rankings-filters";
+import { SectionRankingsTable } from "./_components/section-rankings-table";
+import {
+  listSectionRankings,
+  type SectionRankingsQuery,
+} from "@/lib/api/section-rankings";
+import { requireAdminUser } from "@/lib/auth/session";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+// TODO: derive from active ecclesiastical year via API once endpoint is available
+const DEFAULT_YEAR = 2026;
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+function parseSearchParams(
+  raw: Record<string, string | string[] | undefined>,
+): SectionRankingsQuery & { year_id: number; page: number; limit: number } {
+  const getString = (key: string) => {
+    const v = raw[key];
+    return typeof v === "string" && v.trim().length > 0 ? v.trim() : undefined;
+  };
+  const getNumber = (key: string): number | undefined => {
+    const v = getString(key);
+    if (!v) return undefined;
+    const n = Number(v);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  };
+
+  return {
+    year_id: getNumber("year_id") ?? DEFAULT_YEAR,
+    club_id: getNumber("club_id"),
+    page: getNumber("page") ?? DEFAULT_PAGE,
+    limit: getNumber("limit") ?? DEFAULT_LIMIT,
+  };
+}
+
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+function SectionRankingsTableSkeleton() {
+  return (
+    <div className="space-y-4">
+      {/* Filter bar skeleton */}
+      <div className="flex gap-3">
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-9 w-32" />
+        <Skeleton className="h-9 w-20" />
+      </div>
+      {/* Table skeleton — 7 columns */}
+      <div className="rounded-xl border">
+        {Array.from({ length: 7 }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 border-b p-4 last:border-b-0"
+          >
+            {/* rank */}
+            <Skeleton className="h-4 w-8" />
+            {/* section name */}
+            <Skeleton className="h-4 w-36" />
+            {/* composite badge */}
+            <Skeleton className="h-5 w-16" />
+            {/* member count */}
+            <Skeleton className="h-4 w-10" />
+            {/* category */}
+            <Skeleton className="h-4 w-20" />
+            {/* calculated at */}
+            <Skeleton className="h-4 w-32" />
+            {/* action */}
+            <Skeleton className="h-8 w-28 ml-auto" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── Content ──────────────────────────────────────────────────────────────────
+
+async function SectionRankingsContent({
+  query,
+}: {
+  query: SectionRankingsQuery & { year_id: number; page: number; limit: number };
+}) {
+  const result = await listSectionRankings(query);
+
+  if (!result.endpointAvailable) {
+    return (
+      <div className="space-y-4">
+        <EndpointErrorBanner
+          state={
+            result.endpointState as "forbidden" | "missing" | "rate-limited"
+          }
+          detail={result.endpointDetail ?? "Endpoint no disponible."}
+          showLoginLink={result.endpointState === "forbidden"}
+        />
+        <EmptyState
+          icon={BarChart3}
+          title="No se pueden mostrar rankings de secciones"
+          description={result.endpointDetail ?? "Endpoint no disponible."}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <SectionRankingsTable
+      data={result.items}
+      total={result.total}
+      page={result.page}
+      limit={result.limit}
+      totalPages={result.totalPages}
+      yearId={query.year_id}
+    />
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function SectionRankingsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  await requireAdminUser();
+  const rawParams = await searchParams;
+  const query = parseSearchParams(rawParams);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Ranking de secciones"
+        description="Clasificación general de secciones por composite score."
+      />
+
+      <SectionRankingsFilters
+        defaultYear={query.year_id}
+        defaultClubId={query.club_id}
+      />
+
+      <Suspense fallback={<SectionRankingsTableSkeleton />}>
+        <SectionRankingsContent query={query} />
+      </Suspense>
+    </div>
+  );
+}

--- a/src/components/annual-folders/award-categories-client-page.tsx
+++ b/src/components/annual-folders/award-categories-client-page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { Plus, RefreshCw, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import {
   Table,
   TableBody,
@@ -30,7 +31,7 @@ import {
   deleteAwardCategory,
 } from "@/lib/api/annual-folders";
 import { ApiError } from "@/lib/api/client";
-import type { AwardCategory } from "@/lib/api/annual-folders";
+import type { AwardCategory, AwardCategoryScope } from "@/lib/api/annual-folders";
 import type { ClubType } from "@/lib/api/catalogs";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -60,6 +61,12 @@ function clubTypeLabel(
   return found?.name ?? `Tipo ${clubTypeId}`;
 }
 
+const SCOPE_LABELS: Record<AwardCategoryScope, string> = {
+  club: "Club",
+  section: "Sección",
+  member: "Miembro",
+};
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function AwardCategoriesClientPage({
@@ -67,38 +74,79 @@ export function AwardCategoriesClientPage({
   clubTypes,
 }: AwardCategoriesClientPageProps) {
   const t = useTranslations("annual_folders");
-  const [categories, setCategories] =
-    useState<AwardCategory[]>(initialCategories);
+
+  // Outer tab: scope
+  const [scope, setScope] = useState<AwardCategoryScope>("club");
+  // Inner tab: active filter
+  const [activeFilter, setActiveFilter] = useState<"active" | "legacy">("active");
+
+  const [categories, setCategories] = useState<AwardCategory[]>(
+    initialCategories.filter((c) => c.scope === "club" && c.active),
+  );
   const [isRefreshing, setIsRefreshing] = useState(false);
 
   // Form dialog state
   const [formOpen, setFormOpen] = useState(false);
-  const [editingCategory, setEditingCategory] =
-    useState<AwardCategory | null>(null);
+  const [editingCategory, setEditingCategory] = useState<AwardCategory | null>(null);
 
   // Delete dialog state
   const [deleteOpen, setDeleteOpen] = useState(false);
-  const [deletingCategory, setDeletingCategory] =
-    useState<AwardCategory | null>(null);
+  const [deletingCategory, setDeletingCategory] = useState<AwardCategory | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  // ─── Refresh ──────────────────────────────────────────────────────────────
+  // ─── First-render guard — skip the effect on mount (SSR data already correct) ──
+
+  const isFirstRender = useRef(true);
+
+  // ─── Fetch on scope / activeFilter change ─────────────────────────────────
+
+  const fetchCategories = useCallback(
+    async (targetScope: AwardCategoryScope, targetFilter: "active" | "legacy") => {
+      setIsRefreshing(true);
+      try {
+        const isActive = targetFilter === "active";
+        const payload = await getAwardCategoriesFromClient(
+          undefined,
+          isActive,
+          targetScope,
+        );
+        setCategories(extractCategories(payload));
+      } catch (err) {
+        const message =
+          err instanceof ApiError
+            ? err.message
+            : "No se pudieron cargar las categorías";
+        toast.error(message);
+      } finally {
+        setIsRefreshing(false);
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return; // SSR initialCategories already correct for default (scope, activeFilter) pair
+    }
+    void fetchCategories(scope, activeFilter);
+  }, [scope, activeFilter, fetchCategories]);
 
   const refreshCategories = useCallback(async () => {
-    setIsRefreshing(true);
-    try {
-      const payload = await getAwardCategoriesFromClient();
-      setCategories(extractCategories(payload));
-    } catch (err) {
-      const message =
-        err instanceof ApiError
-          ? err.message
-          : "No se pudieron actualizar las categorias";
-      toast.error(message);
-    } finally {
-      setIsRefreshing(false);
-    }
-  }, []);
+    await fetchCategories(scope, activeFilter);
+  }, [scope, activeFilter, fetchCategories]);
+
+  // ─── Scope tab change ─────────────────────────────────────────────────────
+
+  function handleScopeChange(value: string) {
+    setScope(value as AwardCategoryScope);
+  }
+
+  // ─── Active filter tab change ─────────────────────────────────────────────
+
+  function handleActiveFilterChange(value: string) {
+    setActiveFilter(value as "active" | "legacy");
+  }
 
   // ─── Create ───────────────────────────────────────────────────────────────
 
@@ -134,7 +182,7 @@ export function AwardCategoriesClientPage({
       const message =
         err instanceof ApiError
           ? err.message
-          : "No se pudo eliminar la categoria";
+          : "No se pudo eliminar la categoría";
       toast.error(message);
     } finally {
       setIsDeleting(false);
@@ -145,142 +193,173 @@ export function AwardCategoriesClientPage({
 
   const sortedCategories = [...categories].sort((a, b) => a.order - b.order);
 
+  const scopeLabel = SCOPE_LABELS[scope];
+  const filterLabel = activeFilter === "active" ? "activas" : "legacy";
+
   // ─── Render ───────────────────────────────────────────────────────────────
 
   return (
     <div className="space-y-5">
-      {/* Toolbar */}
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-2">
-          <p className="text-sm text-muted-foreground">
-            <span className="font-medium text-foreground">
-              {categories.length}
-            </span>{" "}
-            {categories.length === 1 ? "categoria" : "categorias"}
-          </p>
-          <Button
-            variant="outline"
-            size="icon-sm"
-            onClick={refreshCategories}
-            disabled={isRefreshing}
-            title="Actualizar"
-          >
-            <RefreshCw
-              className={`size-3.5 ${isRefreshing ? "animate-spin" : ""}`}
-            />
-            <span className="sr-only">Actualizar</span>
-          </Button>
-        </div>
-        <Button size="sm" onClick={handleCreate}>
-          <Plus className="size-4" />
-          Nueva categoria
-        </Button>
-      </div>
+      {/* Scope tabs (outer) */}
+      <Tabs value={scope} onValueChange={handleScopeChange}>
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <TabsList>
+            <TabsTrigger value="club">Club</TabsTrigger>
+            <TabsTrigger value="section">Sección</TabsTrigger>
+            <TabsTrigger value="member">Miembro</TabsTrigger>
+          </TabsList>
 
-      {/* List */}
-      {sortedCategories.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center">
-          <div className="flex size-12 items-center justify-center rounded-full bg-muted">
-            <Plus className="size-6 text-muted-foreground" />
+          {/* Toolbar */}
+          <div className="flex items-center gap-2">
+            <p className="text-sm text-muted-foreground">
+              <span className="font-medium text-foreground">
+                {categories.length}
+              </span>{" "}
+              {categories.length === 1 ? "categoría" : "categorías"}
+            </p>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={refreshCategories}
+              disabled={isRefreshing}
+              title="Actualizar"
+            >
+              <RefreshCw
+                className={`size-3.5 ${isRefreshing ? "animate-spin" : ""}`}
+              />
+              <span className="sr-only">Actualizar</span>
+            </Button>
+            <Button size="sm" onClick={handleCreate}>
+              <Plus className="size-4" />
+              Nueva categoría
+            </Button>
           </div>
-          <h3 className="mt-4 text-base font-semibold">
-            Sin categorias de premio
-          </h3>
-          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-            Crea categorias para clasificar los clubes segun sus puntos obtenidos
-            en la carpeta anual.
-          </p>
-          <Button size="sm" className="mt-4" onClick={handleCreate}>
-            <Plus className="size-4" />
-            Nueva categoria
-          </Button>
         </div>
-      ) : (
-        <div className="rounded-lg border border-border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-16 text-center">Orden</TableHead>
-                <TableHead>Nombre</TableHead>
-                <TableHead className="hidden sm:table-cell">
-                  Tipo club
-                </TableHead>
-                <TableHead className="w-24 text-center">Pts Min</TableHead>
-                <TableHead className="hidden w-24 text-center md:table-cell">
-                  Pts Max
-                </TableHead>
-                <TableHead className="w-20 text-center">Estado</TableHead>
-                <TableHead className="w-20 text-right">Acciones</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {sortedCategories.map((cat) => (
-                <TableRow key={cat.award_category_id}>
-                  <TableCell className="text-center">
-                    <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-xs font-medium">
-                      {cat.order}
-                    </span>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex flex-col gap-0.5">
-                      <span className="font-medium">{cat.name}</span>
-                      {cat.description && (
-                        <span className="line-clamp-1 text-xs text-muted-foreground">
-                          {cat.description}
-                        </span>
-                      )}
-                    </div>
-                  </TableCell>
-                  <TableCell className="hidden text-sm text-muted-foreground sm:table-cell">
-                    {clubTypeLabel(cat.club_type_id, clubTypes)}
-                  </TableCell>
-                  <TableCell className="text-center text-sm">
-                    {cat.min_points}
-                  </TableCell>
-                  <TableCell className="hidden text-center text-sm text-muted-foreground md:table-cell">
-                    {cat.max_points !== null ? cat.max_points : (
-                      <span className="italic text-muted-foreground/60">
-                        Sin limite
-                      </span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    <Badge
-                      variant={cat.active ? "success" : "secondary"}
-                      className="text-xs"
-                    >
-                      {cat.active ? "Activa" : "Inactiva"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        onClick={() => handleEdit(cat)}
-                        title="Editar categoria"
-                      >
-                        <Pencil className="size-3.5" />
-                        <span className="sr-only">Editar</span>
-                      </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        onClick={() => handleDelete(cat)}
-                        title="Eliminar categoria"
-                        className="text-destructive hover:text-destructive"
-                      >
-                        <Trash2 className="size-3.5" />
-                        <span className="sr-only">Eliminar</span>
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
-      )}
+
+        <TabsContent value={scope} className="mt-4 space-y-4">
+          {/* Active / Legacy inner tabs */}
+          <Tabs value={activeFilter} onValueChange={handleActiveFilterChange}>
+            <TabsList variant="line">
+              <TabsTrigger value="active">Activas</TabsTrigger>
+              <TabsTrigger value="legacy">Legacy</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value={activeFilter} className="mt-4">
+              {/* List */}
+              {sortedCategories.length === 0 ? (
+                <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center">
+                  <div className="flex size-12 items-center justify-center rounded-full bg-muted">
+                    <Plus className="size-6 text-muted-foreground" />
+                  </div>
+                  <h3 className="mt-4 text-base font-semibold">
+                    Sin categorías de {scopeLabel.toLowerCase()} {filterLabel}
+                  </h3>
+                  <p className="mt-1 max-w-sm text-sm text-muted-foreground">
+                    No hay categorías de {scopeLabel.toLowerCase()}{" "}
+                    {activeFilter === "active"
+                      ? "activas"
+                      : "inactivas (legacy)"}
+                    . Crea una nueva para clasificar según puntos obtenidos.
+                  </p>
+                  {activeFilter === "active" && (
+                    <Button size="sm" className="mt-4" onClick={handleCreate}>
+                      <Plus className="size-4" />
+                      Nueva categoría
+                    </Button>
+                  )}
+                </div>
+              ) : (
+                <div className="rounded-lg border border-border">
+                  <Table>
+                    <TableHeader>
+                      <TableRow>
+                        <TableHead className="w-16 text-center">Orden</TableHead>
+                        <TableHead>Nombre</TableHead>
+                        <TableHead className="hidden sm:table-cell">
+                          Tipo club
+                        </TableHead>
+                        <TableHead className="w-24 text-center">Pts Min</TableHead>
+                        <TableHead className="hidden w-24 text-center md:table-cell">
+                          Pts Max
+                        </TableHead>
+                        <TableHead className="w-20 text-center">Estado</TableHead>
+                        <TableHead className="w-20 text-right">Acciones</TableHead>
+                      </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                      {sortedCategories.map((cat) => (
+                        <TableRow key={cat.award_category_id}>
+                          <TableCell className="text-center">
+                            <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                              {cat.order}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <div className="flex flex-col gap-0.5">
+                              <span className="font-medium">{cat.name}</span>
+                              {cat.description && (
+                                <span className="line-clamp-1 text-xs text-muted-foreground">
+                                  {cat.description}
+                                </span>
+                              )}
+                            </div>
+                          </TableCell>
+                          <TableCell className="hidden text-sm text-muted-foreground sm:table-cell">
+                            {clubTypeLabel(cat.club_type_id, clubTypes)}
+                          </TableCell>
+                          <TableCell className="text-center text-sm">
+                            {cat.min_points}
+                          </TableCell>
+                          <TableCell className="hidden text-center text-sm text-muted-foreground md:table-cell">
+                            {cat.max_points !== null ? (
+                              cat.max_points
+                            ) : (
+                              <span className="italic text-muted-foreground/60">
+                                Sin límite
+                              </span>
+                            )}
+                          </TableCell>
+                          <TableCell className="text-center">
+                            <Badge
+                              variant={cat.active ? "success" : "secondary"}
+                              className="text-xs"
+                            >
+                              {cat.active ? "Activa" : "Inactiva"}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-right">
+                            <div className="flex items-center justify-end gap-1">
+                              <Button
+                                variant="ghost"
+                                size="icon-xs"
+                                onClick={() => handleEdit(cat)}
+                                title="Editar categoría"
+                              >
+                                <Pencil className="size-3.5" />
+                                <span className="sr-only">Editar</span>
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="icon-xs"
+                                onClick={() => handleDelete(cat)}
+                                title="Eliminar categoría"
+                                className="text-destructive hover:text-destructive"
+                              >
+                                <Trash2 className="size-3.5" />
+                                <span className="sr-only">Eliminar</span>
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                    </TableBody>
+                  </Table>
+                </div>
+              )}
+            </TabsContent>
+          </Tabs>
+        </TabsContent>
+      </Tabs>
 
       {/* Form dialog */}
       <AwardCategoryFormDialog
@@ -288,6 +367,7 @@ export function AwardCategoriesClientPage({
         onOpenChange={setFormOpen}
         category={editingCategory}
         clubTypes={clubTypes}
+        defaultScope={scope}
         onSuccess={refreshCategories}
       />
 
@@ -295,11 +375,11 @@ export function AwardCategoriesClientPage({
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Eliminar categoria</AlertDialogTitle>
+            <AlertDialogTitle>Eliminar categoría</AlertDialogTitle>
             <AlertDialogDescription>
-              Esta accion eliminara la categoria{" "}
+              Esta acción eliminará la categoría{" "}
               <strong>{deletingCategory?.name}</strong>. Los rankings existentes
-              que la referencien podrian verse afectados.
+              que la referencien podrían verse afectados.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -311,7 +391,7 @@ export function AwardCategoriesClientPage({
               disabled={isDeleting}
               className="bg-destructive text-white hover:bg-destructive/90"
             >
-              {isDeleting ? "Eliminando..." : "Eliminar categoria"}
+              {isDeleting ? "Eliminando..." : "Eliminar categoría"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/annual-folders/award-category-form-dialog.tsx
+++ b/src/components/annual-folders/award-category-form-dialog.tsx
@@ -29,7 +29,7 @@ import {
   createAwardCategory,
   updateAwardCategory,
 } from "@/lib/api/annual-folders";
-import type { AwardCategory } from "@/lib/api/annual-folders";
+import type { AwardCategory, AwardCategoryScope } from "@/lib/api/annual-folders";
 import type { ClubType } from "@/lib/api/catalogs";
 
 // ─── Schema ───────────────────────────────────────────────────────────────────
@@ -43,6 +43,7 @@ const formSchema = z.object({
     .string()
     .max(500, "La descripción no puede superar 500 caracteres")
     .optional(),
+  scope: z.enum(["club", "section", "member"] as const),
   club_type_id: z.string(), // "all" | stringified number
   min_points: z.coerce.number().int().min(0, "Debe ser 0 o mayor"),
   max_points: z.coerce
@@ -67,6 +68,8 @@ interface AwardCategoryFormDialogProps {
   onOpenChange: (open: boolean) => void;
   category?: AwardCategory | null;
   clubTypes: ClubType[];
+  /** Default scope for create mode — passed by parent based on active scope tab */
+  defaultScope?: AwardCategoryScope;
   onSuccess: () => void;
 }
 
@@ -77,6 +80,7 @@ export function AwardCategoryFormDialog({
   onOpenChange,
   category,
   clubTypes,
+  defaultScope = "club",
   onSuccess,
 }: AwardCategoryFormDialogProps) {
   const t = useTranslations("annual_folders");
@@ -95,6 +99,7 @@ export function AwardCategoryFormDialog({
     defaultValues: {
       name: "",
       description: "",
+      scope: defaultScope,
       club_type_id: "all",
       min_points: 0,
       max_points: null,
@@ -104,6 +109,7 @@ export function AwardCategoryFormDialog({
   });
 
   const clubTypeValue = watch("club_type_id");
+  const scopeValue = watch("scope");
 
   useEffect(() => {
     if (open) {
@@ -111,6 +117,7 @@ export function AwardCategoryFormDialog({
         reset({
           name: category.name,
           description: category.description ?? "",
+          scope: category.scope ?? defaultScope,
           club_type_id:
             category.club_type_id !== null
               ? String(category.club_type_id)
@@ -124,6 +131,7 @@ export function AwardCategoryFormDialog({
         reset({
           name: "",
           description: "",
+          scope: defaultScope,
           club_type_id: "all",
           min_points: 0,
           max_points: null,
@@ -132,7 +140,7 @@ export function AwardCategoryFormDialog({
         });
       }
     }
-  }, [open, category, reset]);
+  }, [open, category, defaultScope, reset]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -140,6 +148,7 @@ export function AwardCategoryFormDialog({
       const payload = {
         name: values.name,
         description: values.description || null,
+        scope: values.scope,
         club_type_id:
           values.club_type_id === "all" ? null : Number(values.club_type_id),
         min_points: values.min_points,
@@ -197,11 +206,11 @@ export function AwardCategoryFormDialog({
 
           {/* Descripcion */}
           <div className="space-y-1.5">
-            <Label htmlFor="cat-description">Descripcion</Label>
+            <Label htmlFor="cat-description">Descripción</Label>
             <Textarea
               id="cat-description"
               {...register("description")}
-              placeholder="Descripcion opcional de la categoria"
+              placeholder="Descripción opcional de la categoría"
               rows={3}
             />
             {errors.description && (
@@ -211,14 +220,35 @@ export function AwardCategoryFormDialog({
             )}
           </div>
 
+          {/* Alcance */}
+          <div className="space-y-1.5">
+            <Label htmlFor="cat-scope">Alcance *</Label>
+            <Select
+              value={scopeValue}
+              onValueChange={(val) => setValue("scope", val as AwardCategoryScope)}
+            >
+              <SelectTrigger id="cat-scope">
+                <SelectValue placeholder="Seleccionar alcance" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="club">Club</SelectItem>
+                <SelectItem value="section">Sección</SelectItem>
+                <SelectItem value="member">Miembro</SelectItem>
+              </SelectContent>
+            </Select>
+            {errors.scope && (
+              <p className="text-xs text-destructive">{errors.scope.message}</p>
+            )}
+          </div>
+
           {/* Tipo de club */}
           <div className="space-y-1.5">
-            <Label>Tipo de club</Label>
+            <Label htmlFor="cat-club-type">Tipo de club</Label>
             <Select
               value={clubTypeValue}
               onValueChange={(val) => setValue("club_type_id", val)}
             >
-              <SelectTrigger>
+              <SelectTrigger id="cat-club-type">
                 <SelectValue placeholder="Seleccionar tipo de club" />
               </SelectTrigger>
               <SelectContent>
@@ -243,7 +273,7 @@ export function AwardCategoryFormDialog({
           {/* Puntos min / max */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label htmlFor="cat-min-points">Puntos minimos *</Label>
+              <Label htmlFor="cat-min-points">Puntos mínimos *</Label>
               <Input
                 id="cat-min-points"
                 type="number"
@@ -259,13 +289,13 @@ export function AwardCategoryFormDialog({
             </div>
 
             <div className="space-y-1.5">
-              <Label htmlFor="cat-max-points">Puntos maximos</Label>
+              <Label htmlFor="cat-max-points">Puntos máximos</Label>
               <Input
                 id="cat-max-points"
                 type="number"
                 min={0}
                 {...register("max_points")}
-                placeholder="Sin limite"
+                placeholder="Sin límite"
               />
               {errors.max_points && (
                 <p className="text-xs text-destructive">
@@ -278,7 +308,7 @@ export function AwardCategoryFormDialog({
           {/* Icono / Orden */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label htmlFor="cat-icon">Icono</Label>
+              <Label htmlFor="cat-icon">Ícono</Label>
               <Input
                 id="cat-icon"
                 {...register("icon")}
@@ -325,7 +355,7 @@ export function AwardCategoryFormDialog({
                   : "Creando..."
                 : isEdit
                   ? "Guardar cambios"
-                  : "Crear categoria"}
+                  : "Crear categoría"}
             </Button>
           </DialogFooter>
         </form>

--- a/src/components/camporees/camporee-approval-dialog.tsx
+++ b/src/components/camporees/camporee-approval-dialog.tsx
@@ -109,7 +109,7 @@ export function CamporeeApprovalDialog({
           <DialogDescription>
             {isReject
               ? `Se rechazara la solicitud de "${entityName}".`
-              : `Se aprobara la solicitud de "${entityName}". Esta accion no se puede deshacer.`}
+              : `Se aprobará la solicitud de "${entityName}". Esta acción no se puede deshacer.`}
           </DialogDescription>
         </DialogHeader>
 

--- a/src/components/enrollments/enrollments-table.tsx
+++ b/src/components/enrollments/enrollments-table.tsx
@@ -112,9 +112,9 @@ function RejectDialog({ enrollmentId, disabled, onConfirm }: RejectDialogProps) 
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Rechazar inscripcion</AlertDialogTitle>
+          <AlertDialogTitle>Rechazar inscripción</AlertDialogTitle>
           <AlertDialogDescription>
-            Esta accion marcara la inscripcion como rechazada. El miembro no
+            Esta acción marcará la inscripción como rechazada. El miembro no
             podra continuar con el proceso de investidura con esta inscripcion.
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/src/components/users/mfa-tab.tsx
+++ b/src/components/users/mfa-tab.tsx
@@ -69,7 +69,7 @@ function MfaNotConfigured() {
           <div className="space-y-1">
             <p className="text-sm font-medium">MFA no configurado</p>
             <p className="text-[13px] text-muted-foreground">
-              Este usuario no ha configurado la autenticacion de dos factores.
+              Este usuario no ha configurado la autenticación de dos factores.
             </p>
           </div>
         </div>
@@ -95,7 +95,7 @@ function ResetMfaDialog({
       try {
         await adminResetUserMfa(userId);
         toast.success(t("toasts.mfa_reset"), {
-          description: "El usuario debera re-enrolarse en su proximo inicio de sesion.",
+          description: "El usuario deberá re-enrolarse en su próximo inicio de sesión.",
         });
         onSuccess();
       } catch (error) {
@@ -118,15 +118,15 @@ function ResetMfaDialog({
         <AlertDialogHeader>
           <AlertDialogTitle className="flex items-center gap-2">
             <ShieldAlert size={18} className="text-warning-foreground" />
-            Resetear autenticacion de dos factores
+            Resetear autenticación de dos factores
           </AlertDialogTitle>
           <AlertDialogDescription className="space-y-2">
             <span className="block">
-              Esta accion elimina el secreto TOTP y todos los codigos de respaldo del usuario.
+              Esta acción elimina el secreto TOTP y todos los códigos de respaldo del usuario.
             </span>
             <span className="block font-medium text-foreground">
-              El usuario debera configurar MFA nuevamente desde su cuenta. Si el usuario
-              perdio acceso a su app autenticadora, esta accion le permite recuperar el acceso.
+              El usuario deberá configurar MFA nuevamente desde su cuenta. Si el usuario
+              perdió acceso a su app autenticadora, esta acción le permite recuperar el acceso.
             </span>
           </AlertDialogDescription>
         </AlertDialogHeader>
@@ -172,7 +172,7 @@ function DisableMfaDialog({
       try {
         await adminResetUserMfa(userId);
         toast.success(t("toasts.mfa_disabled"), {
-          description: "La autenticacion de dos factores fue removida del usuario.",
+          description: "La autenticación de dos factores fue removida del usuario.",
         });
         onSuccess();
       } catch (error) {
@@ -195,15 +195,15 @@ function DisableMfaDialog({
         <AlertDialogHeader>
           <AlertDialogTitle className="flex items-center gap-2">
             <ShieldOff size={18} className="text-destructive" />
-            Deshabilitar autenticacion de dos factores
+            Deshabilitar autenticación de dos factores
           </AlertDialogTitle>
           <AlertDialogDescription className="space-y-2">
             <span className="block">
-              Esta es una accion de soporte para casos donde el usuario no puede acceder
-              a su cuenta. Se eliminara permanentemente el secreto TOTP y los codigos de respaldo.
+              Esta es una acción de soporte para casos donde el usuario no puede acceder
+              a su cuenta. Se eliminará permanentemente el secreto TOTP y los códigos de respaldo.
             </span>
             <span className="block font-medium text-destructive">
-              La cuenta del usuario quedara protegida unicamente con contrasena.
+              La cuenta del usuario quedará protegida únicamente con contraseña.
               Usar solo cuando el usuario haya solicitado este soporte.
             </span>
           </AlertDialogDescription>
@@ -254,7 +254,7 @@ export function MfaTab({ userId, mfaEnabled, canManageMfa }: MfaTabProps) {
         <CardHeader>
           <CardTitle className="flex items-center gap-2 text-base">
             <ShieldCheck size={16} className="text-success" />
-            Autenticacion de dos factores
+            Autenticación de dos factores
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -277,7 +277,7 @@ export function MfaTab({ userId, mfaEnabled, canManageMfa }: MfaTabProps) {
               <Smartphone size={14} className="text-primary" />
             </div>
             <div className="space-y-0.5">
-              <p className="text-sm font-medium">Metodo</p>
+              <p className="text-sm font-medium">Método</p>
               <p className="text-[13px] text-muted-foreground">
                 TOTP — App autenticadora (Google Authenticator, Authy, etc.)
               </p>
@@ -297,8 +297,8 @@ export function MfaTab({ userId, mfaEnabled, canManageMfa }: MfaTabProps) {
           <CardContent className="space-y-4">
             <p className="text-[13px] text-muted-foreground">
               Estas acciones son irreversibles y estan destinadas a casos de soporte donde
-              el usuario perdio acceso a su app autenticadora. Cada accion elimina el secreto
-              TOTP y los codigos de respaldo almacenados.
+              el usuario perdió acceso a su app autenticadora. Cada acción elimina el secreto
+              TOTP y los códigos de respaldo almacenados.
             </p>
 
             <div className="flex flex-wrap gap-3">

--- a/src/components/users/post-registration-tab.tsx
+++ b/src/components/users/post-registration-tab.tsx
@@ -68,14 +68,14 @@ const STEPS: StepConfig[] = [
   {
     key: "personalInfo",
     number: 2,
-    label: "Informacion personal",
+    label: "Información personal",
     description:
-      "Requiere genero, fecha de nacimiento, bautismo, al menos un contacto de emergencia y representante legal si es menor de 18.",
+      "Requiere género, fecha de nacimiento, bautismo, al menos un contacto de emergencia y representante legal si es menor de 18.",
     icon: User,
     requires: [
-      "Genero",
+      "Género",
       "Fecha de nacimiento",
-      "Bautismo (si/no)",
+      "Bautismo (sí/no)",
       "Al menos 1 contacto de emergencia",
       "Representante legal (si es menor de 18)",
     ],
@@ -83,14 +83,14 @@ const STEPS: StepConfig[] = [
   {
     key: "clubSelection",
     number: 3,
-    label: "Seleccion de club",
+    label: "Selección de club",
     description:
-      "Asigna pais, union, campo local y membresía de club al usuario. Esta accion requiere datos adicionales y no puede forzarse desde aqui.",
+      "Asigna país, unión, campo local y membresía de club al usuario. Esta acción requiere datos adicionales y no puede forzarse desde aquí.",
     icon: Building2,
     requires: [
-      "Seleccion de club y seccion",
-      "Seleccion de clase",
-      "Pais, union y campo local",
+      "Selección de club y sección",
+      "Selección de clase",
+      "País, unión y campo local",
     ],
   },
 ];
@@ -240,13 +240,13 @@ function OverrideButton({
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              Confirmar accion administrativa
+              Confirmar acción administrativa
             </AlertDialogTitle>
             <AlertDialogDescription>
               Vas a marcar como completado el <strong>Paso {stepNumber}: {stepLabel}</strong> de forma manual, sin que el usuario haya cumplido todos los requisitos desde la app.
               <br />
               <br />
-              Esta accion queda registrada bajo tu sesion de administrador. Asegurate de que el usuario realmente cumple las condiciones del paso antes de continuar.
+              Esta acción queda registrada bajo tu sesión de administrador. Asegurate de que el usuario realmente cumple las condiciones del paso antes de continuar.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>

--- a/src/components/users/sessions-tab.tsx
+++ b/src/components/users/sessions-tab.tsx
@@ -182,7 +182,7 @@ function ErrorState({ onRetry }: { onRetry: () => void }) {
       </div>
       <p className="text-sm font-medium">Error al cargar sesiones</p>
       <p className="text-[13px] text-muted-foreground">
-        No se pudieron obtener los datos de sesion.
+        No se pudieron obtener los datos de sesión.
       </p>
       <Button variant="outline" size="sm" onClick={onRetry}>
         <RefreshCw className="mr-2 size-3.5" />
@@ -230,7 +230,7 @@ function SessionRow({ session, index, onRevoke, isRevoking }: SessionRowProps) {
             </p>
             {isCurrent && (
               <Badge variant="success" className="mt-0.5 text-[10px]">
-                Sesion actual
+                Sesión actual
               </Badge>
             )}
           </div>
@@ -272,16 +272,16 @@ function SessionRow({ session, index, onRevoke, isRevoking }: SessionRowProps) {
               variant="ghost"
               size="icon-sm"
               disabled={isRevoking}
-              title="Revocar sesion"
+              title="Revocar sesión"
             >
               <Trash2 className="size-3.5 text-muted-foreground" />
             </Button>
           </AlertDialogTrigger>
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>Revocar sesion</AlertDialogTitle>
+              <AlertDialogTitle>Revocar sesión</AlertDialogTitle>
               <AlertDialogDescription>
-                Esta accion cerrara la sesion de{" "}
+                Esta acción cerrará la sesión de{" "}
                 <strong>
                   {device.browser} en {device.os}
                 </strong>{" "}
@@ -382,7 +382,7 @@ export function SessionsTab({ userId, initialData }: SessionsTabProps) {
             <CardTitle className="text-base">Sesiones activas</CardTitle>
             {data && (
               <p className="text-[13px] text-muted-foreground">
-                {data.totalSessions} {data.totalSessions === 1 ? "sesion activa" : "sesiones activas"}
+                {data.totalSessions} {data.totalSessions === 1 ? "sesión activa" : "sesiones activas"}
               </p>
             )}
           </div>
@@ -418,9 +418,9 @@ export function SessionsTab({ userId, initialData }: SessionsTabProps) {
                       Revocar todas las sesiones
                     </AlertDialogTitle>
                     <AlertDialogDescription>
-                      Se cerraran todas las{" "}
-                      <strong>{sessions.length} sesion(es)</strong>{" "}
-                      del usuario. Debera iniciar sesion nuevamente en todos
+                      Se cerrarán todas las{" "}
+                      <strong>{sessions.length} sesión(es)</strong>{" "}
+                      del usuario. Deberá iniciar sesión nuevamente en todos
                       sus dispositivos.
                     </AlertDialogDescription>
                   </AlertDialogHeader>

--- a/src/lib/api/action-error.ts
+++ b/src/lib/api/action-error.ts
@@ -16,19 +16,19 @@ export function getActionErrorMessage(
   const endpointLabel = options.endpointLabel ? ` (${options.endpointLabel})` : "";
 
   if (error.status === 401 || error.status === 403) {
-    return "No tienes permisos para realizar esta accion.";
+    return "No tienes permisos para realizar esta acción.";
   }
 
   if (error.status === 404 || error.status === 405) {
-    return `El endpoint no esta disponible en este entorno${endpointLabel}.`;
+    return `El endpoint no está disponible en este entorno${endpointLabel}.`;
   }
 
   if (error.status === 409) {
-    return "No se pudo completar la accion por conflicto de datos.";
+    return "No se pudo completar la acción por conflicto de datos.";
   }
 
   if (error.status === 422) {
-    return "Los datos enviados no son validos para esta accion.";
+    return "Los datos enviados no son válidos para esta acción.";
   }
 
   if (error.status === 429) {
@@ -36,7 +36,7 @@ export function getActionErrorMessage(
   }
 
   if (error.status >= 500) {
-    return "El backend no esta disponible temporalmente. Intenta de nuevo mas tarde.";
+    return "El backend no está disponible temporalmente. Intenta de nuevo más tarde.";
   }
 
   return error.message || fallbackMessage;

--- a/src/lib/api/admin-users.ts
+++ b/src/lib/api/admin-users.ts
@@ -581,7 +581,7 @@ function normalizeEndpointState(error: ApiError): AdminUsersResult["endpointStat
 
 function normalizeEndpointDetail(error: ApiError): string {
   if (error.status === 401) {
-    return "Sesion expirada o token invalido. Cierra sesion y vuelve a iniciar.";
+    return "Sesión expirada o token inválido. Cierra sesión y vuelve a iniciar.";
   }
 
   if (error.status === 403) {

--- a/src/lib/api/annual-folders.ts
+++ b/src/lib/api/annual-folders.ts
@@ -380,6 +380,8 @@ export async function getFolderEvaluations(
 
 // ─── Rankings & Award Categories — Types ──────────────────────────────────────
 
+export type AwardCategoryScope = 'club' | 'section' | 'member';
+
 export type AwardCategory = {
   award_category_id: string;
   name: string;
@@ -390,6 +392,7 @@ export type AwardCategory = {
   icon: string | null;
   order: number;
   active: boolean;
+  scope: AwardCategoryScope;
 };
 
 export type ClubRanking = {
@@ -408,7 +411,7 @@ export type RecalculateResult = {
 };
 
 export type CreateAwardCategoryPayload = Omit<AwardCategory, "award_category_id" | "active">;
-export type UpdateAwardCategoryPayload = Partial<AwardCategory>;
+export type UpdateAwardCategoryPayload = Partial<Omit<AwardCategory, "award_category_id">>;
 
 // ─── Rankings — Server-side ───────────────────────────────────────────────────
 
@@ -469,17 +472,19 @@ export async function recalculateRankings(
 // ─── Award Categories — Server-side ──────────────────────────────────────────
 
 /**
- * GET /api/v1/award-categories?club_type_id=X&active=true
+ * GET /api/v1/award-categories?club_type_id=X&active=true&scope=club|section|member
  * Returns the list of award categories.
  */
 export async function getAwardCategories(
   clubTypeId?: number,
   active?: boolean,
+  scope?: AwardCategoryScope,
 ): Promise<AwardCategory[]> {
   return apiRequest<AwardCategory[]>("/award-categories", {
     params: {
       ...(clubTypeId !== undefined ? { club_type_id: clubTypeId } : {}),
       ...(active !== undefined ? { active } : {}),
+      ...(scope !== undefined ? { scope } : {}),
     },
   });
 }
@@ -501,11 +506,13 @@ export async function getAwardCategory(categoryId: string): Promise<AwardCategor
 export async function getAwardCategoriesFromClient(
   clubTypeId?: number,
   active?: boolean,
+  scope?: AwardCategoryScope,
 ): Promise<AwardCategory[]> {
   return apiRequestFromClient<AwardCategory[]>("/award-categories", {
     params: {
       ...(clubTypeId !== undefined ? { club_type_id: clubTypeId } : {}),
       ...(active !== undefined ? { active } : {}),
+      ...(scope !== undefined ? { scope } : {}),
     },
   });
 }

--- a/src/lib/api/enrollments.ts
+++ b/src/lib/api/enrollments.ts
@@ -247,10 +247,10 @@ function normalizeEndpointState(error: ApiError): EnrollmentsListResult["endpoin
 }
 
 function normalizeEndpointDetail(error: ApiError): string {
-  if (error.status === 401) return "Sesion expirada o token invalido.";
+  if (error.status === 401) return "Sesión expirada o token inválido.";
   if (error.status === 403) return "Tu rol no tiene permisos para ver inscripciones.";
   if (error.status === 429) return "Demasiadas solicitudes. Reintenta en unos segundos.";
-  if (error.status >= 500) return "El backend no esta disponible temporalmente.";
+  if (error.status >= 500) return "El backend no está disponible temporalmente.";
   return "Endpoint no disponible en backend.";
 }
 

--- a/src/lib/api/member-ranking-weights.ts
+++ b/src/lib/api/member-ranking-weights.ts
@@ -191,10 +191,10 @@ function normalizeEndpointState(
 }
 
 function normalizeEndpointDetail(error: ApiError): string {
-  if (error.status === 401) return "Sesion expirada o token invalido.";
+  if (error.status === 401) return "Sesión expirada o token inválido.";
   if (error.status === 403) return "Tu rol no tiene permisos para ver pesos de rankings.";
   if (error.status === 429) return "Demasiadas solicitudes. Reintenta en unos segundos.";
-  if (error.status >= 500) return "El backend no esta disponible temporalmente.";
+  if (error.status >= 500) return "El backend no está disponible temporalmente.";
   return "Endpoint no disponible en backend.";
 }
 
@@ -229,11 +229,11 @@ export function mapWeightsErrorMessage(error: unknown): string {
         : "La suma de los porcentajes debe ser 100";
     }
     case "WEIGHTS_CONFLICT":
-      return "Ya existe configuracion para este tipo de club y ano";
+      return "Ya existe configuración para este tipo de club y año";
     case "DEFAULT_WEIGHTS_NOT_DELETABLE":
-      return "No se puede eliminar la configuracion por defecto";
+      return "No se puede eliminar la configuración por defecto";
     case "WEIGHTS_NOT_FOUND":
-      return "Configuracion no encontrada";
+      return "Configuración no encontrada";
     default:
       if (error instanceof ApiError) return error.message;
       if (error instanceof Error) return error.message;

--- a/src/lib/api/member-ranking-weights.ts
+++ b/src/lib/api/member-ranking-weights.ts
@@ -1,0 +1,380 @@
+import { apiRequest, ApiError } from "@/lib/api/client";
+
+/**
+ * Member Ranking Weights API client.
+ *
+ * Manages the `enrollment_ranking_weights` table — the configurable percentage
+ * weights (class / investiture / camporee) used when computing composite scores.
+ *
+ * FIELD NAME NOTE (plan divergence):
+ * The plan spec (Task 14 / D1) refers to `year_id` as the ecclesiastical-year
+ * column. The REAL backend DTO (create-member-ranking-weights.dto.ts and
+ * member-ranking-weights-response.dto.ts) uses `ecclesiastical_year_id` for
+ * BOTH the request payload and the response shape. This client uses
+ * `ecclesiastical_year_id` to match the actual backend contract.
+ *
+ * Route prefix: /api/v1/member-ranking-weights
+ * Auth:         JwtAuthGuard + GlobalRolesGuard(admin, super_admin) + PermissionsGuard
+ * Permission:   member_ranking_weights:read (GET) / member_ranking_weights:write (POST/PATCH/DELETE)
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+/**
+ * Response shape returned by all MemberRankingWeights endpoints.
+ * Decimal(5,2) fields (class_pct, investiture_pct, camporee_pct) are coerced
+ * to plain JS numbers by the backend's `fromRow` helper.
+ */
+export type EnrollmentRankingWeight = {
+  id: string;
+  club_type_id: number | null;
+  /** Real DB column name. Plan spec mistakenly called it `year_id`. */
+  ecclesiastical_year_id: number | null;
+  class_pct: number;
+  investiture_pct: number;
+  camporee_pct: number;
+  /**
+   * True for the single global default row (NULL, NULL) seeded at migration.
+   * This row can be edited but NOT deleted.
+   */
+  is_default: boolean;
+  created_at: string;
+  modified_at: string;
+};
+
+export type CreateEnrollmentRankingWeightDto = {
+  class_pct: number;
+  investiture_pct: number;
+  camporee_pct: number;
+  club_type_id?: number | null;
+  /** Real DB column name — see FIELD NAME NOTE above. */
+  ecclesiastical_year_id?: number | null;
+};
+
+export type UpdateEnrollmentRankingWeightDto = Partial<CreateEnrollmentRankingWeightDto>;
+
+export type WeightsListQuery = {
+  page?: number;
+  limit?: number;
+};
+
+export type WeightsListResult = {
+  items: EnrollmentRankingWeight[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  endpointAvailable: boolean;
+  endpointState: "available" | "forbidden" | "missing" | "rate-limited";
+  endpointDetail: string;
+};
+
+// ─── Normalizer helpers ────────────────────────────────────────────────────────
+
+type GenericRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): GenericRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as GenericRecord)
+    : null;
+}
+
+function pickString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function pickNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function pickBoolean(value: unknown): boolean {
+  return typeof value === "boolean" ? value : false;
+}
+
+function normalizeWeightRow(raw: GenericRecord): EnrollmentRankingWeight | null {
+  const id = pickString(raw.id);
+  const classPct = pickNumber(raw.class_pct);
+  const investiturePct = pickNumber(raw.investiture_pct);
+  const camporeePct = pickNumber(raw.camporee_pct);
+  const createdAt = pickString(raw.created_at);
+  const modifiedAt = pickString(raw.modified_at);
+
+  if (
+    id === null ||
+    classPct === null ||
+    investiturePct === null ||
+    camporeePct === null ||
+    createdAt === null ||
+    modifiedAt === null
+  ) {
+    return null;
+  }
+
+  return {
+    id,
+    club_type_id: pickNumber(raw.club_type_id),
+    ecclesiastical_year_id: pickNumber(raw.ecclesiastical_year_id),
+    class_pct: classPct,
+    investiture_pct: investiturePct,
+    camporee_pct: camporeePct,
+    is_default: pickBoolean(raw.is_default),
+    created_at: createdAt,
+    modified_at: modifiedAt,
+  };
+}
+
+function extractItemArray(payload: unknown): GenericRecord[] {
+  const candidates: string[][] = [
+    ["data", "data"],
+    ["data", "items"],
+    ["data"],
+    ["items"],
+    [],
+  ];
+
+  for (const path of candidates) {
+    let current: unknown = payload;
+    for (const key of path) {
+      current = asRecord(current)?.[key];
+    }
+    if (Array.isArray(current)) {
+      return current.filter((v): v is GenericRecord => Boolean(asRecord(v)));
+    }
+  }
+
+  return [];
+}
+
+function normalizeListMeta(payload: unknown): {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+} {
+  const candidates: string[][] = [["data", "meta"], ["meta"], ["data"]];
+
+  let meta: GenericRecord | null = null;
+  for (const path of candidates) {
+    let current: unknown = payload;
+    for (const key of path) {
+      current = asRecord(current)?.[key];
+    }
+    const r = asRecord(current);
+    if (r && (pickNumber(r.total) !== null || pickNumber(r.totalPages) !== null)) {
+      meta = r;
+      break;
+    }
+  }
+
+  const page = pickNumber(meta?.page) ?? 1;
+  const limit = pickNumber(meta?.limit) ?? 50;
+  const total = pickNumber(meta?.total) ?? 0;
+  const totalPages =
+    pickNumber(meta?.totalPages) ?? Math.max(1, Math.ceil(total / Math.max(limit, 1)));
+
+  return { total, page, limit, totalPages };
+}
+
+function normalizeEndpointState(
+  error: ApiError,
+): WeightsListResult["endpointState"] {
+  if (error.status === 401 || error.status === 403) return "forbidden";
+  if (error.status === 429) return "rate-limited";
+  return "missing";
+}
+
+function normalizeEndpointDetail(error: ApiError): string {
+  if (error.status === 401) return "Sesion expirada o token invalido.";
+  if (error.status === 403) return "Tu rol no tiene permisos para ver pesos de rankings.";
+  if (error.status === 429) return "Demasiadas solicitudes. Reintenta en unos segundos.";
+  if (error.status >= 500) return "El backend no esta disponible temporalmente.";
+  return "Endpoint no disponible en backend.";
+}
+
+// ─── Error code extraction ────────────────────────────────────────────────────
+
+/**
+ * Extracts the backend error `code` string from an ApiError payload.
+ * Backend shape: `{ statusCode, message, code }` or `{ error, code }`.
+ */
+export function extractErrorCode(error: unknown): string | null {
+  if (!(error instanceof ApiError)) return null;
+  const r = asRecord(error.payload);
+  if (!r) return null;
+  return pickString(r.code);
+}
+
+/**
+ * Maps backend error codes to user-facing Spanish messages (D6).
+ * Falls back to the raw ApiError message if code is unrecognised.
+ */
+export function mapWeightsErrorMessage(error: unknown): string {
+  const code = extractErrorCode(error);
+
+  switch (code) {
+    case "WEIGHTS_SUM_INVALID": {
+      // Backend interpolates {sum} in the i18n message — extract from payload if available
+      const r = asRecord((error as ApiError).payload);
+      const args = asRecord(r?.namedArgs);
+      const sum = args ? pickNumber(args.sum) : null;
+      return sum !== null
+        ? `La suma debe ser 100 (recibido ${sum})`
+        : "La suma de los porcentajes debe ser 100";
+    }
+    case "WEIGHTS_CONFLICT":
+      return "Ya existe configuracion para este tipo de club y ano";
+    case "DEFAULT_WEIGHTS_NOT_DELETABLE":
+      return "No se puede eliminar la configuracion por defecto";
+    case "WEIGHTS_NOT_FOUND":
+      return "Configuracion no encontrada";
+    default:
+      if (error instanceof ApiError) return error.message;
+      if (error instanceof Error) return error.message;
+      return "Error desconocido";
+  }
+}
+
+// ─── API functions ────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/member-ranking-weights
+ * Paginated list ordered by is_default DESC (default row first, then overrides).
+ */
+export async function listMemberRankingWeights(
+  query?: WeightsListQuery,
+): Promise<WeightsListResult> {
+  const params: Record<string, string | number | boolean | undefined> = {};
+  if (query?.page) params.page = query.page;
+  if (query?.limit) params.limit = query.limit;
+
+  try {
+    const payload = await apiRequest<unknown>("/member-ranking-weights", { params });
+    const raw = extractItemArray(payload);
+    const items = raw
+      .map((item) => normalizeWeightRow(item))
+      .filter((item): item is EnrollmentRankingWeight => Boolean(item));
+
+    const metaRaw = normalizeListMeta(payload);
+
+    return {
+      items,
+      ...metaRaw,
+      endpointAvailable: true,
+      endpointState: "available",
+      endpointDetail: `Disponible (${metaRaw.total} configuraciones).`,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 50,
+        totalPages: 1,
+        endpointAvailable: false,
+        endpointState: normalizeEndpointState(error),
+        endpointDetail: normalizeEndpointDetail(error),
+      };
+    }
+    throw error;
+  }
+}
+
+/**
+ * GET /api/v1/member-ranking-weights/:id
+ * Returns a single weight configuration by UUID.
+ * Throws ApiError — caller handles 404.
+ */
+export async function getMemberRankingWeights(
+  id: string,
+): Promise<EnrollmentRankingWeight> {
+  const payload = await apiRequest<unknown>(`/member-ranking-weights/${id}`);
+  const r = asRecord(payload);
+  if (!r) {
+    throw new ApiError("Respuesta inesperada del servidor", 500, payload);
+  }
+
+  // Backend may wrap in { data: {...} }
+  const row = asRecord(r.data) ?? r;
+  const normalized = normalizeWeightRow(row);
+  if (!normalized) {
+    throw new ApiError("No se pudo normalizar la configuracion de pesos", 500, payload);
+  }
+
+  return normalized;
+}
+
+/**
+ * POST /api/v1/member-ranking-weights
+ * Creates a new weight configuration.
+ * Backend validates class_pct + investiture_pct + camporee_pct = 100 (±0.01).
+ * Unique constraint: (club_type_id, ecclesiastical_year_id).
+ * Throws ApiError — caller maps via mapWeightsErrorMessage().
+ */
+export async function createMemberRankingWeights(
+  dto: CreateEnrollmentRankingWeightDto,
+): Promise<EnrollmentRankingWeight> {
+  const payload = await apiRequest<unknown>("/member-ranking-weights", {
+    method: "POST",
+    body: dto,
+  });
+  const r = asRecord(payload);
+  if (!r) {
+    throw new ApiError("Respuesta inesperada del servidor", 500, payload);
+  }
+
+  const row = asRecord(r.data) ?? r;
+  const normalized = normalizeWeightRow(row);
+  if (!normalized) {
+    throw new ApiError("No se pudo normalizar la respuesta creada", 500, payload);
+  }
+
+  return normalized;
+}
+
+/**
+ * PATCH /api/v1/member-ranking-weights/:id
+ * Partially updates a weight configuration.
+ * Backend merges provided fields with existing values and re-validates sum.
+ * Throws ApiError — caller maps via mapWeightsErrorMessage().
+ */
+export async function updateMemberRankingWeights(
+  id: string,
+  dto: UpdateEnrollmentRankingWeightDto,
+): Promise<EnrollmentRankingWeight> {
+  const payload = await apiRequest<unknown>(`/member-ranking-weights/${id}`, {
+    method: "PATCH",
+    body: dto,
+  });
+  const r = asRecord(payload);
+  if (!r) {
+    throw new ApiError("Respuesta inesperada del servidor", 500, payload);
+  }
+
+  const row = asRecord(r.data) ?? r;
+  const normalized = normalizeWeightRow(row);
+  if (!normalized) {
+    throw new ApiError("No se pudo normalizar la respuesta actualizada", 500, payload);
+  }
+
+  return normalized;
+}
+
+/**
+ * DELETE /api/v1/member-ranking-weights/:id
+ * Deletes a weight configuration.
+ * The global default row (is_default=true) cannot be deleted — backend returns 400.
+ * Throws ApiError — caller maps via mapWeightsErrorMessage().
+ */
+export async function deleteMemberRankingWeights(id: string): Promise<void> {
+  await apiRequest<unknown>(`/member-ranking-weights/${id}`, {
+    method: "DELETE",
+  });
+}

--- a/src/lib/api/member-rankings.ts
+++ b/src/lib/api/member-rankings.ts
@@ -1,0 +1,262 @@
+import { apiRequest, ApiError } from "@/lib/api/client";
+
+/**
+ * Member Rankings API client.
+ *
+ * NOTE: The plan spec uses `MemberRankingResponse` (flat shape with
+ * `member_name`, `section_name`, etc. at top level). This implementation
+ * uses `MemberRankingItem` (nested `user`/`section` objects) for better
+ * resilience against backend envelope variations. Task 18 (breakdown page)
+ * should import `MemberRankingItem` from this file, NOT `MemberRankingResponse`.
+ */
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type MemberRankingCategory = {
+  scoring_category_id?: number | null;
+  name?: string | null;
+  slug?: string | null;
+};
+
+export type MemberRankingItem = {
+  member_ranking_id: number;
+  enrollment_id: number;
+  ecclesiastical_year_id: number;
+  rank_position: number | null;
+  composite_score_pct: number | null;
+  class_score_pct: number | null;
+  investiture_score_pct: number | null;
+  camporee_score_pct: number | null;
+  awarded_category?: MemberRankingCategory | null;
+  // Nested relations from backend
+  user?: {
+    user_id?: string | null;
+    name?: string | null;
+    first_name?: string | null;
+    paternal_last_name?: string | null;
+    maternal_last_name?: string | null;
+    email?: string | null;
+  } | null;
+  section?: {
+    section_id?: number | null;
+    name?: string | null;
+  } | null;
+};
+
+export type MemberRankingsQuery = {
+  year_id: number;
+  club_id?: number;
+  section_id?: number;
+  page?: number;
+  limit?: number;
+};
+
+export type MemberRankingsListResult = {
+  items: MemberRankingItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  endpointAvailable: boolean;
+  endpointState: "available" | "forbidden" | "missing" | "rate-limited";
+  endpointDetail: string;
+};
+
+// ─── Normalizers ──────────────────────────────────────────────────────────────
+
+type GenericRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): GenericRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as GenericRecord)
+    : null;
+}
+
+function pickString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function pickNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function normalizeCategory(value: unknown): MemberRankingCategory | null {
+  const r = asRecord(value);
+  if (!r) return null;
+  return {
+    scoring_category_id: pickNumber(r.scoring_category_id),
+    name: pickString(r.name),
+    slug: pickString(r.slug),
+  };
+}
+
+function normalizeMemberRankingItem(item: GenericRecord): MemberRankingItem | null {
+  const id = pickNumber(item.member_ranking_id);
+  const enrollmentId = pickNumber(item.enrollment_id);
+  const yearId = pickNumber(item.ecclesiastical_year_id);
+
+  if (id === null || enrollmentId === null || yearId === null) return null;
+
+  const userRaw = asRecord(item.user ?? item.users);
+  const sectionRaw = asRecord(item.section ?? item.sections);
+
+  return {
+    member_ranking_id: id,
+    enrollment_id: enrollmentId,
+    ecclesiastical_year_id: yearId,
+    rank_position: pickNumber(item.rank_position),
+    composite_score_pct: pickNumber(item.composite_score_pct),
+    class_score_pct: pickNumber(item.class_score_pct),
+    investiture_score_pct: pickNumber(item.investiture_score_pct),
+    camporee_score_pct: pickNumber(item.camporee_score_pct),
+    awarded_category: normalizeCategory(item.awarded_category ?? item.scoring_category),
+    user: userRaw
+      ? {
+          user_id: pickString(userRaw.user_id),
+          name: pickString(userRaw.name),
+          first_name: pickString(userRaw.first_name),
+          paternal_last_name: pickString(userRaw.paternal_last_name),
+          maternal_last_name: pickString(userRaw.maternal_last_name),
+          email: pickString(userRaw.email),
+        }
+      : null,
+    section: sectionRaw
+      ? {
+          section_id: pickNumber(sectionRaw.section_id),
+          name: pickString(sectionRaw.name),
+        }
+      : null,
+  };
+}
+
+function extractItemArray(payload: unknown): GenericRecord[] {
+  const candidates: string[][] = [
+    ["data", "data"],
+    ["data", "items"],
+    ["data"],
+    ["items"],
+    [],
+  ];
+
+  for (const path of candidates) {
+    let current: unknown = payload;
+    for (const key of path) {
+      current = asRecord(current)?.[key];
+    }
+    if (Array.isArray(current)) {
+      return current.filter((v): v is GenericRecord => Boolean(asRecord(v)));
+    }
+  }
+
+  return [];
+}
+
+function normalizeListMeta(payload: unknown): {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+} {
+  const candidates: string[][] = [
+    ["data", "meta"],
+    ["meta"],
+    ["data"],
+  ];
+
+  let meta: GenericRecord | null = null;
+  for (const path of candidates) {
+    let current: unknown = payload;
+    for (const key of path) {
+      current = asRecord(current)?.[key];
+    }
+    const r = asRecord(current);
+    if (r && (pickNumber(r.total) !== null || pickNumber(r.totalPages) !== null)) {
+      meta = r;
+      break;
+    }
+  }
+
+  const page = pickNumber(meta?.page) ?? 1;
+  const limit = pickNumber(meta?.limit) ?? 20;
+  const total = pickNumber(meta?.total) ?? 0;
+  const totalPages =
+    pickNumber(meta?.totalPages) ?? Math.max(1, Math.ceil(total / Math.max(limit, 1)));
+
+  return { total, page, limit, totalPages };
+}
+
+function normalizeEndpointState(
+  error: ApiError,
+): MemberRankingsListResult["endpointState"] {
+  if (error.status === 401 || error.status === 403) return "forbidden";
+  if (error.status === 429) return "rate-limited";
+  return "missing";
+}
+
+function normalizeEndpointDetail(error: ApiError): string {
+  if (error.status === 401) return "Sesion expirada o token invalido.";
+  if (error.status === 403) return "Tu rol no tiene permisos para ver rankings de miembros.";
+  if (error.status === 429) return "Demasiadas solicitudes. Reintenta en unos segundos.";
+  if (error.status >= 500) return "El backend no esta disponible temporalmente.";
+  return "Endpoint no disponible en backend.";
+}
+
+// ─── API functions ─────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/member-rankings
+ * Fetches paginated member rankings for a given ecclesiastical year.
+ * Optionally filtered by club_id and section_id.
+ * GlobalRolesGuard (admin, coordinator)
+ */
+export async function listMemberRankings(
+  query: MemberRankingsQuery,
+): Promise<MemberRankingsListResult> {
+  const params: Record<string, string | number | boolean | undefined> = {
+    year_id: query.year_id,
+  };
+
+  if (query.club_id) params.club_id = query.club_id;
+  if (query.section_id) params.section_id = query.section_id;
+  if (query.page) params.page = query.page;
+  if (query.limit) params.limit = query.limit;
+
+  try {
+    const payload = await apiRequest<unknown>("/member-rankings", { params });
+    const raw = extractItemArray(payload);
+    const items = raw
+      .map((item) => normalizeMemberRankingItem(item))
+      .filter((item): item is MemberRankingItem => Boolean(item));
+
+    const metaRaw = normalizeListMeta(payload);
+
+    return {
+      items,
+      ...metaRaw,
+      endpointAvailable: true,
+      endpointState: "available",
+      endpointDetail: `Disponible (${metaRaw.total} rankings).`,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+        endpointAvailable: false,
+        endpointState: normalizeEndpointState(error),
+        endpointDetail: normalizeEndpointDetail(error),
+      };
+    }
+    throw error;
+  }
+}

--- a/src/lib/api/member-rankings.ts
+++ b/src/lib/api/member-rankings.ts
@@ -8,6 +8,10 @@ import { apiRequest, ApiError } from "@/lib/api/client";
  * uses `MemberRankingItem` (nested `user`/`section` objects) for better
  * resilience against backend envelope variations. Task 18 (breakdown page)
  * should import `MemberRankingItem` from this file, NOT `MemberRankingResponse`.
+ *
+ * FIELD NAME DIVERGENCE (Task 18): The plan spec calls the weights field
+ * `weights_applied`. The backend DTO (Task 12 verified) uses `weights`.
+ * This client uses `weights` to match the actual backend contract.
  */
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -41,6 +45,60 @@ export type MemberRankingItem = {
     section_id?: number | null;
     name?: string | null;
   } | null;
+};
+
+// ─── Breakdown types (Task 18) ─────────────────────────────────────────────────
+
+export type MemberClassBreakdown = {
+  completed_sections: number;
+  required_sections: number;
+  /** Folder review status returned by backend, or null if not evaluated. */
+  folder_status: string | null;
+};
+
+export type MemberInvestitureBreakdown = {
+  /** Ceremony / candidacy status string from backend, or null if not recorded. */
+  status: string | null;
+};
+
+export type MemberCamporeeBreakdown = {
+  participated: boolean;
+  /** Total camporees available for the year; null if backend does not track it. */
+  total_camporees: number | null;
+};
+
+/**
+ * Weights applied when computing this member's composite score.
+ *
+ * NOTE — plan divergence: the plan spec calls this field `weights_applied`.
+ * The actual backend DTO (Task 12) returns `weights`. This type and all
+ * consumers use `weights` to match the real contract.
+ */
+export type MemberRankingWeights = {
+  class_pct: number;
+  investiture_pct: number;
+  camporee_pct: number;
+  /** Origin of the weights: e.g. "club-override", "global-default". */
+  source: string;
+};
+
+/**
+ * Full breakdown DTO returned by
+ * GET /api/v1/member-rankings/:enrollmentId/breakdown?year_id=N
+ *
+ * Extends the base ranking item with sub-score details and weights.
+ */
+export type MemberBreakdown = MemberRankingItem & {
+  /** Backend field name is `club_section` (not `section`). */
+  club_section?: {
+    section_id?: number | null;
+    name?: string | null;
+  } | null;
+  composite_calculated_at?: string | null;
+  class_breakdown: MemberClassBreakdown;
+  investiture_breakdown: MemberInvestitureBreakdown;
+  camporee_breakdown: MemberCamporeeBreakdown;
+  weights: MemberRankingWeights;
 };
 
 export type MemberRankingsQuery = {
@@ -210,6 +268,88 @@ function normalizeEndpointDetail(error: ApiError): string {
 
 // ─── API functions ─────────────────────────────────────────────────────────────
 
+// ─── Breakdown normalizer (Task 18) ────────────────────────────────────────────
+
+function normalizeClassBreakdown(value: unknown): MemberClassBreakdown {
+  const r = asRecord(value);
+  return {
+    completed_sections: pickNumber(r?.completed_sections) ?? 0,
+    required_sections: pickNumber(r?.required_sections) ?? 0,
+    folder_status: pickString(r?.folder_status),
+  };
+}
+
+function normalizeInvestitureBreakdown(value: unknown): MemberInvestitureBreakdown {
+  const r = asRecord(value);
+  return {
+    status: pickString(r?.status),
+  };
+}
+
+function normalizeCamporeeBreakdown(value: unknown): MemberCamporeeBreakdown {
+  const r = asRecord(value);
+  const participated =
+    r && typeof r.participated === "boolean" ? r.participated : false;
+  return {
+    participated,
+    total_camporees: pickNumber(r?.total_camporees),
+  };
+}
+
+function normalizeWeights(value: unknown): MemberRankingWeights {
+  const r = asRecord(value);
+  return {
+    class_pct: pickNumber(r?.class_pct) ?? 0,
+    investiture_pct: pickNumber(r?.investiture_pct) ?? 0,
+    camporee_pct: pickNumber(r?.camporee_pct) ?? 0,
+    source: pickString(r?.source) ?? "global-default",
+  };
+}
+
+function extractBreakdownPayload(payload: unknown): GenericRecord | null {
+  const candidates: string[][] = [
+    ["data", "data"],
+    ["data"],
+    [],
+  ];
+
+  for (const path of candidates) {
+    let current: unknown = payload;
+    for (const key of path) {
+      current = asRecord(current)?.[key];
+    }
+    const r = asRecord(current);
+    // A valid breakdown record must have at least one breakdown sub-object.
+    if (r && (r.class_breakdown !== undefined || r.weights !== undefined || r.weights_applied !== undefined)) {
+      return r;
+    }
+  }
+
+  return null;
+}
+
+function normalizeMemberBreakdown(raw: GenericRecord): MemberBreakdown | null {
+  const base = normalizeMemberRankingItem(raw);
+  if (!base) return null;
+
+  const clubSectionRaw = asRecord(raw.club_section ?? raw.section ?? raw.sections);
+
+  return {
+    ...base,
+    club_section: clubSectionRaw
+      ? {
+          section_id: pickNumber(clubSectionRaw.section_id),
+          name: pickString(clubSectionRaw.name),
+        }
+      : null,
+    composite_calculated_at: pickString(raw.composite_calculated_at),
+    class_breakdown: normalizeClassBreakdown(raw.class_breakdown),
+    investiture_breakdown: normalizeInvestitureBreakdown(raw.investiture_breakdown),
+    camporee_breakdown: normalizeCamporeeBreakdown(raw.camporee_breakdown),
+    weights: normalizeWeights(raw.weights ?? raw.weights_applied),
+  };
+}
+
 /**
  * GET /api/v1/member-rankings
  * Fetches paginated member rankings for a given ecclesiastical year.
@@ -259,4 +399,35 @@ export async function listMemberRankings(
     }
     throw error;
   }
+}
+
+/**
+ * GET /api/v1/member-rankings/:enrollmentId/breakdown?year_id=N
+ *
+ * Returns the full score breakdown for a single member enrollment.
+ * Throws ApiError (re-thrown) so the caller can handle 404 → notFound().
+ *
+ * Field name note: the plan spec uses `weights_applied`; the real backend
+ * DTO uses `weights`. The normalizer accepts both to be forward-safe.
+ */
+export async function getMemberBreakdown(
+  enrollmentId: number,
+  yearId: number,
+): Promise<MemberBreakdown> {
+  const payload = await apiRequest<unknown>(
+    `/member-rankings/${enrollmentId}/breakdown`,
+    { params: { year_id: yearId } },
+  );
+
+  const raw = extractBreakdownPayload(payload);
+  if (!raw) {
+    throw new ApiError("Breakdown payload vacío o inesperado", 404, payload);
+  }
+
+  const normalized = normalizeMemberBreakdown(raw);
+  if (!normalized) {
+    throw new ApiError("No se pudo normalizar el breakdown del miembro", 404, payload);
+  }
+
+  return normalized;
 }

--- a/src/lib/api/member-rankings.ts
+++ b/src/lib/api/member-rankings.ts
@@ -259,10 +259,10 @@ function normalizeEndpointState(
 }
 
 function normalizeEndpointDetail(error: ApiError): string {
-  if (error.status === 401) return "Sesion expirada o token invalido.";
+  if (error.status === 401) return "Sesión expirada o token inválido.";
   if (error.status === 403) return "Tu rol no tiene permisos para ver rankings de miembros.";
   if (error.status === 429) return "Demasiadas solicitudes. Reintenta en unos segundos.";
-  if (error.status >= 500) return "El backend no esta disponible temporalmente.";
+  if (error.status >= 500) return "El backend no está disponible temporalmente.";
   return "Endpoint no disponible en backend.";
 }
 

--- a/src/lib/api/section-rankings.ts
+++ b/src/lib/api/section-rankings.ts
@@ -1,0 +1,373 @@
+import { apiRequest, ApiError } from "@/lib/api/client";
+import type { MemberRankingItem } from "@/lib/api/member-rankings";
+
+/**
+ * Section Rankings API client.
+ * Sister module to member-rankings.ts.
+ *
+ * NOTE: The `awarded_category` field is always null at the section level per
+ * the current backend contract — it is reserved for a future roadmap feature.
+ * The type is included for forward compatibility only.
+ *
+ * Re-exports `MemberRankingItem` via import for the drill-down page so callers
+ * do not need to import from two places.
+ */
+
+// ─── Re-export ─────────────────────────────────────────────────────────────────
+
+export type { MemberRankingItem };
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type AwardedCategoryRef = {
+  scoring_category_id: number | string;
+  name: string;
+  slug?: string;
+};
+
+export type SectionRankingItem = {
+  club_section_id: number;
+  section_name: string;
+  composite_score_pct: number | null;
+  rank_position: number | null;
+  active_enrollment_count: number;
+  awarded_category: AwardedCategoryRef | null;
+  composite_calculated_at: string | null;
+};
+
+export type SectionRankingsQuery = {
+  year_id?: number;
+  club_id?: number;
+  page?: number;
+  limit?: number;
+};
+
+export type SectionRankingsResult = {
+  items: SectionRankingItem[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+  endpointAvailable: boolean;
+  endpointState: "available" | "missing" | "forbidden" | "rate-limited" | "unknown";
+  endpointDetail: string | null;
+};
+
+// ─── Normalizer helpers ────────────────────────────────────────────────────────
+
+type GenericRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): GenericRecord | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as GenericRecord)
+    : null;
+}
+
+function pickString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : null;
+}
+
+function pickNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function pickBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") return value;
+  return null;
+}
+
+function normalizeAwardedCategory(value: unknown): AwardedCategoryRef | null {
+  const r = asRecord(value);
+  if (!r) return null;
+  const name = pickString(r.name);
+  if (!name) return null;
+  return {
+    scoring_category_id:
+      pickNumber(r.scoring_category_id) ??
+      pickString(r.scoring_category_id) ??
+      0,
+    name,
+    slug: pickString(r.slug) ?? undefined,
+  };
+}
+
+// ─── Item normalizer ──────────────────────────────────────────────────────────
+
+function normalizeSectionRankingItem(
+  item: GenericRecord,
+): SectionRankingItem | null {
+  // The backend may return club_section_id or id at top level
+  const sectionId =
+    pickNumber(item.club_section_id) ?? pickNumber(item.id);
+  if (sectionId === null) return null;
+
+  // section_name may come as top-level field or via nested relation
+  const sectionNameTopLevel = pickString(item.section_name);
+  const clubSectionRel = asRecord(item.club_section);
+  const sectionName =
+    sectionNameTopLevel ??
+    pickString(clubSectionRel?.name) ??
+    pickString(item.name) ??
+    "Sin nombre";
+
+  return {
+    club_section_id: sectionId,
+    section_name: sectionName,
+    composite_score_pct: pickNumber(item.composite_score_pct),
+    rank_position: pickNumber(item.rank_position),
+    active_enrollment_count: pickNumber(item.active_enrollment_count) ?? 0,
+    awarded_category: normalizeAwardedCategory(
+      item.awarded_category ?? item.scoring_category,
+    ),
+    composite_calculated_at: pickString(item.composite_calculated_at),
+  };
+}
+
+// ─── Payload extraction ───────────────────────────────────────────────────────
+
+function extractItemArray(payload: unknown): GenericRecord[] {
+  const candidates: string[][] = [
+    ["data", "data"],
+    ["data", "items"],
+    ["data"],
+    ["items"],
+    [],
+  ];
+
+  for (const path of candidates) {
+    let current: unknown = payload;
+    for (const key of path) {
+      current = asRecord(current)?.[key];
+    }
+    if (Array.isArray(current)) {
+      return current.filter((v): v is GenericRecord => Boolean(asRecord(v)));
+    }
+  }
+
+  return [];
+}
+
+function normalizeListMeta(payload: unknown): {
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+} {
+  const candidates: string[][] = [
+    ["data", "meta"],
+    ["meta"],
+    ["data"],
+  ];
+
+  let meta: GenericRecord | null = null;
+  for (const path of candidates) {
+    let current: unknown = payload;
+    for (const key of path) {
+      current = asRecord(current)?.[key];
+    }
+    const r = asRecord(current);
+    if (
+      r &&
+      (pickNumber(r.total) !== null || pickNumber(r.totalPages) !== null)
+    ) {
+      meta = r;
+      break;
+    }
+  }
+
+  const page = pickNumber(meta?.page) ?? 1;
+  const limit = pickNumber(meta?.limit) ?? 20;
+  const total = pickNumber(meta?.total) ?? 0;
+  const totalPages =
+    pickNumber(meta?.totalPages) ??
+    Math.max(1, Math.ceil(total / Math.max(limit, 1)));
+
+  return { total, page, limit, totalPages };
+}
+
+// ─── Error normalizers ────────────────────────────────────────────────────────
+
+function normalizeEndpointState(
+  error: ApiError,
+): SectionRankingsResult["endpointState"] {
+  if (error.status === 401 || error.status === 403) return "forbidden";
+  if (error.status === 429) return "rate-limited";
+  return "missing";
+}
+
+function normalizeEndpointDetail(error: ApiError): string {
+  if (error.status === 401) return "Sesion expirada o token invalido.";
+  if (error.status === 403)
+    return "Tu rol no tiene permisos para ver rankings de secciones.";
+  if (error.status === 429)
+    return "Demasiadas solicitudes. Reintenta en unos segundos.";
+  if (error.status >= 500)
+    return "El backend no esta disponible temporalmente.";
+  return "Endpoint no disponible en backend.";
+}
+
+// ─── Flat-array normalizer (drill-down) ───────────────────────────────────────
+
+/**
+ * Extracts a flat array from the drill-down endpoint response.
+ * Backend returns MemberRankingResponseDto[] — same shape as member-rankings.
+ */
+function extractFlatArray(payload: unknown): GenericRecord[] {
+  // Try outer data wrapper first, then direct array
+  const candidates: string[][] = [["data"], []];
+  for (const path of candidates) {
+    let current: unknown = payload;
+    for (const key of path) {
+      current = asRecord(current)?.[key];
+    }
+    if (Array.isArray(current)) {
+      return current.filter((v): v is GenericRecord => Boolean(asRecord(v)));
+    }
+  }
+  return [];
+}
+
+/**
+ * Normalizes a raw member record from the section members endpoint.
+ * The backend returns MemberRankingResponseDto which mirrors MemberRankingItem.
+ */
+function normalizeMemberItem(item: GenericRecord): MemberRankingItem | null {
+  const id = pickNumber(item.member_ranking_id);
+  const enrollmentId = pickNumber(item.enrollment_id);
+  const yearId = pickNumber(item.ecclesiastical_year_id);
+
+  if (id === null || enrollmentId === null || yearId === null) return null;
+
+  const userRaw = asRecord(item.user ?? item.users);
+  const sectionRaw = asRecord(item.section ?? item.sections);
+  const categoryRaw = asRecord(item.awarded_category ?? item.scoring_category);
+
+  return {
+    member_ranking_id: id,
+    enrollment_id: enrollmentId,
+    ecclesiastical_year_id: yearId,
+    rank_position: pickNumber(item.rank_position),
+    composite_score_pct: pickNumber(item.composite_score_pct),
+    class_score_pct: pickNumber(item.class_score_pct),
+    investiture_score_pct: pickNumber(item.investiture_score_pct),
+    camporee_score_pct: pickNumber(item.camporee_score_pct),
+    awarded_category: categoryRaw
+      ? {
+          scoring_category_id: pickNumber(categoryRaw.scoring_category_id),
+          name: pickString(categoryRaw.name),
+          slug: pickString(categoryRaw.slug),
+        }
+      : null,
+    user: userRaw
+      ? {
+          user_id: pickString(userRaw.user_id),
+          name: pickString(userRaw.name),
+          first_name: pickString(userRaw.first_name),
+          paternal_last_name: pickString(userRaw.paternal_last_name),
+          maternal_last_name: pickString(userRaw.maternal_last_name),
+          email: pickString(userRaw.email),
+        }
+      : null,
+    section: sectionRaw
+      ? {
+          section_id: pickNumber(sectionRaw.section_id),
+          name: pickString(sectionRaw.name),
+        }
+      : null,
+  };
+}
+
+// ─── API functions ─────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/v1/section-rankings
+ *
+ * Returns a paginated list of section rankings.
+ * Filtered by year_id (required in practice) and optionally by club_id.
+ * Falls back gracefully if the endpoint is unavailable.
+ */
+export async function listSectionRankings(
+  query: SectionRankingsQuery,
+): Promise<SectionRankingsResult> {
+  const params: Record<string, string | number | boolean | undefined> = {};
+
+  if (query.year_id !== undefined && Number.isFinite(query.year_id) && query.year_id > 0) {
+    params.year_id = query.year_id;
+  }
+  if (query.club_id !== undefined && Number.isFinite(query.club_id) && query.club_id > 0) {
+    params.club_id = query.club_id;
+  }
+  if (query.page !== undefined && Number.isFinite(query.page) && query.page > 0) {
+    params.page = query.page;
+  }
+  if (query.limit !== undefined && Number.isFinite(query.limit) && query.limit > 0) {
+    params.limit = query.limit;
+  }
+
+  try {
+    const payload = await apiRequest<unknown>("/section-rankings", { params });
+    const raw = extractItemArray(payload);
+    const items = raw
+      .map((item) => normalizeSectionRankingItem(item))
+      .filter((item): item is SectionRankingItem => Boolean(item));
+
+    const metaRaw = normalizeListMeta(payload);
+
+    return {
+      items,
+      ...metaRaw,
+      endpointAvailable: true,
+      endpointState: "available",
+      endpointDetail: `Disponible (${metaRaw.total} rankings).`,
+    };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      return {
+        items: [],
+        total: 0,
+        page: 1,
+        limit: 20,
+        totalPages: 1,
+        endpointAvailable: false,
+        endpointState: normalizeEndpointState(error),
+        endpointDetail: normalizeEndpointDetail(error),
+      };
+    }
+    throw error;
+  }
+}
+
+/**
+ * GET /api/v1/section-rankings/:sectionId/members?year_id=N
+ *
+ * Returns a flat (non-paginated) array of MemberRankingItem for all
+ * members in the given section for the given year.
+ *
+ * Throws ApiError so the caller can map 404/403 → notFound().
+ */
+export async function getSectionMembers(
+  sectionId: number,
+  yearId: number,
+): Promise<MemberRankingItem[]> {
+  const payload = await apiRequest<unknown>(
+    `/section-rankings/${sectionId}/members`,
+    { params: { year_id: yearId } },
+  );
+
+  const raw = extractFlatArray(payload);
+  return raw
+    .map((item) => normalizeMemberItem(item))
+    .filter((item): item is MemberRankingItem => Boolean(item));
+}
+
+// ─── Unused import guard ───────────────────────────────────────────────────────
+// pickBoolean is defined for forward-safe resilience (e.g., participated field
+// if the drill-down contract evolves). Suppress unused-vars warning:
+void (pickBoolean as unknown);

--- a/src/lib/api/section-rankings.ts
+++ b/src/lib/api/section-rankings.ts
@@ -78,10 +78,6 @@ function pickNumber(value: unknown): number | null {
   return null;
 }
 
-function pickBoolean(value: unknown): boolean | null {
-  if (typeof value === "boolean") return value;
-  return null;
-}
 
 function normalizeAwardedCategory(value: unknown): AwardedCategoryRef | null {
   const r = asRecord(value);
@@ -203,13 +199,13 @@ function normalizeEndpointState(
 }
 
 function normalizeEndpointDetail(error: ApiError): string {
-  if (error.status === 401) return "Sesion expirada o token invalido.";
+  if (error.status === 401) return "Sesión expirada o token inválido.";
   if (error.status === 403)
     return "Tu rol no tiene permisos para ver rankings de secciones.";
   if (error.status === 429)
     return "Demasiadas solicitudes. Reintenta en unos segundos.";
   if (error.status >= 500)
-    return "El backend no esta disponible temporalmente.";
+    return "El backend no está disponible temporalmente.";
   return "Endpoint no disponible en backend.";
 }
 
@@ -367,7 +363,3 @@ export async function getSectionMembers(
     .filter((item): item is MemberRankingItem => Boolean(item));
 }
 
-// ─── Unused import guard ───────────────────────────────────────────────────────
-// pickBoolean is defined for forward-safe resilience (e.g., participated field
-// if the drill-down contract evolves). Suppress unused-vars warning:
-void (pickBoolean as unknown);


### PR DESCRIPTION
## Summary

Plan 8.4-A admin Phase 5 — 5 new/extended dashboard pages consuming backend rankings APIs.

**Tasks 17-21 shipped.**

## Pages

### `/dashboard/member-rankings` (Task 17)
- SSR list + 3-input filter form + 9-column table
- Score badge cutoffs ≥85/≥65/<65 → success/warning/destructive
- DataTablePagination shared component
- 743 LOC

### `/dashboard/member-rankings/[enrollmentId]/breakdown` (Task 18)
- Drill-down per-signal breakdown card
- Progress bars + composite + member info + weights applied
- 450 LOC

### `/dashboard/section-rankings` + `/[sectionId]/members` (Task 19)
- Section list + drill-down members page
- 6 files +1037 LOC

### `/dashboard/member-ranking-weights` (Task 20)
- Default global Card readonly + overrides Table
- CRUD Dialog + AlertDialog delete with destructive variant
- IEEE tolerance `Math.abs(sum-100) <= 0.01` matching backend
- Both club_type + ecclesiastical_year catalog Selects (D4 upgrade)
- 6 files +1199 LOC

### `/dashboard/annual-folders/categories` extended (Task 21)
- Nested Tabs: outer scope (Club | Sección | Miembro), inner active/legacy
- Form scope Select required, mutable in edit
- API client extended with `?scope=` param + `scope` field on type
- `useRef` first-render guard prevents double-fetch SSR+client
- a11y `htmlFor` ↔ `id` association on Select triggers
- 4 files +292/-175 LOC

## Stack

- Next.js 16.2.4 + React 19 + shadcn/ui (new-york)
- Tailwind v4
- next-intl 4.9.1 (hybrid migration ongoing)
- Axios + apiRequest wrapper
- React Hook Form + Zod
- DataTablePagination shared client component

## Anti-toxicity techniques (admin parallel to mobile)

- Score badge tier colors via `achievementTierColor()` helper
- "Categorías de premio" framing not "Awards"
- Empty states per (scope × active) combo
- shadcn primitives only — NO custom Modal, lucide-react icons mandatory
- Dark mode semantic tokens only (NO hardcoded Tailwind colors)

## Consistency pass (Plan 8.4-A nits A+B)

- 38 Spanish accent fixes across 13 files (Sesion→Sesión, Configuracion→Configuración, Campana→Campaña [campaign not bell], invalido→inválido, etc)
- pickBoolean lint workaround removed in section-rankings.ts API client
- SubmitHandler<FormValues> typing already correct (Tasks 20+21 inline review fixes)

## Test plan

- [x] tsc --noEmit clean
- [x] pnpm build success — all 5 routes appear (`ƒ /dashboard/member-rankings` dynamic SSR, etc)
- [x] Combined reviews per task — N CRITICAL + N IMPORTANT applied inline via Sonnet sub-agents
- [x] Design System compliance verified (shadcn/ui only, semantic tokens, lucide-react)
- [ ] Manual smoke against dev backend post-merge
- [ ] Verify scope tabs filter correctly by hitting backend `?scope=` param

## Companion PRs

- sacdia (root) — orchestration + canon docs
- sacdia-backend — REST APIs (5 endpoints CRUD + 4 list endpoints + scope extension)
- sacdia-app — Flutter consumer