### PR TITLE
fix(forms): widen zodResolver cast with Input generic in 15 dialogs

### DIFF
--- a/src/components/activities/activity-form-dialog.tsx
+++ b/src/components/activities/activity-form-dialog.tsx
@@ -101,7 +101,7 @@ export function ActivityFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/annual-folders/award-category-form-dialog.tsx
+++ b/src/components/annual-folders/award-category-form-dialog.tsx
@@ -123,7 +123,7 @@ export function AwardCategoryFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/annual-folders/section-form-dialog.tsx
+++ b/src/components/annual-folders/section-form-dialog.tsx
@@ -83,7 +83,7 @@ export function SectionFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/annual-folders/template-form-dialog.tsx
+++ b/src/components/annual-folders/template-form-dialog.tsx
@@ -142,7 +142,7 @@ export function TemplateFormDialog({
     control,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues,
   });
 

--- a/src/components/camporees/camporee-form-dialog.tsx
+++ b/src/components/camporees/camporee-form-dialog.tsx
@@ -81,7 +81,7 @@ export function CamporeeFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/camporees/enroll-club-dialog.tsx
+++ b/src/components/camporees/enroll-club-dialog.tsx
@@ -56,7 +56,7 @@ export function EnrollClubDialog({
     reset,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       club_section_id: undefined,
     },

--- a/src/components/camporees/payment-dialog.tsx
+++ b/src/components/camporees/payment-dialog.tsx
@@ -95,7 +95,7 @@ export function PaymentDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       member_id: "",
       amount: undefined,

--- a/src/components/camporees/register-member-dialog.tsx
+++ b/src/components/camporees/register-member-dialog.tsx
@@ -66,7 +66,7 @@ export function RegisterMemberDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       user_id: "",
       camporee_type: "local",

--- a/src/components/camporees/union-camporee-form-dialog.tsx
+++ b/src/components/camporees/union-camporee-form-dialog.tsx
@@ -90,7 +90,7 @@ export function UnionCamporeeFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/finances/transaction-form-dialog.tsx
+++ b/src/components/finances/transaction-form-dialog.tsx
@@ -136,7 +136,7 @@ export function TransactionFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       year: currentYear,
       month: new Date().getMonth() + 1,

--- a/src/components/folders/folder-form-dialog.tsx
+++ b/src/components/folders/folder-form-dialog.tsx
@@ -67,7 +67,7 @@ export function FolderFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/insurance/insurance-form-dialog.tsx
+++ b/src/components/insurance/insurance-form-dialog.tsx
@@ -92,7 +92,7 @@ export function InsuranceFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       insurance_type: "GENERAL_ACTIVITIES",
       start_date: "",

--- a/src/components/inventory/inventory-form-dialog.tsx
+++ b/src/components/inventory/inventory-form-dialog.tsx
@@ -84,7 +84,7 @@ export function InventoryFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/investiture/config-form-dialog.tsx
+++ b/src/components/investiture/config-form-dialog.tsx
@@ -95,7 +95,7 @@ export function ConfigFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       local_field_id: undefined,
       ecclesiastical_year_id: undefined,

--- a/src/components/reports/manual-data-form.tsx
+++ b/src/components/reports/manual-data-form.tsx
@@ -133,7 +133,7 @@ export function ManualDataForm({
     formState: { errors, isDirty },
   } = useForm<FormValues>({
      
-    resolver: zodResolver(manualDataSchema as z.ZodType<FormValues>),
+    resolver: zodResolver(manualDataSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       weekly_meetings_held: initialData?.weekly_meetings_held ?? undefined,
       leadership_meetings: initialData?.leadership_meetings ?? undefined,


### PR DESCRIPTION
## Summary

- `z.ZodType<Output, Input>` in zod v4 defaults `Input` to `unknown`. The single-arg cast `as z.ZodType<FormValues>` left `Input = unknown`, which fails to satisfy `zodResolver`'s `Input extends FieldValues` constraint and falls back to `FieldValues`.
- Result: returned `Resolver<FieldValues, _, FormValues>` diverges from `Resolver<FormValues, _, FormValues>` expected by `useForm<FormValues>`, breaking the TypeScript build.
- Fix: pass `FormValues` for both `Output` and `Input` in 15 dialogs (`as z.ZodType<FormValues, FormValues>`).

## Why

CI build (Vercel) on PR #51 reported `activity-form-dialog.tsx:104:5` with this exact mismatch. The same pattern exists in 15 dialogs from prior commit `68f0396` ("fix(forms): drop unsafe `as unknown as Resolver<FormValues>` cast"), so all are equally vulnerable when TS evaluates them. This PR keeps the safety improvement of casting at the schema (rather than the resolver result) but provides the second generic argument that the constraint requires.

## Test plan

- [ ] CI passes (TypeScript build succeeds)
- [ ] Open each dialog and submit a valid form — no runtime regressions
- [ ] Trigger a validation error in at least 3 dialogs (activity, transaction, insurance) — error rendering still works
- [ ] No lint regressions on touched files (only pre-existing `useEffect` deps warnings remain)