### PR TITLE
fix(auth): critical security fixes — middleware, ?next= flow, Sentry DSN, folder mutations

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://0d9b2caae6c202b23b34dbebb49c8aaf@o4510840511528960.ingest.us.sentry.io/4510840513036288",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || "https://0d9b2caae6c202b23b34dbebb49c8aaf@o4510840511528960.ingest.us.sentry.io/4510840513036288",
   environment: process.env.NODE_ENV,
   release:
     process.env.VERCEL_GIT_COMMIT_SHA ||

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://0d9b2caae6c202b23b34dbebb49c8aaf@o4510840511528960.ingest.us.sentry.io/4510840513036288",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || "https://0d9b2caae6c202b23b34dbebb49c8aaf@o4510840511528960.ingest.us.sentry.io/4510840513036288",
   environment: process.env.NODE_ENV,
   release:
     process.env.VERCEL_GIT_COMMIT_SHA ||

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useActionState, useState } from "react";
 import { useFormStatus } from "react-dom";
+import { useSearchParams } from "next/navigation";
 import Image from "next/image";
 import { Loader2, Eye, EyeOff, AlertCircle } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -40,6 +41,8 @@ export default function LoginPage() {
   const t = useTranslations("auth.login");
   const [state, formAction] = useActionState(loginAction, initialState);
   const [showPassword, setShowPassword] = useState(false);
+  const searchParams = useSearchParams();
+  const nextParam = searchParams.get("next") ?? "";
 
   return (
     <div className="relative min-h-svh overflow-hidden bg-background flex items-center justify-center p-4">
@@ -108,6 +111,7 @@ export default function LoginPage() {
 
           {/* Form */}
           <form action={formAction} className="space-y-4">
+            <input type="hidden" name="next" value={nextParam} />
             {/* Error message */}
             {state.error && (
               <div className="flex items-start gap-2.5 rounded-lg border border-destructive/20 bg-destructive/5 px-3.5 py-3 text-sm text-destructive dark:border-destructive/30 dark:bg-destructive/10">

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 Sentry.init({
-  dsn: "https://0d9b2caae6c202b23b34dbebb49c8aaf@o4510840511528960.ingest.us.sentry.io/4510840513036288",
+  dsn: process.env.NEXT_PUBLIC_SENTRY_DSN || "https://0d9b2caae6c202b23b34dbebb49c8aaf@o4510840511528960.ingest.us.sentry.io/4510840513036288",
   environment: process.env.NODE_ENV,
   release:
     process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ||

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -209,7 +209,8 @@ function ensureClientInterceptors() {
         (normalized.status === 401 || normalized.status === 403) &&
         !window.location.pathname.startsWith("/login")
       ) {
-        window.location.assign("/login");
+        const next = window.location.pathname + window.location.search;
+        window.location.assign(`/login?next=${encodeURIComponent(next)}`);
       }
 
       return Promise.reject(normalized);

--- a/src/lib/api/folders.ts
+++ b/src/lib/api/folders.ts
@@ -106,41 +106,33 @@ export async function fetchFolder(id: string): Promise<FolderTemplate> {
 /**
  * POST /api/v1/folders/folders
  * Creates a new folder template.
- * TODO: Backend endpoint not yet implemented — FoldersController only exposes GET routes.
+ * FIXME: Backend endpoint not yet implemented — guarded with throw to prevent silent failures.
  */
 export async function createFolder(
-  data: CreateFolderPayload,
+  _data: CreateFolderPayload,
 ): Promise<FolderTemplate> {
-  return apiRequestFromClient<FolderTemplate>("/folders/folders", {
-    method: "POST",
-    body: data,
-  });
+  throw new Error("Not implemented: backend endpoint pending. See FoldersController.");
 }
 
 /**
  * PATCH /api/v1/folders/folders/:id
  * Updates a folder template.
- * TODO: Backend endpoint not yet implemented — FoldersController only exposes GET routes.
+ * FIXME: Backend endpoint not yet implemented — guarded with throw to prevent silent failures.
  */
 export async function updateFolder(
-  id: string,
-  data: UpdateFolderPayload,
+  _id: string,
+  _data: UpdateFolderPayload,
 ): Promise<FolderTemplate> {
-  return apiRequestFromClient<FolderTemplate>(`/folders/folders/${id}`, {
-    method: "PATCH",
-    body: data,
-  });
+  throw new Error("Not implemented: backend endpoint pending. See FoldersController.");
 }
 
 /**
  * DELETE /api/v1/folders/folders/:id
  * Deletes a folder template.
- * TODO: Backend endpoint not yet implemented — FoldersController only exposes GET routes.
+ * FIXME: Backend endpoint not yet implemented — guarded with throw to prevent silent failures.
  */
-export async function deleteFolder(id: string): Promise<void> {
-  await apiRequestFromClient<unknown>(`/folders/folders/${id}`, {
-    method: "DELETE",
-  });
+export async function deleteFolder(_id: string): Promise<void> {
+  throw new Error("Not implemented: backend endpoint pending. See FoldersController.");
 }
 
 /**

--- a/src/lib/auth/actions.ts
+++ b/src/lib/auth/actions.ts
@@ -251,7 +251,16 @@ export async function loginAction(_: AuthActionState, formData: FormData): Promi
     cookieStore.set(REFRESH_TOKEN_COOKIE, refreshToken, COOKIE_OPTIONS);
   }
 
-  redirect("/dashboard");
+  const rawNext = formData.get("next");
+  const nextPath = typeof rawNext === "string" ? sanitizeNextPath(rawNext) : null;
+  redirect(nextPath ?? "/dashboard");
+}
+
+function sanitizeNextPath(value: string): string | null {
+  if (!value.startsWith("/")) return null;
+  if (value.startsWith("//") || value.startsWith("/\\")) return null;
+  if (!value.startsWith("/dashboard")) return null;
+  return value;
 }
 
 export async function logoutAction() {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { ACCESS_TOKEN_COOKIE } from "@/lib/auth/cookies";
 
-export function proxy(request: NextRequest) {
+export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const token = request.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
 
@@ -10,6 +10,8 @@ export function proxy(request: NextRequest) {
 
   if (pathname.startsWith("/dashboard") && !token) {
     const loginUrl = new URL("/login", request.url);
+    const next = pathname + request.nextUrl.search;
+    loginUrl.searchParams.set("next", next);
     return NextResponse.redirect(loginUrl);
   }
 


### PR DESCRIPTION
## Summary

Bucket 1 of multi-bucket tech debt cleanup from full audit (lógica + UX + design system) on 2026-05-06. Resolves 4 CRITICAL findings on auth and security boundaries.

- **Activated route protection middleware**: `src/proxy.ts` was named like a Next.js middleware but Next ignores that filename. Renamed to `src/middleware.ts`. Routes `/dashboard/*` were not gated at the Edge layer — only via per-call `requireAdminUser()`.
- **Preserved target path through login**: middleware, axios 401/403 interceptor, login page, and `loginAction` now round-trip a `?next=` param. `loginAction` validates the path is internal (`/dashboard` prefix only) before honoring it — open-redirect guard.
- **Sentry DSN now overridable**: `NEXT_PUBLIC_SENTRY_DSN` env var with the existing literal as fallback. Zero deploy impact.
- **`folders.ts` mutations throw explicitly**: backend `FoldersController` only exposes GET. Previous `apiRequestFromClient` calls would surface confusing 404/405 to users on `folder-form-dialog.tsx` / `folder-delete-dialog.tsx`. Now fail loudly with a message naming the missing backend dependency.

Closes audit findings C-1, C-2, C-3, C-4.

## Test plan

- [ ] `pnpm dev`, navigate to `/dashboard/clubs` while logged out → confirm redirect to `/login?next=%2Fdashboard%2Fclubs`.
- [ ] Submit valid login → land on `/dashboard/clubs` (not `/dashboard`).
- [ ] Manually craft `/login?next=https://evil.com/x` → after login, lands on `/dashboard` (open redirect rejected).
- [ ] Manually craft `/login?next=//evil.com/x` → after login, lands on `/dashboard`.
- [ ] Trigger axios 401 (e.g. expire token) on a `/dashboard/honors` page → URL becomes `/login?next=%2Fdashboard%2Fhonors%3F...`.
- [ ] Open `folder-form-dialog`, attempt save → see "Not implemented: backend endpoint pending" error toast (no silent failure).
- [ ] `pnpm lint` → 4 pre-existing errors only (no new errors introduced).
- [ ] Sentry events still arrive in dashboard for both env-set and env-unset deploys.