### PR TITLE
feat(admin): add SortableHeader shared + pilot client/server sort

### DIFF
--- a/src/components/finances/finances-dashboard.tsx
+++ b/src/components/finances/finances-dashboard.tsx
@@ -25,8 +25,10 @@ import {
   getFinanceSummary,
   type Finance,
   type FinanceSummary,
+  type FinanceSortField,
   type PaginatedFinances,
 } from "@/lib/api/finances";
+import type { SortDirection } from "@/components/shared/sortable-header";
 import type { ClubSection } from "@/components/finances/transaction-form-dialog";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -68,6 +70,10 @@ export function FinancesDashboard({
   const [year, setYear] = useState<number | undefined>(currentYear);
   const [month, setMonth] = useState<number | undefined>(undefined);
 
+  // Sort
+  const [sortField, setSortField] = useState<FinanceSortField>("date");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("desc");
+
   // Data
   const [summary, setSummary] = useState<FinanceSummary | null>(null);
   const [result, setResult] = useState<PaginatedFinances | null>(null);
@@ -97,14 +103,25 @@ export function FinancesDashboard({
   const fetchTransactions = useCallback(async () => {
     setLoadingTable(true);
     try {
-      const data = await listFinances(clubId, { year, month, limit: 50 });
+      const data = await listFinances(clubId, {
+        year,
+        month,
+        limit: 50,
+        sortBy: sortField,
+        sortOrder: sortDirection,
+      });
       setResult(data);
     } catch {
       setResult(null);
     } finally {
       setLoadingTable(false);
     }
-  }, [clubId, year, month]);
+  }, [clubId, year, month, sortField, sortDirection]);
+
+  const handleSort = (field: FinanceSortField, direction: SortDirection) => {
+    setSortField(field);
+    setSortDirection(direction);
+  };
 
   // Refresh both on mount and filter change
   const refresh = useCallback(() => {
@@ -219,6 +236,9 @@ export function FinancesDashboard({
             items={result?.data ?? []}
             onEdit={handleEdit}
             onDelete={handleDelete}
+            sortField={sortField}
+            sortDirection={sortDirection}
+            onSort={handleSort}
           />
         )}
 

--- a/src/components/finances/transactions-table.tsx
+++ b/src/components/finances/transactions-table.tsx
@@ -19,9 +19,13 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { EmptyState } from "@/components/shared/empty-state";
+import {
+  SortableHeader,
+  type SortDirection,
+} from "@/components/shared/sortable-header";
 import { Skeleton } from "@/components/ui/skeleton";
 import { DollarSign } from "lucide-react";
-import type { Finance } from "@/lib/api/finances";
+import type { Finance, FinanceSortField } from "@/lib/api/finances";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -114,9 +118,19 @@ interface TransactionsTableProps {
   items: Finance[];
   onEdit: (finance: Finance) => void;
   onDelete: (finance: Finance) => void;
+  sortField: FinanceSortField;
+  sortDirection: SortDirection;
+  onSort: (field: FinanceSortField, direction: SortDirection) => void;
 }
 
-export function TransactionsTable({ items, onEdit, onDelete }: TransactionsTableProps) {
+export function TransactionsTable({
+  items,
+  onEdit,
+  onDelete,
+  sortField,
+  sortDirection,
+  onSort,
+}: TransactionsTableProps) {
   if (items.length === 0) {
     return (
       <EmptyState
@@ -132,14 +146,46 @@ export function TransactionsTable({ items, onEdit, onDelete }: TransactionsTable
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Fecha
+            <TableHead
+              className="h-9 px-3"
+              aria-sort={
+                sortField === "date"
+                  ? sortDirection === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : "none"
+              }
+            >
+              <SortableHeader
+                field="date"
+                activeField={sortField}
+                direction={sortDirection}
+                onSort={onSort}
+              >
+                Fecha
+              </SortableHeader>
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Descripción
             </TableHead>
-            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Categoría
+            <TableHead
+              className="h-9 px-3"
+              aria-sort={
+                sortField === "category"
+                  ? sortDirection === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : "none"
+              }
+            >
+              <SortableHeader
+                field="category"
+                activeField={sortField}
+                direction={sortDirection}
+                onSort={onSort}
+              >
+                Categoría
+              </SortableHeader>
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Período
@@ -147,8 +193,25 @@ export function TransactionsTable({ items, onEdit, onDelete }: TransactionsTable
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
               Tipo
             </TableHead>
-            <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Monto
+            <TableHead
+              className="h-9 px-3 text-right"
+              aria-sort={
+                sortField === "amount"
+                  ? sortDirection === "asc"
+                    ? "ascending"
+                    : "descending"
+                  : "none"
+              }
+            >
+              <SortableHeader
+                field="amount"
+                activeField={sortField}
+                direction={sortDirection}
+                onSort={onSort}
+                align="right"
+              >
+                Monto
+              </SortableHeader>
             </TableHead>
             <TableHead className="h-9 w-12 px-3" />
           </TableRow>

--- a/src/components/rbac/roles-table.tsx
+++ b/src/components/rbac/roles-table.tsx
@@ -52,6 +52,10 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/shared/empty-state";
 import { DataTableShell } from "@/components/shared/data-table-shell";
+import {
+  SortableHeader,
+  type SortDirection,
+} from "@/components/shared/sortable-header";
 import { deactivateRoleAction } from "@/lib/rbac/actions";
 import type { Role } from "@/lib/rbac/types";
 
@@ -247,6 +251,7 @@ function DeactivateDialog({ role, open, onClose, onSuccess }: DeactivateDialogPr
 
 // ─── Main roles table ────────────────────────────────────────────────────────
 type ActiveFilter = "true" | "false" | "all";
+type SortField = "role_name" | "role_category" | "permissions" | "active";
 
 interface RolesTableProps {
   roles: Role[];
@@ -256,8 +261,15 @@ interface RolesTableProps {
 export function RolesTable({ roles, isSuperAdmin }: RolesTableProps) {
   const [search, setSearch] = useState("");
   const [activeTab, setActiveTab] = useState<ActiveFilter>("true");
+  const [sortField, setSortField] = useState<SortField>("role_name");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
   const [deactivateTarget, setDeactivateTarget] = useState<Role | null>(null);
   const router = useRouter();
+
+  const handleSort = (field: SortField, direction: SortDirection) => {
+    setSortField(field);
+    setSortDirection(direction);
+  };
 
   const filtered = useMemo(() => {
     const byStatus = roles.filter((r) => {
@@ -266,15 +278,40 @@ export function RolesTable({ roles, isSuperAdmin }: RolesTableProps) {
       return true;
     });
 
-    if (!search.trim()) return byStatus;
+    const bySearch = !search.trim()
+      ? byStatus
+      : byStatus.filter((r) => {
+          const q = search.toLowerCase();
+          return (
+            r.role_name.toLowerCase().includes(q) ||
+            (r.description?.toLowerCase().includes(q) ?? false)
+          );
+        });
 
-    const q = search.toLowerCase();
-    return byStatus.filter(
-      (r) =>
-        r.role_name.toLowerCase().includes(q) ||
-        (r.description?.toLowerCase().includes(q) ?? false),
-    );
-  }, [roles, activeTab, search]);
+    const sorted = [...bySearch].sort((a, b) => {
+      const dir = sortDirection === "asc" ? 1 : -1;
+      switch (sortField) {
+        case "role_name":
+          return a.role_name.localeCompare(b.role_name) * dir;
+        case "role_category":
+          return a.role_category.localeCompare(b.role_category) * dir;
+        case "permissions": {
+          const ap = a.role_permissions?.length ?? 0;
+          const bp = b.role_permissions?.length ?? 0;
+          return (ap - bp) * dir;
+        }
+        case "active": {
+          const av = a.active === false ? 0 : 1;
+          const bv = b.active === false ? 0 : 1;
+          return (av - bv) * dir;
+        }
+        default:
+          return 0;
+      }
+    });
+
+    return sorted;
+  }, [roles, activeTab, search, sortField, sortDirection]);
 
   const isProtected = (role: Role) => role.role_name === "super-admin";
 
@@ -326,20 +363,84 @@ export function RolesTable({ roles, isSuperAdmin }: RolesTableProps) {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Nombre
+                    <TableHead
+                      className="h-9 px-3"
+                      aria-sort={
+                        sortField === "role_name"
+                          ? sortDirection === "asc"
+                            ? "ascending"
+                            : "descending"
+                          : "none"
+                      }
+                    >
+                      <SortableHeader
+                        field="role_name"
+                        activeField={sortField}
+                        direction={sortDirection}
+                        onSort={handleSort}
+                      >
+                        Nombre
+                      </SortableHeader>
                     </TableHead>
-                    <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Categoría
+                    <TableHead
+                      className="h-9 px-3"
+                      aria-sort={
+                        sortField === "role_category"
+                          ? sortDirection === "asc"
+                            ? "ascending"
+                            : "descending"
+                          : "none"
+                      }
+                    >
+                      <SortableHeader
+                        field="role_category"
+                        activeField={sortField}
+                        direction={sortDirection}
+                        onSort={handleSort}
+                      >
+                        Categoría
+                      </SortableHeader>
                     </TableHead>
                     <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground hidden md:table-cell">
                       Descripción
                     </TableHead>
-                    <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Permisos
+                    <TableHead
+                      className="h-9 px-3"
+                      aria-sort={
+                        sortField === "permissions"
+                          ? sortDirection === "asc"
+                            ? "ascending"
+                            : "descending"
+                          : "none"
+                      }
+                    >
+                      <SortableHeader
+                        field="permissions"
+                        activeField={sortField}
+                        direction={sortDirection}
+                        onSort={handleSort}
+                      >
+                        Permisos
+                      </SortableHeader>
                     </TableHead>
-                    <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Estado
+                    <TableHead
+                      className="h-9 px-3"
+                      aria-sort={
+                        sortField === "active"
+                          ? sortDirection === "asc"
+                            ? "ascending"
+                            : "descending"
+                          : "none"
+                      }
+                    >
+                      <SortableHeader
+                        field="active"
+                        activeField={sortField}
+                        direction={sortDirection}
+                        onSort={handleSort}
+                      >
+                        Estado
+                      </SortableHeader>
                     </TableHead>
                     {isSuperAdmin && (
                       <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">

--- a/src/components/shared/sortable-header.tsx
+++ b/src/components/shared/sortable-header.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+export type SortDirection = "asc" | "desc";
+
+export interface SortableHeaderProps<TField extends string> {
+  field: TField;
+  activeField?: TField | null;
+  direction?: SortDirection;
+  onSort: (field: TField, direction: SortDirection) => void;
+  children: ReactNode;
+  align?: "left" | "right";
+  className?: string;
+}
+
+export function SortableHeader<TField extends string>({
+  field,
+  activeField,
+  direction,
+  onSort,
+  children,
+  align = "left",
+  className,
+}: SortableHeaderProps<TField>) {
+  const isActive = activeField === field;
+  const nextDirection: SortDirection =
+    isActive && direction === "asc" ? "desc" : "asc";
+
+  const Icon = !isActive
+    ? ArrowUpDown
+    : direction === "asc"
+      ? ArrowUp
+      : ArrowDown;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSort(field, nextDirection)}
+      aria-label={
+        isActive
+          ? `Ordenado por ${field} ${direction === "asc" ? "ascendente" : "descendente"}. Click para invertir.`
+          : `Ordenar por ${field}`
+      }
+      className={cn(
+        "inline-flex h-7 items-center gap-1.5 rounded-md px-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        align === "right" && "ml-auto",
+        isActive && "text-foreground",
+        className,
+      )}
+    >
+      <span>{children}</span>
+      <Icon
+        className={cn(
+          "size-3.5 shrink-0 transition-opacity",
+          isActive ? "opacity-100" : "opacity-50",
+        )}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}

--- a/src/lib/api/finances.ts
+++ b/src/lib/api/finances.ts
@@ -58,6 +58,9 @@ export type PaginatedFinances = {
   limit: number;
 };
 
+export type FinanceSortField = "date" | "amount" | "category";
+export type FinanceSortOrder = "asc" | "desc";
+
 export type FinanceFilters = {
   year?: number;
   month?: number;
@@ -65,6 +68,8 @@ export type FinanceFilters = {
   categoryId?: number;
   page?: number;
   limit?: number;
+  sortBy?: FinanceSortField;
+  sortOrder?: FinanceSortOrder;
 };
 
 export type CreateFinancePayload = {
@@ -106,13 +111,15 @@ export async function listFinances(
   clubId: number,
   filters: FinanceFilters = {},
 ): Promise<PaginatedFinances> {
-  const params: Record<string, number | undefined> = {};
+  const params: Record<string, string | number | undefined> = {};
   if (filters.year) params.year = filters.year;
   if (filters.month) params.month = filters.month;
   if (filters.clubTypeId) params.clubTypeId = filters.clubTypeId;
   if (filters.categoryId) params.categoryId = filters.categoryId;
   if (filters.page) params.page = filters.page;
   if (filters.limit) params.limit = filters.limit;
+  if (filters.sortBy) params.sortBy = filters.sortBy;
+  if (filters.sortOrder) params.sortOrder = filters.sortOrder;
 
   return apiRequest<PaginatedFinances>(`/clubs/${clubId}/finances`, { params });
 }


### PR DESCRIPTION
## Summary

- New `<SortableHeader>` shared component with chevron icons (lucide `ArrowUp`/`ArrowDown`/`ArrowUpDown`), `aria-sort` integration and toggle-direction click behavior.
- Pilot **client-side sort** on `rbac/roles` table: sorts by `role_name`, `role_category`, `permissions count`, `active state`. Safe because endpoint is non-paginated.
- Pilot **server-side sort** on `finances/transactions` table: wires `sortBy` (date|amount|category) + `sortOrder` to `GET /clubs/:clubId/finances` (only endpoint that already supports sort params per backend audit).
- Extends `FinanceFilters` type with `sortBy` + `sortOrder` and threads them through `listFinances`.

## Why this scope

Backend audit found only `/clubs/:clubId/finances/transactions` supports `sortBy`/`sortOrder`. Five paginated endpoints (`/clubs`, `/admin/users`, `/honors`, `/camporees`) have pagination but no sort — client-side would lie. Six non-paginated lists are safe for client sort. This PR establishes the pattern via two pilots; remaining tables can be added incrementally.

## Test plan

- [ ] CI passes
- [ ] `/dashboard/rbac/roles` — click each header toggles asc/desc, chevrons reflect state, aria-sort updates
- [ ] `/dashboard/clubs/[id]/finances` — sorting Fecha / Categoría / Monto fires fresh API request with `sortBy`+`sortOrder`
- [ ] Mobile cards on roles unaffected (only desktop table headers were touched)
- [ ] No lint regressions on touched files