### PR TITLE
fix(finances): centralize currency formatting to MXN (audit C1)

### DIFF
--- a/src/components/clubs/club-sections-panel.tsx
+++ b/src/components/clubs/club-sections-panel.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import { createClubSectionAction, type ClubActionState } from "@/lib/clubs/actions";
 import { MemberOfMonthCard } from "@/components/member-of-month/member-of-month-card";
+import { formatCurrency } from "@/lib/currency";
 
 type Section = {
   club_section_id?: number;
@@ -244,7 +245,7 @@ export function ClubSectionsPanel({ clubId, sections, clubTypes }: ClubSectionsP
                   <InfoRow label="Meta de almas" value={section.souls_target} />
                 )}
                 {section.fee != null && (
-                  <InfoRow label="Cuota" value={`$${section.fee}`} />
+                  <InfoRow label="Cuota" value={formatCurrency(section.fee)} />
                 )}
                 {section.members_count != null && (
                   <InfoRow

--- a/src/components/finances/delete-transaction-dialog.tsx
+++ b/src/components/finances/delete-transaction-dialog.tsx
@@ -15,13 +15,10 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useTranslations } from "next-intl";
 import { deleteFinance, type Finance } from "@/lib/api/finances";
+import { formatCurrency } from "@/lib/currency";
 
 function formatAmount(cents: number): string {
-  return new Intl.NumberFormat("es-MX", {
-    style: "currency",
-    currency: "ARS",
-    minimumFractionDigits: 2,
-  }).format(cents / 100);
+  return formatCurrency(cents / 100);
 }
 
 interface DeleteTransactionDialogProps {

--- a/src/components/finances/finances-summary-cards.tsx
+++ b/src/components/finances/finances-summary-cards.tsx
@@ -4,16 +4,12 @@ import { TrendingUp, TrendingDown, Wallet } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { FinanceSummary } from "@/lib/api/finances";
+import { formatCurrency } from "@/lib/currency";
 
 // ─── Amount formatter ─────────────────────────────────────────────────────────
 
 function formatAmount(cents: number): string {
-  const pesos = cents / 100;
-  return new Intl.NumberFormat("es-MX", {
-    style: "currency",
-    currency: "ARS",
-    minimumFractionDigits: 2,
-  }).format(pesos);
+  return formatCurrency(cents / 100);
 }
 
 // ─── Skeleton ─────────────────────────────────────────────────────────────────

--- a/src/components/finances/transaction-form-dialog.tsx
+++ b/src/components/finances/transaction-form-dialog.tsx
@@ -286,7 +286,7 @@ export function TransactionFormDialog({
           {/* Monto */}
           <div className="space-y-1.5">
             <Label htmlFor="amount">
-              Monto (ARS){" "}
+              Monto{" "}
               <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Input

--- a/src/components/finances/transactions-table.tsx
+++ b/src/components/finances/transactions-table.tsx
@@ -26,16 +26,12 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { DollarSign } from "lucide-react";
 import type { Finance, FinanceSortField } from "@/lib/api/finances";
+import { formatCurrency } from "@/lib/currency";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatAmount(cents: number): string {
-  const pesos = cents / 100;
-  return new Intl.NumberFormat("es-MX", {
-    style: "currency",
-    currency: "ARS",
-    minimumFractionDigits: 2,
-  }).format(pesos);
+  return formatCurrency(cents / 100);
 }
 
 function formatDate(dateStr: string): string {

--- a/src/components/insurance/insurance-table.tsx
+++ b/src/components/insurance/insurance-table.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/shared/sortable-header";
 import { INSURANCE_TYPE_LABELS } from "@/lib/api/insurance";
 import type { MemberInsurance, InsuranceType } from "@/lib/api/insurance";
+import { formatCurrency as formatCurrencyUtil } from "@/lib/currency";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -37,11 +38,7 @@ function formatDate(value: string | null | undefined): string {
 
 function formatCurrency(value: number | null | undefined): string {
   if (value == null) return "—";
-  return new Intl.NumberFormat("es-MX", {
-    style: "currency",
-    currency: "ARS",
-    maximumFractionDigits: 0,
-  }).format(value);
+  return formatCurrencyUtil(value);
 }
 
 function memberFullName(member: MemberInsurance): string {

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,0 +1,10 @@
+export function formatCurrency(
+  amount: number,
+  currency: string = "MXN",
+  locale: string = "es-MX",
+): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+  }).format(amount);
+}


### PR DESCRIPTION
## Summary
- Replace 5 hardcoded `Intl.NumberFormat` instances using `currency: "ARS"` with a shared `formatCurrency()` util defaulting to MXN
- Remove hardcoded `"Monto (ARS)"` form label, now `"Monto"`
- Also fixes club-sections fee using raw `${section.fee}` template literal

## Why
Sistema México formateaba dinero como peso argentino. Bug correctness, no estilo. Treasurers exportando reportes verían amounts ARS sobre data MXN. Fix audit findings C1 (UX critical).

## Files
- new: `src/lib/currency.ts`
- `src/components/finances/{transactions-table,finances-summary-cards,transaction-form-dialog,delete-transaction-dialog}.tsx`
- `src/components/insurance/insurance-table.tsx`
- `src/components/clubs/club-sections-panel.tsx`

## Test plan
- [ ] `pnpm typecheck` no new errors
- [ ] `rg 'currency:\s*"ARS"' src/` returns 0 matches
- [ ] Visual smoke: dashboard finances shows MXN symbol ($), insurance "Vigente" amounts MXN
- [ ] Transaction form label "Monto" no parenthetical currency code