### PR TITLE
feat(admin): i18n E7 sweep — fr/pt-BR locale parity for weights/rankings

### DIFF
--- a/messages/fr.json
+++ b/messages/fr.json
@@ -815,5 +815,72 @@
     "label_name": "Nom",
     "label_description": "Description",
     "helper_optional": "Optionnel. Si laissé vide, l'espagnol sera affiché."
+  },
+  "memberRankingWeights": {
+    "formDialog": {
+      "clasePercent": "Classe (%)",
+      "investiduraPercent": "Investiture (%)",
+      "campanaPercent": "Campagne (%)",
+      "allTypes": "Tous les types",
+      "anoEclesiastico": "Année ecclésiastique",
+      "allYears": "Toutes les années"
+    },
+    "table": {
+      "fallbackClubType": "Type {id}",
+      "fallbackYear": "Année {id}",
+      "defaultCardTitle": "Configuration par défaut",
+      "defaultBadge": "Global",
+      "editDefaultTitle": "Modifier la configuration par défaut",
+      "editButton": "Modifier",
+      "labelClase": "Classe",
+      "labelInvestidura": "Investiture",
+      "labelCampana": "Campagne",
+      "overridesHeading": "Remplacements par type de club / année",
+      "createOverride": "Créer un remplacement",
+      "emptyTitle": "Aucun remplacement",
+      "emptyDescription": "La configuration par défaut s'applique à tous les clubs et années.",
+      "colClubType": "Type de club",
+      "colAnoEclesiastico": "Année ecclésiastique",
+      "colClase": "Classe",
+      "colInvestidura": "Investiture",
+      "colCampana": "Campagne",
+      "colSuma": "Somme",
+      "colAcciones": "Actions",
+      "editOverrideTitle": "Modifier le remplacement",
+      "deleteOverrideTitle": "Supprimer le remplacement",
+      "deleteButton": "Supprimer"
+    }
+  },
+  "rankingWeights": {
+    "clientPage": {
+      "defaultGlobalTitle": "Défaut global",
+      "defaultGlobalDescription": "Poids appliqués à tous les types de clubs sans remplacement configuré. La somme doit être exactement 100.",
+      "defaultGlobalUpdated": "Défaut global mis à jour",
+      "defaultGlobalUpdateError": "Erreur lors de la mise à jour du défaut",
+      "defaultGlobalNotFound": "Défaut global introuvable. Contactez l'administrateur système.",
+      "overridesTitle": "Remplacements par type de club",
+      "overridesDescription": "Poids spécifiques qui remplacent le défaut pour un type de club donné.",
+      "addOverride": "Ajouter un remplacement",
+      "newOverrideTitle": "Nouveau remplacement",
+      "overridesEmpty": "Aucun remplacement configuré. Tous les types de clubs utilisent le défaut global.",
+      "colClubType": "Type de club",
+      "colFolder": "Dossier",
+      "colFinance": "Finance",
+      "colCamporee": "Camporée",
+      "colEvidence": "Preuve",
+      "colSuma": "Somme",
+      "colAcciones": "Actions",
+      "editButton": "Modifier",
+      "editOverrideTitle": "Modifier le remplacement",
+      "overrideUpdated": "Remplacement mis à jour",
+      "overrideUpdateError": "Erreur lors de la mise à jour du remplacement",
+      "deleteButton": "Supprimer",
+      "deleteOverrideTitle": "Supprimer le remplacement ?",
+      "deleteOverrideDescription": "Cette action est irréversible. Le type de club reviendra aux poids du défaut global.",
+      "cancelButton": "Annuler",
+      "deletingLabel": "Suppression...",
+      "overrideDeleted": "Remplacement supprimé",
+      "overrideDeleteError": "Erreur lors de la suppression du remplacement"
+    }
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -815,5 +815,72 @@
     "label_name": "Nome",
     "label_description": "Descrição",
     "helper_optional": "Opcional. Se deixado vazio, o espanhol será exibido."
+  },
+  "memberRankingWeights": {
+    "formDialog": {
+      "clasePercent": "Classe (%)",
+      "investiduraPercent": "Investidura (%)",
+      "campanaPercent": "Campanha (%)",
+      "allTypes": "Todos os tipos",
+      "anoEclesiastico": "Ano eclesiástico",
+      "allYears": "Todos os anos"
+    },
+    "table": {
+      "fallbackClubType": "Tipo {id}",
+      "fallbackYear": "Ano {id}",
+      "defaultCardTitle": "Configuração padrão",
+      "defaultBadge": "Global",
+      "editDefaultTitle": "Editar configuração padrão",
+      "editButton": "Editar",
+      "labelClase": "Classe",
+      "labelInvestidura": "Investidura",
+      "labelCampana": "Campanha",
+      "overridesHeading": "Substituições por tipo de clube / ano",
+      "createOverride": "Criar substituição",
+      "emptyTitle": "Sem substituições",
+      "emptyDescription": "A configuração padrão aplica-se a todos os clubes e anos.",
+      "colClubType": "Tipo de clube",
+      "colAnoEclesiastico": "Ano eclesiástico",
+      "colClase": "Classe",
+      "colInvestidura": "Investidura",
+      "colCampana": "Campanha",
+      "colSuma": "Soma",
+      "colAcciones": "Ações",
+      "editOverrideTitle": "Editar substituição",
+      "deleteOverrideTitle": "Excluir substituição",
+      "deleteButton": "Excluir"
+    }
+  },
+  "rankingWeights": {
+    "clientPage": {
+      "defaultGlobalTitle": "Padrão global",
+      "defaultGlobalDescription": "Pesos aplicados a todos os tipos de clube sem substituição configurada. A soma deve ser exatamente 100.",
+      "defaultGlobalUpdated": "Padrão global atualizado",
+      "defaultGlobalUpdateError": "Erro ao atualizar o padrão",
+      "defaultGlobalNotFound": "Padrão global não encontrado. Contate o administrador do sistema.",
+      "overridesTitle": "Substituições por tipo de clube",
+      "overridesDescription": "Pesos específicos que substituem o padrão para um determinado tipo de clube.",
+      "addOverride": "Adicionar substituição",
+      "newOverrideTitle": "Nova substituição",
+      "overridesEmpty": "Nenhuma substituição configurada. Todos os tipos de clube usam o padrão global.",
+      "colClubType": "Tipo de clube",
+      "colFolder": "Pasta",
+      "colFinance": "Finanças",
+      "colCamporee": "Camporee",
+      "colEvidence": "Evidência",
+      "colSuma": "Soma",
+      "colAcciones": "Ações",
+      "editButton": "Editar",
+      "editOverrideTitle": "Editar substituição",
+      "overrideUpdated": "Substituição atualizada",
+      "overrideUpdateError": "Erro ao atualizar a substituição",
+      "deleteButton": "Excluir",
+      "deleteOverrideTitle": "Excluir substituição?",
+      "deleteOverrideDescription": "Esta ação não pode ser desfeita. O tipo de clube voltará a usar os pesos do padrão global.",
+      "cancelButton": "Cancelar",
+      "deletingLabel": "Excluindo...",
+      "overrideDeleted": "Substituição excluída",
+      "overrideDeleteError": "Erro ao excluir a substituição"
+    }
   }
 }


### PR DESCRIPTION
## Summary

- The component migration for `weights-table.tsx` and `ranking-weights-client-page.tsx` was completed in PR #18 (commit `17912f5`), but `fr.json` and `pt-BR.json` were missing both new namespaces (`memberRankingWeights` + `rankingWeights`).
- This PR closes the parity gap: adds 57 keys to each of the two locales. All 4 locales (`es`, `en`, `fr`, `pt-BR`) now have 0 missing keys.
- No component or logic changes — pure locale additions.

## Keys added

- `memberRankingWeights.formDialog.*` (6 keys) — form labels reused from weights-form-dialog
- `memberRankingWeights.table.*` (23 keys) — table headers, badges, empty state, fallbacks
- `rankingWeights.clientPage.*` (28 keys) — page titles, toast messages, dialog labels

**Total: 57 keys × 2 locales = 114 new strings**

## Test plan

- [ ] Switch locale to Français → weights page renders without missing-key warnings in console
- [ ] Switch locale to Português (Brasil) → same check
- [ ] TypeScript check: `pnpm exec tsc --noEmit` passes
- [ ] No regressions in `es` / `en` locales (keys unchanged)