### PR TITLE
feat(admin): roll out SortableHeader to 4 non-paginated tables

### DIFF
--- a/src/components/annual-folders/award-categories-client-page.tsx
+++ b/src/components/annual-folders/award-categories-client-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { Plus, RefreshCw, Pencil, Trash2 } from "lucide-react";
 import { toast } from "sonner";
@@ -25,6 +25,10 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  SortableHeader,
+  type SortDirection,
+} from "@/components/shared/sortable-header";
 import { AwardCategoryFormDialog } from "@/components/annual-folders/award-category-form-dialog";
 import {
   getAwardCategoriesFromClient,
@@ -33,6 +37,10 @@ import {
 import { ApiError } from "@/lib/api/client";
 import type { AwardCategory, AwardCategoryScope, AwardTier } from "@/lib/api/annual-folders";
 import type { ClubType } from "@/lib/api/catalogs";
+
+// ─── Sort types ───────────────────────────────────────────────────────────────
+
+type SortField = "order" | "name" | "min_points" | "max_points" | "active";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -117,6 +125,15 @@ export function AwardCategoriesClientPage({
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deletingCategory, setDeletingCategory] = useState<AwardCategory | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+
+  // Sort state
+  const [sortField, setSortField] = useState<SortField>("order");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+
+  const handleSort = (field: SortField, direction: SortDirection) => {
+    setSortField(field);
+    setSortDirection(direction);
+  };
 
   // ─── First-render guard — skip the effect on mount (SSR data already correct) ──
 
@@ -216,7 +233,31 @@ export function AwardCategoriesClientPage({
 
   // ─── Derived list ─────────────────────────────────────────────────────────
 
-  const filteredCategories = [...categories].sort((a, b) => a.order - b.order);
+  const filteredCategories = useMemo(() => {
+    return [...categories].sort((a, b) => {
+      const dir = sortDirection === "asc" ? 1 : -1;
+      switch (sortField) {
+        case "order":
+          return (a.order - b.order) * dir;
+        case "name":
+          return a.name.localeCompare(b.name) * dir;
+        case "min_points":
+          return (a.min_points - b.min_points) * dir;
+        case "max_points": {
+          const aMax = a.max_points ?? Number.MAX_SAFE_INTEGER;
+          const bMax = b.max_points ?? Number.MAX_SAFE_INTEGER;
+          return (aMax - bMax) * dir;
+        }
+        case "active": {
+          const aAct = a.active ? 1 : 0;
+          const bAct = b.active ? 1 : 0;
+          return (aAct - bAct) * dir;
+        }
+        default:
+          return 0;
+      }
+    });
+  }, [categories, sortField, sortDirection]);
 
   const scopeLabel = SCOPE_LABELS[scope];
   const filterLabel = activeFilter === "active" ? "activas" : "legacy";
@@ -300,26 +341,59 @@ export function AwardCategoriesClientPage({
                     <Table>
                       <TableHeader>
                         <TableRow>
-                          <TableHead className="w-16 text-center">Orden</TableHead>
-                          <TableHead>Nombre</TableHead>
-                          <TableHead>Tipo club</TableHead>
-                          <TableHead className="w-24 text-center">Pts Min</TableHead>
-                          <TableHead className="w-24 text-center">
-                            Pts Max
+                          <TableHead
+                            className="h-9 w-16 px-3 text-center"
+                            aria-sort={sortField === "order" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                          >
+                            <SortableHeader field="order" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                              Orden
+                            </SortableHeader>
+                          </TableHead>
+                          <TableHead
+                            className="h-9 px-3"
+                            aria-sort={sortField === "name" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                          >
+                            <SortableHeader field="name" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                              Nombre
+                            </SortableHeader>
+                          </TableHead>
+                          <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">Tipo club</TableHead>
+                          <TableHead
+                            className="h-9 w-24 px-3 text-center"
+                            aria-sort={sortField === "min_points" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                          >
+                            <SortableHeader field="min_points" activeField={sortField} direction={sortDirection} onSort={handleSort} align="right">
+                              Pts Min
+                            </SortableHeader>
+                          </TableHead>
+                          <TableHead
+                            className="h-9 w-24 px-3 text-center"
+                            aria-sort={sortField === "max_points" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                          >
+                            <SortableHeader field="max_points" activeField={sortField} direction={sortDirection} onSort={handleSort} align="right">
+                              Pts Max
+                            </SortableHeader>
                           </TableHead>
                           {/* 8.4-C composite % columns */}
-                          <TableHead className="hidden w-24 text-center lg:table-cell">
+                          <TableHead className="hidden h-9 w-24 px-3 text-center lg:table-cell text-xs font-medium uppercase tracking-wider text-muted-foreground">
                             % Min
                           </TableHead>
-                          <TableHead className="hidden w-24 text-center lg:table-cell">
+                          <TableHead className="hidden h-9 w-24 px-3 text-center lg:table-cell text-xs font-medium uppercase tracking-wider text-muted-foreground">
                             % Max
                           </TableHead>
                           {/* 8.4-C Phase C tier column */}
-                          <TableHead className="hidden w-28 text-center xl:table-cell">
+                          <TableHead className="hidden h-9 w-28 px-3 text-center xl:table-cell text-xs font-medium uppercase tracking-wider text-muted-foreground">
                             Nivel
                           </TableHead>
-                          <TableHead className="w-20 text-center">Estado</TableHead>
-                          <TableHead className="w-20 text-right">Acciones</TableHead>
+                          <TableHead
+                            className="h-9 w-20 px-3 text-center"
+                            aria-sort={sortField === "active" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                          >
+                            <SortableHeader field="active" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                              Estado
+                            </SortableHeader>
+                          </TableHead>
+                          <TableHead className="h-9 w-20 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">Acciones</TableHead>
                         </TableRow>
                       </TableHeader>
                       <TableBody>

--- a/src/components/annual-folders/rankings-client-page.tsx
+++ b/src/components/annual-folders/rankings-client-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import {
   Search,
@@ -47,8 +47,21 @@ import {
   recalculateRankings,
 } from "@/lib/api/annual-folders";
 import { ApiError } from "@/lib/api/client";
+import {
+  SortableHeader,
+  type SortDirection,
+} from "@/components/shared/sortable-header";
 import type { ClubRanking, AwardCategory } from "@/lib/api/annual-folders";
 import type { ClubType, EcclesiasticalYear } from "@/lib/api/catalogs";
+
+// ─── Sort types ───────────────────────────────────────────────────────────────
+
+type SortField =
+  | "rank_position"
+  | "club_name"
+  | "composite_score_pct"
+  | "total_earned_points"
+  | "progress_percentage";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -132,6 +145,15 @@ export function RankingsClientPage({
     useState<AwardCategory[]>(initialCategories);
   const [isLoading, setIsLoading] = useState(false);
 
+  // Sort state
+  const [sortField, setSortField] = useState<SortField>("rank_position");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+
+  const handleSort = (field: SortField, direction: SortDirection) => {
+    setSortField(field);
+    setSortDirection(direction);
+  };
+
   // Recalculate dialog
   const [recalcOpen, setRecalcOpen] = useState(false);
   const [isRecalculating, setIsRecalculating] = useState(false);
@@ -196,11 +218,28 @@ export function RankingsClientPage({
 
   // ─── Sorted rankings ──────────────────────────────────────────────────────
 
-  const sortedRankings = [...rankings].sort((a, b) => {
-    const posA = a.rank_position ?? Number.MAX_SAFE_INTEGER;
-    const posB = b.rank_position ?? Number.MAX_SAFE_INTEGER;
-    return posA - posB;
-  });
+  const sortedRankings = useMemo(() => {
+    return [...rankings].sort((a, b) => {
+      const dir = sortDirection === "asc" ? 1 : -1;
+      switch (sortField) {
+        case "rank_position": {
+          const posA = a.rank_position ?? Number.MAX_SAFE_INTEGER;
+          const posB = b.rank_position ?? Number.MAX_SAFE_INTEGER;
+          return (posA - posB) * dir;
+        }
+        case "club_name":
+          return a.club_name.localeCompare(b.club_name) * dir;
+        case "composite_score_pct":
+          return (a.composite_score_pct - b.composite_score_pct) * dir;
+        case "total_earned_points":
+          return (a.total_earned_points - b.total_earned_points) * dir;
+        case "progress_percentage":
+          return (a.progress_percentage - b.progress_percentage) * dir;
+        default:
+          return 0;
+      }
+    });
+  }, [rankings, sortField, sortDirection]);
 
   const activeYear = ecclesiasticalYears.find(
     (y) => y.ecclesiastical_year_id === selectedYearId,
@@ -368,34 +407,65 @@ export function RankingsClientPage({
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead className="w-16 text-center">Posicion</TableHead>
-                  <TableHead>Club</TableHead>
-                  <TableHead className="w-28 text-center">
-                    Composite
+                  <TableHead
+                    className="h-9 w-16 px-3 text-center"
+                    aria-sort={sortField === "rank_position" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                  >
+                    <SortableHeader field="rank_position" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                      Posicion
+                    </SortableHeader>
                   </TableHead>
-                  <TableHead className="hidden w-24 text-center lg:table-cell">
+                  <TableHead
+                    className="h-9 px-3"
+                    aria-sort={sortField === "club_name" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                  >
+                    <SortableHeader field="club_name" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                      Club
+                    </SortableHeader>
+                  </TableHead>
+                  <TableHead
+                    className="h-9 w-28 px-3 text-center"
+                    aria-sort={sortField === "composite_score_pct" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                  >
+                    <SortableHeader field="composite_score_pct" activeField={sortField} direction={sortDirection} onSort={handleSort} align="right">
+                      Composite
+                    </SortableHeader>
+                  </TableHead>
+                  <TableHead className="hidden h-9 w-24 px-3 text-center lg:table-cell text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     Carpeta
                   </TableHead>
-                  <TableHead className="hidden w-24 text-center lg:table-cell">
+                  <TableHead className="hidden h-9 w-24 px-3 text-center lg:table-cell text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     Finanzas
                   </TableHead>
-                  <TableHead className="hidden w-24 text-center lg:table-cell">
+                  <TableHead className="hidden h-9 w-24 px-3 text-center lg:table-cell text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     Camporees
                   </TableHead>
-                  <TableHead className="hidden w-24 text-center lg:table-cell">
+                  <TableHead className="hidden h-9 w-24 px-3 text-center lg:table-cell text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     Evidencias
                   </TableHead>
-                  <TableHead className="w-32 text-center">
-                    Pts Obtenidos
+                  <TableHead
+                    className="h-9 w-32 px-3 text-center"
+                    aria-sort={sortField === "total_earned_points" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                  >
+                    <SortableHeader field="total_earned_points" activeField={sortField} direction={sortDirection} onSort={handleSort} align="right">
+                      Pts Obtenidos
+                    </SortableHeader>
                   </TableHead>
-                  <TableHead className="hidden w-28 text-center lg:table-cell">
+                  <TableHead className="hidden h-9 w-28 px-3 text-center lg:table-cell text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     Pts Maximos
                   </TableHead>
-                  <TableHead className="w-40">Progreso</TableHead>
-                  <TableHead className="hidden w-32 lg:table-cell">
+                  <TableHead
+                    className="h-9 w-40 px-3"
+                    aria-sort={sortField === "progress_percentage" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                  >
+                    <SortableHeader field="progress_percentage" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                      Progreso
+                    </SortableHeader>
+                  </TableHead>
+                  <TableHead className="hidden h-9 w-32 px-3 lg:table-cell text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     Categoria
                   </TableHead>
-                  <TableHead className="w-24 text-center">Acciones</TableHead>
+                  <TableHead className="h-9 w-24 px-3 text-center text-xs font-medium uppercase tracking-wider text-muted-foreground">Acciones</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>

--- a/src/components/insurance/insurance-table.tsx
+++ b/src/components/insurance/insurance-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState, useMemo } from "react";
 import { Pencil, Trash2, ExternalLink, ShieldCheck, Shield, ShieldAlert } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -12,6 +13,10 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { EmptyState } from "@/components/shared/empty-state";
+import {
+  SortableHeader,
+  type SortDirection,
+} from "@/components/shared/sortable-header";
 import { INSURANCE_TYPE_LABELS } from "@/lib/api/insurance";
 import type { MemberInsurance, InsuranceType } from "@/lib/api/insurance";
 
@@ -72,6 +77,16 @@ function isExpired(endDate: string | null | undefined): boolean {
   return new Date(endDate) < new Date();
 }
 
+// ─── Sort types ───────────────────────────────────────────────────────────────
+
+type SortField =
+  | "member_name"
+  | "insurance_type"
+  | "provider"
+  | "end_date"
+  | "coverage_amount"
+  | "active";
+
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 interface InsuranceTableProps {
@@ -83,6 +98,54 @@ interface InsuranceTableProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function InsuranceTable({ items, onEdit, onDelete }: InsuranceTableProps) {
+  const [sortField, setSortField] = useState<SortField>("member_name");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+
+  const handleSort = (field: SortField, direction: SortDirection) => {
+    setSortField(field);
+    setSortDirection(direction);
+  };
+
+  const sortedItems = useMemo(() => {
+    return [...items].sort((a, b) => {
+      const dir = sortDirection === "asc" ? 1 : -1;
+      switch (sortField) {
+        case "member_name": {
+          const aName = memberFullName(a);
+          const bName = memberFullName(b);
+          return aName.localeCompare(bName) * dir;
+        }
+        case "insurance_type": {
+          const aType = a.insurance?.insurance_type ?? "";
+          const bType = b.insurance?.insurance_type ?? "";
+          return aType.localeCompare(bType) * dir;
+        }
+        case "provider": {
+          const aProv = a.insurance?.provider ?? "";
+          const bProv = b.insurance?.provider ?? "";
+          return aProv.localeCompare(bProv) * dir;
+        }
+        case "end_date": {
+          const aDate = a.insurance?.end_date ? new Date(a.insurance.end_date).getTime() : 0;
+          const bDate = b.insurance?.end_date ? new Date(b.insurance.end_date).getTime() : 0;
+          return (aDate - bDate) * dir;
+        }
+        case "coverage_amount": {
+          const aCov = a.insurance?.coverage_amount ?? 0;
+          const bCov = b.insurance?.coverage_amount ?? 0;
+          return (aCov - bCov) * dir;
+        }
+        case "active": {
+          const aAct = a.insurance?.active ? 1 : 0;
+          const bAct = b.insurance?.active ? 1 : 0;
+          return (aAct - bAct) * dir;
+        }
+        default:
+          return 0;
+      }
+    });
+  }, [items, sortField, sortDirection]);
+
   if (items.length === 0) {
     return (
       <EmptyState
@@ -98,32 +161,62 @@ export function InsuranceTable({ items, onEdit, onDelete }: InsuranceTableProps)
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Miembro
+            <TableHead
+              className="h-9 px-3"
+              aria-sort={sortField === "member_name" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+            >
+              <SortableHeader field="member_name" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                Miembro
+              </SortableHeader>
             </TableHead>
-            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Tipo
+            <TableHead
+              className="h-9 px-3"
+              aria-sort={sortField === "insurance_type" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+            >
+              <SortableHeader field="insurance_type" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                Tipo
+              </SortableHeader>
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
               N° Póliza
             </TableHead>
-            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Aseguradora
+            <TableHead
+              className="h-9 px-3"
+              aria-sort={sortField === "provider" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+            >
+              <SortableHeader field="provider" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                Aseguradora
+              </SortableHeader>
             </TableHead>
-            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Vigencia
+            <TableHead
+              className="h-9 px-3"
+              aria-sort={sortField === "end_date" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+            >
+              <SortableHeader field="end_date" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                Vigencia
+              </SortableHeader>
             </TableHead>
-            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Cobertura
+            <TableHead
+              className="h-9 px-3"
+              aria-sort={sortField === "coverage_amount" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+            >
+              <SortableHeader field="coverage_amount" activeField={sortField} direction={sortDirection} onSort={handleSort} align="right">
+                Cobertura
+              </SortableHeader>
             </TableHead>
-            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Estado
+            <TableHead
+              className="h-9 px-3"
+              aria-sort={sortField === "active" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+            >
+              <SortableHeader field="active" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                Estado
+              </SortableHeader>
             </TableHead>
             <TableHead className="h-9 w-32 px-3" />
           </TableRow>
         </TableHeader>
         <TableBody>
-          {items.map((member) => {
+          {sortedItems.map((member) => {
             const ins = member.insurance;
             const expired = isExpired(ins?.end_date);
 

--- a/src/components/scoring-categories/scoring-categories-table.tsx
+++ b/src/components/scoring-categories/scoring-categories-table.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { Plus, Pencil, Trash2, Tags, Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -18,6 +18,10 @@ import {
 } from "@/components/ui/table";
 import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/shared/empty-state";
+import {
+  SortableHeader,
+  type SortDirection,
+} from "@/components/shared/sortable-header";
 import { ScoringCategoryDialog } from "@/components/scoring-categories/scoring-category-dialog";
 import { ScoringCategoryDeleteDialog } from "@/components/scoring-categories/scoring-category-delete-dialog";
 import type {
@@ -90,6 +94,10 @@ function TableSkeleton() {
   );
 }
 
+// ─── Sort types ───────────────────────────────────────────────────────────────
+
+type SortField = "name" | "max_points" | "active";
+
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 interface ScoringCategoriesTableProps {
@@ -130,6 +138,13 @@ export function ScoringCategoriesTable({
   const [categories, setCategories] = useState<ScoringCategory[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [sortField, setSortField] = useState<SortField>("name");
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+
+  const handleSort = (field: SortField, direction: SortDirection) => {
+    setSortField(field);
+    setSortDirection(direction);
+  };
 
   const [createOpen, setCreateOpen] = useState(false);
   const [editCategory, setEditCategory] = useState<ScoringCategory | null>(
@@ -225,6 +240,37 @@ export function ScoringCategoriesTable({
     }
   }
 
+  // ─── Sorted categories (must be before early returns to satisfy Rules of Hooks) ──
+
+  const sortedCategories = useMemo(() => {
+    const editableCategories = categories.filter(
+      (c) => c.origin_level === editableLevel,
+    );
+    const inheritedCategories = categories.filter(
+      (c) => c.origin_level !== editableLevel,
+    );
+    const combined = [...inheritedCategories, ...editableCategories];
+    return combined.sort((a, b) => {
+      const dir = sortDirection === "asc" ? 1 : -1;
+      switch (sortField) {
+        case "name":
+          return a.name.localeCompare(b.name) * dir;
+        case "max_points": {
+          const aMax = a.max_points ?? 0;
+          const bMax = b.max_points ?? 0;
+          return (aMax - bMax) * dir;
+        }
+        case "active": {
+          const aAct = a.active ? 1 : 0;
+          const bAct = b.active ? 1 : 0;
+          return (aAct - bAct) * dir;
+        }
+        default:
+          return 0;
+      }
+    });
+  }, [categories, editableLevel, sortField, sortDirection]);
+
   // ─── Render ─────────────────────────────────────────────────────────────────
 
   if (loading) return <TableSkeleton />;
@@ -243,14 +289,6 @@ export function ScoringCategoriesTable({
       </div>
     );
   }
-
-  const editableCategories = categories.filter(
-    (c) => c.origin_level === editableLevel,
-  );
-  const inheritedCategories = categories.filter(
-    (c) => c.origin_level !== editableLevel,
-  );
-  const sortedCategories = [...inheritedCategories, ...editableCategories];
 
   return (
     <div className="space-y-4">
@@ -284,19 +322,34 @@ export function ScoringCategoriesTable({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Nombre
+                <TableHead
+                  className="h-9 px-3"
+                  aria-sort={sortField === "name" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                >
+                  <SortableHeader field="name" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                    Nombre
+                  </SortableHeader>
                 </TableHead>
-                <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Pts. Máx.
+                <TableHead
+                  className="h-9 px-3"
+                  aria-sort={sortField === "max_points" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                >
+                  <SortableHeader field="max_points" activeField={sortField} direction={sortDirection} onSort={handleSort} align="right">
+                    Pts. Máx.
+                  </SortableHeader>
                 </TableHead>
                 {showOriginBadge && (
                   <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
                     Origen
                   </TableHead>
                 )}
-                <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Estado
+                <TableHead
+                  className="h-9 px-3"
+                  aria-sort={sortField === "active" ? (sortDirection === "asc" ? "ascending" : "descending") : "none"}
+                >
+                  <SortableHeader field="active" activeField={sortField} direction={sortDirection} onSort={handleSort}>
+                    Estado
+                  </SortableHeader>
                 </TableHead>
                 <TableHead className="h-9 px-3 w-[100px] text-xs font-medium uppercase tracking-wider text-muted-foreground">
                   Acciones


### PR DESCRIPTION
## Summary

Apply the `<SortableHeader>` component (PR #49) to four more tables in client-sort mode. All target endpoints return full lists with no pagination, so client-side sort is safe.

| Table | Sortable columns | Default | Notes |
|---|---|---|---|
| `insurance-table` | member_name (asc), insurance_type, provider, end_date, coverage_amount, active | member_name asc | Dates compared as timestamps |
| `scoring-categories-table` | name, max_points, active | name asc | Inherited/editable grouping kept as initial arrangement; sort applied on top |
| `annual-folders/rankings-client-page` | rank_position, club_name, composite_score_pct, total_earned_points, progress_percentage | rank_position asc | Secondary lg-only breakdown columns left static |
| `annual-folders/award-categories-client-page` | order, name, min_points, max_points, active | order asc | `max_points` nullable handled — `null` sorts last asc |

## Skipped

- `src/components/units/units-tab.tsx` — renders `UnitDetailPanel` cards, no `<Table>` to attach to.

## Constraints respected

- Mobile card layouts untouched
- Action columns untouched
- No new lint errors/warnings on touched files

## Test plan

- [ ] CI typecheck (#56) passes
- [ ] Each affected page: clicking a sortable column toggles asc/desc, chevrons update, `aria-sort` reflects state
- [ ] Default sort matches the prior UX (rank order, alphabetical, etc.)