### PR TITLE
chore(ci): add typecheck workflow to catch TS errors on PRs

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -1,0 +1,34 @@
+name: Typecheck
+
+on:
+  pull_request:
+    branches:
+      - main
+      - preproduction
+      - development
+
+jobs:
+  tsc:
+    name: TypeScript type check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        run: pnpm typecheck

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start -p 3001",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test:e2e:smoke": "node scripts/e2e-smoke.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- New `.github/workflows/typecheck.yml` runs `pnpm typecheck` (= `tsc --noEmit`) on every PR targeting `main`, `preproduction`, or `development`.
- New `typecheck` npm script so contributors can run the same command locally before pushing.
- `pnpm/action-setup@v4` pinned to v10 (compatible with current `lockfileVersion: '9.0'`).

## Why

This session exposed 3 pre-existing TS errors (PRs #51, #52, #53) that only Vercel's `next build` caught. ESLint never reported them. The cycle was: merge PR → Vercel deploy fails → fix → repeat. A 30-second `tsc --noEmit` job per PR ends that cycle.

## Test plan

- [ ] CI runs the workflow on this PR itself and surfaces the current TS errors (will likely fail until they're fixed in follow-up PRs — that's the point)
- [ ] Locally: `pnpm typecheck` runs `tsc --noEmit`
- [ ] Future PRs see the new `Typecheck / TypeScript type check` status check on GitHub