### PR TITLE
refactor(data-fetching): React Query pilot — 3 components

### DIFF
--- a/src/components/member-of-month/member-of-month-card.tsx
+++ b/src/components/member-of-month/member-of-month-card.tsx
@@ -1,16 +1,17 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { Trophy, Clock, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { EvaluateMemberOfMonthDialog } from "@/components/member-of-month/evaluate-dialog";
 import { MemberOfMonthHistorySheet } from "@/components/member-of-month/history-sheet";
 import { getMemberOfMonth } from "@/lib/api/member-of-month";
-import type { MemberOfMonth, MemberOfMonthEntry } from "@/lib/api/member-of-month";
+import type { MemberOfMonthEntry } from "@/lib/api/member-of-month";
 import { MONTH_NAMES } from "@/lib/constants";
 
 // ─── Member avatar ────────────────────────────────────────────────────────────
@@ -60,6 +61,8 @@ interface MemberOfMonthCardProps {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
+export const MEMBER_OF_MONTH_QUERY_KEY = "member-of-month" as const;
+
 export function MemberOfMonthCard({
   clubId,
   sectionId,
@@ -67,36 +70,27 @@ export function MemberOfMonthCard({
   isDirector = false,
 }: MemberOfMonthCardProps) {
   const t = useTranslations("member_of_month");
-  const [data, setData] = useState<MemberOfMonth | null>(null);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [evaluateOpen, setEvaluateOpen] = useState(false);
   const [historyOpen, setHistoryOpen] = useState(false);
 
-  const loadMemberOfMonth = useCallback(async () => {
-    setLoading(true);
-    try {
-      const result = await getMemberOfMonth(clubId, sectionId);
-      setData(result);
-    } catch (err: unknown) {
-      // Non-critical: silently ignore — card simply won't render
-      void err;
-    } finally {
-      setLoading(false);
-    }
-  }, [clubId, sectionId]);
-
-  useEffect(() => {
-    loadMemberOfMonth();
-  }, [loadMemberOfMonth]);
+  const { data, isLoading } = useQuery({
+    queryKey: [MEMBER_OF_MONTH_QUERY_KEY, clubId, sectionId],
+    queryFn: () => getMemberOfMonth(clubId, sectionId),
+    // Non-critical data — silently swallow errors so the card simply doesn't render.
+    throwOnError: false,
+  });
 
   function handleEvaluateSuccess() {
     toast.success(t("toasts.evaluation_completed"));
-    loadMemberOfMonth();
+    void queryClient.invalidateQueries({
+      queryKey: [MEMBER_OF_MONTH_QUERY_KEY, clubId, sectionId],
+    });
   }
 
   // ─── Loading state ──────────────────────────────────────────────────────────
 
-  if (loading) {
+  if (isLoading) {
     return (
       <div className="flex items-center gap-2 py-2 text-xs text-muted-foreground">
         <Loader2 className="size-3 animate-spin" />
@@ -107,7 +101,7 @@ export function MemberOfMonthCard({
 
   // ─── No data — render nothing ───────────────────────────────────────────────
 
-  const hasWinners = data && data.members && data.members.length > 0;
+  const hasWinners = data?.members && data.members.length > 0;
 
   if (!hasWinners && !isDirector) return null;
 
@@ -115,7 +109,7 @@ export function MemberOfMonthCard({
 
   return (
     <>
-      {hasWinners && data ? (
+      {hasWinners && data !== undefined ? (
         <div className="rounded-xl border border-warning/25 bg-warning/5 p-4">
           {/* Header */}
           <div className="mb-3 flex items-center justify-between">

--- a/src/components/units/units-tab.tsx
+++ b/src/components/units/units-tab.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { Plus, Layers, Loader2 } from "lucide-react";
-import { toast } from "sonner";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/shared/empty-state";
@@ -35,6 +35,10 @@ function UnitsSkeleton() {
   );
 }
 
+// ─── Query key ───────────────────────────────────────────────────────────────
+
+export const UNITS_QUERY_KEY = "units" as const;
+
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 interface UnitsTabProps {
@@ -47,32 +51,27 @@ interface UnitsTabProps {
 export function UnitsTab({ clubId, localFieldId }: UnitsTabProps) {
   const t = useTranslations("units_admin");
   const router = useRouter();
-  const [units, setUnits] = useState<Unit[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
+  const queryClient = useQueryClient();
   const [deletingUnit, setDeletingUnit] = useState<Unit | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
-  const loadUnits = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const data = await listUnits(clubId);
-      setUnits(data);
-    } catch (err: unknown) {
-      const message =
-        err instanceof Error ? err.message : t("errors.load_units_failed");
-      setError(message);
-      toast.error(message);
-    } finally {
-      setLoading(false);
-    }
-  }, [clubId]);
+  const {
+    data: units = [],
+    isLoading: loading,
+    error: queryError,
+    refetch: loadUnits,
+  } = useQuery({
+    queryKey: [UNITS_QUERY_KEY, clubId],
+    queryFn: () => listUnits(clubId),
+    staleTime: 30_000,
+  });
 
-  useEffect(() => {
-    loadUnits();
-  }, [loadUnits]);
+  const error =
+    queryError instanceof Error
+      ? queryError.message
+      : queryError != null
+        ? t("errors.load_units_failed")
+        : null;
 
   function handleOpenDelete(unit: Unit) {
     setDeletingUnit(unit);
@@ -82,7 +81,7 @@ export function UnitsTab({ clubId, localFieldId }: UnitsTabProps) {
   function handleDeleteSuccess() {
     setDeleteOpen(false);
     setDeletingUnit(null);
-    loadUnits();
+    void queryClient.invalidateQueries({ queryKey: [UNITS_QUERY_KEY, clubId] });
   }
 
   // ─── Render ───────────────────────────────────────────────────────────────
@@ -114,7 +113,7 @@ export function UnitsTab({ clubId, localFieldId }: UnitsTabProps) {
           <button
             type="button"
             className="ml-2 underline underline-offset-2"
-            onClick={loadUnits}
+            onClick={() => void loadUnits()}
           >
             Reintentar
           </button>
@@ -150,7 +149,7 @@ export function UnitsTab({ clubId, localFieldId }: UnitsTabProps) {
                 router.push(`/dashboard/clubs/${clubId}/units/${u.unit_id}`);
               }}
               onDelete={handleOpenDelete}
-              onMembersChanged={loadUnits}
+              onMembersChanged={() => void queryClient.invalidateQueries({ queryKey: [UNITS_QUERY_KEY, clubId] })}
             />
           ))}
         </div>

--- a/src/components/validation/validation-history-dialog.tsx
+++ b/src/components/validation/validation-history-dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { toast } from "sonner";
 import { History, Clock, CheckCircle2, XCircle } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
@@ -83,6 +83,13 @@ interface ValidationHistoryDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+// ─── Query key factory ────────────────────────────────────────────────────────
+
+export const validationHistoryQueryKey = (
+  entityType: ValidationEntityType,
+  entityId: number | string,
+) => ["validation-history", entityType, entityId] as const;
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function ValidationHistoryDialog({
@@ -92,40 +99,28 @@ export function ValidationHistoryDialog({
   title,
   onOpenChange,
 }: ValidationHistoryDialogProps) {
-  const [entries, setEntries] = useState<ValidationHistoryEntry[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [loaded, setLoaded] = useState(false);
-
-  async function loadHistory() {
-    if (loaded) return;
-    setLoading(true);
-    try {
-      const data = await getValidationHistory(entityType, entityId);
-      setEntries(data);
-      setLoaded(true);
-    } catch (error) {
-      const message =
-        error instanceof ApiError
-          ? error.message
-          : "No se pudo cargar el historial";
-      toast.error(message);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  function handleOpenChange(isOpen: boolean) {
-    if (isOpen) {
-      loadHistory();
-    } else {
-      setEntries([]);
-      setLoaded(false);
-    }
-    onOpenChange(isOpen);
-  }
+  const { data: entries = [], isLoading: loading } = useQuery({
+    queryKey: validationHistoryQueryKey(entityType, entityId),
+    queryFn: async () => {
+      try {
+        return await getValidationHistory(entityType, entityId);
+      } catch (error) {
+        const message =
+          error instanceof ApiError
+            ? error.message
+            : "No se pudo cargar el historial";
+        toast.error(message);
+        throw error;
+      }
+    },
+    // Validation history is append-only — once fetched it never changes.
+    staleTime: Infinity,
+    // Only fetch when the dialog is open.
+    enabled: open,
+  });
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">


### PR DESCRIPTION
## Summary

Bucket 8a pilot. Validates the React Query (v5) pattern on three representative components flagged by audit A-2. The library was already installed and `QueryProvider` mounted in the dashboard layout — only the achievements module was using it. The other ~13 components reinvented loading/error/refresh state by hand.

### Why each component

- **`member-of-month/member-of-month-card.tsx`** — the canonical case. Single fetch keyed on `clubId/sectionId`. Post-evaluate refresh becomes `queryClient.invalidateQueries`. Inherits the default 5-min `staleTime` (data changes monthly).
- **`units/units-tab.tsx`** — fetch keyed on `clubId`, used in three places (initial load, retry button, `onMembersChanged` callback). Retry maps to `refetch()`, the callback to `invalidateQueries`. `staleTime: 30_000` because units change with frequent CRUD from other tabs. Inline error UI preserved; the duplicate `toast.error` was dropped (the user already sees the inline error). One pre-existing exhaustive-deps warning was eliminated as a side-effect.
- **`validation/validation-history-dialog.tsx`** — fetch keyed on `entityType/entityId`, gated on `enabled: open` so the dialog does not fire the request until shown. `staleTime: Infinity` because validation history is append-only and effectively immutable. Removed the `loaded` guard, the `setEntries([])` on close, and the custom `onOpenChange`.

### Why these three

They are simple (no shared deps with other in-flight PRs), each represents a different React Query pattern (default cache, short cache + invalidation, infinite cache + lazy fetch), and together they cover the three flavors the rest of the migration will need.

### Out of scope (deferred)

- `scoring-categories-table.tsx` — receives `fetchCategories` as a prop. Migrating internally would be a 3-consumer architecture refactor, not a pilot.
- `roles-table.tsx` — already receives a server-fetched list; no A-2 issue.
- The remaining ~10 components flagged by the audit go in follow-ups once this pattern lands.

Closes the pilot subset of audit finding A-2.

## Test plan

- [ ] `pnpm dev`. Open a club detail with units → loading skeleton, then list. Add a unit from another tab → click "Reintentar" or trigger `onMembersChanged` → list refetches.
- [ ] Open `/dashboard/units/[clubId]` with a section that has a member-of-month set → card renders. Run `evaluate` → card invalidates and shows the new evaluated member.
- [ ] Open a validation history dialog → first time fires the fetch, second time uses cache (no flicker). Closing the dialog and reopening uses the cached history immediately.
- [ ] DevTools Network: confirm only one request per `(clubId, sectionId)`/`(entityType, entityId)`/`clubId` cache key, even if the component remounts.
- [ ] `pnpm lint` → no new warnings (one pre-existing warning in `units-tab` was actually eliminated).