### PR TITLE
feat(shared): DataTableShell + EmptyState variants + create-club-form a11y

### DIFF
--- a/src/app/(dashboard)/dashboard/clubs/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/page.tsx
@@ -15,6 +15,7 @@ import {
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 import { apiRequest, ApiError } from "@/lib/api/client";
 import { requireAdminUser } from "@/lib/auth/session";
 import { hasPermission } from "@/lib/auth/permission-utils";
@@ -92,7 +93,7 @@ async function ClubsContent() {
   }
 
   return (
-    <div className="rounded-md border">
+    <DataTableShell>
       <Table>
         <TableHeader>
           <TableRow>
@@ -134,7 +135,7 @@ async function ClubsContent() {
           })}
         </TableBody>
       </Table>
-    </div>
+    </DataTableShell>
   );
 }
 

--- a/src/components/catalogs/catalog-crud-page.tsx
+++ b/src/components/catalogs/catalog-crud-page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo } from "react";
 import { Plus, Pencil, Trash2, Package, SearchX } from "lucide-react";
+import { EmptyState } from "@/components/shared/empty-state";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -19,6 +20,7 @@ import { CatalogDeleteDialog } from "@/components/catalogs/catalog-delete-dialog
 import type { EntityConfig, EntityKey } from "@/lib/catalogs/entities";
 import type { CatalogItem } from "@/lib/catalogs/service";
 import type { CatalogActionState } from "@/lib/catalogs/actions";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -68,34 +70,7 @@ const TH_BASE = "h-11 bg-muted/40 text-xs font-medium uppercase tracking-wider t
 // Row height — comfortable default; can be swapped to "h-10" for density
 const ROW_H = "h-14";
 
-// ─── NoFilterResults (inline empty state for filtered queries) ───────────────
-
-interface NoFilterResultsProps {
-  entityLabel: string;
-  onClear: () => void;
-}
-
-function NoFilterResults({ entityLabel, onClear }: NoFilterResultsProps) {
-  return (
-    <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-14 text-center">
-      <div className="flex size-12 items-center justify-center rounded-full bg-muted">
-        <SearchX className="size-6 text-muted-foreground" aria-hidden="true" />
-      </div>
-      <h3 className="mt-4 text-base font-semibold">Sin resultados</h3>
-      <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-        No hay {entityLabel} que coincidan con los filtros aplicados.
-      </p>
-      <Button
-        variant="outline"
-        size="sm"
-        className="mt-5"
-        onClick={onClear}
-      >
-        Limpiar filtros
-      </Button>
-    </div>
-  );
-}
+// NoFilterResults removed — replaced by <EmptyState variant="no-results" />
 
 // ─── CatalogCrudPage ──────────────────────────────────────────────────────────
 
@@ -198,34 +173,33 @@ export function CatalogCrudPage({
       {/* ── Content area ── */}
       {items.length === 0 ? (
         /* No data at all */
-        <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center">
-          <div className="flex size-12 items-center justify-center rounded-full bg-muted">
-            <Package className="size-6 text-muted-foreground" aria-hidden="true" />
-          </div>
-          <h3 className="mt-4 text-lg font-semibold">
-            {tActions("empty_state", { entity: entityTitleLower })}
-          </h3>
-          <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-            No se encontraron registros.
-          </p>
+        <EmptyState
+          icon={Package}
+          title={tActions("empty_state", { entity: entityTitleLower })}
+          description="No se encontraron registros."
+        >
           {canMutate && (
-            <div className="mt-4">
-              <Button size="default" onClick={() => setCreateOpen(true)}>
-                <Plus className="mr-1.5 size-4" aria-hidden="true" />
-                {tActions("create", { entity: entitySingular })}
-              </Button>
-            </div>
+            <Button size="default" onClick={() => setCreateOpen(true)}>
+              <Plus className="mr-1.5 size-4" aria-hidden="true" />
+              {tActions("create", { entity: entitySingular })}
+            </Button>
           )}
-        </div>
+        </EmptyState>
       ) : filteredItems.length === 0 ? (
         /* Data exists but filters return nothing */
-        <NoFilterResults
-          entityLabel={entityTitleLower}
-          onClear={handleClearFilters}
-        />
+        <EmptyState
+          variant="no-results"
+          icon={SearchX}
+          title="Sin resultados"
+          description={`No hay ${entityTitleLower} que coincidan con los filtros aplicados.`}
+        >
+          <Button variant="outline" size="sm" onClick={handleClearFilters}>
+            Limpiar filtros
+          </Button>
+        </EmptyState>
       ) : (
         /* ── Table ── */
-        <div className="overflow-hidden rounded-lg border border-border">
+        <DataTableShell>
           <div className="overflow-x-auto">
             <Table>
               <TableHeader>
@@ -364,7 +338,7 @@ export function CatalogCrudPage({
               </TableBody>
             </Table>
           </div>
-        </div>
+        </DataTableShell>
       )}
 
       {/* ── Dialogs ── */}

--- a/src/components/clubs/create-club-form.tsx
+++ b/src/components/clubs/create-club-form.tsx
@@ -23,7 +23,7 @@ function SubmitButton() {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />}
       Crear club
     </Button>
   );
@@ -42,9 +42,13 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
   const [state, action] = useActionState(formAction, initialState);
 
   return (
-    <form action={action} className="space-y-6">
+    <form action={action} className="space-y-6" noValidate>
       {state.error && (
-        <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+        <div
+          role="alert"
+          aria-live="polite"
+          className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
           {state.error}
         </div>
       )}
@@ -56,22 +60,39 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
         <CardContent className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2 sm:col-span-2">
             <Label htmlFor="name">
-              Nombre <span className="text-destructive">*</span>
+              Nombre{" "}
+              <span className="text-destructive" aria-hidden="true">
+                *
+              </span>
             </Label>
-            <Input id="name" name="name" placeholder="Nombre del club" required />
+            <Input
+              id="name"
+              name="name"
+              placeholder="Nombre del club"
+              required
+              aria-required="true"
+            />
           </div>
 
           <div className="space-y-2 sm:col-span-2">
             <Label htmlFor="description">Descripción</Label>
-            <Textarea id="description" name="description" placeholder="Descripción opcional" rows={3} />
+            <Textarea
+              id="description"
+              name="description"
+              placeholder="Descripción opcional"
+              rows={3}
+            />
           </div>
 
           <div className="space-y-2">
             <Label htmlFor="local_field_id">
-              Campo local <span className="text-destructive">*</span>
+              Campo local{" "}
+              <span className="text-destructive" aria-hidden="true">
+                *
+              </span>
             </Label>
             <Select name="local_field_id" required>
-              <SelectTrigger>
+              <SelectTrigger id="local_field_id" aria-required="true">
                 <SelectValue placeholder="Seleccionar campo local" />
               </SelectTrigger>
               <SelectContent>
@@ -86,10 +107,13 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
 
           <div className="space-y-2">
             <Label htmlFor="district_id">
-              Distrito <span className="text-destructive">*</span>
+              Distrito{" "}
+              <span className="text-destructive" aria-hidden="true">
+                *
+              </span>
             </Label>
             <Select name="district_id" required>
-              <SelectTrigger>
+              <SelectTrigger id="district_id" aria-required="true">
                 <SelectValue placeholder="Seleccionar distrito" />
               </SelectTrigger>
               <SelectContent>
@@ -104,10 +128,13 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
 
           <div className="space-y-2">
             <Label htmlFor="church_id">
-              Iglesia <span className="text-destructive">*</span>
+              Iglesia{" "}
+              <span className="text-destructive" aria-hidden="true">
+                *
+              </span>
             </Label>
             <Select name="church_id" required>
-              <SelectTrigger>
+              <SelectTrigger id="church_id" aria-required="true">
                 <SelectValue placeholder="Seleccionar iglesia" />
               </SelectTrigger>
               <SelectContent>
@@ -122,7 +149,11 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
 
           <div className="space-y-2">
             <Label htmlFor="address">Dirección</Label>
-            <Input id="address" name="address" placeholder="Dirección del club" />
+            <Input
+              id="address"
+              name="address"
+              placeholder="Dirección del club"
+            />
           </div>
         </CardContent>
       </Card>
@@ -134,11 +165,23 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
         <CardContent className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2">
             <Label htmlFor="coordinates_lat">Latitud</Label>
-            <Input id="coordinates_lat" name="coordinates_lat" type="number" step="any" placeholder="19.4326" />
+            <Input
+              id="coordinates_lat"
+              name="coordinates_lat"
+              type="number"
+              step="any"
+              placeholder="19.4326"
+            />
           </div>
           <div className="space-y-2">
             <Label htmlFor="coordinates_lng">Longitud</Label>
-            <Input id="coordinates_lng" name="coordinates_lng" type="number" step="any" placeholder="-99.1332" />
+            <Input
+              id="coordinates_lng"
+              name="coordinates_lng"
+              type="number"
+              step="any"
+              placeholder="-99.1332"
+            />
           </div>
         </CardContent>
       </Card>

--- a/src/components/shared/data-table-shell.tsx
+++ b/src/components/shared/data-table-shell.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/lib/utils";
+import type { HTMLAttributes } from "react";
+
+export type DataTableShellProps = HTMLAttributes<HTMLDivElement>;
+
+export function DataTableShell({ className, ...props }: DataTableShellProps) {
+  return (
+    <div
+      className={cn(
+        "overflow-hidden rounded-xl border border-border/60 bg-card shadow-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/src/components/shared/empty-state.tsx
+++ b/src/components/shared/empty-state.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { type LucideIcon } from "lucide-react";
 
 interface EmptyStateProps {
@@ -5,13 +6,31 @@ interface EmptyStateProps {
   title: string;
   description?: string;
   children?: React.ReactNode;
+  /**
+   * "default"    — standard empty (no data at all). Icon container uses bg-muted.
+   * "no-results" — filtered query returned nothing. Icon container uses bg-muted/40.
+   *
+   * @default "default"
+   */
+  variant?: "default" | "no-results";
 }
 
-export function EmptyState({ icon: Icon, title, description, children }: EmptyStateProps) {
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  children,
+  variant = "default",
+}: EmptyStateProps) {
   return (
     <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-8 text-center">
-      <div className="flex size-12 items-center justify-center rounded-full bg-muted">
-        <Icon className="size-6 text-muted-foreground" />
+      <div
+        className={cn(
+          "flex size-12 items-center justify-center rounded-full",
+          variant === "no-results" ? "bg-muted/40" : "bg-muted",
+        )}
+      >
+        <Icon className="size-6 text-muted-foreground" aria-hidden="true" />
       </div>
       <h3 className="mt-4 text-lg font-semibold">{title}</h3>
       {description && (

--- a/src/components/users/users-table.tsx
+++ b/src/components/users/users-table.tsx
@@ -10,6 +10,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import type { AdminUser } from "@/lib/api/admin-users";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 
 function extractRoleNames(user: AdminUser): string[] {
   const roles: string[] = [];
@@ -61,7 +62,7 @@ export function UsersTable({
   showAdministrativeCompletion = false,
 }: UsersTableProps) {
   return (
-    <div className="rounded-md border">
+    <DataTableShell>
       <Table>
         <TableHeader>
           <TableRow>
@@ -162,6 +163,6 @@ export function UsersTable({
           })}
         </TableBody>
       </Table>
-    </div>
+    </DataTableShell>
   );
 }


### PR DESCRIPTION
## Summary

Bucket 3 of multi-bucket tech debt cleanup. Resolves several P0 / P1 findings from the UX and design-system audits on 2026-05-06.

### What

- **`<DataTableShell>` shared.** Three different conventions coexisted for the card-around-a-table chrome (`rounded-md`, `rounded-lg`, vs the spec's `rounded-xl border-border/60 shadow-xs`). Now there's one component, used in `clubs/page.tsx`, `users-table.tsx`, and `catalog-crud-page.tsx`.
- **`<EmptyState>` extended with a `variant` prop.** `catalog-crud-page.tsx` had duplicated the empty-state markup twice instead of reusing the shared component. Any chrome change would have drifted across copies. Migrated both call sites and deleted the local `NoFilterResults` helper.
- **`create-club-form.tsx` accessibility.** Did not meet WCAG 2.1 SC 3.3.1 (Level A) or SC 1.3.1. Added `role="alert"` + `aria-live` on the global error banner, `aria-required` on inputs, `aria-hidden` on decorative `*` markers, and explicit `id` on Radix `<SelectTrigger>` so `<Label htmlFor>` actually wires the label to the combobox.

### What this does NOT do

- No theme toggle UI, no header refresh, no other forms beyond `create-club-form` — those are follow-ups.
- Did not migrate the form to react-hook-form. `shadcn/ui Form` is not installed; adding it is out of scope for this bucket. The aria wiring delivers the same accessibility outcome with the existing `useActionState` plumbing.

Closes audit findings 1.1, 3.1, 3.2, 5.1, 5.2 (UX agent), and the table wrapper subset of A-6 (design-system agent).

## Commits

- `b0c3d14` feat(shared): add DataTableShell and unify table wrappers
- `ec06df0` feat(shared): add EmptyState variant and dedupe catalog-crud
- `97eaeca` fix(a11y): add aria attributes and live region to create-club-form

## Test plan

- [ ] `pnpm dev`. Open `/dashboard/clubs`, `/dashboard/users`, and any catalog page. All three table wrappers should now share the same border, radius, and shadow.
- [ ] On a catalog page, apply a filter that returns nothing → confirm the new `<EmptyState variant="no-results">` renders with a slightly subtler icon container.
- [ ] On `/dashboard/clubs/new`, submit the form with the name field empty → confirm a screen reader announces the resulting error banner. Tab through the required-field selects → label/trigger association works (NVDA/VoiceOver should read the label when the trigger is focused).
- [ ] DevTools accessibility tree: required-field `*` glyphs are hidden from AT, `aria-required="true"` set on inputs and select triggers.
- [ ] `pnpm lint` → 50/4 baseline, no regressions.