### PR TITLE
refactor(data-fetching): React Query expansion — 5 components

### DIFF
--- a/src/components/evidence-review/evidence-history-dialog.tsx
+++ b/src/components/evidence-review/evidence-history-dialog.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState } from "react";
 import { toast } from "sonner";
 import { History, Clock, CheckCircle2, XCircle, Send } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
@@ -84,6 +84,11 @@ interface EvidenceHistoryDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+// ─── Query key factory ────────────────────────────────────────────────────────
+
+export const evidenceHistoryQueryKey = (type: EvidenceType, id: number) =>
+  ["evidence-history", type, id] as const;
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function EvidenceHistoryDialog({
@@ -93,40 +98,28 @@ export function EvidenceHistoryDialog({
   memberName,
   onOpenChange,
 }: EvidenceHistoryDialogProps) {
-  const [entries, setEntries] = useState<EvidenceHistoryEntry[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [loaded, setLoaded] = useState(false);
-
-  async function loadHistory() {
-    if (loaded) return;
-    setLoading(true);
-    try {
-      const data = await getEvidenceHistory(type, id);
-      setEntries(data);
-      setLoaded(true);
-    } catch (error) {
-      const message =
-        error instanceof ApiError
-          ? error.message
-          : "No se pudo cargar el historial";
-      toast.error(message);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  function handleOpenChange(isOpen: boolean) {
-    if (isOpen) {
-      void loadHistory();
-    } else {
-      setEntries([]);
-      setLoaded(false);
-    }
-    onOpenChange(isOpen);
-  }
+  // Evidence history is append-only — once fetched it never changes.
+  const { data: entries = [], isLoading: loading } = useQuery({
+    queryKey: evidenceHistoryQueryKey(type, id),
+    queryFn: async () => {
+      try {
+        return await getEvidenceHistory(type, id);
+      } catch (error) {
+        const message =
+          error instanceof ApiError
+            ? error.message
+            : "No se pudo cargar el historial";
+        toast.error(message);
+        throw error;
+      }
+    },
+    staleTime: Infinity,
+    // Only fetch when the dialog is open.
+    enabled: open,
+  });
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">

--- a/src/components/honors/requirement-edit-dialog.tsx
+++ b/src/components/honors/requirement-edit-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { AlertCircle, Check, Loader2, PenLine, Plus } from "lucide-react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -55,6 +56,11 @@ interface FormState {
   needsReview: boolean;
 }
 
+// ─── Query key factory ────────────────────────────────────────────────────────
+
+export const requirementsQueryKey = (honorId: number) =>
+  ["requirements", honorId] as const;
+
 function buildInitialState(
   mode: DialogMode,
   requirement?: RequirementNode | null,
@@ -97,75 +103,86 @@ export function RequirementEditDialog({
 }: RequirementEditDialogProps) {
   const isEdit = mode === "edit";
   const t = useTranslations("honors");
+  const queryClient = useQueryClient();
 
   const [form, setForm] = useState<FormState>(() =>
     buildInitialState(mode, requirement),
   );
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   // Reset form state whenever the dialog opens or the target requirement changes.
   useEffect(() => {
     if (open) {
       setForm(buildInitialState(mode, requirement));
-      setError(null);
+      setValidationError(null);
     }
   }, [open, mode, requirement]);
 
   const set = <K extends keyof FormState>(key: K, value: FormState[K]) =>
     setForm((prev) => ({ ...prev, [key]: value }));
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setError(null);
+  // ─── Mutation ─────────────────────────────────────────────────────────────
 
-    const trimmedText = form.requirementText.trim();
-    if (!trimmedText) {
-      setError("El texto del requisito es obligatorio.");
-      return;
-    }
-
-    setLoading(true);
-    try {
+  const { mutate: submitForm, isPending: loading, error: mutationError } = useMutation({
+    mutationFn: async (formData: FormState) => {
+      const trimmedText = formData.requirementText.trim();
       if (isEdit && requirement) {
         const payload: UpdateRequirementPayload = {
-          displayLabel: form.displayLabel.trim() || null,
+          displayLabel: formData.displayLabel.trim() || null,
           requirementText: trimmedText,
-          referenceText: form.referenceText.trim() || null,
-          isChoiceGroup: form.isChoiceGroup,
+          referenceText: formData.referenceText.trim() || null,
+          isChoiceGroup: formData.isChoiceGroup,
           choiceMin:
-            form.isChoiceGroup && form.choiceMin !== ""
-              ? Number(form.choiceMin)
+            formData.isChoiceGroup && formData.choiceMin !== ""
+              ? Number(formData.choiceMin)
               : null,
-          requiresEvidence: form.requiresEvidence,
-          needsReview: form.needsReview,
+          requiresEvidence: formData.requiresEvidence,
+          needsReview: formData.needsReview,
         };
         await updateRequirement(requirement.requirement_id, payload);
       } else {
         const payload: CreateRequirementPayload = {
           parentId: parentId ?? null,
           requirementNumber: nextNumber,
-          displayLabel: form.displayLabel.trim() || null,
+          displayLabel: formData.displayLabel.trim() || null,
           requirementText: trimmedText,
-          referenceText: form.referenceText.trim() || null,
-          isChoiceGroup: form.isChoiceGroup,
+          referenceText: formData.referenceText.trim() || null,
+          isChoiceGroup: formData.isChoiceGroup,
           choiceMin:
-            form.isChoiceGroup && form.choiceMin !== ""
-              ? Number(form.choiceMin)
+            formData.isChoiceGroup && formData.choiceMin !== ""
+              ? Number(formData.choiceMin)
               : null,
-          requiresEvidence: form.requiresEvidence,
+          requiresEvidence: formData.requiresEvidence,
         };
         await createRequirement(honorId, payload);
       }
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: requirementsQueryKey(honorId) });
       onSuccess();
       onOpenChange(false);
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : t("errors.unexpected");
-      setError(message);
-    } finally {
-      setLoading(false);
+    },
+  });
+
+  const error =
+    validationError ??
+    (mutationError instanceof Error
+      ? mutationError.message
+      : mutationError != null
+        ? t("errors.unexpected")
+        : null);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setValidationError(null);
+
+    const trimmedText = form.requirementText.trim();
+    if (!trimmedText) {
+      setValidationError("El texto del requisito es obligatorio.");
+      return;
     }
+
+    submitForm(form);
   }
 
   const titleLabel = isEdit

--- a/src/components/investiture/pipeline-history-dialog.tsx
+++ b/src/components/investiture/pipeline-history-dialog.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { toast } from "sonner";
 import {
   History,
@@ -10,6 +9,7 @@ import {
   Send,
   Award,
 } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
@@ -112,6 +112,11 @@ interface PipelineHistoryDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+// ─── Query key factory ────────────────────────────────────────────────────────
+
+export const pipelineHistoryQueryKey = (enrollmentId: number) =>
+  ["pipeline-history", enrollmentId] as const;
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function PipelineHistoryDialog({
@@ -120,40 +125,28 @@ export function PipelineHistoryDialog({
   memberName,
   onOpenChange,
 }: PipelineHistoryDialogProps) {
-  const [entries, setEntries] = useState<PipelineHistoryEntry[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [loaded, setLoaded] = useState(false);
-
-  async function loadHistory() {
-    if (loaded) return;
-    setLoading(true);
-    try {
-      const data = await getPipelineHistory(enrollmentId);
-      setEntries(data);
-      setLoaded(true);
-    } catch (error) {
-      const message =
-        error instanceof ApiError
-          ? error.message
-          : "No se pudo cargar el historial";
-      toast.error(message);
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  function handleOpenChange(isOpen: boolean) {
-    if (isOpen) {
-      loadHistory();
-    } else {
-      setEntries([]);
-      setLoaded(false);
-    }
-    onOpenChange(isOpen);
-  }
+  // Pipeline history is append-only — once fetched it never changes.
+  const { data: entries = [], isLoading: loading } = useQuery({
+    queryKey: pipelineHistoryQueryKey(enrollmentId),
+    queryFn: async () => {
+      try {
+        return await getPipelineHistory(enrollmentId);
+      } catch (error) {
+        const message =
+          error instanceof ApiError
+            ? error.message
+            : "No se pudo cargar el historial";
+        toast.error(message);
+        throw error;
+      }
+    },
+    staleTime: Infinity,
+    // Only fetch when the dialog is open.
+    enabled: open,
+  });
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="sm:max-w-lg">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">

--- a/src/components/member-of-month/history-sheet.tsx
+++ b/src/components/member-of-month/history-sheet.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { Loader2, Trophy, ChevronLeft, ChevronRight } from "lucide-react";
+import { useState } from "react";
+import { Trophy, ChevronLeft, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
+import { useQuery } from "@tanstack/react-query";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -15,10 +16,7 @@ import {
 } from "@/components/ui/sheet";
 import { Skeleton } from "@/components/ui/skeleton";
 import { getMemberOfMonthHistory } from "@/lib/api/member-of-month";
-import type {
-  MemberOfMonthHistoryItem,
-  MemberOfMonthHistoryResponse,
-} from "@/lib/api/member-of-month";
+import type { MemberOfMonthHistoryItem } from "@/lib/api/member-of-month";
 import { MONTH_NAMES } from "@/lib/constants";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -107,6 +105,14 @@ interface MemberOfMonthHistorySheetProps {
   sectionName: string;
 }
 
+// ─── Query key factory ────────────────────────────────────────────────────────
+
+export const memberOfMonthHistoryQueryKey = (
+  clubId: number,
+  sectionId: number,
+  page: number,
+) => ["member-of-month-history", clubId, sectionId, page] as const;
+
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function MemberOfMonthHistorySheet({
@@ -117,47 +123,32 @@ export function MemberOfMonthHistorySheet({
   sectionName,
 }: MemberOfMonthHistorySheetProps) {
   const [page, setPage] = useState(1);
-  const [data, setData] = useState<MemberOfMonthHistoryResponse | null>(null);
-  const [loading, setLoading] = useState(false);
 
-  const loadHistory = useCallback(
-    async (pageNum: number) => {
-      setLoading(true);
+  const { data, isLoading: loading } = useQuery({
+    queryKey: memberOfMonthHistoryQueryKey(clubId, sectionId, page),
+    queryFn: async () => {
       try {
-        const result = await getMemberOfMonthHistory(
-          clubId,
-          sectionId,
-          pageNum,
-          PAGE_LIMIT,
-        );
-        setData(result);
+        return await getMemberOfMonthHistory(clubId, sectionId, page, PAGE_LIMIT);
       } catch (err: unknown) {
         const message =
-          err instanceof Error
-            ? err.message
-            : "No se pudo cargar el historial";
+          err instanceof Error ? err.message : "No se pudo cargar el historial";
         toast.error(message);
-      } finally {
-        setLoading(false);
+        throw err;
       }
     },
-    [clubId, sectionId],
-  );
+    // Each page is a historical snapshot — rarely changes.
+    staleTime: 5 * 60_000,
+    // Only fetch when the sheet is open.
+    enabled: open,
+    // Reset to page 1 when sheet re-opens
+    placeholderData: (prev) => prev,
+  });
 
-  // Load on open or page change
-  useEffect(() => {
-    if (open) {
-      loadHistory(page);
-    }
-  }, [open, page, loadHistory]);
-
-  // Reset page when sheet closes
-  useEffect(() => {
-    if (!open) {
-      setPage(1);
-      setData(null);
-    }
-  }, [open]);
+  // Reset to page 1 when the sheet closes.
+  function handleOpenChange(isOpen: boolean) {
+    if (!isOpen) setPage(1);
+    onOpenChange(isOpen);
+  }
 
   const items: MemberOfMonthHistoryItem[] = data?.data ?? [];
   const total = data?.pagination.total ?? 0;
@@ -166,7 +157,7 @@ export function MemberOfMonthHistorySheet({
   const hasNext = page < totalPages;
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    <Sheet open={open} onOpenChange={handleOpenChange}>
       <SheetContent className="flex w-full flex-col sm:max-w-md">
         <SheetHeader>
           <SheetTitle className="flex items-center gap-2">

--- a/src/components/units/weekly-records-panel.tsx
+++ b/src/components/units/weekly-records-panel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState } from "react";
 import { Plus, CalendarDays, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -63,7 +64,6 @@ function AddRecordDialog({
   onSuccess,
 }: AddRecordDialogProps) {
   const t = useTranslations("units_admin");
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [userId, setUserId] = useState("");
   const [week, setWeek] = useState(1);
   const [attendance, setAttendance] = useState(0);
@@ -98,20 +98,13 @@ function AddRecordDialog({
     0,
   );
 
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (!userId) {
-      toast.error(t("validation.member_required"));
-      return;
-    }
-    setIsSubmitting(true);
-    try {
+  const { mutate: createRecord, isPending: isSubmitting } = useMutation({
+    mutationFn: () => {
       const scores: ScoreEntry[] = activeCategories.map((cat) => ({
         category_id: cat.scoring_category_id,
         points: getCategoryScore(cat.scoring_category_id),
       }));
-
-      await createWeeklyRecord(clubId, unitId, {
+      return createWeeklyRecord(clubId, unitId, {
         user_id: userId,
         week,
         year: new Date().getFullYear(),
@@ -119,16 +112,26 @@ function AddRecordDialog({
         punctuality,
         scores,
       });
+    },
+    onSuccess: () => {
       toast.success(t("toasts.weekly_record_created"));
       onSuccess();
       handleClose(false);
-    } catch (err: unknown) {
+    },
+    onError: (err: unknown) => {
       const message =
         err instanceof Error ? err.message : t("errors.create_record_failed");
       toast.error(message);
-    } finally {
-      setIsSubmitting(false);
+    },
+  });
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!userId) {
+      toast.error(t("validation.member_required"));
+      return;
     }
+    createRecord();
   }
 
   return (
@@ -351,6 +354,14 @@ function TotalCell({ value }: { value: number }) {
   );
 }
 
+// ─── Query key factories ─────────────────────────────────────────────────────
+
+export const weeklyRecordsQueryKey = (clubId: number, unitId: number) =>
+  ["weekly-records", clubId, unitId] as const;
+
+export const scoringCategoriesQueryKey = (localFieldId: number) =>
+  ["scoring-categories", localFieldId] as const;
+
 // ─── Main component ───────────────────────────────────────────────────────────
 
 interface WeeklyRecordsPanelProps {
@@ -368,60 +379,89 @@ export function WeeklyRecordsPanel({
   localFieldId,
 }: WeeklyRecordsPanelProps) {
   const t = useTranslations("units_admin");
-  const [records, setRecords] = useState<WeeklyRecord[] | null>(null);
-  const [categories, setCategories] = useState<ScoringCategory[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [loaded, setLoaded] = useState(false);
+  const queryClient = useQueryClient();
   const [addOpen, setAddOpen] = useState(false);
 
-  const loadAll = useCallback(async () => {
-    setLoading(true);
-    try {
-      const [recordsData, categoriesData] = await Promise.allSettled([
-        listWeeklyRecords(clubId, unitId),
-        localFieldId
-          ? getLocalFieldScoringCategories(localFieldId)
-          : Promise.resolve([] as ScoringCategory[]),
-      ]);
+  // ─── Queries ────────────────────────────────────────────────────────────────
 
-      if (recordsData.status === "fulfilled") {
-        setRecords(recordsData.value);
-      } else {
+  const {
+    data: records = null,
+    isLoading: recordsLoading,
+  } = useQuery({
+    queryKey: weeklyRecordsQueryKey(clubId, unitId),
+    queryFn: async () => {
+      try {
+        return await listWeeklyRecords(clubId, unitId);
+      } catch {
         toast.error(t("errors.load_records_failed"));
+        throw new Error(t("errors.load_records_failed"));
       }
+    },
+    staleTime: 30_000,
+  });
 
-      if (categoriesData.status === "fulfilled") {
-        setCategories(categoriesData.value.filter((c) => c.active));
-      }
+  const { data: allCategories = [] } = useQuery({
+    queryKey: scoringCategoriesQueryKey(localFieldId ?? 0),
+    queryFn: () =>
+      localFieldId
+        ? getLocalFieldScoringCategories(localFieldId)
+        : Promise.resolve([] as ScoringCategory[]),
+    // Scoring categories are catalog data — refresh every 5 min.
+    staleTime: 5 * 60_000,
+    enabled: true,
+  });
 
-      setLoaded(true);
-    } finally {
-      setLoading(false);
-    }
-  }, [clubId, unitId, localFieldId]);
+  const categories = allCategories.filter((c) => c.active);
 
-  // Lazy load on first render of this panel
-  useEffect(() => {
-    if (!loaded && !loading) {
-      loadAll();
-    }
-  }, [loaded, loading, loadAll]);
+  // ─── Mutations ───────────────────────────────────────────────────────────────
 
-  // ─── Update handler ─────────────────────────────────────────────────────────
+  const { mutateAsync: updateFixed } = useMutation({
+    mutationFn: ({
+      recordId,
+      field,
+      value,
+    }: {
+      recordId: number;
+      field: "attendance" | "punctuality";
+      value: number;
+    }) => updateWeeklyRecord(clubId, unitId, recordId, { [field]: value }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: weeklyRecordsQueryKey(clubId, unitId) });
+    },
+    onError: () => {
+      toast.error(t("errors.update_value_failed"));
+    },
+  });
+
+  const { mutateAsync: updateScore } = useMutation({
+    mutationFn: ({
+      recordId,
+      categoryId,
+      value,
+    }: {
+      recordId: number;
+      categoryId: number;
+      value: number;
+    }) =>
+      updateWeeklyRecord(clubId, unitId, recordId, {
+        scores: [{ category_id: categoryId, points: value }],
+      }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: weeklyRecordsQueryKey(clubId, unitId) });
+    },
+    onError: () => {
+      toast.error(t("errors.update_value_failed"));
+    },
+  });
+
+  // ─── Handlers for EditableCell ───────────────────────────────────────────────
 
   async function handleUpdateFixed(
     recordId: number,
     field: "attendance" | "punctuality",
     value: number,
   ) {
-    await updateWeeklyRecord(clubId, unitId, recordId, { [field]: value });
-    setRecords((prev) =>
-      prev
-        ? prev.map((r) =>
-            r.record_id === recordId ? { ...r, [field]: value } : r,
-          )
-        : prev,
-    );
+    await updateFixed({ recordId, field, value });
   }
 
   async function handleUpdateScore(
@@ -429,28 +469,7 @@ export function WeeklyRecordsPanel({
     categoryId: number,
     value: number,
   ) {
-    // Build scores array for update: only the category being changed
-    await updateWeeklyRecord(clubId, unitId, recordId, {
-      scores: [{ category_id: categoryId, points: value }],
-    });
-
-    setRecords((prev) => {
-      if (!prev) return prev;
-      return prev.map((r) => {
-        if (r.record_id !== recordId) return r;
-        const existingScores = r.scores ?? [];
-        const updatedScores = existingScores.some(
-          (s) => s.category_id === categoryId,
-        )
-          ? existingScores.map((s) =>
-              s.category_id === categoryId ? { ...s, points: value } : s,
-            )
-          : [...existingScores, { category_id: categoryId, points: value }];
-        // Recalculate total
-        const newTotal = updatedScores.reduce((sum, s) => sum + s.points, 0);
-        return { ...r, scores: updatedScores, points: newTotal };
-      });
-    });
+    await updateScore({ recordId, categoryId, value });
   }
 
   // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -470,7 +489,7 @@ export function WeeklyRecordsPanel({
 
   // ─── Loading state ──────────────────────────────────────────────────────────
 
-  if (loading && !loaded) {
+  if (recordsLoading) {
     return (
       <div className="flex items-center justify-center py-8 text-muted-foreground">
         <Loader2 className="mr-2 size-4 animate-spin" />
@@ -617,7 +636,7 @@ export function WeeklyRecordsPanel({
         unitId={unitId}
         members={activeMembers}
         categories={categories}
-        onSuccess={loadAll}
+        onSuccess={() => void queryClient.invalidateQueries({ queryKey: weeklyRecordsQueryKey(clubId, unitId) })}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

Bucket 9b — extends the React Query pattern (pilot in #37) to five more components flagged by audit A-2.

### Migrated

| Component | Pattern | queryKey | staleTime |
|-----------|---------|----------|-----------|
| `honors/requirement-edit-dialog.tsx` | `useMutation` (create + update) | n/a — exports `requirementsQueryKey(honorId)` for callers | n/a |
| `investiture/pipeline-history-dialog.tsx` | `useQuery` + `enabled: open` | `["pipeline-history", enrollmentId]` | `Infinity` (append-only) |
| `evidence-review/evidence-history-dialog.tsx` | `useQuery` + `enabled: open` | `["evidence-history", type, id]` | `Infinity` (append-only) |
| `member-of-month/history-sheet.tsx` | paginated `useQuery`, page in queryKey | `["member-of-month-history", clubId, sectionId, page]` | `5 min` |
| `units/weekly-records-panel.tsx` | 2× `useQuery` + 2× `useMutation` | `["weekly-records", clubId, unitId]` / `["scoring-categories", localFieldId]` | `30s` / `5 min` |

### Notes

- `requirement-edit-dialog` had zero fetching — only a mutation. The old `setLoading`/`setError`/`try-catch-finally` collapses to `isPending` + `error` from `useMutation`. Exports the matching query key so parent honor-detail pages can invalidate.
- The two history dialogs both had a manual `loaded` guard. `useQuery` + `enabled: open` + `staleTime: Infinity` replicates "fetch once, never again" cleanly. Re-opening the dialog is instant from cache.
- `history-sheet` uses `placeholderData: (prev) => prev` so page transitions stay smooth.
- `weekly-records-panel` was the most complex: the `Promise.allSettled` becomes two independent queries that React Query parallels. Manual optimistic patching for inline cell edits is replaced with `invalidateQueries` after each mutation — guaranteed consistent with server.
- `EditableCell` keeps its own local `saving`/`draft`/`editing` state — that's correct (UI state, not server state).

Closes audit A-2 expansion (5 of the remaining ~10 components).

## Test plan

- [ ] Open each dialog/sheet/panel above. First open fires the request; subsequent opens use cache.
- [ ] Trigger a mutation (create requirement, edit weekly record). UI invalidates and refetches.
- [ ] DevTools Network: one request per cache key, even on remount.
- [ ] `pnpm lint` → no new errors in the 5 touched files.