### PR TITLE
fix(ui): active/vigente badges use soft-success variant (audit C1-vis)

### DIFF
--- a/src/app/(dashboard)/dashboard/activities/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/activities/[id]/page.tsx
@@ -186,7 +186,7 @@ export default async function ActivityDetailPage({ params }: { params: Params })
           </div>
           <div className="flex items-center gap-2">
             <Badge variant="secondary">{typeLabel}</Badge>
-            <Badge variant={activity.active ? "default" : "outline"}>
+            <Badge variant={activity.active ? "soft-success" : "outline"}>
               {activity.active ? "Activa" : "Inactiva"}
             </Badge>
           </div>

--- a/src/app/(dashboard)/dashboard/catalogs/honor-categories/[categoryId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/honor-categories/[categoryId]/page.tsx
@@ -160,7 +160,7 @@ export default async function HonorCategoryDetailPage({ params }: { params: Para
             <p className="text-sm text-muted-foreground">Categoría de especialidades</p>
           </div>
 
-          <Badge variant={category.active !== false ? "default" : "outline"} className="w-fit">
+          <Badge variant={category.active !== false ? "soft-success" : "outline"} className="w-fit">
             {category.active !== false ? "Activa" : "Inactiva"}
           </Badge>
         </CardContent>

--- a/src/app/(dashboard)/dashboard/certifications/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/certifications/[id]/page.tsx
@@ -229,7 +229,7 @@ export default async function CertificationDetailPage({ params }: { params: Para
               <p className="mt-0.5 text-sm text-muted-foreground">{description}</p>
             )}
           </div>
-          <Badge variant={isActive ? "default" : "outline"}>
+          <Badge variant={isActive ? "soft-success" : "outline"}>
             {isActive ? "Activo" : "Inactivo"}
           </Badge>
         </CardContent>

--- a/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
@@ -73,7 +73,7 @@ function ClubViewCard({ club }: { club: Club }) {
           <InfoRow
             label="Estado"
             value={
-              <Badge variant={club.active !== false ? "default" : "outline"}>
+              <Badge variant={club.active !== false ? "soft-success" : "outline"}>
                 {club.active !== false ? "Activo" : "Inactivo"}
               </Badge>
             }

--- a/src/app/(dashboard)/dashboard/clubs/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/page.tsx
@@ -217,7 +217,7 @@ async function ClubsContent({
                       {club.church?.name ?? club.church_id ?? "—"}
                     </TableCell>
                     <TableCell>
-                      <Badge variant={club.active !== false ? "default" : "outline"} className="text-xs">
+                      <Badge variant={club.active !== false ? "soft-success" : "outline"} className="text-xs">
                         {club.active !== false ? "Activo" : "Inactivo"}
                       </Badge>
                     </TableCell>
@@ -266,7 +266,7 @@ async function ClubsContent({
 
                 <div className="mt-3 flex flex-wrap items-center gap-1.5">
                   <Badge
-                    variant={club.active !== false ? "default" : "outline"}
+                    variant={club.active !== false ? "soft-success" : "outline"}
                     className="text-xs"
                   >
                     {club.active !== false ? "Activo" : "Inactivo"}

--- a/src/app/(dashboard)/dashboard/honors/[honorId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/[honorId]/page.tsx
@@ -342,7 +342,7 @@ export default async function HonorDetailPage({ params }: { params: Params }) {
           </div>
 
           {/* Badge de estado */}
-          <Badge variant={honor.active !== false ? "default" : "outline"} className="shrink-0 w-fit">
+          <Badge variant={honor.active !== false ? "soft-success" : "outline"} className="shrink-0 w-fit">
             {honor.active !== false ? "Activo" : "Inactivo"}
           </Badge>
         </CardContent>

--- a/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
@@ -317,7 +317,7 @@ export default async function UserDetailPage({ params }: { params: Params }) {
             <h2 className="text-xl font-bold">{fullName}</h2>
             <p className="text-sm text-muted-foreground">{user.email ?? "—"}</p>
             <div className="mt-1 flex flex-wrap gap-2">
-              <Badge variant={user.active !== false ? "default" : "outline"}>
+              <Badge variant={user.active !== false ? "soft-success" : "outline"}>
                 {user.active !== false ? "Activo" : "Inactivo"}
               </Badge>
               {roleNames.map((role) => (

--- a/src/components/activities/activities-table.tsx
+++ b/src/components/activities/activities-table.tsx
@@ -96,7 +96,7 @@ export function ActivitiesTable({ items, onEdit, onDelete }: ActivitiesTableProp
                   {platformLabel}
                 </TableCell>
                 <TableCell className="px-3 py-2.5 align-middle">
-                  <Badge variant={activity.active !== false ? "default" : "outline"}>
+                  <Badge variant={activity.active !== false ? "soft-success" : "outline"}>
                     {activity.active !== false ? "Activa" : "Inactiva"}
                   </Badge>
                 </TableCell>

--- a/src/components/camporees/camporee-info-card.tsx
+++ b/src/components/camporees/camporee-info-card.tsx
@@ -93,7 +93,7 @@ export function CamporeeInfoCard({ camporee }: CamporeeInfoCardProps) {
           </div>
 
           {/* Status badge */}
-          <Badge variant={camporee.active !== false ? "default" : "outline"}>
+          <Badge variant={camporee.active !== false ? "soft-success" : "outline"}>
             {camporee.active !== false ? "Activo" : "Inactivo"}
           </Badge>
         </div>

--- a/src/components/camporees/camporees-view.tsx
+++ b/src/components/camporees/camporees-view.tsx
@@ -175,7 +175,7 @@ export function CampoReesView({ initialCamporees }: CampoReesViewProps) {
                     </TableCell>
                     <TableCell className="px-3 py-2.5 align-middle">
                       <Badge
-                        variant={camporee.active !== false ? "default" : "outline"}
+                        variant={camporee.active !== false ? "soft-success" : "outline"}
                         className="text-xs"
                       >
                         {camporee.active !== false ? "Activo" : "Inactivo"}

--- a/src/components/camporees/union-camporees-view.tsx
+++ b/src/components/camporees/union-camporees-view.tsx
@@ -188,7 +188,7 @@ export function UnionCampoReesView({ initialCamporees, unions }: UnionCampoReesV
                     </TableCell>
                     <TableCell className="px-3 py-2.5 align-middle">
                       <Badge
-                        variant={camporee.active !== false ? "default" : "outline"}
+                        variant={camporee.active !== false ? "soft-success" : "outline"}
                         className="text-xs"
                       >
                         {camporee.active !== false ? "Activo" : "Inactivo"}

--- a/src/components/catalogs/honor-categories-crud-page.tsx
+++ b/src/components/catalogs/honor-categories-crud-page.tsx
@@ -432,7 +432,7 @@ export function HonorCategoriesCrudPage({
                         <TableCell className="max-w-[380px] text-sm text-muted-foreground">{description}</TableCell>
                         <TableCell className="text-sm">{honorCount ?? "—"}</TableCell>
                         <TableCell>
-                          <Badge variant={item.active !== false ? "default" : "outline"} className="text-xs">
+                          <Badge variant={item.active !== false ? "soft-success" : "outline"} className="text-xs">
                             {item.active !== false ? "Activa" : "Inactiva"}
                           </Badge>
                         </TableCell>

--- a/src/components/catalogs/phase-e-catalog-crud-page.tsx
+++ b/src/components/catalogs/phase-e-catalog-crud-page.tsx
@@ -454,7 +454,7 @@ export function PhaseECatalogCrudPage({
                         )}
                         <TableCell>
                           <Badge
-                            variant={item.active !== false ? "default" : "outline"}
+                            variant={item.active !== false ? "soft-success" : "outline"}
                             className="text-xs"
                           >
                             {item.active !== false ? "Activo" : "Inactivo"}

--- a/src/components/certifications/certifications-list.tsx
+++ b/src/components/certifications/certifications-list.tsx
@@ -81,7 +81,7 @@ export function CertificationsList({ items }: CertificationsListProps) {
                 {cert.modules_count ?? "—"}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle">
-                <Badge variant={cert.active !== false ? "default" : "outline"}>
+                <Badge variant={cert.active !== false ? "soft-success" : "outline"}>
                   {cert.active !== false ? "Activo" : "Inactivo"}
                 </Badge>
               </TableCell>

--- a/src/components/classes/class-status-badge.tsx
+++ b/src/components/classes/class-status-badge.tsx
@@ -6,7 +6,7 @@ interface ClassStatusBadgeProps {
 
 export function ClassStatusBadge({ active }: ClassStatusBadgeProps) {
   return (
-    <Badge variant={active ? "default" : "outline"}>
+    <Badge variant={active ? "soft-success" : "outline"}>
       {active ? "Activo" : "Inactivo"}
     </Badge>
   );

--- a/src/components/clubs/club-sections-panel.tsx
+++ b/src/components/clubs/club-sections-panel.tsx
@@ -232,7 +232,7 @@ export function ClubSectionsPanel({ clubId, sections, clubTypes }: ClubSectionsP
                   {section.name ?? section.club_type?.name ?? label}
                 </CardTitle>
               </div>
-              <Badge variant={section.active !== false ? "default" : "outline"}>
+              <Badge variant={section.active !== false ? "soft-success" : "outline"}>
                 {section.active !== false ? "Activa" : "Inactiva"}
               </Badge>
             </CardHeader>

--- a/src/components/honors/honors-crud-page.tsx
+++ b/src/components/honors/honors-crud-page.tsx
@@ -680,7 +680,7 @@ export function HonorsCrudPage({
                         <TableCell className="text-sm">{clubTypeName}</TableCell>
                         <TableCell className="text-sm">{skillLevel ?? "—"}</TableCell>
                         <TableCell>
-                          <Badge variant={item.active !== false ? "default" : "outline"} className="text-xs">
+                          <Badge variant={item.active !== false ? "soft-success" : "outline"} className="text-xs">
                             {item.active !== false ? "Activo" : "Inactivo"}
                           </Badge>
                         </TableCell>

--- a/src/components/insurance/insurance-table.tsx
+++ b/src/components/insurance/insurance-table.tsx
@@ -272,7 +272,7 @@ export function InsuranceTable({ items, onEdit, onDelete }: InsuranceTableProps)
                   ) : expired ? (
                     <Badge variant="destructive">Vencido</Badge>
                   ) : ins.active ? (
-                    <Badge variant="default">Vigente</Badge>
+                    <Badge variant="soft-success">Vigente</Badge>
                   ) : (
                     <Badge variant="outline">Inactivo</Badge>
                   )}

--- a/src/components/inventory/inventory-table.tsx
+++ b/src/components/inventory/inventory-table.tsx
@@ -90,7 +90,7 @@ export function InventoryTable({ items, onEdit, onDelete }: InventoryTableProps)
                   {item.amount}
                 </TableCell>
                 <TableCell className="px-3 py-2.5 align-middle">
-                  <Badge variant={item.active !== false ? "default" : "outline"}>
+                  <Badge variant={item.active !== false ? "soft-success" : "outline"}>
                     {item.active !== false ? "Activo" : "Inactivo"}
                   </Badge>
                 </TableCell>

--- a/src/components/rbac/permissions-table.tsx
+++ b/src/components/rbac/permissions-table.tsx
@@ -125,7 +125,7 @@ export function PermissionsTable({ items, createAction, updateAction, deleteActi
                         {perm.description ?? "—"}
                       </TableCell>
                       <TableCell>
-                        <Badge variant={perm.active !== false ? "default" : "outline"} className="text-xs">
+                        <Badge variant={perm.active !== false ? "soft-success" : "outline"} className="text-xs">
                           {perm.active !== false ? "Activo" : "Inactivo"}
                         </Badge>
                       </TableCell>
@@ -174,7 +174,7 @@ export function PermissionsTable({ items, createAction, updateAction, deleteActi
                   </div>
 
                   <div className="mt-3 flex flex-wrap items-center gap-1.5">
-                    <Badge variant={perm.active !== false ? "default" : "outline"} className="text-xs">
+                    <Badge variant={perm.active !== false ? "soft-success" : "outline"} className="text-xs">
                       {perm.active !== false ? "Activo" : "Inactivo"}
                     </Badge>
                   </div>

--- a/src/components/resources/resource-categories-crud-page.tsx
+++ b/src/components/resources/resource-categories-crud-page.tsx
@@ -393,7 +393,7 @@ export function ResourceCategoriesCrudPage({
                         </TableCell>
                         <TableCell>
                           <Badge
-                            variant={item.active !== false ? "default" : "outline"}
+                            variant={item.active !== false ? "soft-success" : "outline"}
                             className="text-xs"
                           >
                             {item.active !== false ? "Activa" : "Inactiva"}

--- a/src/components/shared/module-list-page.tsx
+++ b/src/components/shared/module-list-page.tsx
@@ -137,7 +137,7 @@ export async function ModuleListPage({
                     })}
                     <TableCell>
                       <Badge
-                        variant={item.active !== false ? "default" : "outline"}
+                        variant={item.active !== false ? "soft-success" : "outline"}
                         className="text-xs"
                       >
                         {item.active !== false ? "Activo" : "Inactivo"}

--- a/src/components/users/users-table.tsx
+++ b/src/components/users/users-table.tsx
@@ -105,7 +105,7 @@ function UserMobileCard({
 
       <div className="mt-3 flex flex-wrap items-center gap-1.5">
         <Badge
-          variant={user.active !== false ? "default" : "outline"}
+          variant={user.active !== false ? "soft-success" : "outline"}
           className="text-xs"
         >
           {user.active !== false ? "Activo" : "Inactivo"}
@@ -226,7 +226,7 @@ export function UsersTable({
                       <LocationCell user={user} />
                     </TableCell>
                     <TableCell>
-                      <Badge variant={user.active !== false ? "default" : "outline"} className="text-xs">
+                      <Badge variant={user.active !== false ? "soft-success" : "outline"} className="text-xs">
                         {user.active !== false ? "Activo" : "Inactivo"}
                       </Badge>
                     </TableCell>


### PR DESCRIPTION
## Summary
- Replace `variant="default"` (Ember orange) with `variant="soft-success"` (green) on all active/vigente status badges
- Audit listed 8 files; sweep found 23 — fixed all true-status badges, left non-status `default` badges untouched (App access flags, certifications progress, approve/reject CTAs)

## Why
`variant="default"` renders Ember primary orange — competes with primary CTAs in list views. DESIGN-SYSTEM.md section 5.2 specifies success token for active/validated/completed states. Convention already established in `roles-table.tsx`, `catalog-crud-page.tsx`, `templates-client-page.tsx` (line 732) — this PR brings the rest into line.

## Files (23)
clubs (list + detail + sections), honors (list + detail), users, activities, certifications, camporees, classes status badge, catalogs (honor-categories, phase-e), inventory, insurance, RBAC permissions, resources, module-list-page (shared), users-table.

## Test plan
- [ ] `pnpm lint` clean (no `pnpm typecheck` script in repo)
- [ ] Visual: clubs list — Activo green, Inactivo outline. No more orange dots competing with CTAs
- [ ] Visual: insurance table — Vigente green
- [ ] Spot-check dark mode parity