### PR TITLE
feat: mobile cards round 2 — catalogs, folders, permissions

### DIFF
--- a/src/components/catalogs/catalog-crud-page.tsx
+++ b/src/components/catalogs/catalog-crud-page.tsx
@@ -198,147 +198,276 @@ export function CatalogCrudPage({
           </Button>
         </EmptyState>
       ) : (
-        /* ── Table ── */
-        <DataTableShell>
-          <div className="overflow-x-auto">
-            <Table>
-              <TableHeader>
-                <TableRow className="border-b border-border hover:bg-transparent">
-                  {/* ID — first column */}
-                  <TableHead className={`${TH_BASE} ${COL_FIRST} w-[72px]`}>
-                    ID
-                  </TableHead>
-
-                  {/* Data fields — middle columns */}
-                  {displayFields.map((f) => (
-                    <TableHead
-                      key={f.name}
-                      className={`${TH_BASE} ${COL_MID}`}
-                    >
-                      {tCatalogs(f.label)}
-                    </TableHead>
-                  ))}
-
-                  {/* Estado — middle or last depending on canMutate */}
-                  <TableHead
-                    className={`${TH_BASE} ${lastColIsActions ? COL_MID : COL_LAST}`}
-                  >
-                    Estado
-                  </TableHead>
-
-                  {/* Acciones — last column (only when mutations allowed) */}
-                  {canMutate && (
-                    <TableHead
-                      className={`${TH_BASE} ${COL_LAST} w-[108px]`}
-                    >
-                      Acciones
-                    </TableHead>
-                  )}
-                </TableRow>
-              </TableHeader>
-
-              <TableBody>
-                {filteredItems.map((item, idx) => {
-                  const itemId = getItemId(item);
-                  const rowKey = itemId
-                    ? `${config.key}-${itemId}`
-                    : `${config.key}-row-${idx}`;
-
-                  return (
-                    <TableRow
-                      key={rowKey}
-                      className={`${ROW_H} border-b border-border transition-colors hover:bg-muted/30`}
-                    >
+        <>
+          {/* ── Desktop table ── */}
+          <div className="hidden md:block">
+            <DataTableShell>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow className="border-b border-border hover:bg-transparent">
                       {/* ID — first column */}
-                      <TableCell
-                        className={`${COL_FIRST} text-xs tabular-nums text-muted-foreground`}
-                      >
-                        {itemId ?? "—"}
-                      </TableCell>
+                      <TableHead className={`${TH_BASE} ${COL_FIRST} w-[72px]`}>
+                        ID
+                      </TableHead>
 
                       {/* Data fields — middle columns */}
-                      {displayFields.map((f) => {
-                        const val = item[f.name];
-                        let display: string;
-
-                        if (f.type === "select" && f.optionsEntityKey) {
-                          const opts =
-                            displaySelectOptions[f.optionsEntityKey] ??
-                            selectOptions[f.optionsEntityKey] ??
-                            [];
-                          const match = opts.find((o) => o.value === Number(val));
-                          display = match?.label ?? String(val ?? "—");
-                        } else {
-                          display = val != null ? String(val) : "—";
-                        }
-
-                        const isLongText = f.type === "textarea";
-
-                        return (
-                          <TableCell
-                            key={f.name}
-                            className={`${COL_MID} ${isLongText ? "max-w-[260px]" : ""}`}
-                          >
-                            {isLongText ? (
-                              <span
-                                className="block truncate text-sm text-muted-foreground"
-                                title={display}
-                              >
-                                {display}
-                              </span>
-                            ) : (
-                              <span className="text-sm">{display}</span>
-                            )}
-                          </TableCell>
-                        );
-                      })}
-
-                      {/* Estado — middle or last */}
-                      <TableCell
-                        className={lastColIsActions ? COL_MID : COL_LAST}
-                      >
-                        <Badge
-                          variant={item.active !== false ? "success" : "secondary"}
-                          className="text-xs"
+                      {displayFields.map((f) => (
+                        <TableHead
+                          key={f.name}
+                          className={`${TH_BASE} ${COL_MID}`}
                         >
-                          {item.active !== false ? "Activo" : "Inactivo"}
-                        </Badge>
-                      </TableCell>
+                          {tCatalogs(f.label)}
+                        </TableHead>
+                      ))}
 
-                      {/* Acciones — last column */}
+                      {/* Estado — middle or last depending on canMutate */}
+                      <TableHead
+                        className={`${TH_BASE} ${lastColIsActions ? COL_MID : COL_LAST}`}
+                      >
+                        Estado
+                      </TableHead>
+
+                      {/* Acciones — last column (only when mutations allowed) */}
                       {canMutate && (
-                        <TableCell className={COL_LAST}>
-                          <div className="flex gap-1">
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              className="hover:bg-muted"
-                              disabled={!itemId}
-                              onClick={() => setEditItem(item)}
-                              aria-label="Editar registro"
-                            >
-                              <Pencil className="size-3.5" aria-hidden="true" />
-                            </Button>
-                            <Button
-                              variant="ghost"
-                              size="icon-sm"
-                              className="text-destructive hover:bg-muted hover:text-destructive"
-                              disabled={!itemId}
-                              onClick={() => setDeleteItem(item)}
-                              aria-label="Eliminar registro"
-                            >
-                              <Trash2 className="size-3.5" aria-hidden="true" />
-                            </Button>
-                          </div>
-                        </TableCell>
+                        <TableHead
+                          className={`${TH_BASE} ${COL_LAST} w-[108px]`}
+                        >
+                          Acciones
+                        </TableHead>
                       )}
                     </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
+                  </TableHeader>
+
+                  <TableBody>
+                    {filteredItems.map((item, idx) => {
+                      const itemId = getItemId(item);
+                      const rowKey = itemId
+                        ? `${config.key}-${itemId}`
+                        : `${config.key}-row-${idx}`;
+
+                      return (
+                        <TableRow
+                          key={rowKey}
+                          className={`${ROW_H} border-b border-border transition-colors hover:bg-muted/30`}
+                        >
+                          {/* ID — first column */}
+                          <TableCell
+                            className={`${COL_FIRST} text-xs tabular-nums text-muted-foreground`}
+                          >
+                            {itemId ?? "—"}
+                          </TableCell>
+
+                          {/* Data fields — middle columns */}
+                          {displayFields.map((f) => {
+                            const val = item[f.name];
+                            let display: string;
+
+                            if (f.type === "select" && f.optionsEntityKey) {
+                              const opts =
+                                displaySelectOptions[f.optionsEntityKey] ??
+                                selectOptions[f.optionsEntityKey] ??
+                                [];
+                              const match = opts.find((o) => o.value === Number(val));
+                              display = match?.label ?? String(val ?? "—");
+                            } else {
+                              display = val != null ? String(val) : "—";
+                            }
+
+                            const isLongText = f.type === "textarea";
+
+                            return (
+                              <TableCell
+                                key={f.name}
+                                className={`${COL_MID} ${isLongText ? "max-w-[260px]" : ""}`}
+                              >
+                                {isLongText ? (
+                                  <span
+                                    className="block truncate text-sm text-muted-foreground"
+                                    title={display}
+                                  >
+                                    {display}
+                                  </span>
+                                ) : (
+                                  <span className="text-sm">{display}</span>
+                                )}
+                              </TableCell>
+                            );
+                          })}
+
+                          {/* Estado — middle or last */}
+                          <TableCell
+                            className={lastColIsActions ? COL_MID : COL_LAST}
+                          >
+                            <Badge
+                              variant={item.active !== false ? "success" : "secondary"}
+                              className="text-xs"
+                            >
+                              {item.active !== false ? "Activo" : "Inactivo"}
+                            </Badge>
+                          </TableCell>
+
+                          {/* Acciones — last column */}
+                          {canMutate && (
+                            <TableCell className={COL_LAST}>
+                              <div className="flex gap-1">
+                                <Button
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  className="hover:bg-muted"
+                                  disabled={!itemId}
+                                  onClick={() => setEditItem(item)}
+                                  aria-label="Editar registro"
+                                >
+                                  <Pencil className="size-3.5" aria-hidden="true" />
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  className="text-destructive hover:bg-muted hover:text-destructive"
+                                  disabled={!itemId}
+                                  onClick={() => setDeleteItem(item)}
+                                  aria-label="Eliminar registro"
+                                >
+                                  <Trash2 className="size-3.5" aria-hidden="true" />
+                                </Button>
+                              </div>
+                            </TableCell>
+                          )}
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            </DataTableShell>
           </div>
-        </DataTableShell>
+
+          {/* ── Mobile cards ── */}
+          <ul
+            className="space-y-3 md:hidden"
+            aria-label={`Lista de ${entityTitleLower}`}
+          >
+            {filteredItems.map((item, idx) => {
+              const itemId = getItemId(item);
+              const rowKey = itemId
+                ? `${config.key}-${itemId}`
+                : `${config.key}-row-${idx}`;
+
+              // Primary display: first displayField value
+              const primaryField = displayFields[0];
+              const primaryVal = primaryField
+                ? (() => {
+                    const val = item[primaryField.name];
+                    if (primaryField.type === "select" && primaryField.optionsEntityKey) {
+                      const opts =
+                        displaySelectOptions[primaryField.optionsEntityKey] ??
+                        selectOptions[primaryField.optionsEntityKey] ??
+                        [];
+                      const match = opts.find((o) => o.value === Number(val));
+                      return match?.label ?? String(val ?? "—");
+                    }
+                    return val != null ? String(val) : "—";
+                  })()
+                : "—";
+
+              // Secondary fields: remaining displayFields (up to 2 shown as dl pairs)
+              const secondaryFields = displayFields.slice(1, 3);
+
+              return (
+                <li key={rowKey}>
+                  <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none">
+                    {/* Card header: icon + name + edit chevron */}
+                    <div className="flex items-center gap-3">
+                      <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                        <Package className="size-5 text-primary" aria-hidden="true" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">{primaryVal}</p>
+                        <p className="text-xs tabular-nums text-muted-foreground">
+                          #{itemId ?? "—"}
+                        </p>
+                      </div>
+                      {canMutate && itemId && (
+                        <button
+                          type="button"
+                          className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                          onClick={() => setEditItem(item)}
+                          aria-label={`Editar ${primaryVal}`}
+                        >
+                          <Pencil className="size-4" aria-hidden="true" />
+                        </button>
+                      )}
+                    </div>
+
+                    {/* Status badge */}
+                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                      <Badge
+                        variant={item.active !== false ? "success" : "secondary"}
+                        className="text-xs"
+                      >
+                        {item.active !== false ? "Activo" : "Inactivo"}
+                      </Badge>
+                    </div>
+
+                    {/* Secondary data fields */}
+                    {secondaryFields.length > 0 && (
+                      <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+                        {secondaryFields.map((f) => {
+                          const val = item[f.name];
+                          let display: string;
+                          if (f.type === "select" && f.optionsEntityKey) {
+                            const opts =
+                              displaySelectOptions[f.optionsEntityKey] ??
+                              selectOptions[f.optionsEntityKey] ??
+                              [];
+                            const match = opts.find((o) => o.value === Number(val));
+                            display = match?.label ?? String(val ?? "—");
+                          } else {
+                            display = val != null ? String(val) : "—";
+                          }
+                          return (
+                            <div key={f.name}>
+                              <dt className="text-muted-foreground">
+                                {tCatalogs(f.label)}
+                              </dt>
+                              <dd className="truncate">{display}</dd>
+                            </div>
+                          );
+                        })}
+                      </dl>
+                    )}
+
+                    {/* Actions row */}
+                    {canMutate && itemId && (
+                      <div className="mt-3 flex flex-wrap gap-1.5 border-t border-border/40 pt-3">
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          onClick={() => setEditItem(item)}
+                          aria-label={`Editar ${primaryVal}`}
+                        >
+                          <Pencil className="size-3" aria-hidden="true" />
+                          Editar
+                        </Button>
+                        <Button
+                          variant="outline"
+                          size="xs"
+                          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                          onClick={() => setDeleteItem(item)}
+                          aria-label={`Eliminar ${primaryVal}`}
+                        >
+                          <Trash2 className="size-3" aria-hidden="true" />
+                          Eliminar
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </>
       )}
 
       {/* ── Dialogs ── */}

--- a/src/components/folders/folders-management-client.tsx
+++ b/src/components/folders/folders-management-client.tsx
@@ -8,6 +8,7 @@ import {
   Search,
   FolderOpen,
   Layers,
+  FileStack,
 } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -141,78 +142,134 @@ export function FoldersManagementClient({
         </div>
       )}
 
-      {/* Table */}
+      {/* Table / Cards */}
       {filteredFolders.length > 0 && (
-        <div className="rounded-lg border border-border/60">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Nombre</TableHead>
-                <TableHead className="hidden sm:table-cell">
-                  Descripción
-                </TableHead>
-                <TableHead className="hidden w-28 text-center md:table-cell">
-                  Módulos
-                </TableHead>
-                <TableHead className="hidden w-28 text-center lg:table-cell">
-                  Secciones
-                </TableHead>
-                <TableHead className="w-20 text-center">Estado</TableHead>
-                <TableHead className="w-8" />
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredFolders.map((folder) => {
-                const moduleCount = folder.modules?.length ?? 0;
-                const sectionCount = countTotalSections(folder);
-
-                return (
-                  <TableRow
-                    key={folder.folder_id}
-                    className="cursor-pointer hover:bg-muted/50"
-                  >
-                    <TableCell>
-                      <Link
-                        href={`/dashboard/folders/${folder.folder_id}`}
-                        className="block font-medium hover:underline"
-                      >
-                        {folder.name}
-                      </Link>
-                    </TableCell>
-                    <TableCell className="hidden max-w-xs text-muted-foreground sm:table-cell">
-                      <span className="line-clamp-1">
-                        {folder.description ?? (
-                          <span className="italic text-muted-foreground/60">
-                            Sin descripción
-                          </span>
-                        )}
-                      </span>
-                    </TableCell>
-                    <TableCell className="hidden text-center md:table-cell">
-                      <Badge variant="outline" className="gap-1 text-xs">
-                        <Layers className="size-3" />
-                        {moduleCount}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="hidden text-center lg:table-cell">
-                      <span className="text-sm text-muted-foreground">
-                        {sectionCount}
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-center">
-                      <FolderStatusBadge active={folder.active} />
-                    </TableCell>
-                    <TableCell>
-                      <Link href={`/dashboard/folders/${folder.folder_id}`}>
-                        <ChevronRight className="size-4 text-muted-foreground" />
-                      </Link>
-                    </TableCell>
+        <>
+          {/* Desktop table */}
+          <div className="hidden md:block">
+            <div className="rounded-lg border border-border/60">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Nombre</TableHead>
+                    <TableHead className="hidden sm:table-cell">
+                      Descripción
+                    </TableHead>
+                    <TableHead className="hidden w-28 text-center md:table-cell">
+                      Módulos
+                    </TableHead>
+                    <TableHead className="hidden w-28 text-center lg:table-cell">
+                      Secciones
+                    </TableHead>
+                    <TableHead className="w-20 text-center">Estado</TableHead>
+                    <TableHead className="w-8" />
                   </TableRow>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </div>
+                </TableHeader>
+                <TableBody>
+                  {filteredFolders.map((folder) => {
+                    const moduleCount = folder.modules?.length ?? 0;
+                    const sectionCount = countTotalSections(folder);
+
+                    return (
+                      <TableRow
+                        key={folder.folder_id}
+                        className="cursor-pointer hover:bg-muted/50"
+                      >
+                        <TableCell>
+                          <Link
+                            href={`/dashboard/folders/${folder.folder_id}`}
+                            className="block font-medium hover:underline"
+                          >
+                            {folder.name}
+                          </Link>
+                        </TableCell>
+                        <TableCell className="hidden max-w-xs text-muted-foreground sm:table-cell">
+                          <span className="line-clamp-1">
+                            {folder.description ?? (
+                              <span className="italic text-muted-foreground/60">
+                                Sin descripción
+                              </span>
+                            )}
+                          </span>
+                        </TableCell>
+                        <TableCell className="hidden text-center md:table-cell">
+                          <Badge variant="outline" className="gap-1 text-xs">
+                            <Layers className="size-3" />
+                            {moduleCount}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="hidden text-center lg:table-cell">
+                          <span className="text-sm text-muted-foreground">
+                            {sectionCount}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-center">
+                          <FolderStatusBadge active={folder.active} />
+                        </TableCell>
+                        <TableCell>
+                          <Link href={`/dashboard/folders/${folder.folder_id}`}>
+                            <ChevronRight className="size-4 text-muted-foreground" />
+                          </Link>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+
+          {/* Mobile cards */}
+          <ul className="space-y-3 md:hidden" aria-label="Lista de carpetas">
+            {filteredFolders.map((folder) => {
+              const moduleCount = folder.modules?.length ?? 0;
+              const sectionCount = countTotalSections(folder);
+
+              return (
+                <li key={folder.folder_id}>
+                  <Link
+                    href={`/dashboard/folders/${folder.folder_id}`}
+                    className="block rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    aria-label={`Ver carpeta ${folder.name}`}
+                  >
+                    <div className="flex items-center gap-3">
+                      <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                        <FileStack className="size-5 text-primary" aria-hidden="true" />
+                      </div>
+                      <div className="min-w-0 flex-1">
+                        <p className="truncate text-sm font-medium">{folder.name}</p>
+                        {folder.description && (
+                          <p className="line-clamp-1 text-xs text-muted-foreground">
+                            {folder.description}
+                          </p>
+                        )}
+                      </div>
+                      <ChevronRight className="size-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap items-center gap-1.5">
+                      <FolderStatusBadge active={folder.active} />
+                    </div>
+
+                    <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+                      <div>
+                        <dt className="text-muted-foreground">Módulos</dt>
+                        <dd className="flex items-center gap-1">
+                          <Layers className="size-3 text-muted-foreground" aria-hidden="true" />
+                          {moduleCount}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Secciones</dt>
+                        <dd>{sectionCount}</dd>
+                      </div>
+                    </dl>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </>
       )}
     </div>
   );

--- a/src/components/rbac/permissions-table.tsx
+++ b/src/components/rbac/permissions-table.tsx
@@ -2,7 +2,7 @@
 
 import { useActionState, useState } from "react";
 import { useFormStatus } from "react-dom";
-import { Plus, Pencil, Trash2, Key, Loader2 } from "lucide-react";
+import { Plus, Pencil, Trash2, Key, Loader2, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -98,49 +98,119 @@ export function PermissionsTable({ items, createAction, updateAction, deleteActi
           </Button>
         </EmptyState>
       ) : (
-        <div className="rounded-md border">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-[60px]">ID</TableHead>
-                <TableHead>Clave</TableHead>
-                <TableHead className="hidden md:table-cell">Descripción</TableHead>
-                <TableHead>Estado</TableHead>
-                <TableHead className="w-[100px]">Acciones</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {items.map((perm) => (
-                <TableRow key={perm.permission_id}>
-                  <TableCell className="text-xs text-muted-foreground">{perm.permission_id}</TableCell>
-                  <TableCell>
-                    <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
-                      {perm.permission_name}
-                    </code>
-                  </TableCell>
-                  <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
-                    {perm.description ?? "—"}
-                  </TableCell>
-                  <TableCell>
+        <>
+          {/* Desktop table */}
+          <div className="hidden md:block">
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[60px]">ID</TableHead>
+                    <TableHead>Clave</TableHead>
+                    <TableHead className="hidden md:table-cell">Descripción</TableHead>
+                    <TableHead>Estado</TableHead>
+                    <TableHead className="w-[100px]">Acciones</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {items.map((perm) => (
+                    <TableRow key={perm.permission_id}>
+                      <TableCell className="text-xs text-muted-foreground">{perm.permission_id}</TableCell>
+                      <TableCell>
+                        <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+                          {perm.permission_name}
+                        </code>
+                      </TableCell>
+                      <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
+                        {perm.description ?? "—"}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={perm.active !== false ? "default" : "outline"} className="text-xs">
+                          {perm.active !== false ? "Activo" : "Inactivo"}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex gap-1">
+                          <Button variant="ghost" size="icon" className="size-8" onClick={() => setEditItem(perm)} title="Editar">
+                            <Pencil className="size-3.5" />
+                          </Button>
+                          <Button variant="ghost" size="icon" className="size-8 text-destructive hover:text-destructive" onClick={() => setDeleteItem(perm)} title="Eliminar">
+                            <Trash2 className="size-3.5" />
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          </div>
+
+          {/* Mobile cards */}
+          <ul className="space-y-3 md:hidden" aria-label="Lista de permisos">
+            {items.map((perm) => (
+              <li key={perm.permission_id}>
+                <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none">
+                  <div className="flex items-center gap-3">
+                    <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                      <Key className="size-5 text-primary" aria-hidden="true" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <code className="block truncate rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+                        {perm.permission_name}
+                      </code>
+                      <p className="mt-0.5 text-xs tabular-nums text-muted-foreground">
+                        #{perm.permission_id}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      onClick={() => setEditItem(perm)}
+                      aria-label={`Editar ${perm.permission_name}`}
+                    >
+                      <ChevronRight className="size-4" aria-hidden="true" />
+                    </button>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap items-center gap-1.5">
                     <Badge variant={perm.active !== false ? "default" : "outline"} className="text-xs">
                       {perm.active !== false ? "Activo" : "Inactivo"}
                     </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <div className="flex gap-1">
-                      <Button variant="ghost" size="icon" className="size-8" onClick={() => setEditItem(perm)} title="Editar">
-                        <Pencil className="size-3.5" />
-                      </Button>
-                      <Button variant="ghost" size="icon" className="size-8 text-destructive hover:text-destructive" onClick={() => setDeleteItem(perm)} title="Eliminar">
-                        <Trash2 className="size-3.5" />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+                  </div>
+
+                  {perm.description && (
+                    <p className="mt-2 text-xs text-muted-foreground line-clamp-2">
+                      {perm.description}
+                    </p>
+                  )}
+
+                  <div className="mt-3 flex flex-wrap gap-1.5 border-t border-border/40 pt-3">
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      onClick={() => setEditItem(perm)}
+                      aria-label={`Editar ${perm.permission_name}`}
+                    >
+                      <Pencil className="size-3" aria-hidden="true" />
+                      Editar
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+                      onClick={() => setDeleteItem(perm)}
+                      aria-label={`Eliminar ${perm.permission_name}`}
+                    >
+                      <Trash2 className="size-3" aria-hidden="true" />
+                      Eliminar
+                    </Button>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
 
       {/* Create Dialog */}


### PR DESCRIPTION
## Summary

Round 2 of mobile-cards expansion. Three more tables flip to a card list below `md`.

### What

- **`catalogs/catalog-crud-page.tsx`** (BIG impact — used by ~10 catalog pages). Existing `<DataTableShell>` block wrapped in `hidden md:block`. Mobile `<ul>` cards: `Package` icon header + primary field value + ID chip + edit icon-button. Status badge row. Secondary fields rendered as a `<dl>` grid (up to 2). Action row Editar/Eliminar `size="xs"` outline buttons that fire the existing `setEditItem`/`setDeleteItem` state. `canMutate` guard respected. The shared dialogs are untouched — only the trigger surface changed.
- **`folders/folders-management-client.tsx`** — navigation pattern. The whole mobile card is a `<Link>` to the folder detail (matching the desktop `ChevronRight` link). `FileStack` icon, name, description, `FolderStatusBadge`, `<dl>` with module/section counts. No mutations (backend has no write endpoints).
- **`rbac/permissions-table.tsx`** — flat CRUD table (NOT a matrix), card pattern applied directly. `Key` icon, `permission_name` in `<code>` monospace chip, ID chip, status badge, description, Editar/Eliminar buttons that fire the existing dialog state.

Audit picks: catalog-crud-page was always priority because it's the generic CRUD wrapper for ~10 catalog pages. permissions-table turned out to be a regular row table (audit had it on the maybe-list); card pattern fit cleanly so it stayed in.

Closes audit 8.2 expansion (catalog-crud / folders / permissions subset).

## Commits

- `66b97f3` fix(catalogs): add mobile card layout to CatalogCrudPage
- `4f161b2` fix(folders): add mobile card layout to FoldersManagementClient
- `e21a604` fix(rbac): add mobile card layout to PermissionsTable

## Test plan

- [ ] Below `md` (768px), open any catalog page (`/dashboard/catalogs/club-types`, etc.), the folders management page, and `/dashboard/rbac/permissions`. Each table flips to a card list. Edit/Delete actions in mobile cards open the same dialogs as desktop.
- [ ] Folders mobile card is a full link → tapping anywhere on it navigates to detail.
- [ ] `pnpm lint` → no new warnings in the 3 touched files.