### PR TITLE
fix(a11y): forms accessibility round 2 — 4 dialogs

### DIFF
--- a/src/components/activities/activity-form-dialog.tsx
+++ b/src/components/activities/activity-form-dialog.tsx
@@ -217,11 +217,18 @@ export function ActivityFormDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
           {/* Nombre */}
           <div className="space-y-1.5">
-            <Label htmlFor="name">Nombre *</Label>
-            <Input id="name" {...register("name")} placeholder="Nombre de la actividad" />
+            <Label htmlFor="name">
+              Nombre <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="name"
+              aria-required="true"
+              {...register("name")}
+              placeholder="Nombre de la actividad"
+            />
             {errors.name && (
               <p className="text-xs text-destructive">{errors.name.message}</p>
             )}
@@ -240,12 +247,14 @@ export function ActivityFormDialog({
 
           {/* Tipo de actividad */}
           <div className="space-y-1.5">
-            <Label>Tipo de actividad *</Label>
+            <Label htmlFor="activity_type_id">
+              Tipo de actividad <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Select
               defaultValue={String(activity?.activity_type_id ?? 1)}
               onValueChange={(val) => setValue("activity_type_id", Number(val))}
             >
-              <SelectTrigger>
+              <SelectTrigger id="activity_type_id" aria-required="true">
                 <SelectValue placeholder="Seleccionar tipo" />
               </SelectTrigger>
               <SelectContent>
@@ -267,7 +276,9 @@ export function ActivityFormDialog({
           {!isEdit && (
             <>
               <div className="space-y-1.5">
-                <Label>Tipo de club *</Label>
+                <Label htmlFor="club_type_id">
+                  Tipo de club <span aria-hidden="true" className="text-destructive">*</span>
+                </Label>
                 <Select
                   defaultValue={String(sections[0]?.club_type_id ?? 1)}
                   onValueChange={(val) => {
@@ -279,7 +290,7 @@ export function ActivityFormDialog({
                     setValue("club_section_id", firstMatch?.club_section_id ?? 0);
                   }}
                 >
-                  <SelectTrigger>
+                  <SelectTrigger id="club_type_id" aria-required="true">
                     <SelectValue placeholder="Seleccionar tipo de club" />
                   </SelectTrigger>
                   <SelectContent>
@@ -298,12 +309,14 @@ export function ActivityFormDialog({
               </div>
 
               <div className="space-y-1.5">
-                <Label>Sección del club *</Label>
+                <Label htmlFor="club_section_id">
+                  Sección del club <span aria-hidden="true" className="text-destructive">*</span>
+                </Label>
                 <Select
                   value={String(watch("club_section_id"))}
                   onValueChange={(val) => setValue("club_section_id", Number(val))}
                 >
-                  <SelectTrigger>
+                  <SelectTrigger id="club_section_id" aria-required="true">
                     <SelectValue placeholder="Seleccionar sección" />
                   </SelectTrigger>
                   <SelectContent>
@@ -334,9 +347,12 @@ export function ActivityFormDialog({
 
           {/* Lugar */}
           <div className="space-y-1.5">
-            <Label htmlFor="activity_place">Lugar *</Label>
+            <Label htmlFor="activity_place">
+              Lugar <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Input
               id="activity_place"
+              aria-required="true"
               {...register("activity_place")}
               placeholder="Ej. Iglesia Central"
             />
@@ -360,11 +376,14 @@ export function ActivityFormDialog({
           {/* Coordenadas */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label htmlFor="lat">Latitud *</Label>
+              <Label htmlFor="lat">
+                Latitud <span aria-hidden="true" className="text-destructive">*</span>
+              </Label>
               <Input
                 id="lat"
                 type="number"
                 step="any"
+                aria-required="true"
                 {...register("lat")}
                 placeholder="0.000000"
               />
@@ -373,11 +392,14 @@ export function ActivityFormDialog({
               )}
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="long">Longitud *</Label>
+              <Label htmlFor="long">
+                Longitud <span aria-hidden="true" className="text-destructive">*</span>
+              </Label>
               <Input
                 id="long"
                 type="number"
                 step="any"
+                aria-required="true"
                 {...register("long")}
                 placeholder="0.000000"
               />
@@ -391,12 +413,12 @@ export function ActivityFormDialog({
 
           {/* Modalidad */}
           <div className="space-y-1.5">
-            <Label>Modalidad</Label>
+            <Label htmlFor="platform">Modalidad</Label>
             <Select
               defaultValue={String(activity?.platform ?? 0)}
               onValueChange={(val) => setValue("platform", Number(val))}
             >
-              <SelectTrigger>
+              <SelectTrigger id="platform">
                 <SelectValue placeholder="Seleccionar modalidad" />
               </SelectTrigger>
               <SelectContent>
@@ -424,9 +446,12 @@ export function ActivityFormDialog({
 
           {/* URL de imagen */}
           <div className="space-y-1.5">
-            <Label htmlFor="image">URL de imagen *</Label>
+            <Label htmlFor="image">
+              URL de imagen <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Input
               id="image"
+              aria-required="true"
               {...register("image")}
               placeholder="https://..."
               type="url"

--- a/src/components/camporees/payment-dialog.tsx
+++ b/src/components/camporees/payment-dialog.tsx
@@ -176,10 +176,12 @@ export function PaymentDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
           {/* Member */}
           <div className="space-y-1.5">
-            <Label>Miembro *</Label>
+            <Label htmlFor="member_id">
+              Miembro <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             {isEditing ? (
               <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm">
                 {payment?.member_name ?? payment?.member_id}
@@ -189,7 +191,7 @@ export function PaymentDialog({
                 value={memberId}
                 onValueChange={(val) => setValue("member_id", val)}
               >
-                <SelectTrigger>
+                <SelectTrigger id="member_id" aria-required="true">
                   <SelectValue placeholder="Seleccionar miembro" />
                 </SelectTrigger>
                 <SelectContent>
@@ -208,12 +210,15 @@ export function PaymentDialog({
 
           {/* Amount */}
           <div className="space-y-1.5">
-            <Label htmlFor="amount">Monto *</Label>
+            <Label htmlFor="amount">
+              Monto <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Input
               id="amount"
               type="number"
               min={0.01}
               step={0.01}
+              aria-required="true"
               {...register("amount")}
               placeholder="0.00"
             />
@@ -224,14 +229,16 @@ export function PaymentDialog({
 
           {/* Payment type */}
           <div className="space-y-1.5">
-            <Label>Tipo de pago *</Label>
+            <Label htmlFor="payment_type">
+              Tipo de pago <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Select
               value={paymentType}
               onValueChange={(val) =>
                 setValue("payment_type", val as PaymentType)
               }
             >
-              <SelectTrigger>
+              <SelectTrigger id="payment_type" aria-required="true">
                 <SelectValue placeholder="Seleccionar tipo" />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/camporees/register-member-dialog.tsx
+++ b/src/components/camporees/register-member-dialog.tsx
@@ -127,10 +127,14 @@ export function RegisterMemberDialog({
           <DialogTitle>Registrar miembro</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
           {/* Insurance error callout */}
           {insuranceError && (
-            <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">
+            <div
+              role="alert"
+              aria-live="polite"
+              className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+            >
               <p className="font-medium">Error de validación de seguro</p>
               <p className="mt-0.5">{insuranceError}</p>
             </div>
@@ -138,9 +142,12 @@ export function RegisterMemberDialog({
 
           {/* User ID */}
           <div className="space-y-1.5">
-            <Label htmlFor="user_id">ID del usuario (UUID) *</Label>
+            <Label htmlFor="user_id">
+              ID del usuario (UUID) <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Input
               id="user_id"
+              aria-required="true"
               {...register("user_id")}
               placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
               className="font-mono text-sm"
@@ -154,14 +161,16 @@ export function RegisterMemberDialog({
 
           {/* Tipo de camporee */}
           <div className="space-y-1.5">
-            <Label>Tipo de camporee *</Label>
+            <Label htmlFor="camporee_type">
+              Tipo de camporee <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Select
               value={camporeeType}
               onValueChange={(val) =>
                 setValue("camporee_type", val as "local" | "union")
               }
             >
-              <SelectTrigger>
+              <SelectTrigger id="camporee_type" aria-required="true">
                 <SelectValue placeholder="Seleccionar tipo" />
               </SelectTrigger>
               <SelectContent>

--- a/src/components/folders/folder-form-dialog.tsx
+++ b/src/components/folders/folder-form-dialog.tsx
@@ -136,12 +136,15 @@ export function FolderFormDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
           {/* Nombre */}
           <div className="space-y-1.5">
-            <Label htmlFor="folder-name">Nombre *</Label>
+            <Label htmlFor="folder-name">
+              Nombre <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
             <Input
               id="folder-name"
+              aria-required="true"
               {...register("name")}
               placeholder="Ej. Carpeta Conquistadores 2025"
             />


### PR DESCRIPTION
## Summary

Round 2 of the manual aria-* sweep across raw `useForm` dialogs. Continues the pattern validated in #28 / #38.

### Pattern applied (per file)

| Item | What |
|------|------|
| `noValidate` on `<form>` | Stop browser native validation from competing with server-action errors |
| `aria-hidden="true"` on `*` markers | Hide the visual color-only required indicator from AT |
| `aria-required="true"` on required inputs/SelectTrigger | Real semantic required signal |
| `id` on `<SelectTrigger>` + matching `htmlFor` on `<Label>` | Wire label↔combobox association (Radix Select doesn't auto-link) |
| `role="alert" aria-live="polite"` on inline error callouts | Announce errors to screen readers |

### Per-file breakdown

- **`activity-form-dialog.tsx`** — 4 select triggers got `id` + `htmlFor` (none had it). 5 inputs got `aria-required`. 8 `*` spans got `aria-hidden`.
- **`folder-form-dialog.tsx`** — minimal changes (labels already had `htmlFor`, switch already had `id`). One `*` and one input got attribs; `noValidate` added.
- **`payment-dialog.tsx`** — 2 SelectTriggers had no `id` and bare Labels. Wired up. 3 `*` markers + amount input + 2 triggers got the right attribs.
- **`register-member-dialog.tsx`** — insurance-warning callout was silent to screen readers; wrapped in `role="alert" aria-live="polite"`. SelectTrigger `id`/`htmlFor` wired. 2 required attribs added.

Closes audit 5.1/5.2 expansion (4 of remaining ~10 dialogs).

## Test plan

- [ ] Open each dialog with a screen reader (VoiceOver/NVDA). Tab to a SelectTrigger — the screen reader announces the label.
- [ ] Submit `register-member-dialog` to a state where the insurance callout fires — screen reader announces it (was silent before).
- [ ] DevTools accessibility tree — required-field markers hidden, `aria-required="true"` set on required controls.
- [ ] `pnpm lint` → no new errors in the 4 touched files.