### PR TITLE
fix(a11y): forms accessibility round 3 — 8 dialogs

### DIFF
--- a/src/components/annual-folders/award-category-form-dialog.tsx
+++ b/src/components/annual-folders/award-category-form-dialog.tsx
@@ -239,17 +239,18 @@ export function AwardCategoryFormDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Nombre */}
           <div className="space-y-1.5">
-            <Label htmlFor="cat-name">Nombre *</Label>
+            <Label htmlFor="cat-name">Nombre <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Input
               id="cat-name"
               {...register("name")}
               placeholder="Ej. Oro, Plata, Bronce"
+              aria-required="true"
             />
             {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
             )}
           </div>
 
@@ -263,7 +264,7 @@ export function AwardCategoryFormDialog({
               rows={3}
             />
             {errors.description && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.description.message}
               </p>
             )}
@@ -271,12 +272,12 @@ export function AwardCategoryFormDialog({
 
           {/* Alcance */}
           <div className="space-y-1.5">
-            <Label htmlFor="cat-scope">Alcance *</Label>
+            <Label htmlFor="cat-scope">Alcance <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Select
               value={scopeValue}
               onValueChange={(val) => setValue("scope", val as AwardCategoryScope)}
             >
-              <SelectTrigger id="cat-scope">
+              <SelectTrigger id="cat-scope" aria-required="true">
                 <SelectValue placeholder="Seleccionar alcance" />
               </SelectTrigger>
               <SelectContent>
@@ -286,7 +287,7 @@ export function AwardCategoryFormDialog({
               </SelectContent>
             </Select>
             {errors.scope && (
-              <p className="text-xs text-destructive">{errors.scope.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.scope.message}</p>
             )}
           </div>
 
@@ -311,7 +312,7 @@ export function AwardCategoryFormDialog({
               </SelectContent>
             </Select>
             {errors.tier && (
-              <p className="text-xs text-destructive">{errors.tier.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.tier.message}</p>
             )}
           </div>
 
@@ -338,7 +339,7 @@ export function AwardCategoryFormDialog({
               </SelectContent>
             </Select>
             {errors.club_type_id && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.club_type_id.message}
               </p>
             )}
@@ -347,16 +348,17 @@ export function AwardCategoryFormDialog({
           {/* Puntos min / max */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label htmlFor="cat-min-points">Puntos mínimos *</Label>
+              <Label htmlFor="cat-min-points">Puntos mínimos <span aria-hidden="true" className="text-destructive">*</span></Label>
               <Input
                 id="cat-min-points"
                 type="number"
                 min={0}
                 {...register("min_points")}
                 placeholder="0"
+                aria-required="true"
               />
               {errors.min_points && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.min_points.message}
                 </p>
               )}
@@ -372,7 +374,7 @@ export function AwardCategoryFormDialog({
                 placeholder="Sin límite"
               />
               {errors.max_points && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.max_points.message}
                 </p>
               )}
@@ -393,7 +395,7 @@ export function AwardCategoryFormDialog({
                 placeholder="Ej. 60"
               />
               {errors.min_composite_pct && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.min_composite_pct.message}
                 </p>
               )}
@@ -411,7 +413,7 @@ export function AwardCategoryFormDialog({
                 placeholder="Ej. 80"
               />
               {errors.max_composite_pct && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.max_composite_pct.message}
                 </p>
               )}
@@ -429,23 +431,24 @@ export function AwardCategoryFormDialog({
                 maxLength={100}
               />
               {errors.icon && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.icon.message}
                 </p>
               )}
             </div>
 
             <div className="space-y-1.5">
-              <Label htmlFor="cat-order">Orden *</Label>
+              <Label htmlFor="cat-order">Orden <span aria-hidden="true" className="text-destructive">*</span></Label>
               <Input
                 id="cat-order"
                 type="number"
                 min={0}
                 {...register("order")}
                 placeholder="0"
+                aria-required="true"
               />
               {errors.order && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.order.message}
                 </p>
               )}

--- a/src/components/annual-folders/section-form-dialog.tsx
+++ b/src/components/annual-folders/section-form-dialog.tsx
@@ -164,17 +164,18 @@ export function SectionFormDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Nombre */}
           <div className="space-y-1.5">
-            <Label htmlFor="section-name">Nombre *</Label>
+            <Label htmlFor="section-name">Nombre <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Input
               id="section-name"
               {...register("name")}
               placeholder="Ej. Evidencias de actividades"
+              aria-required="true"
             />
             {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
             )}
           </div>
 
@@ -188,7 +189,7 @@ export function SectionFormDialog({
               rows={3}
             />
             {errors.description && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.description.message}
               </p>
             )}
@@ -196,16 +197,17 @@ export function SectionFormDialog({
 
           {/* Orden */}
           <div className="space-y-1.5">
-            <Label htmlFor="section-order">Orden *</Label>
+            <Label htmlFor="section-order">Orden <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Input
               id="section-order"
               type="number"
               min={1}
               {...register("order")}
               placeholder="1"
+              aria-required="true"
             />
             {errors.order && (
-              <p className="text-xs text-destructive">{errors.order.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.order.message}</p>
             )}
           </div>
 
@@ -230,16 +232,17 @@ export function SectionFormDialog({
           <div className="grid grid-cols-2 gap-3">
             {/* Puntos máximos */}
             <div className="space-y-1.5">
-              <Label htmlFor="section-max-points">Puntos máximos *</Label>
+              <Label htmlFor="section-max-points">Puntos máximos <span aria-hidden="true" className="text-destructive">*</span></Label>
               <Input
                 id="section-max-points"
                 type="number"
                 min={0}
                 {...register("max_points")}
                 placeholder="0"
+                aria-required="true"
               />
               {errors.max_points && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.max_points.message}
                 </p>
               )}
@@ -256,7 +259,7 @@ export function SectionFormDialog({
                 placeholder="0"
               />
               {errors.minimum_points && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.minimum_points.message}
                 </p>
               )}

--- a/src/components/annual-folders/template-form-dialog.tsx
+++ b/src/components/annual-folders/template-form-dialog.tsx
@@ -230,32 +230,33 @@ export function TemplateFormDialog({
           <DialogTitle>{isEdit ? "Editar plantilla" : "Nueva plantilla"}</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Nombre */}
           <div className="space-y-1.5">
             <Label htmlFor="template-name">
-              Nombre <span className="ml-0.5 text-destructive">*</span>
+              Nombre <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Input
               id="template-name"
               {...register("name")}
               placeholder="Ej. Carpeta Conquistadores 2025"
+              aria-required="true"
             />
             {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
             )}
           </div>
 
           {/* Tipo de club */}
           <div className="space-y-1.5">
-            <Label>
-              Tipo de club <span className="ml-0.5 text-destructive">*</span>
+            <Label htmlFor="template-club-type">
+              Tipo de club <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Select
               value={String(clubTypeValue)}
               onValueChange={(val) => setValue("club_type_id", Number(val))}
             >
-              <SelectTrigger>
+              <SelectTrigger id="template-club-type" aria-required="true">
                 <SelectValue placeholder="Seleccionar tipo de club" />
               </SelectTrigger>
               <SelectContent>
@@ -276,7 +277,7 @@ export function TemplateFormDialog({
               </SelectContent>
             </Select>
             {errors.club_type_id && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.club_type_id.message}
               </p>
             )}
@@ -284,8 +285,8 @@ export function TemplateFormDialog({
 
           {/* Año eclesiástico */}
           <div className="space-y-1.5">
-            <Label>
-              Año eclesiástico <span className="ml-0.5 text-destructive">*</span>
+            <Label htmlFor="template-ecclesiastical-year">
+              Año eclesiástico <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Select
               value={String(yearValue)}
@@ -293,7 +294,7 @@ export function TemplateFormDialog({
                 setValue("ecclesiastical_year_id", Number(val))
               }
             >
-              <SelectTrigger>
+              <SelectTrigger id="template-ecclesiastical-year" aria-required="true">
                 <SelectValue placeholder="Seleccionar año" />
               </SelectTrigger>
               <SelectContent>
@@ -319,7 +320,7 @@ export function TemplateFormDialog({
               </SelectContent>
             </Select>
             {errors.ecclesiastical_year_id && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.ecclesiastical_year_id.message}
               </p>
             )}
@@ -328,7 +329,7 @@ export function TemplateFormDialog({
           {/* Owner tier — radio group */}
           <div className="space-y-2">
             <Label>
-              Propietario <span className="ml-0.5 text-destructive">*</span>
+              Propietario <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Controller
               name="owner_tier"
@@ -367,8 +368,8 @@ export function TemplateFormDialog({
           {/* Conditional owner select */}
           {ownerTier === "union" ? (
             <div className="space-y-1.5">
-              <Label>
-                Unión <span className="ml-0.5 text-destructive">*</span>
+              <Label htmlFor="template-owner-union">
+                Unión <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
                 disabled={loadingOwnerCatalogs}
@@ -377,7 +378,7 @@ export function TemplateFormDialog({
                   setValue("owner_union_id", Number(val), { shouldValidate: true })
                 }
               >
-                <SelectTrigger>
+                <SelectTrigger id="template-owner-union" aria-required="true">
                   <SelectValue
                     placeholder={
                       loadingOwnerCatalogs ? "Cargando..." : "Seleccionar unión"
@@ -399,15 +400,15 @@ export function TemplateFormDialog({
                 </SelectContent>
               </Select>
               {errors.owner_union_id && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.owner_union_id.message}
                 </p>
               )}
             </div>
           ) : (
             <div className="space-y-1.5">
-              <Label>
-                Campo local <span className="ml-0.5 text-destructive">*</span>
+              <Label htmlFor="template-owner-local-field">
+                Campo local <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
                 disabled={loadingOwnerCatalogs}
@@ -416,7 +417,7 @@ export function TemplateFormDialog({
                   setValue("owner_local_field_id", Number(val), { shouldValidate: true })
                 }
               >
-                <SelectTrigger>
+                <SelectTrigger id="template-owner-local-field" aria-required="true">
                   <SelectValue
                     placeholder={
                       loadingOwnerCatalogs ? "Cargando..." : "Seleccionar campo local"
@@ -441,7 +442,7 @@ export function TemplateFormDialog({
                 </SelectContent>
               </Select>
               {errors.owner_local_field_id && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.owner_local_field_id.message}
                 </p>
               )}
@@ -460,7 +461,7 @@ export function TemplateFormDialog({
                 placeholder="0"
               />
               {errors.minimum_points && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.minimum_points.message}
                 </p>
               )}
@@ -474,7 +475,7 @@ export function TemplateFormDialog({
                 {...register("closing_date")}
               />
               {errors.closing_date && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.closing_date.message}
                 </p>
               )}

--- a/src/components/camporees/camporee-form-dialog.tsx
+++ b/src/components/camporees/camporee-form-dialog.tsx
@@ -185,17 +185,18 @@ export function CamporeeFormDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Nombre */}
           <div className="space-y-1.5">
-            <Label htmlFor="name">Nombre *</Label>
+            <Label htmlFor="name">Nombre <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Input
               id="name"
               {...register("name")}
               placeholder="Ej. Camporee de Primavera 2025"
+              aria-required="true"
             />
             {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
             )}
           </div>
 
@@ -213,19 +214,19 @@ export function CamporeeFormDialog({
           {/* Fechas */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label htmlFor="start_date">Fecha de inicio *</Label>
-              <Input id="start_date" type="date" {...register("start_date")} />
+              <Label htmlFor="start_date">Fecha de inicio <span aria-hidden="true" className="text-destructive">*</span></Label>
+              <Input id="start_date" type="date" {...register("start_date")} aria-required="true" />
               {errors.start_date && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.start_date.message}
                 </p>
               )}
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="end_date">Fecha de fin *</Label>
-              <Input id="end_date" type="date" {...register("end_date")} />
+              <Label htmlFor="end_date">Fecha de fin <span aria-hidden="true" className="text-destructive">*</span></Label>
+              <Input id="end_date" type="date" {...register("end_date")} aria-required="true" />
               {errors.end_date && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.end_date.message}
                 </p>
               )}
@@ -234,14 +235,15 @@ export function CamporeeFormDialog({
 
           {/* Lugar */}
           <div className="space-y-1.5">
-            <Label htmlFor="local_camporee_place">Lugar *</Label>
+            <Label htmlFor="local_camporee_place">Lugar <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Input
               id="local_camporee_place"
               {...register("local_camporee_place")}
               placeholder="Ej. Centro Recreacional La Montaña"
+              aria-required="true"
             />
             {errors.local_camporee_place && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.local_camporee_place.message}
               </p>
             )}
@@ -249,16 +251,17 @@ export function CamporeeFormDialog({
 
           {/* Campo local */}
           <div className="space-y-1.5">
-            <Label htmlFor="local_field_id">ID del campo local *</Label>
+            <Label htmlFor="local_field_id">ID del campo local <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Input
               id="local_field_id"
               type="number"
               min={1}
               {...register("local_field_id")}
               placeholder="1"
+              aria-required="true"
             />
             {errors.local_field_id && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.local_field_id.message}
               </p>
             )}
@@ -276,7 +279,7 @@ export function CamporeeFormDialog({
               placeholder="0.00"
             />
             {errors.registration_cost && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.registration_cost.message}
               </p>
             )}

--- a/src/components/camporees/enroll-club-dialog.tsx
+++ b/src/components/camporees/enroll-club-dialog.tsx
@@ -92,19 +92,20 @@ export function EnrollClubDialog({
           <DialogTitle>Inscribir club</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Club section ID */}
           <div className="space-y-1.5">
-            <Label htmlFor="club_section_id">ID de sección de club *</Label>
+            <Label htmlFor="club_section_id">ID de sección de club <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Input
               id="club_section_id"
               type="number"
               min={1}
               {...register("club_section_id")}
               placeholder="Ej. 42"
+              aria-required="true"
             />
             {errors.club_section_id && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.club_section_id.message}
               </p>
             )}

--- a/src/components/camporees/union-camporee-form-dialog.tsx
+++ b/src/components/camporees/union-camporee-form-dialog.tsx
@@ -187,17 +187,18 @@ export function UnionCamporeeFormDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Nombre */}
           <div className="space-y-1.5">
-            <Label htmlFor="uc-name">Nombre *</Label>
+            <Label htmlFor="uc-name">Nombre <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Input
               id="uc-name"
               {...register("name")}
               placeholder="Ej. Camporee de Unión 2025"
+              aria-required="true"
             />
             {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
             )}
           </div>
 
@@ -215,29 +216,29 @@ export function UnionCamporeeFormDialog({
           {/* Fechas */}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label htmlFor="uc-start_date">Fecha de inicio *</Label>
-              <Input id="uc-start_date" type="date" {...register("start_date")} />
+              <Label htmlFor="uc-start_date">Fecha de inicio <span aria-hidden="true" className="text-destructive">*</span></Label>
+              <Input id="uc-start_date" type="date" {...register("start_date")} aria-required="true" />
               {errors.start_date && (
-                <p className="text-xs text-destructive">{errors.start_date.message}</p>
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.start_date.message}</p>
               )}
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="uc-end_date">Fecha de fin *</Label>
-              <Input id="uc-end_date" type="date" {...register("end_date")} />
+              <Label htmlFor="uc-end_date">Fecha de fin <span aria-hidden="true" className="text-destructive">*</span></Label>
+              <Input id="uc-end_date" type="date" {...register("end_date")} aria-required="true" />
               {errors.end_date && (
-                <p className="text-xs text-destructive">{errors.end_date.message}</p>
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.end_date.message}</p>
               )}
             </div>
           </div>
 
           {/* Unión */}
           <div className="space-y-1.5">
-            <Label htmlFor="uc-union_id">Unión *</Label>
+            <Label htmlFor="uc-union_id">Unión <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Select
               value={unionId > 0 ? String(unionId) : ""}
               onValueChange={(val) => setValue("union_id", Number(val))}
             >
-              <SelectTrigger id="uc-union_id" className="w-full">
+              <SelectTrigger id="uc-union_id" className="w-full" aria-required="true">
                 <SelectValue placeholder="Selecciona una unión..." />
               </SelectTrigger>
               <SelectContent>
@@ -249,20 +250,21 @@ export function UnionCamporeeFormDialog({
               </SelectContent>
             </Select>
             {errors.union_id && (
-              <p className="text-xs text-destructive">{errors.union_id.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.union_id.message}</p>
             )}
           </div>
 
           {/* Lugar */}
           <div className="space-y-1.5">
-            <Label htmlFor="uc-place">Lugar *</Label>
+            <Label htmlFor="uc-place">Lugar <span aria-hidden="true" className="text-destructive">*</span></Label>
             <Input
               id="uc-place"
               {...register("place")}
               placeholder="Ej. Centro Recreacional Nacional"
+              aria-required="true"
             />
             {errors.place && (
-              <p className="text-xs text-destructive">{errors.place.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.place.message}</p>
             )}
           </div>
 
@@ -278,7 +280,7 @@ export function UnionCamporeeFormDialog({
               placeholder="0.00"
             />
             {errors.registration_cost && (
-              <p className="text-xs text-destructive">{errors.registration_cost.message}</p>
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.registration_cost.message}</p>
             )}
           </div>
 

--- a/src/components/investiture/config-form-dialog.tsx
+++ b/src/components/investiture/config-form-dialog.tsx
@@ -188,19 +188,19 @@ export function ConfigFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Campo Local — solo al crear */}
           {!isEdit && (
             <div className="space-y-1.5">
-              <Label>
-                Campo Local <span className="ml-0.5 text-destructive">*</span>
+              <Label htmlFor="cfg-local_field_id">
+                Campo Local <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
                 value={selectedLocalFieldId?.toString() ?? ""}
                 onValueChange={(v) => setValue("local_field_id", Number(v))}
                 disabled={loadingCatalogs}
               >
-                <SelectTrigger>
+                <SelectTrigger id="cfg-local_field_id" aria-required="true">
                   <SelectValue
                     placeholder={
                       loadingCatalogs ? "Cargando campos..." : "Seleccioná un campo local"
@@ -219,7 +219,7 @@ export function ConfigFormDialog({
                 </SelectContent>
               </Select>
               {errors.local_field_id && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.local_field_id.message}
                 </p>
               )}
@@ -229,15 +229,15 @@ export function ConfigFormDialog({
           {/* Año Eclesiástico — solo al crear */}
           {!isEdit && (
             <div className="space-y-1.5">
-              <Label>
-                Año Eclesiástico <span className="ml-0.5 text-destructive">*</span>
+              <Label htmlFor="cfg-ecclesiastical_year_id">
+                Año Eclesiástico <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
                 value={selectedYearId?.toString() ?? ""}
                 onValueChange={(v) => setValue("ecclesiastical_year_id", Number(v))}
                 disabled={loadingCatalogs}
               >
-                <SelectTrigger>
+                <SelectTrigger id="cfg-ecclesiastical_year_id" aria-required="true">
                   <SelectValue
                     placeholder={
                       loadingCatalogs ? "Cargando años..." : "Seleccioná un año"
@@ -261,7 +261,7 @@ export function ConfigFormDialog({
                 </SelectContent>
               </Select>
               {errors.ecclesiastical_year_id && (
-                <p className="text-xs text-destructive">
+                <p className="text-xs text-destructive" role="alert" aria-live="polite">
                   {errors.ecclesiastical_year_id.message}
                 </p>
               )}
@@ -271,15 +271,16 @@ export function ConfigFormDialog({
           {/* Fecha límite de envío */}
           <div className="space-y-1.5">
             <Label htmlFor="submission_deadline">
-              Límite de Envío <span className="ml-0.5 text-destructive">*</span>
+              Límite de Envío <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Input
               id="submission_deadline"
               type="date"
               {...register("submission_deadline")}
+              aria-required="true"
             />
             {errors.submission_deadline && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.submission_deadline.message}
               </p>
             )}
@@ -288,15 +289,16 @@ export function ConfigFormDialog({
           {/* Fecha de investidura */}
           <div className="space-y-1.5">
             <Label htmlFor="investiture_date">
-              Fecha de Investidura <span className="ml-0.5 text-destructive">*</span>
+              Fecha de Investidura <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Input
               id="investiture_date"
               type="date"
               {...register("investiture_date")}
+              aria-required="true"
             />
             {errors.investiture_date && (
-              <p className="text-xs text-destructive">
+              <p className="text-xs text-destructive" role="alert" aria-live="polite">
                 {errors.investiture_date.message}
               </p>
             )}
@@ -312,7 +314,7 @@ export function ConfigFormDialog({
               Cancelar
             </Button>
             <Button type="submit" disabled={isSubmitting || loadingCatalogs}>
-              {isSubmitting && <Loader2 className="size-4 animate-spin" />}
+              {isSubmitting && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
               {isEdit ? "Guardar cambios" : "Crear configuración"}
             </Button>
           </DialogFooter>

--- a/src/components/reports/manual-data-form.tsx
+++ b/src/components/reports/manual-data-form.tsx
@@ -83,7 +83,7 @@ function NumberField({ label, name, register, error, disabled }: NumberFieldProp
         className="h-8"
         {...register(name)}
       />
-      {error && <p className="text-xs text-destructive">{error}</p>}
+      {error && <p className="text-xs text-destructive" role="alert" aria-live="polite">{error}</p>}
     </div>
   );
 }
@@ -111,7 +111,7 @@ function TextareaField({ label, name, register, error, disabled, rows = 3 }: Tex
         className="resize-none text-sm"
         {...register(name)}
       />
-      {error && <p className="text-xs text-destructive">{error}</p>}
+      {error && <p className="text-xs text-destructive" role="alert" aria-live="polite">{error}</p>}
     </div>
   );
 }
@@ -172,7 +172,7 @@ export function ManualDataForm({
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
       {/* Administración */}
       <Card>
         <CardHeader className="pb-3">
@@ -341,9 +341,9 @@ export function ManualDataForm({
       <div className="flex justify-end">
         <Button type="submit" disabled={disabled || saving || !isDirty} size="sm">
           {saving ? (
-            <Loader2 className="size-4 animate-spin" />
+            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
           ) : (
-            <Save className="size-4" />
+            <Save className="size-4" aria-hidden="true" />
           )}
           Guardar datos manuales
         </Button>


### PR DESCRIPTION
## Summary

Round 3 of the manual aria-* sweep. Eight more raw `useForm` dialogs get the same pattern validated in #28 / #38 / #41.

### Pattern applied (per file as needed)

| Item | What |
|------|------|
| `noValidate` on `<form>` | Stop browser native validation from competing with server-action errors |
| `aria-hidden="true"` on `*` markers | Hide the visual color-only required indicator from AT |
| `aria-required="true"` on required inputs/SelectTrigger | Real semantic required signal |
| `id` on `<SelectTrigger>` + matching `htmlFor` on `<Label>` | Wire label↔combobox association (Radix Select doesn't auto-link) |
| `role="alert" aria-live="polite"` on inline error `<p>` | Announce field errors to screen readers |
| `aria-hidden` on decorative submit icons | Stop AT from reading them |

### Per-dialog summary

- **`camporee-form-dialog`** — 5 required, 6 error `<p>` regions wired.
- **`union-camporee-form-dialog`** — Unión `SelectTrigger` already had `id`. 5 required + 6 errors.
- **`enroll-club-dialog`** — single field. Minimal but necessary.
- **`manual-data-form`** — all fields optional, no `*` markers. Just `noValidate`, decorative-icon `aria-hidden`, and live-region on the shared `NumberField`/`TextareaField` helpers (covers all 14 instances at once).
- **`config-form-dialog`** — 2 create-only selects had no `id`/`htmlFor` — wired. 4 `*` + 2 SelectTriggers + 2 dates required-marked.
- **`section-form-dialog`** — switch (Sección requerida) intentionally not marked `aria-required` (it's a toggle, not a required input).
- **`template-form-dialog`** — 4 SelectTriggers had no `id`/`htmlFor` — all wired. 6 `*` + 1 input + 3 triggers required-marked.
- **`award-category-form-dialog`** — `*` was bare text inside Label, not wrapped. Wrapped + `aria-hidden`-ed across 4 labels.

Closes audit 5.1/5.2 expansion (8 of remaining ~10 dialogs).

## Commits

- `597aff0` camporee-form
- `7a52d3a` union-camporee
- `079b2de` enroll-club
- `36b176c` manual-data-form
- `7da964a` investiture config
- `1e153ec` annual-folders section-form
- `8bfab64` annual-folders template-form
- `b2bed70` annual-folders award-category-form

## Test plan

- [ ] Open each dialog with a screen reader (VoiceOver/NVDA). Tab to a SelectTrigger — the screen reader announces the linked label.
- [ ] Submit invalid → field errors announce via the live region.
- [ ] DevTools accessibility tree — required-field markers hidden, `aria-required="true"` set on required controls.
- [ ] `pnpm lint` → no new errors in the 8 touched files.