### PR TITLE
feat(i18n): migrate users feature strings to next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -702,6 +702,61 @@
     "errors": {
       "mfa_reset_description": "Error resetting MFA",
       "mfa_disable_description": "Error disabling MFA"
+    },
+    "list": {
+      "ariaLabel": "User list",
+      "columns": {
+        "user": "User",
+        "roles": "Roles",
+        "location": "Location",
+        "status": "Status",
+        "access": "Access",
+        "postRegistration": "Post-registration",
+        "registrationDate": "Registration date"
+      },
+      "fields": {
+        "location": "Location",
+        "registrationDate": "Registration date"
+      },
+      "status": {
+        "active": "Active",
+        "inactive": "Inactive"
+      },
+      "postReg": {
+        "complete": "Post-registration",
+        "pending": "Pending",
+        "completeDesktop": "Complete"
+      },
+      "noRole": "No role"
+    },
+    "filters": {
+      "searchPlaceholder": "Search by name or email...",
+      "rolePlaceholder": "Role",
+      "allRoles": "All roles",
+      "roleOptions": {
+        "superAdmin": "Super Admin",
+        "admin": "Admin",
+        "coordinator": "Coordinator"
+      },
+      "statusPlaceholder": "Status",
+      "statusAll": "All",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "scopeLabel": "Scope:"
+    },
+    "approval": {
+      "statusApproved": "Approved",
+      "statusRejected": "Rejected",
+      "statusUnknown": "Unknown status",
+      "actionApprove": "Approve",
+      "actionReject": "Reject",
+      "dialogApproveTitle": "Approve user?",
+      "dialogRejectTitle": "Reject user?",
+      "dialogApproveDescription": "The user will be approved and will be able to access the system.",
+      "dialogRejectDescription": "The user will be rejected. You can include a reason.",
+      "rejectReasonLabel": "Rejection reason (optional)",
+      "rejectReasonPlaceholder": "Describe the reason for rejection...",
+      "cancelButton": "Cancel"
     }
   },
   "annual_folders": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -702,6 +702,61 @@
     "errors": {
       "mfa_reset_description": "Error al resetear MFA",
       "mfa_disable_description": "Error al deshabilitar MFA"
+    },
+    "list": {
+      "ariaLabel": "Lista de usuarios",
+      "columns": {
+        "user": "Usuario",
+        "roles": "Roles",
+        "location": "Ubicación",
+        "status": "Estado",
+        "access": "Accesos",
+        "postRegistration": "Post-registro",
+        "registrationDate": "Fecha de alta"
+      },
+      "fields": {
+        "location": "Ubicación",
+        "registrationDate": "Fecha de alta"
+      },
+      "status": {
+        "active": "Activo",
+        "inactive": "Inactivo"
+      },
+      "postReg": {
+        "complete": "Post-registro",
+        "pending": "Pendiente",
+        "completeDesktop": "Completo"
+      },
+      "noRole": "Sin rol"
+    },
+    "filters": {
+      "searchPlaceholder": "Buscar por nombre o email...",
+      "rolePlaceholder": "Rol",
+      "allRoles": "Todos los roles",
+      "roleOptions": {
+        "superAdmin": "Super Admin",
+        "admin": "Admin",
+        "coordinator": "Coordinador"
+      },
+      "statusPlaceholder": "Estado",
+      "statusAll": "Todos",
+      "statusActive": "Activos",
+      "statusInactive": "Inactivos",
+      "scopeLabel": "Alcance:"
+    },
+    "approval": {
+      "statusApproved": "Aprobado",
+      "statusRejected": "Rechazado",
+      "statusUnknown": "Estado desconocido",
+      "actionApprove": "Aprobar",
+      "actionReject": "Rechazar",
+      "dialogApproveTitle": "¿Aprobar usuario?",
+      "dialogRejectTitle": "¿Rechazar usuario?",
+      "dialogApproveDescription": "El usuario será aprobado y podrá acceder al sistema.",
+      "dialogRejectDescription": "El usuario será rechazado. Puedes incluir una razón.",
+      "rejectReasonLabel": "Razón del rechazo (opcional)",
+      "rejectReasonPlaceholder": "Describe la razón del rechazo...",
+      "cancelButton": "Cancelar"
     }
   },
   "annual_folders": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -702,6 +702,61 @@
     "errors": {
       "mfa_reset_description": "Erreur lors de la réinitialisation MFA",
       "mfa_disable_description": "Erreur lors de la désactivation MFA"
+    },
+    "list": {
+      "ariaLabel": "Liste des utilisateurs",
+      "columns": {
+        "user": "Utilisateur",
+        "roles": "Rôles",
+        "location": "Localisation",
+        "status": "Statut",
+        "access": "Accès",
+        "postRegistration": "Post-inscription",
+        "registrationDate": "Date d'inscription"
+      },
+      "fields": {
+        "location": "Localisation",
+        "registrationDate": "Date d'inscription"
+      },
+      "status": {
+        "active": "Actif",
+        "inactive": "Inactif"
+      },
+      "postReg": {
+        "complete": "Post-inscription",
+        "pending": "En attente",
+        "completeDesktop": "Complet"
+      },
+      "noRole": "Sans rôle"
+    },
+    "filters": {
+      "searchPlaceholder": "Rechercher par nom ou email...",
+      "rolePlaceholder": "Rôle",
+      "allRoles": "Tous les rôles",
+      "roleOptions": {
+        "superAdmin": "Super Admin",
+        "admin": "Admin",
+        "coordinator": "Coordinateur"
+      },
+      "statusPlaceholder": "Statut",
+      "statusAll": "Tous",
+      "statusActive": "Actifs",
+      "statusInactive": "Inactifs",
+      "scopeLabel": "Portée :"
+    },
+    "approval": {
+      "statusApproved": "Approuvé",
+      "statusRejected": "Rejeté",
+      "statusUnknown": "Statut inconnu",
+      "actionApprove": "Approuver",
+      "actionReject": "Rejeter",
+      "dialogApproveTitle": "Approuver l'utilisateur ?",
+      "dialogRejectTitle": "Rejeter l'utilisateur ?",
+      "dialogApproveDescription": "L'utilisateur sera approuvé et pourra accéder au système.",
+      "dialogRejectDescription": "L'utilisateur sera rejeté. Vous pouvez inclure une raison.",
+      "rejectReasonLabel": "Raison du rejet (facultatif)",
+      "rejectReasonPlaceholder": "Décrivez la raison du rejet...",
+      "cancelButton": "Annuler"
     }
   },
   "annual_folders": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -702,6 +702,61 @@
     "errors": {
       "mfa_reset_description": "Erro ao redefinir MFA",
       "mfa_disable_description": "Erro ao desativar MFA"
+    },
+    "list": {
+      "ariaLabel": "Lista de usuários",
+      "columns": {
+        "user": "Usuário",
+        "roles": "Funções",
+        "location": "Localização",
+        "status": "Status",
+        "access": "Acessos",
+        "postRegistration": "Pós-registro",
+        "registrationDate": "Data de cadastro"
+      },
+      "fields": {
+        "location": "Localização",
+        "registrationDate": "Data de cadastro"
+      },
+      "status": {
+        "active": "Ativo",
+        "inactive": "Inativo"
+      },
+      "postReg": {
+        "complete": "Pós-registro",
+        "pending": "Pendente",
+        "completeDesktop": "Completo"
+      },
+      "noRole": "Sem função"
+    },
+    "filters": {
+      "searchPlaceholder": "Buscar por nome ou e-mail...",
+      "rolePlaceholder": "Função",
+      "allRoles": "Todas as funções",
+      "roleOptions": {
+        "superAdmin": "Super Admin",
+        "admin": "Admin",
+        "coordinator": "Coordenador"
+      },
+      "statusPlaceholder": "Status",
+      "statusAll": "Todos",
+      "statusActive": "Ativos",
+      "statusInactive": "Inativos",
+      "scopeLabel": "Escopo:"
+    },
+    "approval": {
+      "statusApproved": "Aprovado",
+      "statusRejected": "Rejeitado",
+      "statusUnknown": "Status desconhecido",
+      "actionApprove": "Aprovar",
+      "actionReject": "Rejeitar",
+      "dialogApproveTitle": "Aprovar usuário?",
+      "dialogRejectTitle": "Rejeitar usuário?",
+      "dialogApproveDescription": "O usuário será aprovado e poderá acessar o sistema.",
+      "dialogRejectDescription": "O usuário será rejeitado. Você pode incluir um motivo.",
+      "rejectReasonLabel": "Motivo da rejeição (opcional)",
+      "rejectReasonPlaceholder": "Descreva o motivo da rejeição...",
+      "cancelButton": "Cancelar"
     }
   },
   "annual_folders": {

--- a/src/components/users/user-approval-actions.tsx
+++ b/src/components/users/user-approval-actions.tsx
@@ -17,8 +17,10 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { submitApprovalDecisionAction } from "@/lib/admin-users/actions";
+import { useTranslations } from "next-intl";
 
 function SubmitButton({ variant }: { variant: "approve" | "reject" }) {
+  const t = useTranslations("users");
   const { pending } = useFormStatus();
   const isApprove = variant === "approve";
 
@@ -29,7 +31,7 @@ function SubmitButton({ variant }: { variant: "approve" | "reject" }) {
       variant={isApprove ? "default" : "destructive"}
     >
       {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
-      {isApprove ? "Aprobar" : "Rechazar"}
+      {isApprove ? t("approval.actionApprove") : t("approval.actionReject")}
     </Button>
   );
 }
@@ -40,6 +42,7 @@ interface UserApprovalActionsProps {
 }
 
 export function UserApprovalActions({ userId, currentApproval }: UserApprovalActionsProps) {
+  const t = useTranslations("users");
   const [dialogOpen, setDialogOpen] = useState(false);
   const [decision, setDecision] = useState<"approve" | "reject">("approve");
 
@@ -64,18 +67,18 @@ export function UserApprovalActions({ userId, currentApproval }: UserApprovalAct
         {isApproved && (
           <Badge variant="success" className="gap-1.5">
             <CheckCircle className="size-3.5" />
-            Aprobado
+            {t("approval.statusApproved")}
           </Badge>
         )}
         {isRejected && (
           <Badge variant="destructive" className="gap-1.5">
             <XCircle className="size-3.5" />
-            Rechazado
+            {t("approval.statusRejected")}
           </Badge>
         )}
         {!isApproved && !isRejected && (
           <Badge variant="outline" className="text-muted-foreground">
-            Estado desconocido
+            {t("approval.statusUnknown")}
           </Badge>
         )}
       </div>
@@ -93,7 +96,7 @@ export function UserApprovalActions({ userId, currentApproval }: UserApprovalAct
           }}
         >
           <CheckCircle className="mr-2 size-4" />
-          Aprobar
+          {t("approval.actionApprove")}
         </Button>
         <Button
           size="sm"
@@ -104,7 +107,7 @@ export function UserApprovalActions({ userId, currentApproval }: UserApprovalAct
           }}
         >
           <XCircle className="mr-2 size-4" />
-          Rechazar
+          {t("approval.actionReject")}
         </Button>
       </div>
 
@@ -112,12 +115,14 @@ export function UserApprovalActions({ userId, currentApproval }: UserApprovalAct
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>
-              {decision === "approve" ? "¿Aprobar usuario?" : "¿Rechazar usuario?"}
+              {decision === "approve"
+                ? t("approval.dialogApproveTitle")
+                : t("approval.dialogRejectTitle")}
             </AlertDialogTitle>
             <AlertDialogDescription>
               {decision === "approve"
-                ? "El usuario será aprobado y podrá acceder al sistema."
-                : "El usuario será rechazado. Puedes incluir una razón."}
+                ? t("approval.dialogApproveDescription")
+                : t("approval.dialogRejectDescription")}
             </AlertDialogDescription>
           </AlertDialogHeader>
 
@@ -127,18 +132,18 @@ export function UserApprovalActions({ userId, currentApproval }: UserApprovalAct
 
             {decision === "reject" && (
               <div className="mb-4 space-y-2">
-                <Label htmlFor="reason">Razón del rechazo (opcional)</Label>
+                <Label htmlFor="reason">{t("approval.rejectReasonLabel")}</Label>
                 <Textarea
                   id="reason"
                   name="reason"
-                  placeholder="Describe la razón del rechazo..."
+                  placeholder={t("approval.rejectReasonPlaceholder")}
                   rows={3}
                 />
               </div>
             )}
 
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancelar</AlertDialogCancel>
+              <AlertDialogCancel>{t("approval.cancelButton")}</AlertDialogCancel>
               <SubmitButton variant={decision} />
             </AlertDialogFooter>
           </form>

--- a/src/components/users/users-filters.tsx
+++ b/src/components/users/users-filters.tsx
@@ -11,6 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { useTranslations } from "next-intl";
 import type { ScopeMeta } from "@/lib/api/admin-users";
 
 interface UsersFiltersProps {
@@ -18,6 +19,7 @@ interface UsersFiltersProps {
 }
 
 export function UsersFilters({ scope }: UsersFiltersProps) {
+  const t = useTranslations("users");
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -61,7 +63,7 @@ export function UsersFilters({ scope }: UsersFiltersProps) {
       <div className="relative flex-1">
         <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
         <Input
-          placeholder="Buscar por nombre o email..."
+          placeholder={t("filters.searchPlaceholder")}
           defaultValue={searchParams.get("search") ?? ""}
           className="pl-9"
           onChange={(e) => handleSearchChange(e.target.value)}
@@ -70,30 +72,30 @@ export function UsersFilters({ scope }: UsersFiltersProps) {
 
       <Select value={currentRole} onValueChange={(v) => updateParam("role", v)}>
         <SelectTrigger className="w-[160px]">
-          <SelectValue placeholder="Rol" />
+          <SelectValue placeholder={t("filters.rolePlaceholder")} />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="all">Todos los roles</SelectItem>
-          <SelectItem value="super-admin">Super Admin</SelectItem>
-          <SelectItem value="admin">Admin</SelectItem>
-          <SelectItem value="coordinator">Coordinator</SelectItem>
+          <SelectItem value="all">{t("filters.allRoles")}</SelectItem>
+          <SelectItem value="super-admin">{t("filters.roleOptions.superAdmin")}</SelectItem>
+          <SelectItem value="admin">{t("filters.roleOptions.admin")}</SelectItem>
+          <SelectItem value="coordinator">{t("filters.roleOptions.coordinator")}</SelectItem>
         </SelectContent>
       </Select>
 
       <Select value={currentActive} onValueChange={(v) => updateParam("active", v)}>
         <SelectTrigger className="w-[140px]">
-          <SelectValue placeholder="Estado" />
+          <SelectValue placeholder={t("filters.statusPlaceholder")} />
         </SelectTrigger>
         <SelectContent>
-          <SelectItem value="all">Todos</SelectItem>
-          <SelectItem value="true">Activos</SelectItem>
-          <SelectItem value="false">Inactivos</SelectItem>
+          <SelectItem value="all">{t("filters.statusAll")}</SelectItem>
+          <SelectItem value="true">{t("filters.statusActive")}</SelectItem>
+          <SelectItem value="false">{t("filters.statusInactive")}</SelectItem>
         </SelectContent>
       </Select>
 
       {isScopeLocked && (
         <div className="text-xs text-muted-foreground">
-          Alcance: <span className="font-medium">{scope?.type}</span>
+          {t("filters.scopeLabel")} <span className="font-medium">{scope?.type}</span>
         </div>
       )}
     </div>

--- a/src/components/users/users-table.tsx
+++ b/src/components/users/users-table.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/table";
 import type { AdminUser } from "@/lib/api/admin-users";
 import { DataTableShell } from "@/components/shared/data-table-shell";
+import { getTranslations } from "next-intl/server";
 
 function extractRoleNames(user: AdminUser): string[] {
   const roles: string[] = [];
@@ -66,12 +67,16 @@ interface UsersTableProps {
   showAdministrativeCompletion?: boolean;
 }
 
+type UsersTranslations = Awaited<ReturnType<typeof getTranslations<"users">>>;
+
 function UserMobileCard({
   user,
   showAdministrativeCompletion,
+  t,
 }: {
   user: AdminUser;
   showAdministrativeCompletion: boolean;
+  t: UsersTranslations;
 }) {
   const roleNames = extractRoleNames(user);
   const fullName = getFullName(user);
@@ -108,7 +113,9 @@ function UserMobileCard({
           variant={user.active !== false ? "soft-success" : "outline"}
           className="text-xs"
         >
-          {user.active !== false ? "Activo" : "Inactivo"}
+          {user.active !== false
+            ? t("list.status.active")
+            : t("list.status.inactive")}
         </Badge>
         <Badge
           variant={user.access_app ? "default" : "outline"}
@@ -127,7 +134,9 @@ function UserMobileCard({
             variant={user.post_registration?.complete ? "default" : "outline"}
             className="text-xs"
           >
-            {user.post_registration?.complete ? "Post-registro" : "Pendiente"}
+            {user.post_registration?.complete
+              ? t("list.postReg.complete")
+              : t("list.postReg.pending")}
           </Badge>
         )}
       </div>
@@ -145,12 +154,12 @@ function UserMobileCard({
       <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
         {location && (
           <div className="col-span-2">
-            <dt className="text-muted-foreground">Ubicación</dt>
+            <dt className="text-muted-foreground">{t("list.fields.location")}</dt>
             <dd className="truncate">{location}</dd>
           </div>
         )}
         <div>
-          <dt className="text-muted-foreground">Fecha de alta</dt>
+          <dt className="text-muted-foreground">{t("list.fields.registrationDate")}</dt>
           <dd>{formatDate(user.created_at)}</dd>
         </div>
       </dl>
@@ -158,10 +167,12 @@ function UserMobileCard({
   );
 }
 
-export function UsersTable({
+export async function UsersTable({
   users,
   showAdministrativeCompletion = false,
 }: UsersTableProps) {
+  const t = await getTranslations("users");
+
   return (
     <>
       {/* Desktop: full table */}
@@ -170,15 +181,15 @@ export function UsersTable({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="pl-6">Usuario</TableHead>
-                <TableHead className="hidden md:table-cell">Roles</TableHead>
-                <TableHead className="hidden lg:table-cell">Ubicación</TableHead>
-                <TableHead>Estado</TableHead>
-                <TableHead className="hidden sm:table-cell">Accesos</TableHead>
+                <TableHead className="pl-6">{t("list.columns.user")}</TableHead>
+                <TableHead className="hidden md:table-cell">{t("list.columns.roles")}</TableHead>
+                <TableHead className="hidden lg:table-cell">{t("list.columns.location")}</TableHead>
+                <TableHead>{t("list.columns.status")}</TableHead>
+                <TableHead className="hidden sm:table-cell">{t("list.columns.access")}</TableHead>
                 {showAdministrativeCompletion ? (
-                  <TableHead className="hidden lg:table-cell">Post-registro</TableHead>
+                  <TableHead className="hidden lg:table-cell">{t("list.columns.postRegistration")}</TableHead>
                 ) : null}
-                <TableHead className="hidden pr-6 md:table-cell">Fecha de alta</TableHead>
+                <TableHead className="hidden pr-6 md:table-cell">{t("list.columns.registrationDate")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -218,7 +229,7 @@ export function UsersTable({
                             </Badge>
                           ))
                         ) : (
-                          <span className="text-xs text-muted-foreground">Sin rol</span>
+                          <span className="text-xs text-muted-foreground">{t("list.noRole")}</span>
                         )}
                       </div>
                     </TableCell>
@@ -227,7 +238,7 @@ export function UsersTable({
                     </TableCell>
                     <TableCell>
                       <Badge variant={user.active !== false ? "soft-success" : "outline"} className="text-xs">
-                        {user.active !== false ? "Activo" : "Inactivo"}
+                        {user.active !== false ? t("list.status.active") : t("list.status.inactive")}
                       </Badge>
                     </TableCell>
                     <TableCell className="hidden sm:table-cell">
@@ -252,7 +263,9 @@ export function UsersTable({
                           variant={user.post_registration?.complete ? "default" : "outline"}
                           className="text-xs"
                         >
-                          {user.post_registration?.complete ? "Completo" : "Pendiente"}
+                          {user.post_registration?.complete
+                            ? t("list.postReg.completeDesktop")
+                            : t("list.postReg.pending")}
                         </Badge>
                       </TableCell>
                     ) : null}
@@ -268,12 +281,13 @@ export function UsersTable({
       </div>
 
       {/* Mobile: descriptive cards */}
-      <ul className="space-y-3 md:hidden" aria-label="Lista de usuarios">
+      <ul className="space-y-3 md:hidden" aria-label={t("list.ariaLabel")}>
         {users.map((user) => (
           <li key={user.user_id}>
             <UserMobileCard
               user={user}
               showAdministrativeCompletion={showAdministrativeCompletion}
+              t={t}
             />
           </li>
         ))}


### PR DESCRIPTION
## Summary

Batch 2 of the next-intl rollout. Migrates the users feature listing/filter/approval flows. Extends the existing `users` namespace with 39 new keys across 4 locales.

| Sub-namespace | Keys | Purpose |
|---|---|---|
| `users.list.*` | 16 | Table headers, status labels, mobile card variants |
| `users.filters.*` | 10 | Search, role, status filter UI |
| `users.approval.*` | 13 | Approve/reject dialog copy |

## Files

| File | Notes |
|---|---|
| `users-table.tsx` | Promoted to async server component; uses `getTranslations("users")`. Mobile sub-card receives typed translations bag |
| `users-filters.tsx` | Client `useTranslations("users")` |
| `user-approval-actions.tsx` | Client `useTranslations("users")` for SubmitButton + dialogs |

## Caveat

en/fr/pt-BR are best-effort. Native review recommended on:
- `fr.filters.scopeLabel` — `"Portée :"` (French typographic space before colon)
- `pt-BR.list.columns.roles` — `"Funções"` vs `"Roles"` (verify org convention)

## Out of scope (batch 3)

`mfa-tab`, `sessions-tab`, `user-access-toggles`, `post-registration-tab` — different sub-flows.

## Test plan

- [ ] CI typecheck (#56) passes
- [ ] CI tests (#60) passes — 41/41
- [ ] `/dashboard/users` table renders with all 4 locales without missing-key warnings
- [ ] Approve/reject dialogs render correctly in `es`