### PR TITLE
fix(a11y): pagination disabled state real, not styled (audit C4)

### DIFF
--- a/src/components/shared/data-table-pagination.tsx
+++ b/src/components/shared/data-table-pagination.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -68,15 +67,25 @@ export function DataTablePagination({
           <span className="text-sm text-muted-foreground">
             Página {page} de {totalPages}
           </span>
-          <Button variant="outline" size="icon" className="size-8" asChild disabled={page <= 1}>
-            <Link href={buildHref(page - 1)} aria-label="Página anterior">
-              <ChevronLeft className="size-4" />
-            </Link>
+          <Button
+            variant="outline"
+            size="icon"
+            className="size-8"
+            disabled={page <= 1}
+            aria-label="Página anterior"
+            onClick={() => router.push(buildHref(page - 1))}
+          >
+            <ChevronLeft className="size-4" />
           </Button>
-          <Button variant="outline" size="icon" className="size-8" asChild disabled={page >= totalPages}>
-            <Link href={buildHref(page + 1)} aria-label="Página siguiente">
-              <ChevronRight className="size-4" />
-            </Link>
+          <Button
+            variant="outline"
+            size="icon"
+            className="size-8"
+            disabled={page >= totalPages}
+            aria-label="Página siguiente"
+            onClick={() => router.push(buildHref(page + 1))}
+          >
+            <ChevronRight className="size-4" />
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Refactor `DataTablePagination` prev/next from `<Button asChild disabled><Link/></Button>` to real `<Button onClick={() => router.push(...)} disabled>`
- HTML anchors don't support `disabled` — links stayed keyboard-activatable on page bounds despite visual disabled state
- Component is already `"use client"` with hooks, so no SSR regression

## Why
Fixes WCAG 2.1.1 (Keyboard) y 4.1.2 (Name, Role, Value). Audit critical C4. Users on page 1 podían navegar a page 0/-1 (server retornaba vacío).

## Test plan
- [ ] `pnpm typecheck` clean
- [ ] Manual: page 1 — botón "Página anterior" no debe responder a click ni Enter/Space ni Tab activation
- [ ] Manual: última página — botón "Página siguiente" mismo comportamiento
- [ ] Verify cualquier paginated table (clubs, users, transactions) navegación normal funciona