### PR TITLE
feat(award-categories): add tier enum field to admin form and table

### DIFF
--- a/src/components/annual-folders/award-categories-client-page.tsx
+++ b/src/components/annual-folders/award-categories-client-page.tsx
@@ -31,7 +31,7 @@ import {
   deleteAwardCategory,
 } from "@/lib/api/annual-folders";
 import { ApiError } from "@/lib/api/client";
-import type { AwardCategory, AwardCategoryScope } from "@/lib/api/annual-folders";
+import type { AwardCategory, AwardCategoryScope, AwardTier } from "@/lib/api/annual-folders";
 import type { ClubType } from "@/lib/api/catalogs";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -73,6 +73,23 @@ function formatPct(value: number | null): string {
   if (value === null) return "—";
   return `${value}%`;
 }
+
+// ── 8.4-C Phase C: tier display ────────────────────────────────────────────
+const TIER_LABELS: Record<AwardTier, string> = {
+  BRONZE: "Bronce",
+  SILVER: "Plata",
+  GOLD: "Oro",
+  DIAMOND: "Diamante",
+};
+
+type BadgeVariant = "default" | "secondary" | "success" | "destructive" | "warning" | "outline";
+
+const TIER_BADGE_VARIANT: Record<AwardTier, BadgeVariant> = {
+  BRONZE: "secondary",
+  SILVER: "outline",
+  GOLD: "warning",
+  DIAMOND: "default",
+};
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
@@ -296,6 +313,10 @@ export function AwardCategoriesClientPage({
                         <TableHead className="hidden w-24 text-center lg:table-cell">
                           % Max
                         </TableHead>
+                        {/* 8.4-C Phase C tier column */}
+                        <TableHead className="hidden w-28 text-center xl:table-cell">
+                          Nivel
+                        </TableHead>
                         <TableHead className="w-20 text-center">Estado</TableHead>
                         <TableHead className="w-20 text-right">Acciones</TableHead>
                       </TableRow>
@@ -349,6 +370,19 @@ export function AwardCategoriesClientPage({
                           </TableCell>
                           <TableCell className="hidden text-center text-sm text-muted-foreground lg:table-cell">
                             {formatPct(cat.max_composite_pct)}
+                          </TableCell>
+                          {/* 8.4-C Phase C tier cell */}
+                          <TableCell className="hidden text-center xl:table-cell">
+                            {cat.tier !== null ? (
+                              <Badge
+                                variant={TIER_BADGE_VARIANT[cat.tier]}
+                                className="text-xs"
+                              >
+                                {TIER_LABELS[cat.tier]}
+                              </Badge>
+                            ) : (
+                              <span className="text-sm text-muted-foreground/60">—</span>
+                            )}
                           </TableCell>
                           <TableCell className="text-center">
                             <Badge

--- a/src/components/annual-folders/award-category-form-dialog.tsx
+++ b/src/components/annual-folders/award-category-form-dialog.tsx
@@ -29,7 +29,7 @@ import {
   createAwardCategory,
   updateAwardCategory,
 } from "@/lib/api/annual-folders";
-import type { AwardCategory, AwardCategoryScope } from "@/lib/api/annual-folders";
+import type { AwardCategory, AwardCategoryScope, AwardTier } from "@/lib/api/annual-folders";
 import type { ClubType } from "@/lib/api/catalogs";
 
 // ─── Schema ───────────────────────────────────────────────────────────────────
@@ -72,6 +72,8 @@ const formSchema = z
       .max(100, "No puede superar 100")
       .optional()
       .nullable(),
+    // ── 8.4-C Phase C — visual tier ──────────────────────────────────────────
+    tier: z.enum(["BRONZE", "SILVER", "GOLD", "DIAMOND"] as const).nullable().optional(),
   })
   .superRefine((data, ctx) => {
     const min = data.min_composite_pct;
@@ -133,11 +135,13 @@ export function AwardCategoryFormDialog({
       order: 0,
       min_composite_pct: null,
       max_composite_pct: null,
+      tier: null,
     },
   });
 
   const clubTypeValue = watch("club_type_id");
   const scopeValue = watch("scope");
+  const tierValue = watch("tier");
 
   useEffect(() => {
     if (open) {
@@ -156,6 +160,7 @@ export function AwardCategoryFormDialog({
           order: category.order,
           min_composite_pct: category.min_composite_pct ?? null,
           max_composite_pct: category.max_composite_pct ?? null,
+          tier: category.tier ?? null,
         });
       } else {
         reset({
@@ -169,6 +174,7 @@ export function AwardCategoryFormDialog({
           order: 0,
           min_composite_pct: null,
           max_composite_pct: null,
+          tier: null,
         });
       }
     }
@@ -200,6 +206,7 @@ export function AwardCategoryFormDialog({
           values.max_composite_pct !== undefined
             ? values.max_composite_pct
             : null,
+        tier: values.tier ?? null,
       };
 
       if (isEdit && category) {
@@ -280,6 +287,31 @@ export function AwardCategoryFormDialog({
             </Select>
             {errors.scope && (
               <p className="text-xs text-destructive">{errors.scope.message}</p>
+            )}
+          </div>
+
+          {/* Tier visual */}
+          <div className="space-y-1.5">
+            <Label htmlFor="cat-tier">Nivel visual</Label>
+            <Select
+              value={tierValue ?? "none"}
+              onValueChange={(val) =>
+                setValue("tier", val === "none" ? null : (val as AwardTier))
+              }
+            >
+              <SelectTrigger id="cat-tier">
+                <SelectValue placeholder="Sin clasificación" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="none">Sin clasificación</SelectItem>
+                <SelectItem value="BRONZE">Bronce</SelectItem>
+                <SelectItem value="SILVER">Plata</SelectItem>
+                <SelectItem value="GOLD">Oro</SelectItem>
+                <SelectItem value="DIAMOND">Diamante</SelectItem>
+              </SelectContent>
+            </Select>
+            {errors.tier && (
+              <p className="text-xs text-destructive">{errors.tier.message}</p>
             )}
           </div>
 

--- a/src/lib/api/annual-folders.ts
+++ b/src/lib/api/annual-folders.ts
@@ -382,6 +382,9 @@ export async function getFolderEvaluations(
 
 export type AwardCategoryScope = 'club' | 'section' | 'member';
 
+/** Visual tier assigned to an award category — maps to Prisma AwardTier enum (nullable). */
+export type AwardTier = 'BRONZE' | 'SILVER' | 'GOLD' | 'DIAMOND';
+
 export type AwardCategory = {
   award_category_id: string;
   name: string;
@@ -398,6 +401,8 @@ export type AwardCategory = {
   min_composite_pct: number | null;
   max_composite_pct: number | null;
   is_legacy: boolean;
+  // ── 8.4-C Phase C — visual tier ──────────────────────────────────────────
+  tier: AwardTier | null;
 };
 
 export type ClubRanking = {


### PR DESCRIPTION
## Summary

Plan 8.4-A Category D Phase C — admin UI for the new \`AwardTier\` enum. Backend Phase A+B already merged (sacdia-backend#38) + dev Neon migration applied.

## Changes

- **\`src/lib/api/annual-folders.ts\`**: New \`AwardTier\` union (\`BRONZE | SILVER | GOLD | DIAMOND\`) + \`AwardCategory.tier: AwardTier | null\`. \`Create\`/\`Update\` payloads inherit via existing derivations.
- **\`award-category-form-dialog.tsx\`**: Zod schema adds nullable optional \`tier\` enum. New "Nivel visual" \`<Select>\` with sentinel \`"none"\` option labeled "Sin clasificación" (maps to \`null\` on submit). Reset paths handle null gracefully.
- **\`award-categories-client-page.tsx\`**: New "Nivel" table column (hidden below \`xl:\`) with color-coded \`<Badge>\` per tier — \`BRONZE → secondary\`, \`SILVER → outline\`, \`GOLD → warning\`, \`DIAMOND → default\`. Null renders em dash in \`text-muted-foreground/60\`.

## UI decisions

- Spanish vocabulary throughout: form label "Nivel visual"; table header "Nivel"; values labeled "Bronce / Plata / Oro / Diamante".
- "Clear tier" pattern: \`SelectItem value="none"\` ↔ \`null\` in the form state via \`onValueChange\`.
- Table column hidden below \`xl\` (1280px) to avoid crowding the 9-column layout.

## Verification

- \`tsc --noEmit\`: exit 0, zero errors
- \`eslint\` on changed files: zero errors, zero warnings
- 4 pre-existing lint errors in unrelated files (\`sidebar.tsx\`, \`honors requirements page\`) — out of scope

## Test plan

- [ ] CI lint + type-check pass
- [ ] Manual: open \`/dashboard/annual-folders/categories\`, create category with tier "Oro" → verify Badge shows in table
- [ ] Manual: edit existing category, set tier to "Plata" then back to "Sin clasificación" → verify null persists and em dash shows
- [ ] Visual QA on \`xl\` and below breakpoints (1280px is the divider)

## References

- Backend PR: sacdia-backend#38 (merged)
- Survey: engram \`sacdia-backend/category-d/tier-enum-survey\`
- Migration applied to dev Neon: engram \`sacdia-backend/category-d/tier-enum-migration-dev\`

## Out of scope

- Mobile Phase D (sacdia-app PR — in flight separately)
- Staging/prod Neon migration (pending pause + confirm)