### PR TITLE
feat(admin): rediseñar login con layout split editorial

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -230,7 +230,8 @@
     "login": {
       "brand_subtitle": "Administrative System",
       "welcome_title": "Welcome back",
-      "welcome_description": "Enter your credentials to continue",
+      "welcome_description": "Enter your credentials to access your club's panel.",
+      "eyebrow": "Admin · Access",
       "email_label": "Email",
       "email_placeholder": "admin@sacdia.org",
       "password_label": "Password",
@@ -238,7 +239,11 @@
       "submit_loading": "Verifying…",
       "show_password": "Show password",
       "hide_password": "Hide password",
-      "verse": "“I can do all things through Christ who strengthens me” — Phil. 4:13"
+      "verse_reference": "Philippians 4:13",
+      "verse_text": "“I can do all things through Christ who strengthens me.”",
+      "brand_description": "Platform for Adventurer, Pathfinder and Master Guide clubs. Memberships, classes, honors and finance in one place.",
+      "version_label": "v1.0 · 2026",
+      "region_label": "North Pacific Association"
     },
     "validation": {
       "email_invalid": "Enter a valid email",

--- a/messages/es.json
+++ b/messages/es.json
@@ -230,7 +230,8 @@
     "login": {
       "brand_subtitle": "Sistema Administrativo",
       "welcome_title": "Bienvenido de nuevo",
-      "welcome_description": "Ingrese sus credenciales para acceder",
+      "welcome_description": "Ingresa tus credenciales para continuar al panel de tu club.",
+      "eyebrow": "Acceso · Administrador",
       "email_label": "Correo electrónico",
       "email_placeholder": "admin@sacdia.org",
       "password_label": "Contraseña",
@@ -238,7 +239,11 @@
       "submit_loading": "Verificando…",
       "show_password": "Mostrar contraseña",
       "hide_password": "Ocultar contraseña",
-      "verse": "«Todo lo puedo en Cristo que me fortalece» — Fil. 4:13"
+      "verse_reference": "Filipenses 4:13",
+      "verse_text": "«Todo lo puedo en Cristo que me fortalece.»",
+      "brand_description": "Plataforma para clubes de Aventureros, Conquistadores y Guías Mayores. Inscripciones, clases, especialidades y finanzas en un solo lugar.",
+      "version_label": "v1.0 · 2026",
+      "region_label": "Asociación Norte · Pacífico"
     },
     "validation": {
       "email_invalid": "Ingresa un correo válido",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -230,7 +230,8 @@
     "login": {
       "brand_subtitle": "Système administratif",
       "welcome_title": "Bon retour",
-      "welcome_description": "Saisissez vos identifiants pour continuer",
+      "welcome_description": "Saisissez vos identifiants pour accéder au panneau de votre club.",
+      "eyebrow": "Accès · Administrateur",
       "email_label": "Adresse e-mail",
       "email_placeholder": "admin@sacdia.org",
       "password_label": "Mot de passe",
@@ -238,7 +239,11 @@
       "submit_loading": "Vérification…",
       "show_password": "Afficher le mot de passe",
       "hide_password": "Masquer le mot de passe",
-      "verse": "« Je puis tout par Celui qui me fortifie » — Phil. 4:13"
+      "verse_reference": "Philippiens 4:13",
+      "verse_text": "« Je puis tout par Celui qui me fortifie. »",
+      "brand_description": "Plateforme pour les clubs d'Aventuriers, d'Éclaireurs et de Guides Maîtres. Inscriptions, classes, spécialités et finances en un seul endroit.",
+      "version_label": "v1.0 · 2026",
+      "region_label": "Association Nord-Pacifique"
     },
     "validation": {
       "email_invalid": "Saisissez un e-mail valide",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -230,7 +230,7 @@
     "login": {
       "brand_subtitle": "Sistema Administrativo",
       "welcome_title": "Bem-vindo de volta",
-      "welcome_description": "Insira suas credenciais para continuar",
+      "welcome_description": "Insira suas credenciais para acessar o painel do seu clube.",
       "email_label": "E-mail",
       "email_placeholder": "admin@sacdia.org",
       "password_label": "Senha",
@@ -238,7 +238,12 @@
       "submit_loading": "Verificando…",
       "show_password": "Mostrar senha",
       "hide_password": "Ocultar senha",
-      "verse": "“Tudo posso naquele que me fortalece” — Fp. 4:13"
+      "eyebrow": "Acesso · Administrador",
+      "verse_reference": "Filipenses 4:13",
+      "verse_text": "“Tudo posso naquele que me fortalece.”",
+      "brand_description": "Plataforma para clubes de Aventureiros, Desbravadores e Guias Mestres. Inscrições, classes, especialidades e finanças em um só lugar.",
+      "version_label": "v1.0 · 2026",
+      "region_label": "Associação Norte · Pacífico"
     },
     "validation": {
       "email_invalid": "Insira um e-mail válido",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,181 +1,19 @@
-"use client";
+import { LoginBrandPanel } from "@/components/auth/login-brand-panel";
+import { LoginForm } from "@/components/auth/login-form";
 
-import { useActionState, useState } from "react";
-import { useFormStatus } from "react-dom";
-import Image from "next/image";
-import { Loader2, Eye, EyeOff, AlertCircle } from "lucide-react";
-import { useTranslations } from "next-intl";
-import { loginAction } from "@/lib/auth/actions";
-import type { AuthActionState } from "@/lib/auth/types";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import { cn } from "@/lib/utils";
-
-function SubmitButton() {
-  const t = useTranslations("auth.login");
-  const { pending } = useFormStatus();
-  return (
-    <Button
-      type="submit"
-      disabled={pending}
-      className="w-full"
-      size="lg"
-    >
-      {pending ? (
-        <>
-          <Loader2 className="animate-spin" />
-          {t("submit_loading")}
-        </>
-      ) : (
-        t("submit_idle")
-      )}
-    </Button>
-  );
+interface LoginPageProps {
+  searchParams: Promise<{ next?: string }>;
 }
 
-const initialState: AuthActionState = {};
-
-export default function LoginPage() {
-  const t = useTranslations("auth.login");
-  const [state, formAction] = useActionState(loginAction, initialState);
-  const [showPassword, setShowPassword] = useState(false);
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const { next } = await searchParams;
 
   return (
-    <div className="relative min-h-svh overflow-hidden bg-background flex items-center justify-center p-4">
-      {/* Subtle grid pattern */}
-      <div
-        className="absolute inset-0 opacity-[0.03] dark:opacity-[0.06]"
-        style={{
-          backgroundImage:
-            "linear-gradient(to right, currentColor 1px, transparent 1px), linear-gradient(to bottom, currentColor 1px, transparent 1px)",
-          backgroundSize: "64px 64px",
-        }}
-        aria-hidden="true"
-      />
-
-      {/* Ambient glow — top left */}
-      <div
-        className="pointer-events-none absolute -top-32 -left-32 size-[480px] rounded-full bg-primary/10 dark:bg-primary/15 blur-3xl"
-        aria-hidden="true"
-      />
-
-      {/* Ambient glow — bottom right */}
-      <div
-        className="pointer-events-none absolute -bottom-32 -right-32 size-[360px] rounded-full bg-primary/8 dark:bg-primary/10 blur-3xl"
-        aria-hidden="true"
-      />
-
-      {/* Card */}
-      <div
-        className={cn(
-          "relative z-10 w-full max-w-sm",
-          "animate-in fade-in slide-in-from-bottom-4 duration-700 ease-out"
-        )}
-      >
-        {/* Brand header — outside the card */}
-        <div className="mb-8 flex flex-col items-center gap-3">
-          <div className="flex size-12 items-center justify-center rounded-xl border border-border/60 bg-card shadow-sm">
-            <Image
-              src="/svg/LogoSACDIA.svg"
-              alt="SACDIA"
-              width={28}
-              height={28}
-              priority
-            />
-          </div>
-          <div className="text-center">
-            <p className="text-xs font-semibold tracking-[0.18em] text-muted-foreground uppercase">
-              SACDIA
-            </p>
-            <p className="text-[11px] tracking-wide text-muted-foreground/60">
-              {t("brand_subtitle")}
-            </p>
-          </div>
-        </div>
-
-        {/* Card body */}
-        <div className="rounded-2xl border border-border/60 bg-card shadow-sm px-8 py-8">
-          {/* Title */}
-          <div className="mb-6">
-            <h1 className="text-xl font-semibold tracking-tight text-foreground">
-              {t("welcome_title")}
-            </h1>
-            <p className="mt-1 text-sm text-muted-foreground">
-              {t("welcome_description")}
-            </p>
-          </div>
-
-          {/* Form */}
-          <form action={formAction} className="space-y-4">
-            {/* Error message */}
-            {state.error && (
-              <div className="flex items-start gap-2.5 rounded-lg border border-destructive/20 bg-destructive/5 px-3.5 py-3 text-sm text-destructive dark:border-destructive/30 dark:bg-destructive/10">
-                <AlertCircle className="mt-0.5 size-4 shrink-0" />
-                <span>{state.error}</span>
-              </div>
-            )}
-
-            {/* Email field */}
-            <div className="space-y-1.5">
-              <Label htmlFor="email" className="text-sm font-medium">
-                {t("email_label")}
-              </Label>
-              <Input
-                id="email"
-                name="email"
-                type="email"
-                placeholder={t("email_placeholder")}
-                required
-                autoComplete="email"
-                autoFocus
-                className="h-10"
-              />
-            </div>
-
-            {/* Password field */}
-            <div className="space-y-1.5">
-              <Label htmlFor="password" className="text-sm font-medium">
-                {t("password_label")}
-              </Label>
-              <div className="relative">
-                <Input
-                  id="password"
-                  name="password"
-                  type={showPassword ? "text" : "password"}
-                  placeholder="••••••••"
-                  required
-                  autoComplete="current-password"
-                  minLength={8}
-                  className="h-10 pr-10"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword((v) => !v)}
-                  tabIndex={-1}
-                  aria-label={showPassword ? t("hide_password") : t("show_password")}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground/50 transition-colors hover:text-muted-foreground"
-                >
-                  {showPassword ? (
-                    <EyeOff className="size-4" />
-                  ) : (
-                    <Eye className="size-4" />
-                  )}
-                </button>
-              </div>
-            </div>
-
-            <div className="pt-1">
-              <SubmitButton />
-            </div>
-          </form>
-        </div>
-
-        {/* Bible verse — outside the card, below */}
-        <p className="mt-6 text-center text-[11px] italic text-muted-foreground/40 dark:text-muted-foreground/30">
-          {t("verse")}
-        </p>
-      </div>
-    </div>
+    <main className="grid min-h-svh w-full bg-background lg:grid-cols-[1.05fr_1fr]">
+      <LoginBrandPanel />
+      <section className="relative flex items-center justify-center px-6 py-12 sm:px-10 lg:px-20">
+        <LoginForm nextParam={next ?? ""} />
+      </section>
+    </main>
   );
 }

--- a/src/components/auth/login-brand-panel.tsx
+++ b/src/components/auth/login-brand-panel.tsx
@@ -1,0 +1,77 @@
+import Image from "next/image";
+import { useTranslations } from "next-intl";
+
+export function LoginBrandPanel() {
+  const t = useTranslations("auth.login");
+
+  return (
+    <aside className="relative hidden flex-col justify-between overflow-hidden bg-gradient-to-br from-primary via-primary to-primary/85 p-12 text-primary-foreground lg:flex">
+      <svg
+        width="700"
+        height="700"
+        viewBox="0 0 700 700"
+        className="pointer-events-none absolute -right-64 -top-48 opacity-[0.18]"
+        aria-hidden="true"
+      >
+        {[80, 160, 240, 320, 400].map((r) => (
+          <circle
+            key={r}
+            cx="350"
+            cy="350"
+            r={r}
+            stroke="currentColor"
+            strokeWidth="1"
+            fill="none"
+          />
+        ))}
+      </svg>
+
+      <svg
+        width="200"
+        height="200"
+        viewBox="0 0 200 200"
+        className="pointer-events-none absolute -bottom-16 -left-16 opacity-[0.14]"
+        aria-hidden="true"
+      >
+        <circle cx="100" cy="100" r="80" stroke="currentColor" strokeWidth="1" fill="none" />
+        <circle cx="100" cy="100" r="50" stroke="currentColor" strokeWidth="1" fill="none" />
+      </svg>
+
+      <div className="relative flex items-center gap-3">
+        <div className="grid size-10 place-items-center rounded-xl border border-white/30 bg-white/15 backdrop-blur-sm">
+          <Image
+            src="/svg/LogoSACDIA.svg"
+            alt="SACDIA"
+            width={24}
+            height={24}
+            style={{ filter: "brightness(0) invert(1)" }}
+            priority
+          />
+        </div>
+        <div className="leading-tight">
+          <div className="text-base font-bold tracking-tight">SACDIA</div>
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.08em] opacity-75">
+            {t("brand_subtitle")}
+          </div>
+        </div>
+      </div>
+
+      <div className="relative max-w-[480px]">
+        <div className="mb-5 font-mono text-[11px] uppercase tracking-[0.14em] opacity-75">
+          {t("verse_reference")}
+        </div>
+        <p className="text-[38px] font-semibold leading-[1.18] tracking-tight">
+          {t("verse_text")}
+        </p>
+        <p className="mt-7 max-w-[420px] border-t border-white/20 pt-5 text-sm leading-relaxed opacity-85">
+          {t("brand_description")}
+        </p>
+      </div>
+
+      <div className="relative flex items-center justify-between font-mono text-[11.5px] uppercase tracking-[0.06em] opacity-70">
+        <span>{t("version_label")}</span>
+        <span>{t("region_label")}</span>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useActionState, useState } from "react";
+import { useFormStatus } from "react-dom";
+import Image from "next/image";
+import { Loader2, Eye, EyeOff, AlertCircle, ArrowRight } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { loginAction } from "@/lib/auth/actions";
+import type { AuthActionState } from "@/lib/auth/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+const initialState: AuthActionState = {};
+
+function SubmitButton() {
+  const t = useTranslations("auth.login");
+  const { pending } = useFormStatus();
+  return (
+    <Button
+      type="submit"
+      disabled={pending}
+      size="lg"
+      className="group h-11 w-full gap-2 text-sm font-semibold"
+    >
+      {pending ? (
+        <>
+          <Loader2 className="size-4 animate-spin" />
+          {t("submit_loading")}
+        </>
+      ) : (
+        <>
+          {t("submit_idle")}
+          <ArrowRight className="size-4 transition-transform group-hover:translate-x-0.5" />
+        </>
+      )}
+    </Button>
+  );
+}
+
+type Props = {
+  nextParam: string;
+};
+
+export function LoginForm({ nextParam }: Props) {
+  const t = useTranslations("auth.login");
+  const [state, formAction] = useActionState(loginAction, initialState);
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        "w-full max-w-[380px]",
+        "animate-in fade-in slide-in-from-bottom-4 duration-700 ease-out"
+      )}
+    >
+      {/* Mobile-only brand mark above form */}
+      <div className="mb-8 flex items-center gap-3 lg:hidden">
+        <div className="grid size-10 place-items-center rounded-xl border border-border bg-card shadow-xs">
+          <Image
+            src="/svg/LogoSACDIA.svg"
+            alt="SACDIA"
+            width={22}
+            height={22}
+            priority
+          />
+        </div>
+        <div className="leading-tight">
+          <div className="text-base font-bold tracking-tight text-foreground">
+            SACDIA
+          </div>
+          <div className="font-mono text-[10.5px] uppercase tracking-[0.08em] text-muted-foreground">
+            {t("brand_subtitle")}
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-2.5 font-mono text-[11px] font-semibold uppercase tracking-[0.14em] text-primary">
+        {t("eyebrow")}
+      </div>
+
+      <h1 className="mb-2 text-3xl font-bold leading-[1.1] tracking-tight text-foreground sm:text-[32px]">
+        {t("welcome_title")}
+      </h1>
+      <p className="mb-8 text-[14.5px] leading-relaxed text-muted-foreground">
+        {t("welcome_description")}
+      </p>
+
+      <form action={formAction} className="flex flex-col gap-4">
+        <input type="hidden" name="next" value={nextParam} />
+
+        {state.error && (
+          <div
+            role="alert"
+            className="flex items-start gap-2.5 rounded-lg border border-destructive/20 bg-destructive/5 px-3.5 py-3 text-sm text-destructive dark:border-destructive/30 dark:bg-destructive/10"
+          >
+            <AlertCircle className="mt-0.5 size-4 shrink-0" />
+            <span>{state.error}</span>
+          </div>
+        )}
+
+        <div className="space-y-1.5">
+          <Label
+            htmlFor="email"
+            className="text-[12.5px] font-semibold tracking-tight"
+          >
+            {t("email_label")}
+          </Label>
+          <Input
+            id="email"
+            name="email"
+            type="email"
+            placeholder={t("email_placeholder")}
+            required
+            autoComplete="email"
+            autoFocus
+            className="h-11"
+          />
+        </div>
+
+        <div className="space-y-1.5">
+          <Label
+            htmlFor="password"
+            className="text-[12.5px] font-semibold tracking-tight"
+          >
+            {t("password_label")}
+          </Label>
+          <div className="relative">
+            <Input
+              id="password"
+              name="password"
+              type={showPassword ? "text" : "password"}
+              placeholder="••••••••"
+              required
+              autoComplete="current-password"
+              minLength={8}
+              className="h-11 pr-10"
+            />
+            <button
+              type="button"
+              onClick={() => setShowPassword((v) => !v)}
+              tabIndex={-1}
+              aria-label={
+                showPassword ? t("hide_password") : t("show_password")
+              }
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground/60 transition-colors hover:text-foreground"
+            >
+              {showPassword ? (
+                <EyeOff className="size-4" />
+              ) : (
+                <Eye className="size-4" />
+              )}
+            </button>
+          </div>
+        </div>
+
+        <div className="pt-2">
+          <SubmitButton />
+        </div>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Layout split editorial (panel marca coral + form) basado en plantilla `nextjs-login` de claude-design.
- Brand panel como **RSC** para reducir bundle JS; form aislado como client component que conserva `loginAction`, `useActionState`, password toggle y manejo de errores.
- Mobile colapsa a form full-width con mini brand mark.
- i18n: nuevos keys `eyebrow`, `verse_reference`, `verse_text`, `brand_description`, `version_label`, `region_label` en es/en/fr/pt-BR; reemplazado `verse` legacy.
- Tokens shadcn (`bg-primary` ya es coral en light/dark) — sin agregar tokens nuevos.
- Sin forgot-password, sin signup, sin remember-me (fuera de alcance).

## Decisiones aplicadas

- Split fiel al recurso + dark mode con tokens shadcn
- Página convertida a RSC; `searchParams` resuelto con `await` (patrón Next 16)
- `nextParam` pasado como prop al form en vez de `useSearchParams` cliente

## Test plan

- [ ] `/login` renderiza split layout en `lg+` (≥1024px)
- [ ] Mobile (<1024px): brand panel oculto, mini brand mark arriba del form
- [ ] Light mode: form sobre `bg-background`, panel coral con texto blanco
- [ ] Dark mode: tokens shadcn aplicados, panel sigue coral
- [ ] Submit con credenciales inválidas muestra `state.error` en alert destructive
- [ ] Submit válido respeta `?next=` y redirige
- [ ] Password toggle muestra/oculta clave
- [ ] `autoFocus` en email
- [ ] Cambio de idioma (es/en/fr/pt-BR) actualiza todos los textos
- [ ] Sin warnings TS/lint nuevos