### PR TITLE
chore(ci): add Vitest tests workflow on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+      - preproduction
+      - development
+
+jobs:
+  vitest:
+    name: Vitest unit tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test


### PR DESCRIPTION
## Summary

- Mirror of `.github/workflows/typecheck.yml` (PR #56) but runs `pnpm test` (= `vitest run`).
- Triggers on PRs targeting `main`, `preproduction`, `development`.
- Same Node 22 + pnpm 10 + frozen-lockfile install pattern.

## Why

PR #58 added 37 Vitest tests. Without a CI gate, future PRs can break tests undetected until someone runs them locally. This adds the safety net.

## Test plan

- [ ] CI runs the `Vitest unit tests` job on this PR and reports pass
- [ ] No interaction with the existing `Typecheck` workflow — both run in parallel