### PR TITLE
fix(ui): table skeletons match DataTableShell geometry (audit C2-vis)

### DIFF
--- a/src/app/(dashboard)/dashboard/clubs/loading.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/loading.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 
 export default function ClubsLoading() {
   return (
@@ -10,7 +11,7 @@ export default function ClubsLoading() {
         </div>
         <Skeleton className="h-9 w-28" />
       </div>
-      <div className="rounded-md border">
+      <DataTableShell>
         {Array.from({ length: 6 }).map((_, i) => (
           <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
             <Skeleton className="h-4 w-40" />
@@ -19,7 +20,7 @@ export default function ClubsLoading() {
             <Skeleton className="ml-auto h-8 w-12" />
           </div>
         ))}
-      </div>
+      </DataTableShell>
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/clubs/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/page.tsx
@@ -314,7 +314,7 @@ async function ClubsContent({
 function ClubsSkeleton() {
   return (
     <div className="space-y-4">
-      <div className="rounded-md border">
+      <DataTableShell>
         {Array.from({ length: 6 }).map((_, i) => (
           <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
             <Skeleton className="h-4 w-40" />
@@ -322,7 +322,7 @@ function ClubsSkeleton() {
             <Skeleton className="h-5 w-14" />
           </div>
         ))}
-      </div>
+      </DataTableShell>
       <div className="flex items-center justify-between">
         <Skeleton className="h-4 w-40" />
         <div className="flex items-center gap-2">

--- a/src/app/(dashboard)/dashboard/enrollments/page.tsx
+++ b/src/app/(dashboard)/dashboard/enrollments/page.tsx
@@ -5,6 +5,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 import { EnrollmentsTable } from "@/components/enrollments/enrollments-table";
 import { listEnrollments, type EnrollmentsQuery } from "@/lib/api/enrollments";
 import { requireAdminUser } from "@/lib/auth/session";
@@ -39,7 +40,7 @@ function EnrollmentsListSkeleton() {
       <div className="flex gap-3">
         <Skeleton className="h-9 flex-1 max-w-xs" />
       </div>
-      <div className="rounded-md border">
+      <DataTableShell>
         {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
@@ -56,7 +57,7 @@ function EnrollmentsListSkeleton() {
             <Skeleton className="h-8 w-28" />
           </div>
         ))}
-      </div>
+      </DataTableShell>
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/loading.tsx
+++ b/src/app/(dashboard)/dashboard/loading.tsx
@@ -9,7 +9,7 @@ export default function DashboardLoading() {
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="rounded-lg border p-6">
+          <div key={i} className="rounded-xl border border-border/60 bg-card p-5">
             <Skeleton className="h-4 w-24" />
             <Skeleton className="mt-3 h-7 w-16" />
             <Skeleton className="mt-2 h-3 w-32" />
@@ -17,7 +17,7 @@ export default function DashboardLoading() {
         ))}
       </div>
       <div className="grid gap-4 lg:grid-cols-3">
-        <div className="col-span-2 rounded-lg border p-6">
+        <div className="col-span-2 rounded-xl border border-border/60 bg-card p-5">
           <Skeleton className="mb-4 h-5 w-40" />
           <div className="space-y-3">
             {Array.from({ length: 5 }).map((_, i) => (
@@ -31,7 +31,7 @@ export default function DashboardLoading() {
             ))}
           </div>
         </div>
-        <div className="rounded-lg border p-6">
+        <div className="rounded-xl border border-border/60 bg-card p-5">
           <Skeleton className="mb-4 h-5 w-40" />
           <Skeleton className="h-20 w-full" />
         </div>

--- a/src/app/(dashboard)/dashboard/reports/loading.tsx
+++ b/src/app/(dashboard)/dashboard/reports/loading.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 
 export default function ReportsLoading() {
   return (
@@ -17,7 +18,7 @@ export default function ReportsLoading() {
           <Skeleton className="h-8 w-[120px]" />
         </div>
       </div>
-      <div className="rounded-md border">
+      <DataTableShell>
         {Array.from({ length: 5 }).map((_, i) => (
           <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
             <Skeleton className="h-4 w-24" />
@@ -28,7 +29,7 @@ export default function ReportsLoading() {
             <Skeleton className="h-8 w-40" />
           </div>
         ))}
-      </div>
+      </DataTableShell>
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/reports/page.tsx
+++ b/src/app/(dashboard)/dashboard/reports/page.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 import { ReportsListClient } from "@/components/reports/reports-list-client";
 import { requireAdminUser } from "@/lib/auth/session";
 import { apiRequest, ApiError } from "@/lib/api/client";
@@ -99,7 +100,7 @@ function ReportsPageSkeleton() {
           <Skeleton className="h-8 w-[120px]" />
         </div>
       </div>
-      <div className="rounded-md border">
+      <DataTableShell>
         {Array.from({ length: 5 }).map((_, i) => (
           <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
             <Skeleton className="h-4 w-24" />
@@ -110,7 +111,7 @@ function ReportsPageSkeleton() {
             <Skeleton className="h-8 w-40" />
           </div>
         ))}
-      </div>
+      </DataTableShell>
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/users/loading.tsx
+++ b/src/app/(dashboard)/dashboard/users/loading.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 
 export default function UsersLoading() {
   return (
@@ -12,7 +13,7 @@ export default function UsersLoading() {
         <Skeleton className="h-9 w-[160px]" />
         <Skeleton className="h-9 w-[140px]" />
       </div>
-      <div className="rounded-md border">
+      <DataTableShell>
         {Array.from({ length: 8 }).map((_, i) => (
           <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
             <Skeleton className="size-8 rounded-full" />
@@ -24,7 +25,7 @@ export default function UsersLoading() {
             <Skeleton className="h-5 w-14" />
           </div>
         ))}
-      </div>
+      </DataTableShell>
     </div>
   );
 }

--- a/src/app/(dashboard)/dashboard/users/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/page.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 import { DataTablePagination } from "@/components/shared/data-table-pagination";
 import { UsersFilters } from "@/components/users/users-filters";
 import { UsersTable } from "@/components/users/users-table";
@@ -100,7 +101,7 @@ function UsersListSkeleton() {
         <Skeleton className="h-9 w-[160px]" />
         <Skeleton className="h-9 w-[140px]" />
       </div>
-      <div className="rounded-md border">
+      <DataTableShell>
         {Array.from({ length: 8 }).map((_, i) => (
           <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
             <Skeleton className="size-8 rounded-full" />
@@ -112,7 +113,7 @@ function UsersListSkeleton() {
             <Skeleton className="h-5 w-14" />
           </div>
         ))}
-      </div>
+      </DataTableShell>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace pre-Ember `rounded-md border` (8px, full opacity) with `<DataTableShell>` (`rounded-xl border-border/60 bg-card shadow-xs`) in 7 table-row skeletons
- Update 3 KPI card containers in dashboard loading: `rounded-lg border p-6` → `rounded-xl border border-border/60 bg-card p-5`
- Sweep found 2 additional skeletons in `users/` not in original audit list

## Why
Audit critical C2-vis. Skeleton geometry mismatch = visible "pop" on hydration. References (Linear, Vercel, Stripe) precisely mirror live geometry in skeletons.

## Test plan
- [ ] `pnpm lint` clean (only pre-existing warnings, none in modified files)
- [ ] Hard refresh on /clubs, /enrollments, /reports, /users, /dashboard — no layout shift between skeleton and content
- [ ] Dark mode parity: KPI card border-border/60 visible