### PR TITLE
feat(weights): migrate weights-form-dialog to dedicated pages

### DIFF
--- a/src/app/(dashboard)/dashboard/member-ranking-weights/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/[id]/edit/page.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link";
+import { ArrowLeft, Scale } from "lucide-react";
+import { notFound } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/shared/page-header";
+import { EmptyState } from "@/components/shared/empty-state";
+import { requireAdminUser } from "@/lib/auth/session";
+import { getMemberRankingWeights } from "@/lib/api/member-ranking-weights";
+import { listClubTypes, listEcclesiasticalYears } from "@/lib/api/catalogs";
+import { ApiError } from "@/lib/api/client";
+import { WeightsForm } from "../../_components/weights-form";
+
+const BACK_HREF = "/dashboard/member-ranking-weights";
+
+interface EditWeightsPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function EditWeightsPage({ params }: EditWeightsPageProps) {
+  const { id } = await params;
+
+  await requireAdminUser();
+
+  let weightRow;
+  let loadError: string | null = null;
+
+  try {
+    weightRow = await getMemberRankingWeights(id);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      notFound();
+    }
+    loadError = err instanceof ApiError ? err.message : "Error al cargar la configuración";
+  }
+
+  const [clubTypes, ecclesiasticalYears] = await Promise.all([
+    listClubTypes().catch(() => []),
+    listEcclesiasticalYears().catch(() => []),
+  ]);
+
+  const isDefault = weightRow?.is_default ?? false;
+  const pageTitle = isDefault
+    ? "Editar configuración por defecto"
+    : "Editar sobreescritura de pesos";
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <PageHeader
+        title={pageTitle}
+        description="Modifica los porcentajes de clase, investidura y campaña. La suma debe ser exactamente 100."
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Pesos de ranking", href: BACK_HREF },
+          { label: isDefault ? "Configuración por defecto" : "Editar sobreescritura" },
+        ]}
+      >
+        <Button variant="outline" size="sm" asChild>
+          <Link href={BACK_HREF}>
+            <ArrowLeft className="mr-2 size-4" />
+            Volver
+          </Link>
+        </Button>
+      </PageHeader>
+
+      {loadError && (
+        <EmptyState
+          icon={Scale}
+          title="No se pudo cargar la configuración"
+          description={loadError}
+        />
+      )}
+
+      {!loadError && weightRow && (
+        <WeightsForm
+          mode="edit"
+          defaultValues={weightRow}
+          clubTypes={clubTypes}
+          ecclesiasticalYears={ecclesiasticalYears}
+          backHref={BACK_HREF}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-client-page.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-client-page.tsx
@@ -14,7 +14,6 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { WeightsTable } from "./weights-table";
-import { WeightsFormDialog } from "./weights-form-dialog";
 import {
   deleteMemberRankingWeights,
   mapWeightsErrorMessage,
@@ -39,31 +38,15 @@ export function WeightsClientPage({
 }: WeightsClientPageProps) {
   const router = useRouter();
 
-  // ── Form dialog state ─────────────────────────────────────────────────────
-  const [formOpen, setFormOpen] = useState(false);
-  const [editingRow, setEditingRow] = useState<EnrollmentRankingWeight | null>(null);
-
   // ── Delete dialog state ───────────────────────────────────────────────────
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deletingRow, setDeletingRow] = useState<EnrollmentRankingWeight | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
 
-  // ── Refresh after mutations ───────────────────────────────────────────────
+  // ── Refresh after delete ──────────────────────────────────────────────────
   const refresh = useCallback(() => {
     router.refresh();
   }, [router]);
-
-  // ── Create ────────────────────────────────────────────────────────────────
-  function handleCreate() {
-    setEditingRow(null);
-    setFormOpen(true);
-  }
-
-  // ── Edit ──────────────────────────────────────────────────────────────────
-  function handleEdit(row: EnrollmentRankingWeight) {
-    setEditingRow(row);
-    setFormOpen(true);
-  }
 
   // ── Delete ────────────────────────────────────────────────────────────────
   function handleDelete(row: EnrollmentRankingWeight) {
@@ -94,19 +77,7 @@ export function WeightsClientPage({
         items={initialData}
         clubTypes={clubTypes}
         ecclesiasticalYears={ecclesiasticalYears}
-        onEdit={handleEdit}
         onDelete={handleDelete}
-        onCreate={handleCreate}
-      />
-
-      {/* Form dialog — create & edit */}
-      <WeightsFormDialog
-        open={formOpen}
-        onOpenChange={setFormOpen}
-        editingRow={editingRow}
-        clubTypes={clubTypes}
-        ecclesiasticalYears={ecclesiasticalYears}
-        onSuccess={refresh}
       />
 
       {/* Delete confirmation — AlertDialog per design system */}

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-form.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-form.tsx
@@ -1,19 +1,13 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import type { Resolver, SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -24,6 +18,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Card, CardContent } from "@/components/ui/card";
 import { WeightSumIndicator } from "./weight-sum-indicator";
 import {
   createMemberRankingWeights,
@@ -68,19 +63,19 @@ type FormValues = z.infer<typeof formSchema>;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface WeightsFormDialogProps {
-  open: boolean;
-  onOpenChange: (open: boolean) => void;
-  /** When provided, the dialog operates in edit mode. */
-  editingRow?: EnrollmentRankingWeight | null;
+export interface WeightsFormProps {
+  mode: "create" | "edit";
+  /** Required when mode === "edit" */
+  defaultValues?: EnrollmentRankingWeight;
   clubTypes: ClubType[];
   ecclesiasticalYears: EcclesiasticalYear[];
-  onSuccess: () => void;
+  /** URL to redirect to on success or cancel. Defaults to /dashboard/member-ranking-weights */
+  backHref?: string;
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function rowToDefaultValues(row: EnrollmentRankingWeight): FormValues {
+function rowToFormValues(row: EnrollmentRankingWeight): FormValues {
   return {
     class_pct: row.class_pct,
     investiture_pct: row.investiture_pct,
@@ -104,17 +99,21 @@ const EMPTY_DEFAULTS: FormValues = {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export function WeightsFormDialog({
-  open,
-  onOpenChange,
-  editingRow,
+export function WeightsForm({
+  mode,
+  defaultValues,
   clubTypes,
   ecclesiasticalYears,
-  onSuccess,
-}: WeightsFormDialogProps) {
-  const isEdit = !!editingRow;
+  backHref = "/dashboard/member-ranking-weights",
+}: WeightsFormProps) {
+  const isEdit = mode === "edit";
   const t = useTranslations("memberRankingWeights.formDialog");
+  const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const initialValues = isEdit && defaultValues
+    ? rowToFormValues(defaultValues)
+    : EMPTY_DEFAULTS;
 
   const {
     register,
@@ -128,20 +127,19 @@ export function WeightsFormDialog({
     // so zodResolver's inferred Resolver type doesn't match useForm<FormValues>'s
     // unified signature. Cast is safe because runtime behavior is identical.
     resolver: zodResolver(formSchema) as unknown as Resolver<FormValues>,
-    defaultValues: EMPTY_DEFAULTS,
+    defaultValues: initialValues,
   });
+
+  // Re-seed if the server data changes (e.g. navigating between edit pages)
+  useEffect(() => {
+    reset(isEdit && defaultValues ? rowToFormValues(defaultValues) : EMPTY_DEFAULTS);
+  }, [isEdit, defaultValues, reset]);
 
   const classPct = watch("class_pct");
   const investiturePct = watch("investiture_pct");
   const camporeePct = watch("camporee_pct");
   const clubTypeValue = watch("club_type_id");
   const yearValue = watch("ecclesiastical_year_id");
-
-  useEffect(() => {
-    if (open) {
-      reset(editingRow ? rowToDefaultValues(editingRow) : EMPTY_DEFAULTS);
-    }
-  }, [open, editingRow, reset]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -158,16 +156,16 @@ export function WeightsFormDialog({
             : Number(values.ecclesiastical_year_id),
       };
 
-      if (isEdit && editingRow) {
-        await updateMemberRankingWeights(editingRow.id, payload);
+      if (isEdit && defaultValues) {
+        await updateMemberRankingWeights(defaultValues.id, payload);
         toast.success("Configuración de pesos actualizada");
       } else {
         await createMemberRankingWeights(payload);
         toast.success("Sobreescritura de pesos creada");
       }
 
-      onSuccess();
-      onOpenChange(false);
+      router.push(backHref);
+      router.refresh();
     } catch (err: unknown) {
       toast.error(mapWeightsErrorMessage(err));
     } finally {
@@ -186,17 +184,11 @@ export function WeightsFormDialog({
     isSubmitting || !sumIsValid || (isEdit && !isDirty);
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>
-            {isEdit ? "Editar configuración de pesos" : "Nueva sobreescritura de pesos"}
-          </DialogTitle>
-        </DialogHeader>
-
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-5">
+    <Card>
+      <CardContent className="pt-6">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
           {/* Porcentajes */}
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
             <div className="space-y-1.5">
               <Label htmlFor="w-class">{t("clasePercent")}</Label>
               <Input
@@ -257,13 +249,13 @@ export function WeightsFormDialog({
             <WeightSumIndicator values={sumValues} />
           </div>
 
-          {/* Tipo de club — catalog Select */}
+          {/* Tipo de club */}
           <div className="space-y-1.5">
             <Label>Tipo de club</Label>
             <Select
               value={clubTypeValue}
               onValueChange={(val) => setValue("club_type_id", val, { shouldDirty: true })}
-              disabled={isEdit && editingRow?.is_default}
+              disabled={isEdit && defaultValues?.is_default}
             >
               <SelectTrigger>
                 <SelectValue placeholder="Seleccionar tipo de club" />
@@ -287,7 +279,7 @@ export function WeightsFormDialog({
             )}
           </div>
 
-          {/* Ano eclesiastico — catalog Select */}
+          {/* Ano eclesiastico */}
           <div className="space-y-1.5">
             <Label>{t("anoEclesiastico")}</Label>
             <Select
@@ -295,7 +287,7 @@ export function WeightsFormDialog({
               onValueChange={(val) =>
                 setValue("ecclesiastical_year_id", val, { shouldDirty: true })
               }
-              disabled={isEdit && editingRow?.is_default}
+              disabled={isEdit && defaultValues?.is_default}
             >
               <SelectTrigger>
                 <SelectValue placeholder="Seleccionar ano" />
@@ -319,17 +311,18 @@ export function WeightsFormDialog({
             )}
           </div>
 
-          {isEdit && editingRow?.is_default && (
+          {isEdit && defaultValues?.is_default && (
             <p className="text-xs text-muted-foreground">
               La fila por defecto no puede cambiar su tipo de club ni ano eclesiastico.
             </p>
           )}
 
-          <DialogFooter className="pt-2">
+          {/* Actions */}
+          <div className="flex items-center justify-end gap-3 pt-2">
             <Button
               type="button"
               variant="outline"
-              onClick={() => onOpenChange(false)}
+              onClick={() => router.push(backHref)}
               disabled={isSubmitting}
             >
               Cancelar
@@ -343,9 +336,9 @@ export function WeightsFormDialog({
                   ? "Guardar cambios"
                   : "Crear sobreescritura"}
             </Button>
-          </DialogFooter>
+          </div>
         </form>
-      </DialogContent>
-    </Dialog>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-table.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Pencil, Trash2, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -23,9 +24,7 @@ interface WeightsTableProps {
   items: EnrollmentRankingWeight[];
   clubTypes: ClubType[];
   ecclesiasticalYears: EcclesiasticalYear[];
-  onEdit: (row: EnrollmentRankingWeight) => void;
   onDelete: (row: EnrollmentRankingWeight) => void;
-  onCreate: () => void;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -34,9 +33,7 @@ export function WeightsTable({
   items,
   clubTypes,
   ecclesiasticalYears,
-  onEdit,
   onDelete,
-  onCreate,
 }: WeightsTableProps) {
   const t = useTranslations("memberRankingWeights.table");
   const tForm = useTranslations("memberRankingWeights.formDialog");
@@ -76,11 +73,13 @@ export function WeightsTable({
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => onEdit(defaultRow)}
+                asChild
                 title={t("editDefaultTitle")}
               >
-                <Pencil className="size-3.5" />
-                {t("editButton")}
+                <Link href={`/dashboard/member-ranking-weights/${defaultRow.id}/edit`}>
+                  <Pencil className="size-3.5" />
+                  {t("editButton")}
+                </Link>
               </Button>
             </div>
           </CardHeader>
@@ -133,9 +132,11 @@ export function WeightsTable({
             <h2 className="text-sm font-medium">{t("overridesHeading")}</h2>
             <Badge variant="secondary">{overrides.length}</Badge>
           </div>
-          <Button size="sm" onClick={onCreate}>
-            <Plus className="size-4" />
-            {t("createOverride")}
+          <Button size="sm" asChild>
+            <Link href="/dashboard/member-ranking-weights/new">
+              <Plus className="size-4" />
+              {t("createOverride")}
+            </Link>
           </Button>
         </div>
 
@@ -145,9 +146,11 @@ export function WeightsTable({
             <p className="mt-1 max-w-xs text-xs text-muted-foreground">
               {t("emptyDescription")}
             </p>
-            <Button size="sm" variant="outline" className="mt-4" onClick={onCreate}>
-              <Plus className="size-4" />
-              {t("createOverride")}
+            <Button size="sm" variant="outline" className="mt-4" asChild>
+              <Link href="/dashboard/member-ranking-weights/new">
+                <Plus className="size-4" />
+                {t("createOverride")}
+              </Link>
             </Button>
           </div>
         ) : (
@@ -202,11 +205,13 @@ export function WeightsTable({
                         <Button
                           variant="ghost"
                           size="icon-xs"
-                          onClick={() => onEdit(row)}
+                          asChild
                           title={t("editOverrideTitle")}
                         >
-                          <Pencil className="size-3.5" />
-                          <span className="sr-only">{t("editButton")}</span>
+                          <Link href={`/dashboard/member-ranking-weights/${row.id}/edit`}>
+                            <Pencil className="size-3.5" />
+                            <span className="sr-only">{t("editButton")}</span>
+                          </Link>
                         </Button>
                         <Button
                           variant="ghost"

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/new/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/shared/page-header";
+import { requireAdminUser } from "@/lib/auth/session";
+import { listClubTypes, listEcclesiasticalYears } from "@/lib/api/catalogs";
+import { WeightsForm } from "../_components/weights-form";
+
+const BACK_HREF = "/dashboard/member-ranking-weights";
+
+export default async function NewWeightsPage() {
+  await requireAdminUser();
+
+  const [clubTypes, ecclesiasticalYears] = await Promise.all([
+    listClubTypes().catch(() => []),
+    listEcclesiasticalYears().catch(() => []),
+  ]);
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <PageHeader
+        title="Nueva sobreescritura de pesos"
+        description="Define los porcentajes de clase, investidura y campaña para una combinación específica de tipo de club y año eclesiástico."
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: "Pesos de ranking", href: BACK_HREF },
+          { label: "Nueva sobreescritura" },
+        ]}
+      >
+        <Button variant="outline" size="sm" asChild>
+          <Link href={BACK_HREF}>
+            <ArrowLeft className="mr-2 size-4" />
+            Volver
+          </Link>
+        </Button>
+      </PageHeader>
+
+      <WeightsForm
+        mode="create"
+        clubTypes={clubTypes}
+        ecclesiasticalYears={ecclesiasticalYears}
+        backHref={BACK_HREF}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Bucket 7b-2. Refactors `weights-form-dialog.tsx` (Dialog with >4 form fields plus a cross-field weight-sum validator) into dedicated `/new` and `/[id]/edit` pages per DESIGN-SYSTEM §6.1.1.

### Why

Even though the form has only 5 fields (3 numeric inputs + 2 selects), the cross-field weight-sum validator and the `is_default` row gating make the UX cognitively heavy for a modal. The §6.1.1 rule (Dialog only when ≤ 4 simple fields and the operation is secondary) covers exactly this case.

### What

- Extract the dialog form into a standalone `<WeightsForm>` component. RHF + zod resolver, error/state plumbing, the cross-field validator — all preserved, just wrapped without the Dialog chrome. Cancel returns to the listing.
- Two new pages:
  - `/dashboard/member-ranking-weights/new` — server component with auth + permissions + catalog data, renders `<WeightsForm mode="create">`.
  - `/dashboard/member-ranking-weights/[id]/edit` — fetches by UUID via `getMemberRankingWeights(id)`, renders `<WeightsForm mode="edit" defaultValues>`. Detects `is_default` rows and adjusts title/disabled selects accordingly.
- Listing updates: the "Crear" button and the per-row "Editar" actions are now `<Link>` to the new pages. Dialog open state and the dialog render itself are gone.
- `weights-form-dialog.tsx` deleted (git tracked it as a rename to `weights-form.tsx` because of the 85% content overlap; the delete is implicit in the rename commit).

### Out of scope (not touched)

`src/components/ranking-weights/` is a separate domain (different API, different fields — `folder_weight`, `finance_weight`, etc.) that also uses Dialog. Left as-is. Worth a follow-up audit if the same §6.1.1 reasoning applies there.

Closes the weights subset of audit finding A-4.

## Commits

- `9da1c83` refactor(weights): extract standalone WeightsForm from dialog
- `51ec7f5` feat(weights): add /new and /[id]/edit dedicated pages

## Test plan

- [ ] `pnpm dev`. From the weights listing, click "Crear" → lands on `/dashboard/member-ranking-weights/new`. Submit valid → toast.success, redirect back to listing.
- [ ] Click "Editar" on a non-default row → lands on `/dashboard/member-ranking-weights/[id]/edit` with values pre-filled. Submit → toast.success, redirect.
- [ ] Click "Editar" on the default row — the page loads with the right title/locked selects.
- [ ] Submit with weights that don't sum correctly → cross-field validator fires inline.
- [ ] Browser back from `/new` returns cleanly to the listing.
- [ ] `pnpm lint` → 50/4 baseline, no new warnings.