### PR TITLE
fix(theme): mount ThemeProvider and fix Instrument Serif token

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,7 +9,7 @@
 
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
-  --font-display: var(--font-geist-sans);
+  --font-display: var(--font-instrument-serif);
 
   --color-sidebar: var(--sidebar);
   --color-sidebar-foreground: var(--sidebar-foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { getLocale, getMessages } from "next-intl/server";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppAlertListener } from "@/components/shared/app-alert-listener";
+import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -47,15 +48,22 @@ export default async function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable} font-sans antialiased`}
       >
-        <NextIntlClientProvider locale={locale} messages={messages}>
-          <TooltipProvider delayDuration={300}>
-            {children}
-            <Suspense fallback={null}>
-              <AppAlertListener />
-            </Suspense>
-          </TooltipProvider>
-          <Toaster position="top-center" richColors closeButton />
-        </NextIntlClientProvider>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          enableSystem={false}
+          disableTransitionOnChange
+        >
+          <NextIntlClientProvider locale={locale} messages={messages}>
+            <TooltipProvider delayDuration={300}>
+              {children}
+              <Suspense fallback={null}>
+                <AppAlertListener />
+              </Suspense>
+            </TooltipProvider>
+            <Toaster position="top-center" richColors closeButton />
+          </NextIntlClientProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/shared/page-header.tsx
+++ b/src/components/shared/page-header.tsx
@@ -58,7 +58,7 @@ export function PageHeader({
 
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 space-y-1">
-          <h1 className="font-display text-3xl font-semibold leading-[1.05] tracking-tight text-foreground sm:text-4xl">
+          <h1 className="font-display text-3xl font-normal leading-[1.05] tracking-tight text-foreground sm:text-4xl">
             {title}
           </h1>
           {description && (

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}


### PR DESCRIPTION
## Summary

Bucket 2 of multi-bucket tech debt cleanup. Resolves 2 BLOCKER findings from the design system audit on 2026-05-06.

The Ember design system (dark default, OKLCH tokens, Instrument Serif editorial h1) shipped on paper but never ran:

- `next-themes` was installed but **no `ThemeProvider` was ever mounted**. The `.dark` class never gets applied, so the entire dark-mode color system was unreachable. `Sonner` fell through to the `system` fallback silently.
- `globals.css` had `--font-display: var(--font-geist-sans)`, so every `PageHeader` rendered the h1 in sans even though Instrument Serif is loaded into `--font-instrument-serif`.
- `PageHeader` hardcoded `font-semibold` on the h1, but Instrument Serif only ships weight 400 in Google Fonts — the browser was synthesizing a faux bold and collapsing the serif character.

## Changes

- New `src/components/theme-provider.tsx` thin client wrapper around `next-themes`.
- Mount `ThemeProvider` in root layout with `attribute="class"`, `defaultTheme="dark"`, `enableSystem={false}`, `disableTransitionOnChange`. Wraps `NextIntlClientProvider` so `Sonner` picks up theme correctly.
- `globals.css`: `--font-display` resolves to `--font-instrument-serif`.
- `page-header.tsx`: h1 uses `font-normal` to match the available font weight.

`<html suppressHydrationWarning>` was already in place, so the SSR/CSR class diff next-themes introduces is silenced.

No theme toggle UI in this PR — follow-up.

Closes audit findings B-1, B-2, M-6.

## Test plan

- [ ] `pnpm dev`, hit any page → confirm `<html class="dark">` is set on first interactive paint.
- [ ] Inspect `PageHeader` h1 in DevTools → `font-family` resolves to Instrument Serif (not Geist).
- [ ] Visual: h1 renders as a real serif, not a synthetic bold serif (compare to before — characters should look thinner and more elegant).
- [ ] No hydration warnings in browser console.
- [ ] `Sonner` toasts inherit dark styling.
- [ ] `pnpm lint` → no new errors.