### PR TITLE
feat: mobile cards round 3 — insurance + annual-folders (4 tables)

### DIFF
--- a/src/components/annual-folders/award-categories-client-page.tsx
+++ b/src/components/annual-folders/award-categories-client-page.tsx
@@ -294,107 +294,164 @@ export function AwardCategoriesClientPage({
                   )}
                 </div>
               ) : (
-                <div className="rounded-lg border border-border/60">
-                  <Table>
-                    <TableHeader>
-                      <TableRow>
-                        <TableHead className="w-16 text-center">Orden</TableHead>
-                        <TableHead>Nombre</TableHead>
-                        <TableHead className="hidden sm:table-cell">
-                          Tipo club
-                        </TableHead>
-                        <TableHead className="w-24 text-center">Pts Min</TableHead>
-                        <TableHead className="hidden w-24 text-center md:table-cell">
-                          Pts Max
-                        </TableHead>
-                        {/* 8.4-C composite % columns */}
-                        <TableHead className="hidden w-24 text-center lg:table-cell">
-                          % Min
-                        </TableHead>
-                        <TableHead className="hidden w-24 text-center lg:table-cell">
-                          % Max
-                        </TableHead>
-                        {/* 8.4-C Phase C tier column */}
-                        <TableHead className="hidden w-28 text-center xl:table-cell">
-                          Nivel
-                        </TableHead>
-                        <TableHead className="w-20 text-center">Estado</TableHead>
-                        <TableHead className="w-20 text-right">Acciones</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody>
-                      {filteredCategories.map((cat) => (
-                        <TableRow
-                          key={cat.award_category_id}
-                          className={cat.is_legacy ? "opacity-60" : ""}
-                        >
-                          <TableCell className="text-center">
-                            <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-xs font-medium">
-                              {cat.order}
-                            </span>
-                          </TableCell>
-                          <TableCell>
-                            <div className="flex flex-col gap-0.5">
-                              <div className="flex items-center gap-2">
-                                <span className="font-medium">{cat.name}</span>
-                                {cat.is_legacy && (
-                                  <Badge variant="outline" className="text-xs">
-                                    Legacy
-                                  </Badge>
+                <>
+                  {/* Desktop: categories table */}
+                  <div className="hidden rounded-lg border border-border/60 md:block">
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead className="w-16 text-center">Orden</TableHead>
+                          <TableHead>Nombre</TableHead>
+                          <TableHead>Tipo club</TableHead>
+                          <TableHead className="w-24 text-center">Pts Min</TableHead>
+                          <TableHead className="w-24 text-center">
+                            Pts Max
+                          </TableHead>
+                          {/* 8.4-C composite % columns */}
+                          <TableHead className="hidden w-24 text-center lg:table-cell">
+                            % Min
+                          </TableHead>
+                          <TableHead className="hidden w-24 text-center lg:table-cell">
+                            % Max
+                          </TableHead>
+                          {/* 8.4-C Phase C tier column */}
+                          <TableHead className="hidden w-28 text-center xl:table-cell">
+                            Nivel
+                          </TableHead>
+                          <TableHead className="w-20 text-center">Estado</TableHead>
+                          <TableHead className="w-20 text-right">Acciones</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {filteredCategories.map((cat) => (
+                          <TableRow
+                            key={cat.award_category_id}
+                            className={cat.is_legacy ? "opacity-60" : ""}
+                          >
+                            <TableCell className="text-center">
+                              <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                                {cat.order}
+                              </span>
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex flex-col gap-0.5">
+                                <div className="flex items-center gap-2">
+                                  <span className="font-medium">{cat.name}</span>
+                                  {cat.is_legacy && (
+                                    <Badge variant="outline" className="text-xs">
+                                      Legacy
+                                    </Badge>
+                                  )}
+                                </div>
+                                {cat.description && (
+                                  <span className="line-clamp-1 text-xs text-muted-foreground">
+                                    {cat.description}
+                                  </span>
                                 )}
                               </div>
-                              {cat.description && (
-                                <span className="line-clamp-1 text-xs text-muted-foreground">
-                                  {cat.description}
+                            </TableCell>
+                            <TableCell className="text-sm text-muted-foreground">
+                              {clubTypeLabel(cat.club_type_id, clubTypes)}
+                            </TableCell>
+                            <TableCell className="text-center text-sm">
+                              {cat.min_points}
+                            </TableCell>
+                            <TableCell className="text-center text-sm text-muted-foreground">
+                              {cat.max_points !== null ? (
+                                cat.max_points
+                              ) : (
+                                <span className="italic text-muted-foreground/60">
+                                  Sin límite
                                 </span>
                               )}
-                            </div>
-                          </TableCell>
-                          <TableCell className="hidden text-sm text-muted-foreground sm:table-cell">
-                            {clubTypeLabel(cat.club_type_id, clubTypes)}
-                          </TableCell>
-                          <TableCell className="text-center text-sm">
-                            {cat.min_points}
-                          </TableCell>
-                          <TableCell className="hidden text-center text-sm text-muted-foreground md:table-cell">
-                            {cat.max_points !== null ? (
-                              cat.max_points
-                            ) : (
-                              <span className="italic text-muted-foreground/60">
-                                Sin límite
-                              </span>
-                            )}
-                          </TableCell>
-                          {/* 8.4-C composite % cells */}
-                          <TableCell className="hidden text-center text-sm text-muted-foreground lg:table-cell">
-                            {formatPct(cat.min_composite_pct)}
-                          </TableCell>
-                          <TableCell className="hidden text-center text-sm text-muted-foreground lg:table-cell">
-                            {formatPct(cat.max_composite_pct)}
-                          </TableCell>
-                          {/* 8.4-C Phase C tier cell */}
-                          <TableCell className="hidden text-center xl:table-cell">
-                            {cat.tier !== null ? (
+                            </TableCell>
+                            {/* 8.4-C composite % cells */}
+                            <TableCell className="hidden text-center text-sm text-muted-foreground lg:table-cell">
+                              {formatPct(cat.min_composite_pct)}
+                            </TableCell>
+                            <TableCell className="hidden text-center text-sm text-muted-foreground lg:table-cell">
+                              {formatPct(cat.max_composite_pct)}
+                            </TableCell>
+                            {/* 8.4-C Phase C tier cell */}
+                            <TableCell className="hidden text-center xl:table-cell">
+                              {cat.tier !== null ? (
+                                <Badge
+                                  variant={TIER_BADGE_VARIANT[cat.tier]}
+                                  className="text-xs"
+                                >
+                                  {TIER_LABELS[cat.tier]}
+                                </Badge>
+                              ) : (
+                                <span className="text-sm text-muted-foreground/60">—</span>
+                              )}
+                            </TableCell>
+                            <TableCell className="text-center">
                               <Badge
-                                variant={TIER_BADGE_VARIANT[cat.tier]}
+                                variant={cat.active ? "success" : "secondary"}
                                 className="text-xs"
                               >
-                                {TIER_LABELS[cat.tier]}
+                                {cat.active ? "Activa" : "Inactiva"}
                               </Badge>
-                            ) : (
-                              <span className="text-sm text-muted-foreground/60">—</span>
-                            )}
-                          </TableCell>
-                          <TableCell className="text-center">
-                            <Badge
-                              variant={cat.active ? "success" : "secondary"}
-                              className="text-xs"
-                            >
-                              {cat.active ? "Activa" : "Inactiva"}
-                            </Badge>
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <div className="flex items-center justify-end gap-1">
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <div className="flex items-center justify-end gap-1">
+                                <Button
+                                  variant="ghost"
+                                  size="icon-xs"
+                                  onClick={() => handleEdit(cat)}
+                                  title="Editar categoría"
+                                  disabled={cat.is_legacy}
+                                >
+                                  <Pencil className="size-3.5" />
+                                  <span className="sr-only">Editar</span>
+                                </Button>
+                                <Button
+                                  variant="ghost"
+                                  size="icon-xs"
+                                  onClick={() => handleDelete(cat)}
+                                  title="Eliminar categoría"
+                                  className="text-destructive hover:text-destructive"
+                                >
+                                  <Trash2 className="size-3.5" />
+                                  <span className="sr-only">Eliminar</span>
+                                </Button>
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+
+                  {/* Mobile: category cards */}
+                  <ul className="space-y-3 md:hidden" aria-label={`Categorías de ${scopeLabel}`}>
+                    {filteredCategories.map((cat) => (
+                      <li key={cat.award_category_id}>
+                        <div
+                          className={`rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none${cat.is_legacy ? " opacity-60" : ""}`}
+                        >
+                          <div className="flex items-start justify-between gap-3">
+                            <div className="flex items-center gap-2.5 min-w-0 flex-1">
+                              <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                                {cat.order}
+                              </span>
+                              <div className="min-w-0 flex-1">
+                                <div className="flex flex-wrap items-center gap-1.5">
+                                  <span className="font-medium">{cat.name}</span>
+                                  {cat.is_legacy && (
+                                    <Badge variant="outline" className="text-xs">
+                                      Legacy
+                                    </Badge>
+                                  )}
+                                </div>
+                                {cat.description && (
+                                  <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+                                    {cat.description}
+                                  </p>
+                                )}
+                              </div>
+                            </div>
+                            <div className="flex shrink-0 items-center gap-1">
                               <Button
                                 variant="ghost"
                                 size="icon-xs"
@@ -416,12 +473,61 @@ export function AwardCategoriesClientPage({
                                 <span className="sr-only">Eliminar</span>
                               </Button>
                             </div>
-                          </TableCell>
-                        </TableRow>
-                      ))}
-                    </TableBody>
-                  </Table>
-                </div>
+                          </div>
+
+                          <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+                            <Badge
+                              variant={cat.active ? "success" : "secondary"}
+                              className="text-xs"
+                            >
+                              {cat.active ? "Activa" : "Inactiva"}
+                            </Badge>
+                            {cat.tier !== null && (
+                              <Badge
+                                variant={TIER_BADGE_VARIANT[cat.tier]}
+                                className="text-xs"
+                              >
+                                {TIER_LABELS[cat.tier]}
+                              </Badge>
+                            )}
+                            <span className="text-xs text-muted-foreground">
+                              {clubTypeLabel(cat.club_type_id, clubTypes)}
+                            </span>
+                          </div>
+
+                          <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1.5 text-xs">
+                            <div>
+                              <dt className="text-muted-foreground">Pts mín</dt>
+                              <dd>{cat.min_points}</dd>
+                            </div>
+                            <div>
+                              <dt className="text-muted-foreground">Pts máx</dt>
+                              <dd>
+                                {cat.max_points !== null ? (
+                                  cat.max_points
+                                ) : (
+                                  <span className="italic text-muted-foreground/60">Sin límite</span>
+                                )}
+                              </dd>
+                            </div>
+                            {(cat.min_composite_pct !== null || cat.max_composite_pct !== null) && (
+                              <>
+                                <div>
+                                  <dt className="text-muted-foreground">% mín</dt>
+                                  <dd>{formatPct(cat.min_composite_pct)}</dd>
+                                </div>
+                                <div>
+                                  <dt className="text-muted-foreground">% máx</dt>
+                                  <dd>{formatPct(cat.max_composite_pct)}</dd>
+                                </div>
+                              </>
+                            )}
+                          </dl>
+                        </div>
+                      </li>
+                    ))}
+                  </ul>
+                </>
               )}
             </TabsContent>
           </Tabs>

--- a/src/components/annual-folders/rankings-client-page.tsx
+++ b/src/components/annual-folders/rankings-client-page.tsx
@@ -362,82 +362,149 @@ export function RankingsClientPage({
           </Button>
         </div>
       ) : (
-        <div className="rounded-lg border border-border/60">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="w-16 text-center">Posicion</TableHead>
-                <TableHead>Club</TableHead>
-                <TableHead className="w-28 text-center">
-                  Composite
-                </TableHead>
-                <TableHead className="hidden w-24 text-center lg:table-cell">
-                  Carpeta
-                </TableHead>
-                <TableHead className="hidden w-24 text-center lg:table-cell">
-                  Finanzas
-                </TableHead>
-                <TableHead className="hidden w-24 text-center lg:table-cell">
-                  Camporees
-                </TableHead>
-                <TableHead className="hidden w-24 text-center lg:table-cell">
-                  Evidencias
-                </TableHead>
-                <TableHead className="hidden w-32 text-center md:table-cell">
-                  Pts Obtenidos
-                </TableHead>
-                <TableHead className="hidden w-28 text-center md:table-cell">
-                  Pts Maximos
-                </TableHead>
-                <TableHead className="w-40">Progreso</TableHead>
-                <TableHead className="hidden w-32 sm:table-cell">
-                  Categoria
-                </TableHead>
-                <TableHead className="w-24 text-center">Acciones</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {sortedRankings.map((item) => (
-                <TableRow
-                  key={item.club_enrollment_id}
-                  className={rowHighlight(item.rank_position)}
+        <>
+          {/* Desktop: rankings table */}
+          <div className="hidden rounded-lg border border-border/60 md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-16 text-center">Posicion</TableHead>
+                  <TableHead>Club</TableHead>
+                  <TableHead className="w-28 text-center">
+                    Composite
+                  </TableHead>
+                  <TableHead className="hidden w-24 text-center lg:table-cell">
+                    Carpeta
+                  </TableHead>
+                  <TableHead className="hidden w-24 text-center lg:table-cell">
+                    Finanzas
+                  </TableHead>
+                  <TableHead className="hidden w-24 text-center lg:table-cell">
+                    Camporees
+                  </TableHead>
+                  <TableHead className="hidden w-24 text-center lg:table-cell">
+                    Evidencias
+                  </TableHead>
+                  <TableHead className="w-32 text-center">
+                    Pts Obtenidos
+                  </TableHead>
+                  <TableHead className="hidden w-28 text-center lg:table-cell">
+                    Pts Maximos
+                  </TableHead>
+                  <TableHead className="w-40">Progreso</TableHead>
+                  <TableHead className="hidden w-32 lg:table-cell">
+                    Categoria
+                  </TableHead>
+                  <TableHead className="w-24 text-center">Acciones</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {sortedRankings.map((item) => (
+                  <TableRow
+                    key={item.club_enrollment_id}
+                    className={rowHighlight(item.rank_position)}
+                  >
+                    <TableCell className="text-center">
+                      <RankBadge position={item.rank_position} />
+                    </TableCell>
+                    <TableCell>
+                      <span
+                        className={
+                          item.rank_position !== null && item.rank_position <= 3
+                            ? "font-semibold"
+                            : "font-medium"
+                        }
+                      >
+                        {item.club_name}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <RankingScoreBadge value={item.composite_score_pct} />
+                    </TableCell>
+                    <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
+                      {item.folder_score_pct.toFixed(1)}%
+                    </TableCell>
+                    <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
+                      {item.finance_score_pct.toFixed(1)}%
+                    </TableCell>
+                    <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
+                      {item.camporee_score_pct.toFixed(1)}%
+                    </TableCell>
+                    <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
+                      {item.evidence_score_pct.toFixed(1)}%
+                    </TableCell>
+                    <TableCell className="text-center text-sm font-medium">
+                      {item.total_earned_points}
+                    </TableCell>
+                    <TableCell className="hidden text-center text-sm text-muted-foreground lg:table-cell">
+                      {item.total_max_points}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex items-center gap-2">
+                        <Progress
+                          value={Math.min(item.progress_percentage, 100)}
+                          className="h-2 flex-1"
+                        />
+                        <span className="w-10 shrink-0 text-right text-xs tabular-nums text-muted-foreground">
+                          {item.progress_percentage.toFixed(1)}%
+                        </span>
+                      </div>
+                    </TableCell>
+                    <TableCell className="hidden lg:table-cell">
+                      {item.award_category_name ? (
+                        <Badge variant="outline" className="text-xs">
+                          {item.award_category_name}
+                        </Badge>
+                      ) : (
+                        <span className="text-xs italic text-muted-foreground/60">
+                          Sin categoria
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <Link
+                        href={`/dashboard/annual-folders/rankings/${item.club_enrollment_id}/breakdown?year_id=${item.ecclesiastical_year_id ?? selectedYearId}`}
+                        className="inline-flex items-center gap-1 text-xs text-primary underline-offset-4 hover:underline"
+                      >
+                        Ver detalle
+                        <ArrowRight className="size-3" />
+                      </Link>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Mobile: ranking cards */}
+          <ul className="space-y-3 md:hidden" aria-label="Rankings de clubes">
+            {sortedRankings.map((item) => (
+              <li key={item.club_enrollment_id}>
+                <div
+                  className={`rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none${item.rank_position === 1 ? " bg-warning/10" : item.rank_position === 2 ? " bg-muted/40" : item.rank_position === 3 ? " bg-primary/10" : ""}`}
                 >
-                  <TableCell className="text-center">
+                  <div className="flex items-start gap-3">
                     <RankBadge position={item.rank_position} />
-                  </TableCell>
-                  <TableCell>
-                    <span
-                      className={
-                        item.rank_position !== null && item.rank_position <= 3
-                          ? "font-semibold"
-                          : "font-medium"
-                      }
-                    >
-                      {item.club_name}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-center">
-                    <RankingScoreBadge value={item.composite_score_pct} />
-                  </TableCell>
-                  <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
-                    {item.folder_score_pct.toFixed(1)}%
-                  </TableCell>
-                  <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
-                    {item.finance_score_pct.toFixed(1)}%
-                  </TableCell>
-                  <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
-                    {item.camporee_score_pct.toFixed(1)}%
-                  </TableCell>
-                  <TableCell className="hidden text-center text-sm tabular-nums text-muted-foreground lg:table-cell">
-                    {item.evidence_score_pct.toFixed(1)}%
-                  </TableCell>
-                  <TableCell className="hidden text-center text-sm font-medium md:table-cell">
-                    {item.total_earned_points}
-                  </TableCell>
-                  <TableCell className="hidden text-center text-sm text-muted-foreground md:table-cell">
-                    {item.total_max_points}
-                  </TableCell>
-                  <TableCell>
+                    <div className="min-w-0 flex-1">
+                      <p
+                        className={`truncate ${item.rank_position !== null && item.rank_position <= 3 ? "font-semibold" : "font-medium"}`}
+                      >
+                        {item.club_name}
+                      </p>
+                      {item.award_category_name && (
+                        <p className="mt-0.5">
+                          <Badge variant="outline" className="text-xs">
+                            {item.award_category_name}
+                          </Badge>
+                        </p>
+                      )}
+                    </div>
+                    <div className="shrink-0">
+                      <RankingScoreBadge value={item.composite_score_pct} />
+                    </div>
+                  </div>
+
+                  <div className="mt-3">
                     <div className="flex items-center gap-2">
                       <Progress
                         value={Math.min(item.progress_percentage, 100)}
@@ -447,19 +514,36 @@ export function RankingsClientPage({
                         {item.progress_percentage.toFixed(1)}%
                       </span>
                     </div>
-                  </TableCell>
-                  <TableCell className="hidden sm:table-cell">
-                    {item.award_category_name ? (
-                      <Badge variant="outline" className="text-xs">
-                        {item.award_category_name}
-                      </Badge>
-                    ) : (
-                      <span className="text-xs italic text-muted-foreground/60">
-                        Sin categoria
-                      </span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-center">
+                  </div>
+
+                  <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1.5 text-xs">
+                    <div>
+                      <dt className="text-muted-foreground">Pts obtenidos</dt>
+                      <dd className="font-medium tabular-nums">{item.total_earned_points}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Pts máximos</dt>
+                      <dd className="tabular-nums text-muted-foreground">{item.total_max_points}</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Carpeta</dt>
+                      <dd className="tabular-nums">{item.folder_score_pct.toFixed(1)}%</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Finanzas</dt>
+                      <dd className="tabular-nums">{item.finance_score_pct.toFixed(1)}%</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Camporees</dt>
+                      <dd className="tabular-nums">{item.camporee_score_pct.toFixed(1)}%</dd>
+                    </div>
+                    <div>
+                      <dt className="text-muted-foreground">Evidencias</dt>
+                      <dd className="tabular-nums">{item.evidence_score_pct.toFixed(1)}%</dd>
+                    </div>
+                  </dl>
+
+                  <div className="mt-3 border-t pt-3">
                     <Link
                       href={`/dashboard/annual-folders/rankings/${item.club_enrollment_id}/breakdown?year_id=${item.ecclesiastical_year_id ?? selectedYearId}`}
                       className="inline-flex items-center gap-1 text-xs text-primary underline-offset-4 hover:underline"
@@ -467,12 +551,12 @@ export function RankingsClientPage({
                       Ver detalle
                       <ArrowRight className="size-3" />
                     </Link>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
 
       {/* Recalculate confirmation */}

--- a/src/components/annual-folders/templates-client-page.tsx
+++ b/src/components/annual-folders/templates-client-page.tsx
@@ -379,48 +379,97 @@ export function TemplatesClientPage({
             </Button>
           </div>
         ) : (
-          <div className="rounded-lg border border-border/60">
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead className="w-12 text-center">Orden</TableHead>
-                  <TableHead>Nombre</TableHead>
-                  <TableHead className="hidden sm:table-cell">Descripción</TableHead>
-                  <TableHead className="w-28 text-center">Requerida</TableHead>
-                  <TableHead className="hidden w-24 text-center md:table-cell">Max Pts</TableHead>
-                  <TableHead className="hidden w-24 text-center md:table-cell">Min Pts</TableHead>
-                  <TableHead className="w-20 text-right">Acciones</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {sortedSections.map((section) => (
-                  <TableRow key={section.section_id}>
-                    <TableCell className="text-center">
-                      <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-xs font-medium">
-                        {section.order}
-                      </span>
-                    </TableCell>
-                    <TableCell className="font-medium">{section.name}</TableCell>
-                    <TableCell className="hidden max-w-xs truncate text-muted-foreground sm:table-cell">
-                      {section.description ?? (
-                        <span className="italic text-muted-foreground/60">Sin descripción</span>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-center">
-                      {section.required ? (
-                        <CheckCircle2 className="mx-auto size-4 text-success" />
-                      ) : (
-                        <Circle className="mx-auto size-4 text-muted-foreground/40" />
-                      )}
-                    </TableCell>
-                    <TableCell className="hidden text-center text-sm text-muted-foreground md:table-cell">
-                      {section.max_points}
-                    </TableCell>
-                    <TableCell className="hidden text-center text-sm text-muted-foreground md:table-cell">
-                      {section.minimum_points}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <div className="flex items-center justify-end gap-1">
+          <>
+            {/* Desktop: sections table */}
+            <div className="hidden rounded-lg border border-border/60 md:block">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-12 text-center">Orden</TableHead>
+                    <TableHead>Nombre</TableHead>
+                    <TableHead>Descripción</TableHead>
+                    <TableHead className="w-28 text-center">Requerida</TableHead>
+                    <TableHead className="w-24 text-center">Max Pts</TableHead>
+                    <TableHead className="w-24 text-center">Min Pts</TableHead>
+                    <TableHead className="w-20 text-right">Acciones</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {sortedSections.map((section) => (
+                    <TableRow key={section.section_id}>
+                      <TableCell className="text-center">
+                        <span className="inline-flex size-6 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                          {section.order}
+                        </span>
+                      </TableCell>
+                      <TableCell className="font-medium">{section.name}</TableCell>
+                      <TableCell className="max-w-xs truncate text-muted-foreground">
+                        {section.description ?? (
+                          <span className="italic text-muted-foreground/60">Sin descripción</span>
+                        )}
+                      </TableCell>
+                      <TableCell className="text-center">
+                        {section.required ? (
+                          <CheckCircle2 className="mx-auto size-4 text-success" />
+                        ) : (
+                          <Circle className="mx-auto size-4 text-muted-foreground/40" />
+                        )}
+                      </TableCell>
+                      <TableCell className="text-center text-sm text-muted-foreground">
+                        {section.max_points}
+                      </TableCell>
+                      <TableCell className="text-center text-sm text-muted-foreground">
+                        {section.minimum_points}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex items-center justify-end gap-1">
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => handleEditSection(section)}
+                            title="Editar sección"
+                          >
+                            <Pencil className="size-3.5" />
+                            <span className="sr-only">Editar</span>
+                          </Button>
+                          <Button
+                            variant="ghost"
+                            size="icon-xs"
+                            onClick={() => handleDeleteSection(section)}
+                            title="Eliminar sección"
+                            className="text-destructive hover:text-destructive"
+                          >
+                            <Trash2 className="size-3.5" />
+                            <span className="sr-only">Eliminar</span>
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+
+            {/* Mobile: section cards */}
+            <ul className="space-y-3 md:hidden" aria-label="Secciones de la plantilla">
+              {sortedSections.map((section) => (
+                <li key={section.section_id}>
+                  <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="flex items-center gap-2.5 min-w-0 flex-1">
+                        <span className="inline-flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium">
+                          {section.order}
+                        </span>
+                        <div className="min-w-0 flex-1">
+                          <p className="truncate font-medium">{section.name}</p>
+                          {section.description && (
+                            <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+                              {section.description}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                      <div className="flex shrink-0 items-center gap-1">
                         <Button
                           variant="ghost"
                           size="icon-xs"
@@ -441,12 +490,33 @@ export function TemplatesClientPage({
                           <span className="sr-only">Eliminar</span>
                         </Button>
                       </div>
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          </div>
+                    </div>
+
+                    <dl className="mt-3 grid grid-cols-3 gap-x-3 gap-y-1.5 text-xs">
+                      <div>
+                        <dt className="text-muted-foreground">Requerida</dt>
+                        <dd className="mt-0.5">
+                          {section.required ? (
+                            <CheckCircle2 className="size-4 text-success" />
+                          ) : (
+                            <Circle className="size-4 text-muted-foreground/40" />
+                          )}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Max Pts</dt>
+                        <dd>{section.max_points}</dd>
+                      </div>
+                      <div>
+                        <dt className="text-muted-foreground">Min Pts</dt>
+                        <dd>{section.minimum_points}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </>
         )}
 
         {/* Section dialogs */}
@@ -607,34 +677,125 @@ export function TemplatesClientPage({
           )}
         </div>
       ) : (
-        <div className="rounded-lg border border-border/60">
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Nombre</TableHead>
-                <TableHead>Tipo de club</TableHead>
-                <TableHead>Año eclesiástico</TableHead>
-                <TableHead>Propietario</TableHead>
-                <TableHead className="w-24 text-center">Secciones</TableHead>
-                <TableHead className="w-16 text-center">Estado</TableHead>
-                <TableHead className="w-16 text-right">Acciones</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {filteredTemplates.map((template) => (
-                <TableRow
-                  key={template.template_id}
-                  className="cursor-pointer"
+        <>
+          {/* Desktop: templates table */}
+          <div className="hidden rounded-lg border border-border/60 md:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Nombre</TableHead>
+                  <TableHead>Tipo de club</TableHead>
+                  <TableHead>Año eclesiástico</TableHead>
+                  <TableHead>Propietario</TableHead>
+                  <TableHead className="w-24 text-center">Secciones</TableHead>
+                  <TableHead className="w-16 text-center">Estado</TableHead>
+                  <TableHead className="w-16 text-right">Acciones</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredTemplates.map((template) => (
+                  <TableRow
+                    key={template.template_id}
+                    className="cursor-pointer"
+                    onClick={() => handleOpenTemplate(template)}
+                  >
+                    <TableCell className="font-medium">{template.name}</TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {template.club_type?.name ?? `Tipo ${template.club_type_id}`}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {template.ecclesiastical_year?.name ?? `Año ${template.ecclesiastical_year_id}`}
+                    </TableCell>
+                    <TableCell>
+                      {template.owner_union_id !== null &&
+                      template.owner_union_id !== undefined ? (
+                        <Badge variant="default" className="gap-1 text-xs">
+                          <Building2 className="size-3" />
+                          {resolveOwnerLabel(template)}
+                        </Badge>
+                      ) : template.owner_local_field_id !== null &&
+                        template.owner_local_field_id !== undefined ? (
+                        <Badge variant="secondary" className="gap-1 text-xs">
+                          <MapPin className="size-3" />
+                          {resolveOwnerLabel(template)}
+                        </Badge>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <span className="text-sm text-muted-foreground">
+                        {template.sections?.length ?? "—"}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <Badge
+                        variant={template.active ? "success" : "secondary"}
+                        className="text-xs"
+                      >
+                        {template.active ? "Activa" : "Inactiva"}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon-xs"
+                          onClick={(e) => handleEditTemplate(template, e)}
+                          title="Editar plantilla"
+                        >
+                          <Pencil className="size-3.5" />
+                          <span className="sr-only">Editar</span>
+                        </Button>
+                        <ChevronRight className="size-4 text-muted-foreground" />
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Mobile: template cards */}
+          <ul className="space-y-3 md:hidden" aria-label="Lista de plantillas">
+            {filteredTemplates.map((template) => (
+              <li key={template.template_id}>
+                <button
+                  type="button"
+                  className="w-full rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring text-left"
                   onClick={() => handleOpenTemplate(template)}
+                  aria-label={`Abrir plantilla ${template.name}`}
                 >
-                  <TableCell className="font-medium">{template.name}</TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {template.club_type?.name ?? `Tipo ${template.club_type_id}`}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground">
-                    {template.ecclesiastical_year?.name ?? `Año ${template.ecclesiastical_year_id}`}
-                  </TableCell>
-                  <TableCell>
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate font-medium">{template.name}</p>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        {template.club_type?.name ?? `Tipo ${template.club_type_id}`}
+                        {" · "}
+                        {template.ecclesiastical_year?.name ?? `Año ${template.ecclesiastical_year_id}`}
+                      </p>
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      <Badge
+                        variant={template.active ? "success" : "secondary"}
+                        className="text-xs"
+                      >
+                        {template.active ? "Activa" : "Inactiva"}
+                      </Badge>
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        onClick={(e) => handleEditTemplate(template, e)}
+                        title="Editar plantilla"
+                      >
+                        <Pencil className="size-3.5" />
+                        <span className="sr-only">Editar</span>
+                      </Button>
+                      <ChevronRight className="size-4 text-muted-foreground" aria-hidden="true" />
+                    </div>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap items-center gap-1.5">
                     {template.owner_union_id !== null &&
                     template.owner_union_id !== undefined ? (
                       <Badge variant="default" className="gap-1 text-xs">
@@ -647,42 +808,17 @@ export function TemplatesClientPage({
                         <MapPin className="size-3" />
                         {resolveOwnerLabel(template)}
                       </Badge>
-                    ) : (
-                      <span className="text-xs text-muted-foreground">—</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-center">
-                    <span className="text-sm text-muted-foreground">
-                      {template.sections?.length ?? "—"}
+                    ) : null}
+                    <span className="text-xs text-muted-foreground">
+                      {template.sections?.length ?? 0}{" "}
+                      {(template.sections?.length ?? 0) === 1 ? "sección" : "secciones"}
                     </span>
-                  </TableCell>
-                  <TableCell className="text-center">
-                    <Badge
-                      variant={template.active ? "success" : "secondary"}
-                      className="text-xs"
-                    >
-                      {template.active ? "Activa" : "Inactiva"}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex items-center justify-end gap-1">
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        onClick={(e) => handleEditTemplate(template, e)}
-                        title="Editar plantilla"
-                      >
-                        <Pencil className="size-3.5" />
-                        <span className="sr-only">Editar</span>
-                      </Button>
-                      <ChevronRight className="size-4 text-muted-foreground" />
-                    </div>
-                  </TableCell>
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        </div>
+                  </div>
+                </button>
+              </li>
+            ))}
+          </ul>
+        </>
       )}
 
       {/* Create / edit template dialog */}

--- a/src/components/insurance/expiring-dashboard.tsx
+++ b/src/components/insurance/expiring-dashboard.tsx
@@ -372,119 +372,175 @@ export function ExpiringDashboard({ items, daysAhead }: ExpiringDashboardProps) 
             </div>
           ) : (
             <>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>
-                      <SortButton
-                        field="user_name"
-                        label="Miembro"
-                        current={sortField}
-                        direction={sortDir}
-                        onSort={handleSort}
-                      />
-                    </TableHead>
-                    <TableHead className="hidden md:table-cell">
-                      <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                        Club
-                      </span>
-                    </TableHead>
-                    <TableHead className="hidden lg:table-cell">
-                      <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                        Tipo
-                      </span>
-                    </TableHead>
-                    <TableHead className="hidden sm:table-cell">
-                      <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                        N° Poliza
-                      </span>
-                    </TableHead>
-                    <TableHead>
-                      <SortButton
-                        field="end_date"
-                        label="Vencimiento"
-                        current={sortField}
-                        direction={sortDir}
-                        onSort={handleSort}
-                      />
-                    </TableHead>
-                    <TableHead>
-                      <SortButton
-                        field="days_remaining"
-                        label="Dias"
-                        current={sortField}
-                        direction={sortDir}
-                        onSort={handleSort}
-                      />
-                    </TableHead>
-                    <TableHead>
-                      <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                        Estado
-                      </span>
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {paginated.map((item) => {
-                    const status = getUrgencyStatus(item.days_remaining);
-                    return (
-                      <TableRow key={item.insurance_id}>
-                        <TableCell>
-                          <div className="font-medium">{formatMemberName(item)}</div>
-                          {item.club_section && (
-                            <div className="mt-0.5 text-xs text-muted-foreground md:hidden">
-                              {item.club?.name ?? "—"}
-                              {item.club_section
-                                ? ` · ${item.club_section.name}`
-                                : ""}
+              {/* Desktop table */}
+              <div className="hidden md:block">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>
+                        <SortButton
+                          field="user_name"
+                          label="Miembro"
+                          current={sortField}
+                          direction={sortDir}
+                          onSort={handleSort}
+                        />
+                      </TableHead>
+                      <TableHead>
+                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                          Club
+                        </span>
+                      </TableHead>
+                      <TableHead className="hidden lg:table-cell">
+                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                          Tipo
+                        </span>
+                      </TableHead>
+                      <TableHead className="hidden lg:table-cell">
+                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                          N° Poliza
+                        </span>
+                      </TableHead>
+                      <TableHead>
+                        <SortButton
+                          field="end_date"
+                          label="Vencimiento"
+                          current={sortField}
+                          direction={sortDir}
+                          onSort={handleSort}
+                        />
+                      </TableHead>
+                      <TableHead>
+                        <SortButton
+                          field="days_remaining"
+                          label="Dias"
+                          current={sortField}
+                          direction={sortDir}
+                          onSort={handleSort}
+                        />
+                      </TableHead>
+                      <TableHead>
+                        <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                          Estado
+                        </span>
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {paginated.map((item) => {
+                      const status = getUrgencyStatus(item.days_remaining);
+                      return (
+                        <TableRow key={item.insurance_id}>
+                          <TableCell>
+                            <div className="font-medium">{formatMemberName(item)}</div>
+                          </TableCell>
+                          <TableCell>
+                            <div className="text-sm">
+                              {item.club?.name ?? (
+                                <span className="text-muted-foreground">—</span>
+                              )}
                             </div>
-                          )}
-                        </TableCell>
-                        <TableCell className="hidden md:table-cell">
-                          <div className="text-sm">
-                            {item.club?.name ?? (
+                            {item.club_section && (
+                              <div className="text-xs text-muted-foreground">
+                                {item.club_section.name}
+                              </div>
+                            )}
+                          </TableCell>
+                          <TableCell className="hidden lg:table-cell">
+                            {item.insurance_type ? (
+                              <span className="text-sm">
+                                {INSURANCE_TYPE_LABELS[item.insurance_type] ??
+                                  item.insurance_type}
+                              </span>
+                            ) : (
                               <span className="text-muted-foreground">—</span>
                             )}
+                          </TableCell>
+                          <TableCell className="hidden lg:table-cell">
+                            <span className="font-mono text-xs text-muted-foreground">
+                              {item.policy_number ?? "—"}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <span className="text-sm tabular-nums">
+                              {formatDate(item.end_date)}
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <span className={getDaysColor(item.days_remaining)}>
+                              {item.days_remaining}d
+                            </span>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant={status.variant}>{status.label}</Badge>
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+
+              {/* Mobile cards */}
+              <ul className="space-y-3 md:hidden" aria-label="Seguros por vencer">
+                {paginated.map((item) => {
+                  const status = getUrgencyStatus(item.days_remaining);
+                  return (
+                    <li key={item.insurance_id}>
+                      <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0 flex-1">
+                            <p className="truncate font-medium">
+                              {formatMemberName(item)}
+                            </p>
+                            {(item.club?.name || item.club_section) && (
+                              <p className="mt-0.5 text-xs text-muted-foreground">
+                                {item.club?.name ?? "—"}
+                                {item.club_section
+                                  ? ` · ${item.club_section.name}`
+                                  : ""}
+                              </p>
+                            )}
                           </div>
-                          {item.club_section && (
-                            <div className="text-xs text-muted-foreground">
-                              {item.club_section.name}
+                          <Badge variant={status.variant} className="shrink-0">
+                            {status.label}
+                          </Badge>
+                        </div>
+
+                        <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1.5 text-xs">
+                          <div>
+                            <dt className="text-muted-foreground">Vencimiento</dt>
+                            <dd className="tabular-nums">{formatDate(item.end_date)}</dd>
+                          </div>
+                          <div>
+                            <dt className="text-muted-foreground">Días restantes</dt>
+                            <dd>
+                              <span className={getDaysColor(item.days_remaining)}>
+                                {item.days_remaining}d
+                              </span>
+                            </dd>
+                          </div>
+                          {item.insurance_type && (
+                            <div>
+                              <dt className="text-muted-foreground">Tipo</dt>
+                              <dd>
+                                {INSURANCE_TYPE_LABELS[item.insurance_type] ??
+                                  item.insurance_type}
+                              </dd>
                             </div>
                           )}
-                        </TableCell>
-                        <TableCell className="hidden lg:table-cell">
-                          {item.insurance_type ? (
-                            <span className="text-sm">
-                              {INSURANCE_TYPE_LABELS[item.insurance_type] ??
-                                item.insurance_type}
-                            </span>
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
+                          {item.policy_number && (
+                            <div>
+                              <dt className="text-muted-foreground">N° Póliza</dt>
+                              <dd className="font-mono">{item.policy_number}</dd>
+                            </div>
                           )}
-                        </TableCell>
-                        <TableCell className="hidden sm:table-cell">
-                          <span className="font-mono text-xs text-muted-foreground">
-                            {item.policy_number ?? "—"}
-                          </span>
-                        </TableCell>
-                        <TableCell>
-                          <span className="text-sm tabular-nums">
-                            {formatDate(item.end_date)}
-                          </span>
-                        </TableCell>
-                        <TableCell>
-                          <span className={getDaysColor(item.days_remaining)}>
-                            {item.days_remaining}d
-                          </span>
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant={status.variant}>{status.label}</Badge>
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
+                        </dl>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
 
               {/* Pagination */}
               {totalPages > 1 && (


### PR DESCRIPTION
## Summary

Round 3 of mobile-cards expansion. Four more tables flip to a card list below `md`.

### What

- **`insurance/expiring-dashboard.tsx`** — table inside `<Card>` split into `hidden md:block` desktop + `md:hidden` cards. Cards show member name, club/section, vencimiento date, days-remaining (color-coded), tipo + N° Póliza (only when present). Pagination shared. Previously `hidden md:table-cell` columns (Club, N° Póliza) promoted to always-visible on desktop (no regression — they were already shown on `md+`).
- **`annual-folders/templates-client-page.tsx`** — two tables migrated:
  - **Sections detail** (when `activeTemplate` is set): cards with order badge, name, description, required icon, pts grid.
  - **Templates list**: clickable `<button>` cards (preserves `onClick → handleOpenTemplate`) with name, club type/year, owner badge, section count, status badge, edit button.
- **`annual-folders/rankings-client-page.tsx`** — ranking cards: rank badge + row highlight, club name, composite score badge, progress bar, pts earned/max, all 4 sub-scores (Carpeta / Finanzas / Camporees / Evidencias) in a `<dl>` grid. "Ver detalle" link preserved.
- **`annual-folders/award-categories-client-page.tsx`** — category cards correctly nested inside the existing `Tabs > TabsContent > Tabs > TabsContent` structure. Order badge, name + legacy badge, description, active/tier/scope badges, pts + composite % grid (composite % only rendered when non-null).

Closes audit 8.2 expansion (insurance / annual-folders subset). With this PR + #32 + #38 + #42, all 12 tables originally flagged for the mobile-cards pattern have it.

## Commits

- `c7d7c6c` insurance dashboard table
- `f36feb9` folder templates list + sections detail
- `2e3810b` rankings table
- `4e32a3d` award categories table

## Test plan

- [ ] Below `md` (768px), open each affected page. Each table flips to a card list with the same data the desktop columns show.
- [ ] Templates: tapping a card opens the template detail (preserves the previous click → setActiveTemplate flow).
- [ ] Rankings: rank-row highlight (top 3) carries over to the mobile card.
- [ ] Award categories: composite % grid only shows when the composite is set on the row.
- [ ] `pnpm lint` → no new warnings in the 4 touched files.