### PR TITLE
refactor(data-fetching): React Query round 2 — 3 components

### DIFF
--- a/src/components/membership/pending-members-panel.tsx
+++ b/src/components/membership/pending-members-panel.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
-import { toast } from "sonner";
+import { useState } from "react";
 import { UserPlus } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import {
   Select,
   SelectContent,
@@ -16,9 +16,7 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { PendingMembersTable } from "@/components/membership/pending-members-table";
 import {
   listMembershipRequestsFromClient,
-  type MembershipRequest,
 } from "@/lib/api/membership-requests";
-import { ApiError } from "@/lib/api/client";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -42,34 +40,24 @@ export function PendingMembersPanel({ sections }: PendingMembersPanelProps) {
   const [selectedSectionId, setSelectedSectionId] = useState<number | null>(
     activeSections[0]?.club_section_id ?? null,
   );
-  const [requests, setRequests] = useState<MembershipRequest[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
 
-  const loadRequests = useCallback(async (sectionId: number) => {
-    setIsLoading(true);
-    setLoadError(null);
-    try {
-      const data = await listMembershipRequestsFromClient(sectionId);
-      setRequests(data);
-    } catch (error) {
-      const message =
-        error instanceof ApiError
-          ? error.message
-          : "No se pudieron cargar las solicitudes de membresía.";
-      setLoadError(message);
-      setRequests([]);
-      toast.error(message);
-    } finally {
-      setIsLoading(false);
-    }
-  }, []);
+  const {
+    data: requests = [],
+    isFetching: isLoading,
+    error: queryError,
+  } = useQuery({
+    queryKey: ["membership-requests", selectedSectionId],
+    queryFn: () => listMembershipRequestsFromClient(selectedSectionId!),
+    enabled: selectedSectionId !== null,
+    staleTime: 30_000,
+  });
 
-  useEffect(() => {
-    if (selectedSectionId) {
-      loadRequests(selectedSectionId);
-    }
-  }, [selectedSectionId, loadRequests]);
+  const loadError =
+    queryError instanceof Error
+      ? queryError.message
+      : queryError
+        ? "No se pudieron cargar las solicitudes de membresía."
+        : null;
 
   if (activeSections.length === 0) {
     return (

--- a/src/components/reports/reports-list-client.tsx
+++ b/src/components/reports/reports-list-client.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import {
   Eye,
   Pencil,
@@ -131,97 +132,114 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
   const [filterYear, setFilterYear] = useState<number | undefined>(currentYear);
   const [filterStatus, setFilterStatus] = useState<ReportStatus | "all">("all");
 
-  // Data
-  const [reports, setReports] = useState<MonthlyReport[]>([]);
-  const [loading, setLoading] = useState(true);
-
   // Action loading per report
   const [actionLoading, setActionLoading] = useState<Record<number, string>>({});
 
   // New report creation state
   const [createMonth, setCreateMonth] = useState<number>(new Date().getMonth() + 1);
   const [createYear, setCreateYear] = useState<number>(currentYear);
-  const [creating, setCreating] = useState(false);
 
-  const fetchReports = useCallback(async () => {
-    setLoading(true);
-    try {
-      let data = await listMonthlyReports(
+  const queryClient = useQueryClient();
+
+  const {
+    data: rawReports = [],
+    isFetching: loading,
+    refetch: fetchReports,
+  } = useQuery({
+    queryKey: ["monthly-reports", enrollmentId, filterStatus],
+    queryFn: () =>
+      listMonthlyReports(
         enrollmentId,
         filterStatus !== "all" ? filterStatus : undefined,
-      );
-      if (filterYear) {
-        data = data.filter((r) => r.year === filterYear);
-      }
-      setReports(data);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : t("errors.load_reports");
-      toast.error(message);
-      setReports([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [enrollmentId, filterYear, filterStatus]);
+      ),
+    staleTime: 30_000,
+  });
 
-  useEffect(() => {
-    fetchReports();
-  }, [fetchReports]);
+  const reports = filterYear
+    ? rawReports.filter((r) => r.year === filterYear)
+    : rawReports;
 
   // ─── Action handlers ──────────────────────────────────────────────────────
 
-  async function handleCreateReport() {
-    setCreating(true);
-    try {
-      const report = await createOrGetDraftReport(enrollmentId, createMonth, createYear);
-      toast.success(`Reporte para ${MONTH_NAMES[createMonth]} ${createYear} creado/abierto.`);
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createOrGetDraftReport(enrollmentId, createMonth, createYear),
+    onSuccess: (report) => {
+      toast.success(
+        `Reporte para ${MONTH_NAMES[createMonth]} ${createYear} creado/abierto.`,
+      );
       router.push(`/dashboard/reports/${report.report_id}`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : t("errors.create_report");
+    },
+    onError: (error) => {
+      const message =
+        error instanceof Error ? error.message : t("errors.create_report");
       toast.error(message);
-    } finally {
-      setCreating(false);
-    }
-  }
+    },
+  });
 
-  async function handleGenerate(report: MonthlyReport) {
-    setActionLoading((prev) => ({ ...prev, [report.report_id]: "generate" }));
-    try {
-      const updated = await generateReport(report.report_id);
-      setReports((prev) =>
-        prev.map((r) => (r.report_id === updated.report_id ? updated : r)),
+  const generateMutation = useMutation({
+    mutationFn: (report: MonthlyReport) => {
+      setActionLoading((prev) => ({ ...prev, [report.report_id]: "generate" }));
+      return generateReport(report.report_id);
+    },
+    onSuccess: (_, report) => {
+      toast.success(
+        `Reporte de ${MONTH_NAMES[report.month]} ${report.year} generado.`,
       );
-      toast.success(`Reporte de ${MONTH_NAMES[report.month]} ${report.year} generado.`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : t("errors.generate_report");
+      void queryClient.invalidateQueries({
+        queryKey: ["monthly-reports", enrollmentId],
+      });
+    },
+    onError: (error, report) => {
+      const message =
+        error instanceof Error ? error.message : t("errors.generate_report");
       toast.error(message);
-    } finally {
       setActionLoading((prev) => {
         const next = { ...prev };
         delete next[report.report_id];
         return next;
       });
-    }
-  }
-
-  async function handleSubmit(report: MonthlyReport) {
-    setActionLoading((prev) => ({ ...prev, [report.report_id]: "submit" }));
-    try {
-      const updated = await submitReport(report.report_id);
-      setReports((prev) =>
-        prev.map((r) => (r.report_id === updated.report_id ? updated : r)),
-      );
-      toast.success(`Reporte de ${MONTH_NAMES[report.month]} ${report.year} enviado al campo.`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : t("errors.send_report");
-      toast.error(message);
-    } finally {
+    },
+    onSettled: (_, __, report) => {
       setActionLoading((prev) => {
         const next = { ...prev };
         delete next[report.report_id];
         return next;
       });
-    }
-  }
+    },
+  });
+
+  const submitMutation = useMutation({
+    mutationFn: (report: MonthlyReport) => {
+      setActionLoading((prev) => ({ ...prev, [report.report_id]: "submit" }));
+      return submitReport(report.report_id);
+    },
+    onSuccess: (_, report) => {
+      toast.success(
+        `Reporte de ${MONTH_NAMES[report.month]} ${report.year} enviado al campo.`,
+      );
+      void queryClient.invalidateQueries({
+        queryKey: ["monthly-reports", enrollmentId],
+      });
+    },
+    onError: (error, report) => {
+      const message =
+        error instanceof Error ? error.message : t("errors.send_report");
+      toast.error(message);
+      setActionLoading((prev) => {
+        const next = { ...prev };
+        delete next[report.report_id];
+        return next;
+      });
+    },
+    onSettled: (_, __, report) => {
+      setActionLoading((prev) => {
+        const next = { ...prev };
+        delete next[report.report_id];
+        return next;
+      });
+    },
+  });
 
   function handleDownloadPdf(report: MonthlyReport) {
     const url = getReportPdfUrl(report.report_id);
@@ -318,8 +336,12 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
             </SelectContent>
           </Select>
 
-          <Button size="sm" onClick={handleCreateReport} disabled={creating}>
-            {creating ? (
+          <Button
+            size="sm"
+            onClick={() => createMutation.mutate()}
+            disabled={createMutation.isPending}
+          >
+            {createMutation.isPending ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (
               <Plus className="size-4" />
@@ -396,7 +418,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                               <Button
                                 variant="ghost"
                                 size="xs"
-                                onClick={() => handleGenerate(report)}
+                                onClick={() => generateMutation.mutate(report)}
                                 disabled={isDisabled}
                               >
                                 {loadingAction === "generate" ? (
@@ -412,7 +434,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                               <Button
                                 variant="ghost"
                                 size="xs"
-                                onClick={() => handleSubmit(report)}
+                                onClick={() => submitMutation.mutate(report)}
                                 disabled={isDisabled}
                               >
                                 {loadingAction === "submit" ? (
@@ -514,7 +536,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                         <Button
                           variant="outline"
                           size="xs"
-                          onClick={() => handleGenerate(report)}
+                          onClick={() => generateMutation.mutate(report)}
                           disabled={isDisabled}
                         >
                           {loadingAction === "generate" ? (
@@ -530,7 +552,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                         <Button
                           variant="outline"
                           size="xs"
-                          onClick={() => handleSubmit(report)}
+                          onClick={() => submitMutation.mutate(report)}
                           disabled={isDisabled}
                         >
                           {loadingAction === "submit" ? (

--- a/src/components/units/member-combobox.tsx
+++ b/src/components/units/member-combobox.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState } from "react";
 import { Check, ChevronsUpDown, X, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
@@ -18,6 +18,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { useQuery } from "@tanstack/react-query";
 import { listClubMembers } from "@/lib/api/clubs";
 import type { ClubSectionMember } from "@/lib/api/clubs";
 
@@ -63,39 +64,35 @@ export function MemberCombobox({
   onMembersLoaded,
 }: MemberComboboxProps) {
   const [open, setOpen] = useState(false);
-  const [members, setMembers] = useState<ClubSectionMember[]>(externalMembers ?? []);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const hasFetched = useRef(false);
+  // Delay enabling the query until the popover is opened at least once,
+  // and only when no external list was provided.
+  const [hasOpened, setHasOpened] = useState(false);
 
-  // Load members once when the popover is opened for the first time,
-  // unless the parent already provided the list via the `members` prop.
-  const loadMembers = useCallback(async () => {
-    if (externalMembers !== undefined || hasFetched.current) return;
-    hasFetched.current = true;
-    setLoading(true);
-    setError(null);
-    try {
+  const {
+    data: fetchedMembers = [],
+    isFetching: loading,
+    error: fetchError,
+  } = useQuery({
+    queryKey: ["club-members", clubId],
+    queryFn: async () => {
       const data = await listClubMembers(clubId);
-      setMembers(data);
       onMembersLoaded?.(data);
-    } catch {
-      setError("No se pudieron cargar los miembros");
-    } finally {
-      setLoading(false);
-    }
-  }, [clubId, externalMembers, onMembersLoaded]);
+      return data;
+    },
+    enabled: hasOpened && externalMembers === undefined,
+    staleTime: 60_000,
+  });
 
-  // Sync if parent provides / updates the external list
-  useEffect(() => {
-    if (externalMembers !== undefined) {
-      setMembers(externalMembers);
-    }
-  }, [externalMembers]);
+  const members: ClubSectionMember[] = externalMembers ?? fetchedMembers;
+  const error = fetchError
+    ? fetchError instanceof Error
+      ? fetchError.message
+      : "No se pudieron cargar los miembros"
+    : null;
 
   function handleOpenChange(nextOpen: boolean) {
     setOpen(nextOpen);
-    if (nextOpen) loadMembers();
+    if (nextOpen && !hasOpened) setHasOpened(true);
   }
 
   const filteredMembers = excludeUserIds?.length


### PR DESCRIPTION
## Summary

Round 2 React Query migration. Three more components flagged by audit A-2 swap their hand-rolled `useEffect + setLoading` loops for `useQuery` / `useMutation`.

### Migrated

| Component | queryKey | staleTime | Notes |
|-----------|----------|-----------|-------|
| `reports/reports-list-client.tsx` | `["monthly-reports", enrollmentId, filterStatus]` | `30s` | 3 mutations (`create`, `generate`, `submit`) with `onSuccess: invalidateQueries`. The `filterYear` is now client-side over `rawReports` because the API doesn't support it as a param. |
| `units/member-combobox.tsx` | `["club-members", clubId]` | `60s` | `enabled: hasOpened && externalMembers === undefined` — query doesn't fire until popover opens, and is bypassed when parent provides the list via `externalMembers` prop. `onMembersLoaded` is called inside `queryFn` to preserve the parent list-sharing contract without an extra `useEffect`. |
| `membership/pending-members-panel.tsx` | `["membership-requests", selectedSectionId]` | `30s` | `enabled: selectedSectionId !== null`. |

### Skip

- **`honors/review-split-view.tsx`** — not a fetch case. Receives `requirement` as a prop; the 3 handlers (`handleApprove`, `handleEditApprove`, `handleReject`) are pure mutations that delegate to `onAction(...)`. No cache to manage. Replaced with `pending-members-panel.tsx`.

Closes audit A-2 expansion (3 of remaining ~7 components).

## Commits

- `ec2f4fd` refactor(reports): migrate reports-list-client to useQuery/useMutation
- `5c99730` refactor(units): migrate member-combobox to useQuery
- `07f0caf` refactor(membership): migrate pending-members-panel to useQuery

## Test plan

- [ ] Reports list: filters update without refetch where filter is client-side; create/generate/submit mutations invalidate the listing.
- [ ] Member combobox: open popover for the first time → fires the request once; reopens use cache.
- [ ] Pending members: selecting a section fires the fetch; dropping the selection stops the query (no orphan request).
- [ ] DevTools Network: one request per cache key per arg combo.
- [ ] `pnpm lint` → no new errors.