### PR TITLE
fix(reports): wrap refetch in arrow for refresh button onClick

### DIFF
--- a/src/components/reports/reports-list-client.tsx
+++ b/src/components/reports/reports-list-client.tsx
@@ -294,7 +294,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
         <Button
           variant="outline"
           size="sm"
-          onClick={fetchReports}
+          onClick={() => fetchReports()}
           disabled={loading}
         >
           <RefreshCw className={`size-4 ${loading ? "animate-spin" : ""}`} />


### PR DESCRIPTION
## Summary

- `useQuery`'s `refetch` is typed `(options?: RefetchOptions) => Promise<...>`. Passing it directly to `<Button onClick={fetchReports}>` failed type check because `MouseEventHandler<HTMLButtonElement>` expects `(event: MouseEvent) => void` and the parameter shapes are incompatible.
- Wrap with `() => fetchReports()` so the click event is discarded — same pattern already used in `src/components/units/units-tab.tsx:116`.

## Test plan

- [ ] CI passes (TypeScript build succeeds)
- [ ] `/dashboard/reports` (or wherever the list is rendered) — click "Actualizar" — query refetches without runtime errors