### PR TITLE
feat: mobile cards expansion + forms a11y sweep

### DIFF
--- a/src/app/(dashboard)/dashboard/clubs/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/page.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from "react";
 import Link from "next/link";
-import { Building2, Plus } from "lucide-react";
+import { Building2, ChevronRight, Plus } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -187,49 +187,117 @@ async function ClubsContent({
 
   return (
     <div className="space-y-4">
-      <DataTableShell>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Nombre</TableHead>
-              <TableHead className="hidden md:table-cell">Campo local</TableHead>
-              <TableHead className="hidden lg:table-cell">Distrito</TableHead>
-              <TableHead className="hidden lg:table-cell">Iglesia</TableHead>
-              <TableHead>Estado</TableHead>
-              <TableHead className="w-[100px]">Acciones</TableHead>
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {result.items.map((club) => {
-              const clubId = club.club_id ?? club.id;
-              return (
-                <TableRow key={clubId}>
-                  <TableCell className="font-medium">{club.name ?? "—"}</TableCell>
-                  <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
-                    {club.local_field?.name ?? club.local_field_id ?? "—"}
-                  </TableCell>
-                  <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
-                    {club.district?.name ?? club.district_id ?? "—"}
-                  </TableCell>
-                  <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
-                    {club.church?.name ?? club.church_id ?? "—"}
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={club.active !== false ? "default" : "outline"} className="text-xs">
-                      {club.active !== false ? "Activo" : "Inactivo"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <Button variant="ghost" size="sm" asChild>
-                      <Link href={`/dashboard/clubs/${clubId}`}>Ver</Link>
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </DataTableShell>
+      {/* Desktop: full table */}
+      <div className="hidden md:block">
+        <DataTableShell>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Nombre</TableHead>
+                <TableHead className="hidden md:table-cell">Campo local</TableHead>
+                <TableHead className="hidden lg:table-cell">Distrito</TableHead>
+                <TableHead className="hidden lg:table-cell">Iglesia</TableHead>
+                <TableHead>Estado</TableHead>
+                <TableHead className="w-[100px]">Acciones</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {result.items.map((club) => {
+                const clubId = club.club_id ?? club.id;
+                return (
+                  <TableRow key={clubId}>
+                    <TableCell className="font-medium">{club.name ?? "—"}</TableCell>
+                    <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
+                      {club.local_field?.name ?? club.local_field_id ?? "—"}
+                    </TableCell>
+                    <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
+                      {club.district?.name ?? club.district_id ?? "—"}
+                    </TableCell>
+                    <TableCell className="hidden text-sm text-muted-foreground lg:table-cell">
+                      {club.church?.name ?? club.church_id ?? "—"}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={club.active !== false ? "default" : "outline"} className="text-xs">
+                        {club.active !== false ? "Activo" : "Inactivo"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <Button variant="ghost" size="sm" asChild>
+                        <Link href={`/dashboard/clubs/${clubId}`}>Ver</Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </DataTableShell>
+      </div>
+
+      {/* Mobile: descriptive cards */}
+      <ul className="space-y-3 md:hidden" aria-label="Lista de clubes">
+        {result.items.map((club) => {
+          const clubId = club.club_id ?? club.id;
+          const localField = club.local_field?.name ?? (club.local_field_id ? String(club.local_field_id) : null);
+          const district = club.district?.name ?? (club.district_id ? String(club.district_id) : null);
+          const church = club.church?.name ?? (club.church_id ? String(club.church_id) : null);
+
+          return (
+            <li key={clubId}>
+              <Link
+                href={`/dashboard/clubs/${clubId}`}
+                className="block rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <div className="flex items-center gap-3">
+                  <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                    <Building2 className="size-5 text-primary" aria-hidden="true" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium">{club.name ?? "—"}</p>
+                    {localField && (
+                      <p className="truncate text-xs text-muted-foreground">{localField}</p>
+                    )}
+                  </div>
+                  <ChevronRight
+                    className="size-4 shrink-0 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                </div>
+
+                <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                  <Badge
+                    variant={club.active !== false ? "default" : "outline"}
+                    className="text-xs"
+                  >
+                    {club.active !== false ? "Activo" : "Inactivo"}
+                  </Badge>
+                </div>
+
+                <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+                  {localField && (
+                    <div className="col-span-2">
+                      <dt className="text-muted-foreground">Campo local</dt>
+                      <dd className="truncate">{localField}</dd>
+                    </div>
+                  )}
+                  {district && (
+                    <div>
+                      <dt className="text-muted-foreground">Distrito</dt>
+                      <dd className="truncate">{district}</dd>
+                    </div>
+                  )}
+                  {church && (
+                    <div>
+                      <dt className="text-muted-foreground">Iglesia</dt>
+                      <dd className="truncate">{church}</dd>
+                    </div>
+                  )}
+                </dl>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
 
       <DataTablePagination
         page={result.meta.page}

--- a/src/components/finances/transaction-form-dialog.tsx
+++ b/src/components/finances/transaction-form-dialog.tsx
@@ -229,18 +229,19 @@ export function TransactionFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Categoría */}
           <div className="space-y-1.5">
-            <Label>
-              Categoría <span className="ml-0.5 text-destructive">*</span>
+            <Label htmlFor="finance_category_id">
+              Categoría{" "}
+              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Select
               value={selectedCategoryId?.toString() ?? ""}
               onValueChange={(v) => setValue("finance_category_id", Number(v))}
               disabled={loadingCategories}
             >
-              <SelectTrigger>
+              <SelectTrigger id="finance_category_id" aria-required="true">
                 <SelectValue
                   placeholder={
                     loadingCategories ? "Cargando categorías..." : "Seleccioná una categoría"
@@ -268,9 +269,15 @@ export function TransactionFormDialog({
           {/* Fecha */}
           <div className="space-y-1.5">
             <Label htmlFor="finance_date">
-              Fecha <span className="ml-0.5 text-destructive">*</span>
+              Fecha{" "}
+              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
-            <Input id="finance_date" type="date" {...register("finance_date")} />
+            <Input
+              id="finance_date"
+              type="date"
+              aria-required="true"
+              {...register("finance_date")}
+            />
             {errors.finance_date && (
               <p className="text-xs text-destructive">{errors.finance_date.message}</p>
             )}
@@ -279,7 +286,8 @@ export function TransactionFormDialog({
           {/* Monto */}
           <div className="space-y-1.5">
             <Label htmlFor="amount">
-              Monto (ARS) <span className="ml-0.5 text-destructive">*</span>
+              Monto (ARS){" "}
+              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Input
               id="amount"
@@ -287,6 +295,7 @@ export function TransactionFormDialog({
               min="0.01"
               step="0.01"
               placeholder="0.00"
+              aria-required="true"
               {...register("amount")}
             />
             {errors.amount && (
@@ -297,15 +306,16 @@ export function TransactionFormDialog({
           {/* Año y Mes */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label>
-                Año <span className="ml-0.5 text-destructive">*</span>
+              <Label htmlFor="year">
+                Año{" "}
+                <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
                 value={selectedYear?.toString() ?? ""}
                 onValueChange={(v) => setValue("year", Number(v))}
                 disabled={isEdit}
               >
-                <SelectTrigger>
+                <SelectTrigger id="year" aria-required="true">
                   <SelectValue placeholder="Año" />
                 </SelectTrigger>
                 <SelectContent>
@@ -322,15 +332,16 @@ export function TransactionFormDialog({
             </div>
 
             <div className="space-y-1.5">
-              <Label>
-                Mes <span className="ml-0.5 text-destructive">*</span>
+              <Label htmlFor="month">
+                Mes{" "}
+                <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
                 value={selectedMonth?.toString() ?? ""}
                 onValueChange={(v) => setValue("month", Number(v))}
                 disabled={isEdit}
               >
-                <SelectTrigger>
+                <SelectTrigger id="month" aria-required="true">
                   <SelectValue placeholder="Mes" />
                 </SelectTrigger>
                 <SelectContent>
@@ -350,8 +361,9 @@ export function TransactionFormDialog({
           {/* Sección del club (solo al crear) */}
           {!isEdit && (
             <div className="space-y-1.5">
-              <Label>
-                Sección del club <span className="ml-0.5 text-destructive">*</span>
+              <Label htmlFor="club_section_id">
+                Sección del club{" "}
+                <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
                 value={selectedSectionId?.toString() ?? ""}
@@ -366,7 +378,7 @@ export function TransactionFormDialog({
                   }
                 }}
               >
-                <SelectTrigger>
+                <SelectTrigger id="club_section_id" aria-required="true">
                   <SelectValue placeholder="Seleccioná una sección" />
                 </SelectTrigger>
                 <SelectContent>
@@ -411,7 +423,7 @@ export function TransactionFormDialog({
               Cancelar
             </Button>
             <Button type="submit" disabled={isSubmitting || loadingCategories}>
-              {isSubmitting && <Loader2 className="size-4 animate-spin" />}
+              {isSubmitting && <Loader2 aria-hidden="true" className="size-4 animate-spin" />}
               {isEdit ? "Guardar cambios" : "Crear movimiento"}
             </Button>
           </DialogFooter>

--- a/src/components/insurance/insurance-form-dialog.tsx
+++ b/src/components/insurance/insurance-form-dialog.tsx
@@ -186,15 +186,18 @@ export function InsuranceFormDialog({
           )}
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Tipo de seguro */}
           <div className="space-y-1.5">
-            <Label>Tipo de seguro *</Label>
+            <Label htmlFor="insurance_type">
+              Tipo de seguro{" "}
+              <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Select
               value={insuranceTypeValue}
               onValueChange={(val) => setValue("insurance_type", val as InsuranceType)}
             >
-              <SelectTrigger>
+              <SelectTrigger id="insurance_type" aria-required="true">
                 <SelectValue placeholder="Seleccionar tipo" />
               </SelectTrigger>
               <SelectContent>
@@ -233,10 +236,14 @@ export function InsuranceFormDialog({
           {/* Fechas */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label htmlFor="start_date">Fecha de inicio *</Label>
+              <Label htmlFor="start_date">
+                Fecha de inicio{" "}
+                <span aria-hidden="true" className="text-destructive">*</span>
+              </Label>
               <Input
                 id="start_date"
                 type="date"
+                aria-required="true"
                 {...register("start_date")}
               />
               {errors.start_date && (
@@ -244,10 +251,14 @@ export function InsuranceFormDialog({
               )}
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="end_date">Fecha de vencimiento *</Label>
+              <Label htmlFor="end_date">
+                Fecha de vencimiento{" "}
+                <span aria-hidden="true" className="text-destructive">*</span>
+              </Label>
               <Input
                 id="end_date"
                 type="date"
+                aria-required="true"
                 {...register("end_date")}
               />
               {errors.end_date && (
@@ -283,7 +294,7 @@ export function InsuranceFormDialog({
                 onClick={() => fileInputRef.current?.click()}
                 className="gap-1.5"
               >
-                <Paperclip className="size-3.5" />
+                <Paperclip aria-hidden="true" className="size-3.5" />
                 {evidenceFile ? "Cambiar archivo" : "Adjuntar archivo"}
               </Button>
               {evidenceFile && (
@@ -298,7 +309,7 @@ export function InsuranceFormDialog({
                       if (fileInputRef.current) fileInputRef.current.value = "";
                     }}
                   >
-                    <X className="size-3" />
+                    <X aria-hidden="true" className="size-3" />
                     <span className="sr-only">Quitar archivo</span>
                   </Button>
                 </div>

--- a/src/components/inventory/inventory-form-dialog.tsx
+++ b/src/components/inventory/inventory-form-dialog.tsx
@@ -157,12 +157,16 @@ export function InventoryFormDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Nombre */}
           <div className="space-y-1.5">
-            <Label htmlFor="name">Nombre *</Label>
+            <Label htmlFor="name">
+              Nombre{" "}
+              <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Input
               id="name"
+              aria-required="true"
               {...register("name")}
               placeholder="Ej. Carpas 4 personas"
             />
@@ -187,14 +191,17 @@ export function InventoryFormDialog({
 
           {/* Categoría */}
           <div className="space-y-1.5">
-            <Label>Categoría *</Label>
+            <Label htmlFor="inventory_category_id">
+              Categoría{" "}
+              <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Select
               value={String(selectedCategoryId)}
               onValueChange={(val) =>
                 setValue("inventory_category_id", Number(val))
               }
             >
-              <SelectTrigger>
+              <SelectTrigger id="inventory_category_id" aria-required="true">
                 <SelectValue placeholder="Seleccionar categoría" />
               </SelectTrigger>
               <SelectContent>
@@ -223,11 +230,15 @@ export function InventoryFormDialog({
 
           {/* Cantidad */}
           <div className="space-y-1.5">
-            <Label htmlFor="amount">Cantidad *</Label>
+            <Label htmlFor="amount">
+              Cantidad{" "}
+              <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Input
               id="amount"
               type="number"
               min={0}
+              aria-required="true"
               {...register("amount")}
               placeholder="0"
             />

--- a/src/components/rbac/roles-table.tsx
+++ b/src/components/rbac/roles-table.tsx
@@ -13,6 +13,7 @@ import {
   Loader2,
   ShieldCheck,
   Users,
+  ChevronRight,
 } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
@@ -50,6 +51,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/shared/empty-state";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 import { deactivateRoleAction } from "@/lib/rbac/actions";
 import type { Role } from "@/lib/rbac/types";
 
@@ -317,173 +319,265 @@ export function RolesTable({ roles, isSuperAdmin }: RolesTableProps) {
           }
         />
       ) : (
-        <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Nombre
-                </TableHead>
-                <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Categoría
-                </TableHead>
-                <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground hidden md:table-cell">
-                  Descripción
-                </TableHead>
-                <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Permisos
-                </TableHead>
-                <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Estado
-                </TableHead>
-                {isSuperAdmin && (
-                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
-                    Acciones
-                  </TableHead>
-                )}
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filtered.map((role, index) => {
-                const protected_ = isProtected(role);
-                return (
-                  <TableRow
-                    key={role.role_id}
-                    className="transition-colors hover:bg-muted/30 animate-in fade-in slide-in-from-bottom-2 duration-300"
-                    style={{ animationDelay: `${index * 40}ms`, animationFillMode: "backwards" }}
-                  >
-                    {/* role_name — mono, lock icon for super-admin */}
-                    <TableCell className="px-3 py-2.5 align-middle">
-                      <div className="flex items-center gap-1.5">
-                        {protected_ && (
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <Lock className="size-3.5 shrink-0 text-muted-foreground" />
-                            </TooltipTrigger>
-                            <TooltipContent>Rol protegido del sistema</TooltipContent>
-                          </Tooltip>
-                        )}
-                        <span className="font-mono text-sm font-medium">{role.role_name}</span>
-                      </div>
-                    </TableCell>
-
-                    {/* role_category badge */}
-                    <TableCell className="px-3 py-2.5 align-middle">
-                      <Badge variant={role.role_category === "GLOBAL" ? "secondary" : "outline"}>
-                        {role.role_category}
-                      </Badge>
-                    </TableCell>
-
-                    {/* description — truncated with tooltip */}
-                    <TableCell className="px-3 py-2.5 align-middle hidden md:table-cell max-w-[260px]">
-                      {role.description ? (
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <span className="block truncate text-sm text-muted-foreground cursor-default">
-                              {role.description}
-                            </span>
-                          </TooltipTrigger>
-                          <TooltipContent className="max-w-xs">{role.description}</TooltipContent>
-                        </Tooltip>
-                      ) : (
-                        <span className="text-sm text-muted-foreground">—</span>
-                      )}
-                    </TableCell>
-
-                    {/* permissions count with popover */}
-                    <TableCell className="px-3 py-2.5 align-middle">
-                      <PermissionsPopover role={role} />
-                    </TableCell>
-
-                    {/* active status */}
-                    <TableCell className="px-3 py-2.5 align-middle">
-                      <Badge variant={role.active !== false ? "soft-success" : "outline"}>
-                        {role.active !== false ? "Activo" : "Inactivo"}
-                      </Badge>
-                    </TableCell>
-
-                    {/* actions — super-admin only */}
+        <>
+          {/* Desktop: full table */}
+          <div className="hidden md:block">
+            <DataTableShell>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Nombre
+                    </TableHead>
+                    <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Categoría
+                    </TableHead>
+                    <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground hidden md:table-cell">
+                      Descripción
+                    </TableHead>
+                    <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Permisos
+                    </TableHead>
+                    <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                      Estado
+                    </TableHead>
                     {isSuperAdmin && (
-                      <TableCell className="px-3 py-2.5 align-middle text-right">
-                        <div className="flex items-center justify-end gap-1">
-                          {protected_ ? (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="inline-flex">
-                                  <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    className="size-8 opacity-40"
-                                    disabled
-                                    aria-label="Editar rol protegido"
-                                  >
-                                    <Pencil className="size-3.5" />
-                                  </Button>
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent>Rol protegido — no se puede modificar desde la UI</TooltipContent>
-                            </Tooltip>
-                          ) : (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="size-8"
-                                  asChild
-                                >
-                                  <Link href={`/dashboard/rbac/roles/${role.role_id}`}>
-                                    <Pencil className="size-3.5" />
-                                    <span className="sr-only">Editar {role.role_name}</span>
-                                  </Link>
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent>Editar rol</TooltipContent>
-                            </Tooltip>
-                          )}
-
-                          {protected_ ? (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <span className="inline-flex">
-                                  <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    className="size-8 opacity-40"
-                                    disabled
-                                    aria-label="Desactivar rol protegido"
-                                  >
-                                    <Power className="size-3.5" />
-                                  </Button>
-                                </span>
-                              </TooltipTrigger>
-                              <TooltipContent>Rol protegido — no se puede modificar desde la UI</TooltipContent>
-                            </Tooltip>
-                          ) : role.active !== false ? (
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  variant="ghost"
-                                  size="icon"
-                                  className="size-8 text-destructive hover:text-destructive hover:bg-destructive/10"
-                                  onClick={() => setDeactivateTarget(role)}
-                                  aria-label={`Desactivar ${role.role_name}`}
-                                >
-                                  <Power className="size-3.5" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent>Desactivar rol</TooltipContent>
-                            </Tooltip>
-                          ) : null}
-                        </div>
-                      </TableCell>
+                      <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+                        Acciones
+                      </TableHead>
                     )}
                   </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </div>
+                </TableHeader>
+                <TableBody>
+                  {filtered.map((role, index) => {
+                    const protected_ = isProtected(role);
+                    return (
+                      <TableRow
+                        key={role.role_id}
+                        className="transition-colors hover:bg-muted/30 animate-in fade-in slide-in-from-bottom-2 duration-300"
+                        style={{ animationDelay: `${index * 40}ms`, animationFillMode: "backwards" }}
+                      >
+                        {/* role_name — mono, lock icon for super-admin */}
+                        <TableCell className="px-3 py-2.5 align-middle">
+                          <div className="flex items-center gap-1.5">
+                            {protected_ && (
+                              <Tooltip>
+                                <TooltipTrigger asChild>
+                                  <Lock className="size-3.5 shrink-0 text-muted-foreground" />
+                                </TooltipTrigger>
+                                <TooltipContent>Rol protegido del sistema</TooltipContent>
+                              </Tooltip>
+                            )}
+                            <span className="font-mono text-sm font-medium">{role.role_name}</span>
+                          </div>
+                        </TableCell>
+
+                        {/* role_category badge */}
+                        <TableCell className="px-3 py-2.5 align-middle">
+                          <Badge variant={role.role_category === "GLOBAL" ? "secondary" : "outline"}>
+                            {role.role_category}
+                          </Badge>
+                        </TableCell>
+
+                        {/* description — truncated with tooltip */}
+                        <TableCell className="px-3 py-2.5 align-middle hidden md:table-cell max-w-[260px]">
+                          {role.description ? (
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <span className="block truncate text-sm text-muted-foreground cursor-default">
+                                  {role.description}
+                                </span>
+                              </TooltipTrigger>
+                              <TooltipContent className="max-w-xs">{role.description}</TooltipContent>
+                            </Tooltip>
+                          ) : (
+                            <span className="text-sm text-muted-foreground">—</span>
+                          )}
+                        </TableCell>
+
+                        {/* permissions count with popover */}
+                        <TableCell className="px-3 py-2.5 align-middle">
+                          <PermissionsPopover role={role} />
+                        </TableCell>
+
+                        {/* active status */}
+                        <TableCell className="px-3 py-2.5 align-middle">
+                          <Badge variant={role.active !== false ? "soft-success" : "outline"}>
+                            {role.active !== false ? "Activo" : "Inactivo"}
+                          </Badge>
+                        </TableCell>
+
+                        {/* actions — super-admin only */}
+                        {isSuperAdmin && (
+                          <TableCell className="px-3 py-2.5 align-middle text-right">
+                            <div className="flex items-center justify-end gap-1">
+                              {protected_ ? (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <span className="inline-flex">
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="size-8 opacity-40"
+                                        disabled
+                                        aria-label="Editar rol protegido"
+                                      >
+                                        <Pencil className="size-3.5" />
+                                      </Button>
+                                    </span>
+                                  </TooltipTrigger>
+                                  <TooltipContent>Rol protegido — no se puede modificar desde la UI</TooltipContent>
+                                </Tooltip>
+                              ) : (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      className="size-8"
+                                      asChild
+                                    >
+                                      <Link href={`/dashboard/rbac/roles/${role.role_id}`}>
+                                        <Pencil className="size-3.5" />
+                                        <span className="sr-only">Editar {role.role_name}</span>
+                                      </Link>
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent>Editar rol</TooltipContent>
+                                </Tooltip>
+                              )}
+
+                              {protected_ ? (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <span className="inline-flex">
+                                      <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="size-8 opacity-40"
+                                        disabled
+                                        aria-label="Desactivar rol protegido"
+                                      >
+                                        <Power className="size-3.5" />
+                                      </Button>
+                                    </span>
+                                  </TooltipTrigger>
+                                  <TooltipContent>Rol protegido — no se puede modificar desde la UI</TooltipContent>
+                                </Tooltip>
+                              ) : role.active !== false ? (
+                                <Tooltip>
+                                  <TooltipTrigger asChild>
+                                    <Button
+                                      variant="ghost"
+                                      size="icon"
+                                      className="size-8 text-destructive hover:text-destructive hover:bg-destructive/10"
+                                      onClick={() => setDeactivateTarget(role)}
+                                      aria-label={`Desactivar ${role.role_name}`}
+                                    >
+                                      <Power className="size-3.5" />
+                                    </Button>
+                                  </TooltipTrigger>
+                                  <TooltipContent>Desactivar rol</TooltipContent>
+                                </Tooltip>
+                              ) : null}
+                            </div>
+                          </TableCell>
+                        )}
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </DataTableShell>
+          </div>
+
+          {/* Mobile: descriptive cards */}
+          <ul className="space-y-3 md:hidden" aria-label="Lista de roles">
+            {filtered.map((role) => {
+              const protected_ = isProtected(role);
+              const permCount = role.role_permissions?.length ?? 0;
+
+              return (
+                <li key={role.role_id}>
+                  <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none">
+                    <div className="flex items-center gap-3">
+                      <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                        {protected_ ? (
+                          <Lock className="size-5 text-primary" aria-hidden="true" />
+                        ) : (
+                          <ShieldCheck className="size-5 text-primary" aria-hidden="true" />
+                        )}
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate font-mono text-sm font-medium">{role.role_name}</p>
+                        {role.description && (
+                          <p className="line-clamp-1 text-xs text-muted-foreground">
+                            {role.description}
+                          </p>
+                        )}
+                      </div>
+                      {!protected_ && isSuperAdmin && (
+                        <Link
+                          href={`/dashboard/rbac/roles/${role.role_id}`}
+                          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          aria-label={`Editar ${role.role_name}`}
+                        >
+                          <ChevronRight className="size-4" aria-hidden="true" />
+                        </Link>
+                      )}
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                      <Badge variant={role.active !== false ? "soft-success" : "outline"} className="text-xs">
+                        {role.active !== false ? "Activo" : "Inactivo"}
+                      </Badge>
+                      <Badge variant={role.role_category === "GLOBAL" ? "secondary" : "outline"} className="text-xs">
+                        {role.role_category}
+                      </Badge>
+                      {protected_ && (
+                        <Badge variant="outline" className="text-xs">
+                          Protegido
+                        </Badge>
+                      )}
+                    </div>
+
+                    <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+                      <div>
+                        <dt className="text-muted-foreground">Permisos</dt>
+                        <dd>{permCount}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Categoría</dt>
+                        <dd>{role.role_category}</dd>
+                      </div>
+                    </dl>
+
+                    {isSuperAdmin && !protected_ && role.active !== false && (
+                      <div className="mt-3 flex flex-wrap gap-1.5 border-t border-border/40 pt-3">
+                        <Button variant="outline" size="xs" asChild>
+                          <Link href={`/dashboard/rbac/roles/${role.role_id}`}>
+                            <Pencil className="size-3" />
+                            Editar
+                          </Link>
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                          onClick={() => setDeactivateTarget(role)}
+                          aria-label={`Desactivar ${role.role_name}`}
+                        >
+                          <Power className="size-3" />
+                          Desactivar
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </>
       )}
 
       {/* Footer count */}

--- a/src/components/reports/reports-list-client.tsx
+++ b/src/components/reports/reports-list-client.tsx
@@ -16,6 +16,7 @@ import {
   Filter,
   Loader2,
   FileText,
+  ChevronRight,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -36,6 +37,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/shared/empty-state";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 import {
   listMonthlyReports,
   createOrGetDraftReport,
@@ -327,7 +329,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
         </div>
       </div>
 
-      {/* Table */}
+      {/* Table / Cards */}
       {loading ? (
         <ReportsTableSkeleton />
       ) : reports.length === 0 ? (
@@ -337,110 +339,226 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
           description="No se encontraron reportes mensuales para los filtros seleccionados."
         />
       ) : (
-        <div className="rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Mes</TableHead>
-                <TableHead>Año</TableHead>
-                <TableHead>Estado</TableHead>
-                <TableHead className="hidden md:table-cell">Generado</TableHead>
-                <TableHead className="hidden md:table-cell">Enviado</TableHead>
-                <TableHead className="w-[200px]">Acciones</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {reports.map((report) => {
-                const statusConfig = STATUS_CONFIG[report.status] ?? STATUS_CONFIG.draft;
-                const loadingAction = actionLoading[report.report_id];
-                const isDisabled = Boolean(loadingAction);
-                const isSubmitted = report.status === "submitted";
-                const isGenerated = report.status === "generated";
+        <>
+          {/* Desktop: full table */}
+          <div className="hidden md:block">
+            <DataTableShell>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Mes</TableHead>
+                    <TableHead>Año</TableHead>
+                    <TableHead>Estado</TableHead>
+                    <TableHead className="hidden md:table-cell">Generado</TableHead>
+                    <TableHead className="hidden md:table-cell">Enviado</TableHead>
+                    <TableHead className="w-[200px]">Acciones</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {reports.map((report) => {
+                    const statusConfig = STATUS_CONFIG[report.status] ?? STATUS_CONFIG.draft;
+                    const loadingAction = actionLoading[report.report_id];
+                    const isDisabled = Boolean(loadingAction);
+                    const isSubmitted = report.status === "submitted";
+                    const isGenerated = report.status === "generated";
 
-                return (
-                  <TableRow key={report.report_id}>
-                    <TableCell className="font-medium">
-                      {MONTH_NAMES[report.month] ?? report.month}
-                    </TableCell>
-                    <TableCell className="tabular-nums">{report.year}</TableCell>
-                    <TableCell>
+                    return (
+                      <TableRow key={report.report_id}>
+                        <TableCell className="font-medium">
+                          {MONTH_NAMES[report.month] ?? report.month}
+                        </TableCell>
+                        <TableCell className="tabular-nums">{report.year}</TableCell>
+                        <TableCell>
+                          <Badge variant={statusConfig.variant} className="text-xs">
+                            {statusConfig.label}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
+                          {formatDate(report.generated_at)}
+                        </TableCell>
+                        <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
+                          {formatDate(report.submitted_at)}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-1.5">
+                            <Button variant="ghost" size="xs" asChild>
+                              <Link href={`/dashboard/reports/${report.report_id}`}>
+                                {isSubmitted ? (
+                                  <Eye className="size-3" />
+                                ) : (
+                                  <Pencil className="size-3" />
+                                )}
+                                {isSubmitted ? "Ver" : "Editar"}
+                              </Link>
+                            </Button>
+
+                            {!isSubmitted && (
+                              <Button
+                                variant="ghost"
+                                size="xs"
+                                onClick={() => handleGenerate(report)}
+                                disabled={isDisabled}
+                              >
+                                {loadingAction === "generate" ? (
+                                  <Loader2 className="size-3 animate-spin" />
+                                ) : (
+                                  <Zap className="size-3" />
+                                )}
+                                Generar
+                              </Button>
+                            )}
+
+                            {isGenerated && (
+                              <Button
+                                variant="ghost"
+                                size="xs"
+                                onClick={() => handleSubmit(report)}
+                                disabled={isDisabled}
+                              >
+                                {loadingAction === "submit" ? (
+                                  <Loader2 className="size-3 animate-spin" />
+                                ) : (
+                                  <Send className="size-3" />
+                                )}
+                                Enviar
+                              </Button>
+                            )}
+
+                            {(isGenerated || isSubmitted) && (
+                              <Button
+                                variant="ghost"
+                                size="xs"
+                                onClick={() => handleDownloadPdf(report)}
+                              >
+                                <Download className="size-3" />
+                                PDF
+                              </Button>
+                            )}
+                          </div>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </DataTableShell>
+          </div>
+
+          {/* Mobile: descriptive cards */}
+          <ul className="space-y-3 md:hidden" aria-label="Lista de reportes">
+            {reports.map((report) => {
+              const statusConfig = STATUS_CONFIG[report.status] ?? STATUS_CONFIG.draft;
+              const loadingAction = actionLoading[report.report_id];
+              const isDisabled = Boolean(loadingAction);
+              const isSubmitted = report.status === "submitted";
+              const isGenerated = report.status === "generated";
+
+              return (
+                <li key={report.report_id}>
+                  <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs">
+                    <div className="flex items-center gap-3">
+                      <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                        <FileText className="size-5 text-primary" aria-hidden="true" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">
+                          {MONTH_NAMES[report.month] ?? report.month} {report.year}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground tabular-nums">
+                          #{report.report_id}
+                        </p>
+                      </div>
+                      <Link
+                        href={`/dashboard/reports/${report.report_id}`}
+                        className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        aria-label={isSubmitted ? "Ver reporte" : "Editar reporte"}
+                      >
+                        <ChevronRight className="size-4" aria-hidden="true" />
+                      </Link>
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
                       <Badge variant={statusConfig.variant} className="text-xs">
                         {statusConfig.label}
                       </Badge>
-                    </TableCell>
-                    <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
-                      {formatDate(report.generated_at)}
-                    </TableCell>
-                    <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
-                      {formatDate(report.submitted_at)}
-                    </TableCell>
-                    <TableCell>
-                      <div className="flex items-center gap-1.5">
-                        {/* View / Edit */}
-                        <Button variant="ghost" size="xs" asChild>
-                          <Link href={`/dashboard/reports/${report.report_id}`}>
-                            {isSubmitted ? (
-                              <Eye className="size-3" />
-                            ) : (
-                              <Pencil className="size-3" />
-                            )}
-                            {isSubmitted ? "Ver" : "Editar"}
-                          </Link>
+                    </div>
+
+                    <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+                      {report.generated_at && (
+                        <div>
+                          <dt className="text-muted-foreground">Generado</dt>
+                          <dd>{formatDate(report.generated_at)}</dd>
+                        </div>
+                      )}
+                      {report.submitted_at && (
+                        <div>
+                          <dt className="text-muted-foreground">Enviado</dt>
+                          <dd>{formatDate(report.submitted_at)}</dd>
+                        </div>
+                      )}
+                    </dl>
+
+                    <div className="mt-3 flex flex-wrap gap-1.5 border-t border-border/40 pt-3">
+                      <Button variant="outline" size="xs" asChild>
+                        <Link href={`/dashboard/reports/${report.report_id}`}>
+                          {isSubmitted ? (
+                            <Eye className="size-3" />
+                          ) : (
+                            <Pencil className="size-3" />
+                          )}
+                          {isSubmitted ? "Ver" : "Editar"}
+                        </Link>
+                      </Button>
+
+                      {!isSubmitted && (
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          onClick={() => handleGenerate(report)}
+                          disabled={isDisabled}
+                        >
+                          {loadingAction === "generate" ? (
+                            <Loader2 className="size-3 animate-spin" />
+                          ) : (
+                            <Zap className="size-3" />
+                          )}
+                          Generar
                         </Button>
+                      )}
 
-                        {/* Generate */}
-                        {!isSubmitted && (
-                          <Button
-                            variant="ghost"
-                            size="xs"
-                            onClick={() => handleGenerate(report)}
-                            disabled={isDisabled}
-                          >
-                            {loadingAction === "generate" ? (
-                              <Loader2 className="size-3 animate-spin" />
-                            ) : (
-                              <Zap className="size-3" />
-                            )}
-                            Generar
-                          </Button>
-                        )}
+                      {isGenerated && (
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          onClick={() => handleSubmit(report)}
+                          disabled={isDisabled}
+                        >
+                          {loadingAction === "submit" ? (
+                            <Loader2 className="size-3 animate-spin" />
+                          ) : (
+                            <Send className="size-3" />
+                          )}
+                          Enviar
+                        </Button>
+                      )}
 
-                        {/* Submit */}
-                        {isGenerated && (
-                          <Button
-                            variant="ghost"
-                            size="xs"
-                            onClick={() => handleSubmit(report)}
-                            disabled={isDisabled}
-                          >
-                            {loadingAction === "submit" ? (
-                              <Loader2 className="size-3 animate-spin" />
-                            ) : (
-                              <Send className="size-3" />
-                            )}
-                            Enviar
-                          </Button>
-                        )}
-
-                        {/* PDF */}
-                        {(isGenerated || isSubmitted) && (
-                          <Button
-                            variant="ghost"
-                            size="xs"
-                            onClick={() => handleDownloadPdf(report)}
-                          >
-                            <Download className="size-3" />
-                            PDF
-                          </Button>
-                        )}
-                      </div>
-                    </TableCell>
-                  </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </div>
+                      {(isGenerated || isSubmitted) && (
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          onClick={() => handleDownloadPdf(report)}
+                        >
+                          <Download className="size-3" />
+                          PDF
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary

Two related buckets bundled because the agent producing them ended up stacking the commits on a single branch.

### Bucket 9a — mobile cards expansion (3 commits)

Extends the mobile-cards pattern (POC in #32 on `users-table`) to:
- **`clubs/page.tsx`** — `Building2` icon header, whole card is a `<Link>` to `/dashboard/clubs/:id`. `DataTablePagination` sits outside the desktop/mobile fork.
- **`reports/reports-list-client.tsx`** — per-row async actions (Generar / Enviar / PDF) so the whole card can't be one link. `ChevronRight` icon-link in the header, action buttons in a footer strip with `variant="outline"` (touch hit-target).
- **`rbac/roles-table.tsx`** — `PermissionsPopover` is desktop-only; on mobile the permission count surfaces in the `<dl>`. Protected roles get a `Lock` icon and no action strip. Super-admin action strip only renders when the desktop guards (`isSuperAdmin && !protected_ && role.active !== false`) all pass.

### Bucket 9c — forms a11y sweep (3 commits)

Extends the manual aria-* pattern (validated in `create-club-form.tsx` from #28) to three more raw `useForm` dialogs (none of these used shadcn `<Form>`, so the wiring is manual):

- **`insurance/insurance-form-dialog.tsx`** — `noValidate` on form, `aria-hidden` on `*` markers, `id` + `aria-required` on the `<SelectTrigger>` (was missing entirely), `aria-required` on `start_date` / `end_date`, `aria-hidden` on `Paperclip` / `X` icons.
- **`inventory/inventory-form-dialog.tsx`** — same plus added the missing `htmlFor`/`id` link between the Categoría label and trigger (was completely disconnected before).
- **`finances/transaction-form-dialog.tsx`** — most complex (5 selects). All four un-`id`'d triggers got `id` + `htmlFor` + `aria-required`. Inputs `finance_date` / `amount` got `aria-required`. `Loader2` got `aria-hidden`.

Errors in all three forms surface as `toast.error` rather than an inline banner, so there was no `role="alert"` region to wrap.

Closes audit 8.2 expansion (mobile cards) + audit 5.1/5.2 expansion (forms a11y).

## Commits

- `d2eb65a` feat(clubs-table): add descriptive mobile cards
- `c30f1e3` feat(reports-list): add descriptive mobile cards
- `0b7f1f6` feat(roles-table): add descriptive mobile cards
- `81af73f` fix(insurance): add aria attributes to insurance-form-dialog
- `c3bd78b` fix(inventory): add aria attributes to inventory-form-dialog
- `b4bb6aa` fix(finances): add aria attributes to transaction-form-dialog

## Test plan

- [ ] `/dashboard/clubs`, `/dashboard/reports`, `/dashboard/rbac` below `md` → tables flip to card lists with the same data.
- [ ] Open each form dialog with a screen reader. After clicking submit on an invalid form, the error toast announces. Required-field markers are announced via `aria-required`, not the visual `*`.
- [ ] Tab to each `<SelectTrigger>` — the screen reader reads the label name (the `htmlFor`/`id` wiring is the fix).
- [ ] `pnpm lint` → no new errors in the 6 touched files.