### PR TITLE
feat(shared): StatusBadge wrapper for domain status

### DIFF
--- a/src/app/(dashboard)/dashboard/reports/supervision/_components/reports-supervision-client.tsx
+++ b/src/app/(dashboard)/dashboard/reports/supervision/_components/reports-supervision-client.tsx
@@ -9,7 +9,7 @@ import {
   Download,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/shared/status-badge";
 import {
   Select,
   SelectContent,
@@ -70,14 +70,14 @@ function formatShortDate(iso: string | null): string {
   }).format(date);
 }
 
-function StatusBadge({ status }: { status: AdminReportItem["status"] }) {
+function ReportStatusBadge({ status }: { status: AdminReportItem["status"] }) {
   if (status === "submitted") {
-    return <Badge variant="success">Enviado</Badge>;
+    return <StatusBadge intent="success">Enviado</StatusBadge>;
   }
   if (status === "generated") {
-    return <Badge variant="outline">Generado</Badge>;
+    return <StatusBadge intent="neutral">Generado</StatusBadge>;
   }
-  return <Badge variant="secondary">Borrador</Badge>;
+  return <StatusBadge intent="secondary">Borrador</StatusBadge>;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -276,7 +276,7 @@ export function ReportsSupervisionClient({
                     {formatPeriod(item.month, item.year)}
                   </TableCell>
                   <TableCell>
-                    <StatusBadge status={item.status} />
+                    <ReportStatusBadge status={item.status} />
                   </TableCell>
                   <TableCell>{formatShortDate(item.generated_at)}</TableCell>
                   <TableCell>{formatShortDate(item.submitted_at)}</TableCell>

--- a/src/components/camporees/camporee-clubs-panel.tsx
+++ b/src/components/camporees/camporee-clubs-panel.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { Building2, CheckCircle2, Loader2, Trash2, XCircle } from "lucide-react";
 import { toast } from "sonner";
-import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/shared/status-badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -35,38 +35,38 @@ import { ApiError } from "@/lib/api/client";
 function ClubStatusBadge({ status }: { status?: string | null }) {
   if (!status) {
     return (
-      <Badge variant="secondary" className="text-xs">
+      <StatusBadge intent="secondary" className="text-xs">
         —
-      </Badge>
+      </StatusBadge>
     );
   }
 
   const normalized = status.toLowerCase();
 
   if (normalized === "active" || normalized === "activo" || normalized === "enrolled") {
-    return <Badge variant="success">Activo</Badge>;
+    return <StatusBadge intent="success">Activo</StatusBadge>;
   }
 
   if (normalized === "approved") {
-    return <Badge variant="success">Aprobado</Badge>;
+    return <StatusBadge intent="success">Aprobado</StatusBadge>;
   }
 
   if (normalized === "pending_approval") {
-    return <Badge variant="warning">Pendiente</Badge>;
+    return <StatusBadge intent="warning">Pendiente</StatusBadge>;
   }
 
   if (normalized === "rejected") {
-    return <Badge variant="destructive">Rechazado</Badge>;
+    return <StatusBadge intent="destructive">Rechazado</StatusBadge>;
   }
 
   if (normalized === "cancelled" || normalized === "cancelado") {
-    return <Badge variant="destructive">Cancelado</Badge>;
+    return <StatusBadge intent="destructive">Cancelado</StatusBadge>;
   }
 
   return (
-    <Badge variant="secondary" className="text-xs capitalize">
+    <StatusBadge intent="secondary" className="text-xs capitalize">
       {status}
-    </Badge>
+    </StatusBadge>
   );
 }
 

--- a/src/components/camporees/camporee-members-panel.tsx
+++ b/src/components/camporees/camporee-members-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { CheckCircle2, Loader2, UserMinus, Users, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/shared/status-badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -34,31 +35,31 @@ import { ApiError } from "@/lib/api/client";
 
 function MemberStatusBadge({ status }: { status?: string | null }) {
   if (!status) {
-    return <Badge variant="secondary" className="text-xs">—</Badge>;
+    return <StatusBadge intent="secondary" className="text-xs">—</StatusBadge>;
   }
 
   const normalized = status.toLowerCase();
 
   if (normalized === "approved" || normalized === "registered") {
-    return <Badge variant="success">{normalized === "registered" ? "Registrado" : "Aprobado"}</Badge>;
+    return <StatusBadge intent="success">{normalized === "registered" ? "Registrado" : "Aprobado"}</StatusBadge>;
   }
 
   if (normalized === "pending_approval") {
-    return <Badge variant="warning">Pendiente</Badge>;
+    return <StatusBadge intent="warning">Pendiente</StatusBadge>;
   }
 
   if (normalized === "rejected") {
-    return <Badge variant="destructive">Rechazado</Badge>;
+    return <StatusBadge intent="destructive">Rechazado</StatusBadge>;
   }
 
   if (normalized === "cancelled" || normalized === "cancelado") {
-    return <Badge variant="destructive">Cancelado</Badge>;
+    return <StatusBadge intent="destructive">Cancelado</StatusBadge>;
   }
 
   return (
-    <Badge variant="secondary" className="text-xs capitalize">
+    <StatusBadge intent="secondary" className="text-xs capitalize">
       {status}
-    </Badge>
+    </StatusBadge>
   );
 }
 
@@ -66,7 +67,7 @@ function MemberStatusBadge({ status }: { status?: string | null }) {
 
 function InsuranceBadge({ status }: { status?: string | null }) {
   if (!status) {
-    return <Badge variant="warning">Sin seguro</Badge>;
+    return <StatusBadge intent="warning">Sin seguro</StatusBadge>;
   }
 
   const isVerified =
@@ -75,10 +76,10 @@ function InsuranceBadge({ status }: { status?: string | null }) {
     status.toLowerCase() === "active";
 
   if (isVerified) {
-    return <Badge variant="success">Seguro verificado</Badge>;
+    return <StatusBadge intent="success">Seguro verificado</StatusBadge>;
   }
 
-  return <Badge variant="warning">Seguro pendiente</Badge>;
+  return <StatusBadge intent="warning">Seguro pendiente</StatusBadge>;
 }
 
 // ─── Dialog state ─────────────────────────────────────────────────────────────

--- a/src/components/camporees/camporee-payments-panel.tsx
+++ b/src/components/camporees/camporee-payments-panel.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { CheckCircle2, DollarSign, Loader2, Pencil, XCircle } from "lucide-react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/shared/status-badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -53,21 +54,21 @@ function PaymentStatusBadge({ status }: { status?: string | null }) {
   const normalized = status.toLowerCase();
 
   if (normalized === "approved") {
-    return <Badge variant="success">Aprobado</Badge>;
+    return <StatusBadge intent="success">Aprobado</StatusBadge>;
   }
 
   if (normalized === "pending_approval") {
-    return <Badge variant="warning">Pendiente</Badge>;
+    return <StatusBadge intent="warning">Pendiente</StatusBadge>;
   }
 
   if (normalized === "rejected") {
-    return <Badge variant="destructive">Rechazado</Badge>;
+    return <StatusBadge intent="destructive">Rechazado</StatusBadge>;
   }
 
   return (
-    <Badge variant="secondary" className="text-xs capitalize">
+    <StatusBadge intent="secondary" className="text-xs capitalize">
       {status}
-    </Badge>
+    </StatusBadge>
   );
 }
 

--- a/src/components/honors/review-split-view.tsx
+++ b/src/components/honors/review-split-view.tsx
@@ -17,7 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/shared/status-badge";
 import { useTranslations } from "next-intl";
 import {
   deleteRequirement,
@@ -185,7 +185,7 @@ export function ReviewSplitView({
         </div>
 
         <div className="flex items-center gap-2">
-          <Badge variant="warning">Pendiente de revisión</Badge>
+          <StatusBadge intent="warning">Pendiente de revisión</StatusBadge>
           <span className="text-sm font-medium text-muted-foreground">
             {requirement.honors.name}
           </span>

--- a/src/components/shared/status-badge.tsx
+++ b/src/components/shared/status-badge.tsx
@@ -1,0 +1,36 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+export type StatusIntent =
+  | "success"
+  | "warning"
+  | "info"
+  | "destructive"
+  | "neutral"
+  | "secondary";
+
+interface StatusBadgeProps {
+  intent: StatusIntent;
+  children: React.ReactNode;
+  className?: string;
+}
+
+const intentVariantMap: Record<
+  StatusIntent,
+  React.ComponentProps<typeof Badge>["variant"]
+> = {
+  success: "success",
+  warning: "warning",
+  info: "soft-info",
+  destructive: "destructive",
+  neutral: "outline",
+  secondary: "secondary",
+};
+
+export function StatusBadge({ intent, children, className }: StatusBadgeProps) {
+  return (
+    <Badge variant={intentVariantMap[intent]} className={cn(className)}>
+      {children}
+    </Badge>
+  );
+}

--- a/src/components/users/sessions-tab.tsx
+++ b/src/components/users/sessions-tab.tsx
@@ -13,7 +13,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
-import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/shared/status-badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -229,9 +229,9 @@ function SessionRow({ session, index, onRevoke, isRevoking }: SessionRowProps) {
               {device.browser} en {device.os}
             </p>
             {isCurrent && (
-              <Badge variant="success" className="mt-0.5 text-[10px]">
+              <StatusBadge intent="success" className="mt-0.5 text-[10px]">
                 Sesión actual
-              </Badge>
+              </StatusBadge>
             )}
           </div>
         </div>
@@ -261,7 +261,7 @@ function SessionRow({ session, index, onRevoke, isRevoking }: SessionRowProps) {
 
       {/* Status */}
       <TableCell>
-        <Badge variant="success">Activa</Badge>
+        <StatusBadge intent="success">Activa</StatusBadge>
       </TableCell>
 
       {/* Actions */}


### PR DESCRIPTION
## Summary

Bucket 7a. Introduces the shared `<StatusBadge>` wrapper called for in DESIGN-SYSTEM §5.2 and migrates six consumers that were using raw `<Badge variant="success">` for domain status.

### What

- New `src/components/shared/status-badge.tsx`. Thin wrapper around `<Badge>` that maps semantic intents (`success | warning | info | destructive | neutral | secondary`) onto existing Badge variants. No new colors — re-uses what's there so there's zero palette drift risk.
- Migrated audit consumers:
  - `camporees/camporee-clubs-panel.tsx` (6 calls)
  - `camporees/camporee-members-panel.tsx` (8 calls — `MemberStatusBadge` + `InsuranceBadge`; `camporee_type` outline tag intentionally untouched, it's a category not a status)
  - `camporees/camporee-payments-panel.tsx` (4 calls in `PaymentStatusBadge`; `PaymentTypeBadge` left as raw `<Badge>` for the same reason)
  - `reports/supervision/reports-supervision-client.tsx` (3 calls; the local function `StatusBadge` was renamed to `ReportStatusBadge` to free the name for the shared import)
  - `honors/review-split-view.tsx` (1 call)
  - `users/sessions-tab.tsx` (2 calls)

Raw `<Badge>` is still the right call for tags, categories, and neutral chips. Only domain status moved to the wrapper.

Closes the migration subset of audit finding A-5.

## Test plan

- [ ] `pnpm dev`, browse each touched page and confirm visuals are unchanged (the wrapper is purely structural — same Badge underneath).
- [ ] Toggle dark mode on `/dashboard/camporees/[id]` panels and `/dashboard/users/[id]` sessions tab; confirm color tokens render correctly.
- [ ] `pnpm lint` → 50/4 baseline, no new warnings.