### PR TITLE
feat(clubs): server-side pagination + fix honors filter silent cap

### DIFF
--- a/src/app/(dashboard)/dashboard/clubs/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/page.tsx
@@ -16,9 +16,19 @@ import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 import { DataTableShell } from "@/components/shared/data-table-shell";
+import { DataTablePagination } from "@/components/shared/data-table-pagination";
 import { apiRequest, ApiError } from "@/lib/api/client";
 import { requireAdminUser } from "@/lib/auth/session";
 import { hasPermission } from "@/lib/auth/permission-utils";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 20;
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 
 type Club = {
   club_id?: number;
@@ -34,39 +44,122 @@ type Club = {
   [key: string]: unknown;
 };
 
+type PaginationMeta = {
+  page: number;
+  limit: number;
+  total: number;
+  totalPages: number;
+};
+
 type ClubsResult = {
   items: Club[];
+  meta: PaginationMeta;
   available: boolean;
   error?: string;
 };
 
-async function fetchClubs(): Promise<ClubsResult> {
-  try {
-    const payload = await apiRequest<unknown>("/clubs");
-    let items: Club[] = [];
+// ─── Helpers ──────────────────────────────────────────────────────────────────
 
-    if (Array.isArray(payload)) {
-      items = payload as Club[];
-    } else if (payload && typeof payload === "object") {
-      const res = payload as { data?: unknown; status?: string };
+function parseSearchParams(
+  raw: Record<string, string | string[] | undefined>,
+): { page: number; limit: number } {
+  const getString = (key: string) => {
+    const v = raw[key];
+    return typeof v === "string" && v.trim().length > 0 ? v.trim() : undefined;
+  };
+  const getPositiveInt = (key: string, fallback: number): number => {
+    const v = getString(key);
+    if (!v) return fallback;
+    const parsed = Number(v);
+    return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+  };
+
+  return {
+    page: getPositiveInt("page", DEFAULT_PAGE),
+    limit: getPositiveInt("limit", DEFAULT_LIMIT),
+  };
+}
+
+// ─── Data fetching ────────────────────────────────────────────────────────────
+
+async function fetchClubs(query: {
+  page: number;
+  limit: number;
+}): Promise<ClubsResult> {
+  const fallbackMeta: PaginationMeta = {
+    page: query.page,
+    limit: query.limit,
+    total: 0,
+    totalPages: 1,
+  };
+
+  try {
+    const payload = await apiRequest<unknown>(
+      `/clubs?page=${query.page}&limit=${query.limit}`,
+    );
+
+    // Backend returns PaginatedResult<Club>: { data: Club[], meta: { page, limit, total, totalPages, ... } }
+    if (
+      payload &&
+      typeof payload === "object" &&
+      !Array.isArray(payload)
+    ) {
+      const res = payload as {
+        data?: unknown;
+        meta?: {
+          page?: number;
+          limit?: number;
+          total?: number;
+          totalPages?: number;
+        };
+      };
+
       if (Array.isArray(res.data)) {
-        items = res.data as Club[];
+        const items = res.data as Club[];
+        const meta: PaginationMeta = {
+          page: res.meta?.page ?? query.page,
+          limit: res.meta?.limit ?? query.limit,
+          total: res.meta?.total ?? items.length,
+          totalPages: res.meta?.totalPages ?? 1,
+        };
+        return { items, meta, available: true };
       }
     }
 
-    return { items, available: true };
+    // Graceful degradation: backend returned a plain array (no pagination)
+    if (Array.isArray(payload)) {
+      const items = payload as Club[];
+      return {
+        items,
+        meta: {
+          page: 1,
+          limit: items.length || query.limit,
+          total: items.length,
+          totalPages: 1,
+        },
+        available: true,
+      };
+    }
+
+    return { items: [], meta: fallbackMeta, available: true };
   } catch (error) {
     if (error instanceof ApiError) {
-      return { items: [], available: false, error: error.message };
+      return { items: [], meta: fallbackMeta, available: false, error: error.message };
     }
-    return { items: [], available: false, error: "Error inesperado" };
+    return { items: [], meta: fallbackMeta, available: false, error: "Error inesperado" };
   }
 }
 
-async function ClubsContent() {
+// ─── Content ──────────────────────────────────────────────────────────────────
+
+async function ClubsContent({
+  query,
+}: {
+  query: { page: number; limit: number };
+}) {
   const user = await requireAdminUser();
   const canCreate = hasPermission(user, "clubs:create");
-  const result = await fetchClubs();
+  const result = await fetchClubs(query);
 
   if (!result.available) {
     return (
@@ -93,69 +186,98 @@ async function ClubsContent() {
   }
 
   return (
-    <DataTableShell>
-      <Table>
-        <TableHeader>
-          <TableRow>
-            <TableHead>Nombre</TableHead>
-            <TableHead className="hidden md:table-cell">Campo local</TableHead>
-            <TableHead className="hidden lg:table-cell">Distrito</TableHead>
-            <TableHead className="hidden lg:table-cell">Iglesia</TableHead>
-            <TableHead>Estado</TableHead>
-            <TableHead className="w-[100px]">Acciones</TableHead>
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {result.items.map((club) => {
-            const clubId = club.club_id ?? club.id;
-            return (
-              <TableRow key={clubId}>
-                <TableCell className="font-medium">{club.name ?? "—"}</TableCell>
-                <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
-                  {club.local_field?.name ?? club.local_field_id ?? "—"}
-                </TableCell>
-                <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
-                  {club.district?.name ?? club.district_id ?? "—"}
-                </TableCell>
-                <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
-                  {club.church?.name ?? club.church_id ?? "—"}
-                </TableCell>
-                <TableCell>
-                  <Badge variant={club.active !== false ? "default" : "outline"} className="text-xs">
-                    {club.active !== false ? "Activo" : "Inactivo"}
-                  </Badge>
-                </TableCell>
-                <TableCell>
-                  <Button variant="ghost" size="sm" asChild>
-                    <Link href={`/dashboard/clubs/${clubId}`}>Ver</Link>
-                  </Button>
-                </TableCell>
-              </TableRow>
-            );
-          })}
-        </TableBody>
-      </Table>
-    </DataTableShell>
-  );
-}
+    <div className="space-y-4">
+      <DataTableShell>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Nombre</TableHead>
+              <TableHead className="hidden md:table-cell">Campo local</TableHead>
+              <TableHead className="hidden lg:table-cell">Distrito</TableHead>
+              <TableHead className="hidden lg:table-cell">Iglesia</TableHead>
+              <TableHead>Estado</TableHead>
+              <TableHead className="w-[100px]">Acciones</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {result.items.map((club) => {
+              const clubId = club.club_id ?? club.id;
+              return (
+                <TableRow key={clubId}>
+                  <TableCell className="font-medium">{club.name ?? "—"}</TableCell>
+                  <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
+                    {club.local_field?.name ?? club.local_field_id ?? "—"}
+                  </TableCell>
+                  <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
+                    {club.district?.name ?? club.district_id ?? "—"}
+                  </TableCell>
+                  <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
+                    {club.church?.name ?? club.church_id ?? "—"}
+                  </TableCell>
+                  <TableCell>
+                    <Badge variant={club.active !== false ? "default" : "outline"} className="text-xs">
+                      {club.active !== false ? "Activo" : "Inactivo"}
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link href={`/dashboard/clubs/${clubId}`}>Ver</Link>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </DataTableShell>
 
-function ClubsSkeleton() {
-  return (
-    <div className="rounded-md border">
-      {Array.from({ length: 6 }).map((_, i) => (
-        <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
-          <Skeleton className="h-4 w-40" />
-          <Skeleton className="hidden h-4 w-24 md:block" />
-          <Skeleton className="h-5 w-14" />
-        </div>
-      ))}
+      <DataTablePagination
+        page={result.meta.page}
+        totalPages={result.meta.totalPages}
+        total={result.meta.total}
+        limit={result.meta.limit}
+      />
     </div>
   );
 }
 
-export default async function ClubsPage() {
+// ─── Skeleton ─────────────────────────────────────────────────────────────────
+
+function ClubsSkeleton() {
+  return (
+    <div className="space-y-4">
+      <div className="rounded-md border">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="hidden h-4 w-24 md:block" />
+            <Skeleton className="h-5 w-14" />
+          </div>
+        ))}
+      </div>
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-4 w-40" />
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-20" />
+          <Skeleton className="h-8 w-8" />
+          <Skeleton className="h-8 w-8" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function ClubsPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
   const user = await requireAdminUser();
   const canCreate = hasPermission(user, "clubs:create");
+  const rawParams = await searchParams;
+  const query = parseSearchParams(rawParams);
 
   return (
     <div className="space-y-6">
@@ -171,7 +293,7 @@ export default async function ClubsPage() {
       </PageHeader>
 
       <Suspense fallback={<ClubsSkeleton />}>
-        <ClubsContent />
+        <ClubsContent query={query} />
       </Suspense>
     </div>
   );

--- a/src/app/(dashboard)/dashboard/honors/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/page.tsx
@@ -24,7 +24,7 @@ type HonorsListMeta = {
   totalPages: number;
 };
 
-const HONORS_FILTER_FETCH_LIMIT = 100;
+const HONORS_FILTER_FETCH_LIMIT = 5000;
 const CATALOGS_CACHE_TTL_MS = 5 * 60 * 1000;
 const EMPTY_ARRAY: unknown[] = [];
 
@@ -270,7 +270,13 @@ async function listAllHonorsForFiltering(): Promise<GenericRecord[]> {
     page: 1,
     limit: HONORS_FILTER_FETCH_LIMIT,
   });
-  return extractItems(payload);
+  const items = extractItems(payload);
+  if (items.length === HONORS_FILTER_FETCH_LIMIT) {
+    console.warn(
+      `[honors] Filter dropdown fetch saturated at limit ${HONORS_FILTER_FETCH_LIMIT} — some options may be missing. Consider raising HONORS_FILTER_FETCH_LIMIT or implementing server-side filter resolution.`,
+    );
+  }
+  return items;
 }
 
 async function getCachedHonorCategoriesPayload() {


### PR DESCRIPTION
## Summary

Bucket 6a (first slice of the larger tables work). Two focused fixes from audit finding 6.1.

### What

- **Clubs pagination.** `/dashboard/clubs` rendered every club from `/clubs` in a single un-paginated table. The backend already supports `?page=` / `?limit=` (capped at 100) and returns a `PaginatedResult<Club>` envelope — the frontend just was not wiring it. Page now reads `searchParams`, fetches with pagination, renders the shared `<DataTablePagination>`, and the skeleton matches the final layout. Graceful fallback if the backend ever returns a plain array.
- **Honors filter silent cap.** `listAllHonorsForFiltering()` fetched up to 100 honors to populate filter dropdowns and silently dropped anything beyond — making it impossible to filter by extras. Bumped to 5000 (covers realistic catalogs) and added a `console.warn` when the response saturates the limit, so the issue surfaces in server logs and Sentry breadcrumbs instead of failing silently.

### Out of scope (deferred)

- **6b** TanStack Table integration with column sort (re-installs the dep we dropped in #29).
- **6c** Mobile cards pattern for tables that hide columns at small breakpoints.
- Server-side filter resolution for honors (the proper fix). The cap warn is a pragmatic patch; the architectural rewrite belongs in its own bucket.
- Search by name in clubs (out of scope).
- Migration of `clubs/page.tsx` to `<DataTableShell>` (lives in PR #28; will conflict on rebase if that PR merges first — happy to rebase).

Closes the clubs and honors-cap subsets of audit finding 6.1.

## Commits

- `f4ae151` fix(honors): warn when filter dropdown fetch saturates the limit
- `105d43d` feat(clubs): add server-side pagination

## Test plan

- [ ] `pnpm dev`. Hit `/dashboard/clubs` and confirm only 20 rows render even when the catalog has more. Click "next" → URL gets `?page=2&limit=20`, page navigates.
- [ ] Manually visit `/dashboard/clubs?page=99` → page clamps gracefully.
- [ ] Stop the backend or block `/clubs` → confirm the existing error banner still renders (no crashes from the new pagination path).
- [ ] Force `listHonors` to return exactly 5000 items in a dev probe → confirm the saturation warn fires in server logs (`[honors] Filter dropdown fetch saturated at limit 5000 ...`).
- [ ] `pnpm lint` → 50/4 baseline, no new errors.