### PR TITLE
feat(i18n): migrate dashboard hub-page strings to next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -316,6 +316,70 @@
       "ecclesiastical_year": "Ecclesiastical year"
     }
   },
+  "dashboardHub": {
+    "title": "Dashboard",
+    "description": "General system overview for SACDIA.",
+    "stats": {
+      "registeredUsers": "Registered users",
+      "pendingApproval": "{count} pending approval",
+      "totalInSystem": "Total in the system",
+      "activeClubs": "Active clubs",
+      "totalClubs": "{count} clubs total",
+      "activeClubsStatus": "Clubs with active status",
+      "camporees": "Camporees",
+      "activeEvents": "Active events",
+      "honors": "Honors",
+      "totalClasses": "{count} classes registered",
+      "totalHonors": "Total honors"
+    },
+    "recentUsers": {
+      "title": "Recent users",
+      "description": "Latest registrations in the system",
+      "viewAll": "View all",
+      "noRole": "No role",
+      "loadError": "Could not load recent users."
+    },
+    "relativeDate": {
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "daysAgo": "{count} days ago",
+      "weeksAgo": "{count} wk. ago"
+    },
+    "roleChart": {
+      "title": "Role distribution",
+      "description": "Assignments in the last 100 users",
+      "noRolesFound": "No assigned roles found in the sample.",
+      "basedOn": "Based on the last {count} registered users",
+      "userCount": "{count, plural, one {{count} user} other {{count} users}} — {percentage}%"
+    },
+    "quickLinks": {
+      "title": "Quick links",
+      "users": "Users",
+      "usersDesc": "Manage accounts",
+      "clubs": "Clubs",
+      "clubsDesc": "Manage clubs",
+      "classes": "Classes",
+      "classesDesc": "View and edit classes",
+      "honors": "Honors",
+      "honorsDesc": "Manage honors"
+    },
+    "roleLabels": {
+      "superAdmin": "Super Admin",
+      "admin": "Admin",
+      "assistantAdmin": "Asst. Admin",
+      "coordinator": "Coordinator",
+      "pastor": "Pastor",
+      "user": "User",
+      "director": "Director",
+      "deputyDirector": "Deputy Director",
+      "secretary": "Secretary",
+      "treasurer": "Treasurer",
+      "counselor": "Counselor",
+      "instructor": "Instructor",
+      "member": "Member",
+      "noRole": "No role"
+    }
+  },
   "post_registration": {
     "errors": {
       "step_failed": "Failed to complete step {step}"

--- a/messages/es.json
+++ b/messages/es.json
@@ -316,6 +316,70 @@
       "ecclesiastical_year": "Año eclesiástico"
     }
   },
+  "dashboardHub": {
+    "title": "Dashboard",
+    "description": "Resumen general del sistema SACDIA.",
+    "stats": {
+      "registeredUsers": "Usuarios registrados",
+      "pendingApproval": "{count} pendientes de aprobación",
+      "totalInSystem": "Total en el sistema",
+      "activeClubs": "Clubes activos",
+      "totalClubs": "{count} clubes en total",
+      "activeClubsStatus": "Clubes con estado activo",
+      "camporees": "Camporees",
+      "activeEvents": "Eventos activos",
+      "honors": "Especialidades",
+      "totalClasses": "{count} clases registradas",
+      "totalHonors": "Total de especialidades"
+    },
+    "recentUsers": {
+      "title": "Usuarios recientes",
+      "description": "Últimos registros en el sistema",
+      "viewAll": "Ver todos",
+      "noRole": "Sin rol",
+      "loadError": "No se pudieron cargar los usuarios recientes."
+    },
+    "relativeDate": {
+      "today": "Hoy",
+      "yesterday": "Ayer",
+      "daysAgo": "Hace {count} días",
+      "weeksAgo": "Hace {count} sem."
+    },
+    "roleChart": {
+      "title": "Distribución de roles",
+      "description": "Asignaciones en los últimos 100 usuarios",
+      "noRolesFound": "No se encontraron roles asignados en la muestra.",
+      "basedOn": "Basado en los últimos {count} usuarios registrados",
+      "userCount": "{count, plural, one {{count} usuario} other {{count} usuarios}} — {percentage}%"
+    },
+    "quickLinks": {
+      "title": "Accesos rápidos",
+      "users": "Usuarios",
+      "usersDesc": "Gestionar cuentas",
+      "clubs": "Clubes",
+      "clubsDesc": "Administrar clubes",
+      "classes": "Clases",
+      "classesDesc": "Ver y editar clases",
+      "honors": "Especialidades",
+      "honorsDesc": "Gestionar honores"
+    },
+    "roleLabels": {
+      "superAdmin": "Super Admin",
+      "admin": "Admin",
+      "assistantAdmin": "Asist. Admin",
+      "coordinator": "Coordinador",
+      "pastor": "Pastor",
+      "user": "Usuario",
+      "director": "Director",
+      "deputyDirector": "Subdirector",
+      "secretary": "Secretario",
+      "treasurer": "Tesorero",
+      "counselor": "Consejero",
+      "instructor": "Instructor",
+      "member": "Miembro",
+      "noRole": "Sin rol"
+    }
+  },
   "post_registration": {
     "errors": {
       "step_failed": "Error al completar el paso {step}"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -316,6 +316,70 @@
       "ecclesiastical_year": "Année ecclésiastique"
     }
   },
+  "dashboardHub": {
+    "title": "Tableau de bord",
+    "description": "Vue d'ensemble générale du système SACDIA.",
+    "stats": {
+      "registeredUsers": "Utilisateurs enregistrés",
+      "pendingApproval": "{count} en attente d'approbation",
+      "totalInSystem": "Total dans le système",
+      "activeClubs": "Clubs actifs",
+      "totalClubs": "{count} clubs au total",
+      "activeClubsStatus": "Clubs avec statut actif",
+      "camporees": "Camporees",
+      "activeEvents": "Événements actifs",
+      "honors": "Spécialités",
+      "totalClasses": "{count} classes enregistrées",
+      "totalHonors": "Total des spécialités"
+    },
+    "recentUsers": {
+      "title": "Utilisateurs récents",
+      "description": "Dernières inscriptions dans le système",
+      "viewAll": "Voir tout",
+      "noRole": "Sans rôle",
+      "loadError": "Impossible de charger les utilisateurs récents."
+    },
+    "relativeDate": {
+      "today": "Aujourd'hui",
+      "yesterday": "Hier",
+      "daysAgo": "Il y a {count} jours",
+      "weeksAgo": "Il y a {count} sem."
+    },
+    "roleChart": {
+      "title": "Répartition des rôles",
+      "description": "Attributions dans les 100 derniers utilisateurs",
+      "noRolesFound": "Aucun rôle attribué trouvé dans l'échantillon.",
+      "basedOn": "Basé sur les {count} derniers utilisateurs enregistrés",
+      "userCount": "{count, plural, one {{count} utilisateur} other {{count} utilisateurs}} — {percentage}%"
+    },
+    "quickLinks": {
+      "title": "Accès rapides",
+      "users": "Utilisateurs",
+      "usersDesc": "Gérer les comptes",
+      "clubs": "Clubs",
+      "clubsDesc": "Administrer les clubs",
+      "classes": "Classes",
+      "classesDesc": "Voir et modifier les classes",
+      "honors": "Spécialités",
+      "honorsDesc": "Gérer les spécialités"
+    },
+    "roleLabels": {
+      "superAdmin": "Super Admin",
+      "admin": "Admin",
+      "assistantAdmin": "Assist. Admin",
+      "coordinator": "Coordinateur",
+      "pastor": "Pasteur",
+      "user": "Utilisateur",
+      "director": "Directeur",
+      "deputyDirector": "Sous-directeur",
+      "secretary": "Secrétaire",
+      "treasurer": "Trésorier",
+      "counselor": "Conseiller",
+      "instructor": "Instructeur",
+      "member": "Membre",
+      "noRole": "Sans rôle"
+    }
+  },
   "post_registration": {
     "errors": {
       "step_failed": "Échec de l'étape {step}"

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -316,6 +316,70 @@
       "ecclesiastical_year": "Ano eclesiástico"
     }
   },
+  "dashboardHub": {
+    "title": "Painel",
+    "description": "Resumo geral do sistema SACDIA.",
+    "stats": {
+      "registeredUsers": "Usuários registrados",
+      "pendingApproval": "{count} pendentes de aprovação",
+      "totalInSystem": "Total no sistema",
+      "activeClubs": "Clubes ativos",
+      "totalClubs": "{count} clubes no total",
+      "activeClubsStatus": "Clubes com status ativo",
+      "camporees": "Camporeias",
+      "activeEvents": "Eventos ativos",
+      "honors": "Especialidades",
+      "totalClasses": "{count} classes registradas",
+      "totalHonors": "Total de especialidades"
+    },
+    "recentUsers": {
+      "title": "Usuários recentes",
+      "description": "Últimos registros no sistema",
+      "viewAll": "Ver todos",
+      "noRole": "Sem função",
+      "loadError": "Não foi possível carregar os usuários recentes."
+    },
+    "relativeDate": {
+      "today": "Hoje",
+      "yesterday": "Ontem",
+      "daysAgo": "Há {count} dias",
+      "weeksAgo": "Há {count} sem."
+    },
+    "roleChart": {
+      "title": "Distribuição de funções",
+      "description": "Atribuições nos últimos 100 usuários",
+      "noRolesFound": "Nenhuma função atribuída encontrada na amostra.",
+      "basedOn": "Baseado nos últimos {count} usuários registrados",
+      "userCount": "{count, plural, one {{count} usuário} other {{count} usuários}} — {percentage}%"
+    },
+    "quickLinks": {
+      "title": "Acesso rápido",
+      "users": "Usuários",
+      "usersDesc": "Gerenciar contas",
+      "clubs": "Clubes",
+      "clubsDesc": "Administrar clubes",
+      "classes": "Classes",
+      "classesDesc": "Ver e editar classes",
+      "honors": "Especialidades",
+      "honorsDesc": "Gerenciar especialidades"
+    },
+    "roleLabels": {
+      "superAdmin": "Super Admin",
+      "admin": "Admin",
+      "assistantAdmin": "Assist. Admin",
+      "coordinator": "Coordenador",
+      "pastor": "Pastor",
+      "user": "Usuário",
+      "director": "Diretor",
+      "deputyDirector": "Subdiretor",
+      "secretary": "Secretário",
+      "treasurer": "Tesoureiro",
+      "counselor": "Conselheiro",
+      "instructor": "Instrutor",
+      "member": "Membro",
+      "noRole": "Sem função"
+    }
+  },
   "post_registration": {
     "errors": {
       "step_failed": "Erro ao concluir a etapa {step}"

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/dashboard/role-distribution-chart";
 import { cn } from "@/lib/utils";
 import { PageHeader } from "@/components/shared/page-header";
+import { getTranslations } from "next-intl/server";
 
 type StatsData = {
   totalUsers: number | null;
@@ -279,18 +280,29 @@ function extractRoleNames(user: RecentUser): string[] {
   return [...new Set(roles)];
 }
 
-function formatRelativeDate(dateStr?: string | null): string {
+type RelativeDateTranslations = {
+  today: string;
+  yesterday: string;
+  daysAgo: (count: number) => string;
+  weeksAgo: (count: number) => string;
+};
+
+function formatRelativeDate(
+  dateStr: string | null | undefined,
+  tx: RelativeDateTranslations,
+  locale: string
+): string {
   if (!dateStr) return "—";
   try {
     const date = new Date(dateStr);
     const now = new Date();
     const diffMs = now.getTime() - date.getTime();
     const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
-    if (diffDays === 0) return "Hoy";
-    if (diffDays === 1) return "Ayer";
-    if (diffDays < 7) return `Hace ${diffDays} días`;
-    if (diffDays < 30) return `Hace ${Math.floor(diffDays / 7)} sem.`;
-    return date.toLocaleDateString("es-MX", {
+    if (diffDays === 0) return tx.today;
+    if (diffDays === 1) return tx.yesterday;
+    if (diffDays < 7) return tx.daysAgo(diffDays);
+    if (diffDays < 30) return tx.weeksAgo(Math.floor(diffDays / 7));
+    return date.toLocaleDateString(locale, {
       day: "numeric",
       month: "short",
       year: "numeric",
@@ -301,40 +313,41 @@ function formatRelativeDate(dateStr?: string | null): string {
 }
 
 async function StatsSection() {
+  const t = await getTranslations("dashboardHub");
   const stats = await fetchStats();
 
   const statCards = [
     {
-      title: "Usuarios registrados",
+      title: t("stats.registeredUsers"),
       value: stats.totalUsers,
       subtitle:
         stats.pendingUsers !== null
-          ? `${stats.pendingUsers} pendientes de aprobación`
-          : "Total en el sistema",
+          ? t("stats.pendingApproval", { count: stats.pendingUsers })
+          : t("stats.totalInSystem"),
       icon: Users,
     },
     {
-      title: "Clubes activos",
+      title: t("stats.activeClubs"),
       value: stats.activeClubs,
       subtitle:
         stats.totalClubs !== null
-          ? `${stats.totalClubs} clubes en total`
-          : "Clubes con estado activo",
+          ? t("stats.totalClubs", { count: stats.totalClubs })
+          : t("stats.activeClubsStatus"),
       icon: Building2,
     },
     {
-      title: "Camporees",
+      title: t("stats.camporees"),
       value: stats.activeCamporees,
-      subtitle: "Eventos activos",
+      subtitle: t("stats.activeEvents"),
       icon: Tent,
     },
     {
-      title: "Especialidades",
+      title: t("stats.honors"),
       value: stats.totalHonors,
       subtitle:
         stats.totalClasses !== null
-          ? `${stats.totalClasses} clases registradas`
-          : "Total de especialidades",
+          ? t("stats.totalClasses", { count: stats.totalClasses })
+          : t("stats.totalHonors"),
       icon: Award,
     },
   ];
@@ -349,27 +362,35 @@ async function StatsSection() {
 }
 
 async function RecentUsersSection() {
+  const t = await getTranslations("dashboardHub");
   const users = await fetchRecentUsers();
+
+  const relativeDateTx: RelativeDateTranslations = {
+    today: t("relativeDate.today"),
+    yesterday: t("relativeDate.yesterday"),
+    daysAgo: (count) => t("relativeDate.daysAgo", { count }),
+    weeksAgo: (count) => t("relativeDate.weeksAgo", { count }),
+  };
 
   if (users.length === 0) {
     return (
       <Card className="col-span-2">
         <CardHeader className="flex flex-row items-center justify-between">
           <div>
-            <CardTitle className="text-base">Usuarios recientes</CardTitle>
-            <CardDescription>Últimos registros en el sistema</CardDescription>
+            <CardTitle className="text-base">{t("recentUsers.title")}</CardTitle>
+            <CardDescription>{t("recentUsers.description")}</CardDescription>
           </div>
           <Link
             href="/dashboard/users"
             className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
           >
-            Ver todos
+            {t("recentUsers.viewAll")}
             <ArrowRight className="size-3" />
           </Link>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground">
-            No se pudieron cargar los usuarios recientes.
+            {t("recentUsers.loadError")}
           </p>
         </CardContent>
       </Card>
@@ -380,14 +401,14 @@ async function RecentUsersSection() {
     <Card className="col-span-2">
       <CardHeader className="flex flex-row items-center justify-between pb-4">
         <div>
-          <CardTitle className="text-base">Usuarios recientes</CardTitle>
-          <CardDescription>Últimos registros en el sistema</CardDescription>
+          <CardTitle className="text-base">{t("recentUsers.title")}</CardTitle>
+          <CardDescription>{t("recentUsers.description")}</CardDescription>
         </div>
         <Link
           href="/dashboard/users"
           className="flex items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
         >
-          Ver todos
+          {t("recentUsers.viewAll")}
           <ArrowRight className="size-3" />
         </Link>
       </CardHeader>
@@ -434,7 +455,7 @@ async function RecentUsersSection() {
                     ))
                   ) : (
                     <Badge variant="outline" className="text-xs font-normal">
-                      Sin rol
+                      {t("recentUsers.noRole")}
                     </Badge>
                   )}
                 </div>
@@ -448,7 +469,7 @@ async function RecentUsersSection() {
                     )}
                   />
                   <span className="hidden text-xs tabular-nums text-muted-foreground lg:inline">
-                    {formatRelativeDate(user.created_at)}
+                    {formatRelativeDate(user.created_at, relativeDateTx, "es-MX")}
                   </span>
                 </div>
               </div>
@@ -460,36 +481,38 @@ async function RecentUsersSection() {
   );
 }
 
-const quickLinks = [
-  {
-    title: "Usuarios",
-    description: "Gestionar cuentas",
-    href: "/dashboard/users",
-    icon: Users,
-    colorIndex: 0, // primary
-  },
-  {
-    title: "Clubes",
-    description: "Administrar clubes",
-    href: "/dashboard/clubs",
-    icon: Building2,
-    colorIndex: 3, // info
-  },
-  {
-    title: "Clases",
-    description: "Ver y editar clases",
-    href: "/dashboard/classes",
-    icon: GraduationCap,
-    colorIndex: 1, // success
-  },
-  {
-    title: "Especialidades",
-    description: "Gestionar honores",
-    href: "/dashboard/honors",
-    icon: Award,
-    colorIndex: 2, // warning
-  },
-];
+async function buildQuickLinks(t: Awaited<ReturnType<typeof getTranslations<"dashboardHub">>>) {
+  return [
+    {
+      title: t("quickLinks.users"),
+      description: t("quickLinks.usersDesc"),
+      href: "/dashboard/users",
+      icon: Users,
+      colorIndex: 0, // primary
+    },
+    {
+      title: t("quickLinks.clubs"),
+      description: t("quickLinks.clubsDesc"),
+      href: "/dashboard/clubs",
+      icon: Building2,
+      colorIndex: 3, // info
+    },
+    {
+      title: t("quickLinks.classes"),
+      description: t("quickLinks.classesDesc"),
+      href: "/dashboard/classes",
+      icon: GraduationCap,
+      colorIndex: 1, // success
+    },
+    {
+      title: t("quickLinks.honors"),
+      description: t("quickLinks.honorsDesc"),
+      href: "/dashboard/honors",
+      icon: Award,
+      colorIndex: 2, // warning
+    },
+  ];
+}
 
 function StatsSkeleton() {
   return (
@@ -511,6 +534,7 @@ function StatsSkeleton() {
 }
 
 async function RoleDistributionSection() {
+  const t = await getTranslations("dashboardHub");
   const { data, sampleSize } = await fetchRoleDistribution();
 
   return (
@@ -518,8 +542,8 @@ async function RoleDistributionSection() {
       <CardHeader className="pb-4">
         <div className="flex items-start justify-between">
           <div>
-            <CardTitle className="text-base">Distribución de roles</CardTitle>
-            <CardDescription>Asignaciones en los últimos 100 usuarios</CardDescription>
+            <CardTitle className="text-base">{t("roleChart.title")}</CardTitle>
+            <CardDescription>{t("roleChart.description")}</CardDescription>
           </div>
           <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10">
             <TrendingUp className="size-4 text-primary" />
@@ -590,12 +614,14 @@ function RecentUsersSkeleton() {
 
 export default async function DashboardPage() {
   await requireAdminUser();
+  const t = await getTranslations("dashboardHub");
+  const quickLinks = await buildQuickLinks(t);
 
   return (
     <div className="space-y-8">
       <PageHeader
-        title="Dashboard"
-        description="Resumen general del sistema SACDIA."
+        title={t("title")}
+        description={t("description")}
       />
 
       {/* Stats grid */}
@@ -617,7 +643,7 @@ export default async function DashboardPage() {
       {/* Quick links */}
       <div>
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-base font-semibold">Accesos rápidos</h2>
+          <h2 className="text-base font-semibold">{t("quickLinks.title")}</h2>
         </div>
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
           {quickLinks.map((link) => {

--- a/src/components/dashboard/role-distribution-chart.tsx
+++ b/src/components/dashboard/role-distribution-chart.tsx
@@ -9,6 +9,7 @@ import {
   ResponsiveContainer,
   Cell,
 } from "recharts";
+import { useTranslations } from "next-intl";
 
 export type RoleDistributionEntry = {
   role: string;
@@ -16,21 +17,21 @@ export type RoleDistributionEntry = {
   percentage: number;
 };
 
-const ROLE_LABELS: Record<string, string> = {
-  "super-admin": "Super Admin",
-  admin: "Admin",
-  "assistant-admin": "Asist. Admin",
-  coordinator: "Coordinador",
-  pastor: "Pastor",
-  user: "Usuario",
-  director: "Director",
-  "deputy-director": "Subdirector",
-  secretary: "Secretario",
-  treasurer: "Tesorero",
-  counselor: "Consejero",
-  instructor: "Instructor",
-  member: "Miembro",
-  sin_rol: "Sin rol",
+const ROLE_LABEL_KEYS: Record<string, string> = {
+  "super-admin": "superAdmin",
+  admin: "admin",
+  "assistant-admin": "assistantAdmin",
+  coordinator: "coordinator",
+  pastor: "pastor",
+  user: "user",
+  director: "director",
+  "deputy-director": "deputyDirector",
+  secretary: "secretary",
+  treasurer: "treasurer",
+  counselor: "counselor",
+  instructor: "instructor",
+  member: "member",
+  sin_rol: "noRole",
 };
 
 const ROLE_COLORS: Record<string, string> = {
@@ -52,10 +53,6 @@ const ROLE_COLORS: Record<string, string> = {
 
 const DEFAULT_COLOR = "color-mix(in oklch, var(--muted-foreground) 40%, transparent)";
 
-function roleLabel(role: string): string {
-  return ROLE_LABELS[role] ?? role.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-}
-
 function roleColor(role: string): string {
   return ROLE_COLORS[role] ?? DEFAULT_COLOR;
 }
@@ -63,16 +60,18 @@ function roleColor(role: string): string {
 interface CustomTooltipProps {
   active?: boolean;
   payload?: Array<{ payload: RoleDistributionEntry }>;
+  roleLabel: (role: string) => string;
+  userCount: (count: number, percentage: string) => string;
 }
 
-function CustomTooltip({ active, payload }: CustomTooltipProps) {
+function CustomTooltip({ active, payload, roleLabel, userCount }: CustomTooltipProps) {
   if (!active || !payload?.length) return null;
   const entry = payload[0].payload;
   return (
     <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
       <p className="font-medium">{roleLabel(entry.role)}</p>
       <p className="text-muted-foreground">
-        {entry.count} usuario{entry.count !== 1 ? "s" : ""} &mdash; {entry.percentage.toFixed(1)}%
+        {userCount(entry.count, entry.percentage.toFixed(1))}
       </p>
     </div>
   );
@@ -84,10 +83,24 @@ interface RoleDistributionChartProps {
 }
 
 export function RoleDistributionChart({ data, sampleSize }: RoleDistributionChartProps) {
+  const t = useTranslations("dashboardHub");
+
+  function roleLabel(role: string): string {
+    const key = ROLE_LABEL_KEYS[role];
+    if (key) {
+      return t(`roleLabels.${key}` as Parameters<typeof t>[0]);
+    }
+    return role.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  function userCount(count: number, percentage: string): string {
+    return t("roleChart.userCount", { count, percentage });
+  }
+
   if (data.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
-        No se encontraron roles asignados en la muestra.
+        {t("roleChart.noRolesFound")}
       </p>
     );
   }
@@ -106,7 +119,15 @@ export function RoleDistributionChart({ data, sampleSize }: RoleDistributionChar
             tickLine={false}
             axisLine={false}
           />
-          <Tooltip content={<CustomTooltip />} cursor={{ fill: "color-mix(in oklch, var(--muted) 40%, transparent)" }} />
+          <Tooltip
+            content={
+              <CustomTooltip
+                roleLabel={roleLabel}
+                userCount={userCount}
+              />
+            }
+            cursor={{ fill: "color-mix(in oklch, var(--muted) 40%, transparent)" }}
+          />
           <Bar dataKey="count" radius={[0, 4, 4, 0]} maxBarSize={18}>
             {data.map((entry) => (
               <Cell key={entry.role} fill={roleColor(entry.role)} />
@@ -116,7 +137,7 @@ export function RoleDistributionChart({ data, sampleSize }: RoleDistributionChar
       </ResponsiveContainer>
 
       <p className="text-[11px] text-muted-foreground">
-        Basado en los últimos {sampleSize} usuarios registrados
+        {t("roleChart.basedOn", { count: sampleSize })}
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary

First batch of the next-intl coverage rollout. Migrates the dashboard hub-page (`src/app/(dashboard)/dashboard/page.tsx`) and `role-distribution-chart.tsx` from hardcoded Spanish to `next-intl`, adding a new `dashboardHub` namespace with 44 keys to all 4 locales.

## Files changed

| File | What |
|---|---|
| `messages/{en,es,fr,pt-BR}.json` | New `dashboardHub` namespace, 44 keys each |
| `src/app/(dashboard)/dashboard/page.tsx` | Server component — `getTranslations("dashboardHub")` |
| `src/components/dashboard/role-distribution-chart.tsx` | Client component — `useTranslations("dashboardHub")` |

## Pattern reference (for future i18n PRs)

- **Server (RSC)**: `getTranslations("namespace")` from `next-intl/server`. Sub-components in async boundaries call it independently — Suspense boundaries stay intact.
- **Client**: `useTranslations("namespace")` from `next-intl`.
- **Pure helpers**: accept a typed translation bag so the helper stays synchronous and locale-aware (see `formatRelativeDate`).
- **Backend slug → i18n key**: a small static map (`ROLE_LABEL_KEYS`) bridges backend role slugs to camelCase keys.

## Out of scope

- `PageHeader` migration — used in 79 files; call sites pass already-translated `title`/`description`, the component itself has no hardcoded text. Feature-wide PR if/when needed.
- Locale-aware `toLocaleDateString` fallback — still hardcoded `es-MX`. Worth a separate PR once locale routing lands.

## Caveat

French and Portuguese-BR translations are best-effort. A native-speaker pass on `fr.json → roleChart.userCount` (ICU plural) and `pt-BR.json → stats.camporees` ("Camporeias" — confirm regional term) is recommended.

## Test plan

- [ ] CI typecheck (#56) passes
- [ ] CI tests (#60 once merged) passes
- [ ] `/dashboard` renders with all 4 locales without missing-key warnings
- [ ] Stats cards, recent users, role chart, quick links all render correctly in `es`