### PR TITLE
fix(member-ranking-weights): use apiRequestFromClient for browser mutations

### DIFF
--- a/src/lib/api/member-ranking-weights.ts
+++ b/src/lib/api/member-ranking-weights.ts
@@ -1,4 +1,4 @@
-import { apiRequest, ApiError } from "@/lib/api/client";
+import { apiRequest, apiRequestFromClient, ApiError } from "@/lib/api/client";
 
 /**
  * Member Ranking Weights API client.
@@ -321,7 +321,7 @@ export async function getMemberRankingWeights(
 export async function createMemberRankingWeights(
   dto: CreateEnrollmentRankingWeightDto,
 ): Promise<EnrollmentRankingWeight> {
-  const payload = await apiRequest<unknown>("/member-ranking-weights", {
+  const payload = await apiRequestFromClient<unknown>("/member-ranking-weights", {
     method: "POST",
     body: dto,
   });
@@ -349,7 +349,7 @@ export async function updateMemberRankingWeights(
   id: string,
   dto: UpdateEnrollmentRankingWeightDto,
 ): Promise<EnrollmentRankingWeight> {
-  const payload = await apiRequest<unknown>(`/member-ranking-weights/${id}`, {
+  const payload = await apiRequestFromClient<unknown>(`/member-ranking-weights/${id}`, {
     method: "PATCH",
     body: dto,
   });
@@ -374,7 +374,7 @@ export async function updateMemberRankingWeights(
  * Throws ApiError — caller maps via mapWeightsErrorMessage().
  */
 export async function deleteMemberRankingWeights(id: string): Promise<void> {
-  await apiRequest<unknown>(`/member-ranking-weights/${id}`, {
+  await apiRequestFromClient<unknown>(`/member-ranking-weights/${id}`, {
     method: "DELETE",
   });
 }


### PR DESCRIPTION
## Summary

- Three mutations (`create`, `update`, `delete` member-ranking-weights) called `apiRequest` (server-only path) from `"use client"` components.
- **Severity reassessed P0 → P3 during fix**: `client.ts:227-229` already auto-delegates to `apiRequestFromClient` when `typeof window !== "undefined"`. The runtime was self-healing — the bug was semantic, not functional.
- Fix is still correct as explicit semantic usage (avoids drift if the runtime guard is ever removed).

## Same pattern elsewhere (cleanup candidates, NOT in this PR)

- `src/lib/api/honors.ts:232, 239, 246, 252, 271`
- `src/lib/api/analytics.ts:109`

Both runtime-OK due to the same guard.

## Test plan

- [ ] Login as `super_admin` → `/dashboard/member-ranking-weights` → CRUD operations succeed
- [ ] Network tab confirms `Authorization: Bearer …` header on POST/PATCH/DELETE
- [ ] Default weights row shows `DEFAULT_WEIGHTS_NOT_DELETABLE` toast on delete attempt

Closes #10