### PR TITLE
fix(scoring-categories): hoist category derivations out of sortedCategories memo

### DIFF
--- a/src/components/scoring-categories/scoring-categories-table.tsx
+++ b/src/components/scoring-categories/scoring-categories-table.tsx
@@ -242,13 +242,16 @@ export function ScoringCategoriesTable({
 
   // ─── Sorted categories (must be before early returns to satisfy Rules of Hooks) ──
 
+  const editableCategories = useMemo(
+    () => categories.filter((c) => c.origin_level === editableLevel),
+    [categories, editableLevel],
+  );
+  const inheritedCategories = useMemo(
+    () => categories.filter((c) => c.origin_level !== editableLevel),
+    [categories, editableLevel],
+  );
+
   const sortedCategories = useMemo(() => {
-    const editableCategories = categories.filter(
-      (c) => c.origin_level === editableLevel,
-    );
-    const inheritedCategories = categories.filter(
-      (c) => c.origin_level !== editableLevel,
-    );
     const combined = [...inheritedCategories, ...editableCategories];
     return combined.sort((a, b) => {
       const dir = sortDirection === "asc" ? 1 : -1;
@@ -269,7 +272,7 @@ export function ScoringCategoriesTable({
           return 0;
       }
     });
-  }, [categories, editableLevel, sortField, sortDirection]);
+  }, [editableCategories, inheritedCategories, sortField, sortDirection]);
 
   // ─── Render ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

PR #57 moved `editableCategories` and `inheritedCategories` derivations inside the `sortedCategories` useMemo, but the JSX header still reads `inheritedCategories.length` / `editableCategories.length` for the count summary line. Result: `TS2552 — Cannot find name 'inheritedCategories'` × 5 in `tsc --noEmit`.

Hoist both filters into their own `useMemo`s with the same deps. `sortedCategories` now consumes them as inputs.

## Why caught now

PR #56 just added `tsc --noEmit` to CI, which surfaced this regression. Vercel's `next build` would have caught it on the next deploy regardless.

## Test plan

- [ ] CI typecheck passes
- [ ] `/dashboard/scoring-categories` (or wherever this table lives) — count summary renders correctly: `N heredada(s), M propia(s)`
- [ ] Sorting by name / max_points / active still works