### PR TITLE
feat(i18n): migrate finances feature strings to next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1078,10 +1078,103 @@
       "transaction_deleted": "Transaction deleted successfully"
     },
     "validation": {
-      "section_required": "Select a club section"
+      "section_required": "Select a club section",
+      "year_invalid": "Enter a valid year",
+      "year_range": "Invalid year",
+      "month_invalid": "Enter a valid month",
+      "month_range": "Invalid month",
+      "amount_invalid": "Enter a valid amount",
+      "amount_positive": "Amount must be positive",
+      "category_required": "Select a category",
+      "date_required": "Enter the date"
     },
     "errors": {
-      "delete_transaction_failed": "Could not delete the transaction"
+      "delete_transaction_failed": "Could not delete the transaction",
+      "update_transaction_failed": "Could not update the transaction",
+      "create_transaction_failed": "Could not create the transaction"
+    },
+    "dashboard": {
+      "filtersLabel": "Filters:",
+      "allYears": "All years",
+      "allMonths": "All months",
+      "refreshButton": "Refresh",
+      "newTransactionButton": "New transaction",
+      "transactionsTitle": "Transactions",
+      "showing": "Showing {shown} of {total} transactions."
+    },
+    "form": {
+      "titleNew": "New transaction",
+      "titleEdit": "Edit transaction",
+      "descriptionNew": "Record a new income or expense for the club.",
+      "descriptionEdit": "Update the financial transaction details.",
+      "categoryLabel": "Category",
+      "categoryPlaceholder": "Select a category",
+      "categoryLoading": "Loading categories...",
+      "dateLabel": "Date",
+      "amountLabel": "Amount",
+      "yearLabel": "Year",
+      "yearPlaceholder": "Year",
+      "monthLabel": "Month",
+      "monthPlaceholder": "Month",
+      "sectionLabel": "Club section",
+      "sectionPlaceholder": "Select a section",
+      "sectionEmpty": "No sections available",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Transaction description (optional)",
+      "cancelButton": "Cancel",
+      "saveButton": "Save changes",
+      "createButton": "Create transaction"
+    },
+    "table": {
+      "colDate": "Date",
+      "colDescription": "Description",
+      "colCategory": "Category",
+      "colPeriod": "Period",
+      "colType": "Type",
+      "colAmount": "Amount",
+      "emptyTitle": "No transactions",
+      "emptyDescription": "No financial transactions found for the selected filters.",
+      "actionsLabel": "Actions",
+      "actionEdit": "Edit",
+      "actionDelete": "Delete",
+      "typeIncome": "Income",
+      "typeExpense": "Expense"
+    },
+    "delete": {
+      "title": "Delete transaction?",
+      "descriptionPre": "You are about to delete the transaction of",
+      "cannotUndo": "This action cannot be undone.",
+      "descriptionFallback": "This action cannot be undone.",
+      "cancelButton": "Cancel",
+      "confirmButton": "Delete"
+    },
+    "summary": {
+      "totalIncome": "Total Income",
+      "totalExpense": "Total Expenses",
+      "balance": "Balance",
+      "movementsCount": "{count} transaction",
+      "movementsCountPlural": "{count} transactions",
+      "inPeriod": "in the period",
+      "positiveBalance": "Positive balance",
+      "negativeBalance": "Negative balance"
+    },
+    "months": {
+      "january": "January",
+      "february": "February",
+      "march": "March",
+      "april": "April",
+      "may": "May",
+      "june": "June",
+      "july": "July",
+      "august": "August",
+      "september": "September",
+      "october": "October",
+      "november": "November",
+      "december": "December"
+    },
+    "categoryType": {
+      "income": "Income",
+      "expense": "Expense"
     }
   },
   "certifications": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -1078,10 +1078,103 @@
       "transaction_deleted": "Movimiento eliminado correctamente"
     },
     "validation": {
-      "section_required": "Seleccioná una sección del club"
+      "section_required": "Seleccioná una sección del club",
+      "year_invalid": "Ingresá un año válido",
+      "year_range": "Año inválido",
+      "month_invalid": "Ingresá un mes válido",
+      "month_range": "Mes inválido",
+      "amount_invalid": "Ingresá un monto válido",
+      "amount_positive": "El monto debe ser positivo",
+      "category_required": "Seleccioná una categoría",
+      "date_required": "Ingresá la fecha"
     },
     "errors": {
-      "delete_transaction_failed": "No se pudo eliminar el movimiento"
+      "delete_transaction_failed": "No se pudo eliminar el movimiento",
+      "update_transaction_failed": "No se pudo actualizar el movimiento",
+      "create_transaction_failed": "No se pudo crear el movimiento"
+    },
+    "dashboard": {
+      "filtersLabel": "Filtros:",
+      "allYears": "Todos los años",
+      "allMonths": "Todos los meses",
+      "refreshButton": "Actualizar",
+      "newTransactionButton": "Nuevo movimiento",
+      "transactionsTitle": "Movimientos",
+      "showing": "Mostrando {shown} de {total} movimientos."
+    },
+    "form": {
+      "titleNew": "Nuevo movimiento",
+      "titleEdit": "Editar movimiento",
+      "descriptionNew": "Registrá un nuevo ingreso o egreso del club.",
+      "descriptionEdit": "Modificá los datos del movimiento financiero.",
+      "categoryLabel": "Categoría",
+      "categoryPlaceholder": "Seleccioná una categoría",
+      "categoryLoading": "Cargando categorías...",
+      "dateLabel": "Fecha",
+      "amountLabel": "Monto",
+      "yearLabel": "Año",
+      "yearPlaceholder": "Año",
+      "monthLabel": "Mes",
+      "monthPlaceholder": "Mes",
+      "sectionLabel": "Sección del club",
+      "sectionPlaceholder": "Seleccioná una sección",
+      "sectionEmpty": "No hay secciones disponibles",
+      "descriptionLabel": "Descripción",
+      "descriptionPlaceholder": "Descripción del movimiento (opcional)",
+      "cancelButton": "Cancelar",
+      "saveButton": "Guardar cambios",
+      "createButton": "Crear movimiento"
+    },
+    "table": {
+      "colDate": "Fecha",
+      "colDescription": "Descripción",
+      "colCategory": "Categoría",
+      "colPeriod": "Período",
+      "colType": "Tipo",
+      "colAmount": "Monto",
+      "emptyTitle": "Sin movimientos",
+      "emptyDescription": "No se encontraron movimientos financieros para los filtros seleccionados.",
+      "actionsLabel": "Acciones",
+      "actionEdit": "Editar",
+      "actionDelete": "Eliminar",
+      "typeIncome": "Ingreso",
+      "typeExpense": "Egreso"
+    },
+    "delete": {
+      "title": "¿Eliminar movimiento?",
+      "descriptionPre": "Estás por eliminar el movimiento de",
+      "cannotUndo": "Esta acción no se puede deshacer.",
+      "descriptionFallback": "Esta acción no se puede deshacer.",
+      "cancelButton": "Cancelar",
+      "confirmButton": "Eliminar"
+    },
+    "summary": {
+      "totalIncome": "Total Ingresos",
+      "totalExpense": "Total Egresos",
+      "balance": "Balance",
+      "movementsCount": "{count} movimiento",
+      "movementsCountPlural": "{count} movimientos",
+      "inPeriod": "en el período",
+      "positiveBalance": "Saldo positivo",
+      "negativeBalance": "Saldo negativo"
+    },
+    "months": {
+      "january": "Enero",
+      "february": "Febrero",
+      "march": "Marzo",
+      "april": "Abril",
+      "may": "Mayo",
+      "june": "Junio",
+      "july": "Julio",
+      "august": "Agosto",
+      "september": "Septiembre",
+      "october": "Octubre",
+      "november": "Noviembre",
+      "december": "Diciembre"
+    },
+    "categoryType": {
+      "income": "Ingreso",
+      "expense": "Egreso"
     }
   },
   "certifications": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1078,10 +1078,103 @@
       "transaction_deleted": "Transaction supprimée avec succès"
     },
     "validation": {
-      "section_required": "Sélectionnez une section du club"
+      "section_required": "Sélectionnez une section du club",
+      "year_invalid": "Saisissez une année valide",
+      "year_range": "Année invalide",
+      "month_invalid": "Saisissez un mois valide",
+      "month_range": "Mois invalide",
+      "amount_invalid": "Saisissez un montant valide",
+      "amount_positive": "Le montant doit être positif",
+      "category_required": "Sélectionnez une catégorie",
+      "date_required": "Saisissez la date"
     },
     "errors": {
-      "delete_transaction_failed": "Impossible de supprimer la transaction"
+      "delete_transaction_failed": "Impossible de supprimer la transaction",
+      "update_transaction_failed": "Impossible de mettre à jour la transaction",
+      "create_transaction_failed": "Impossible de créer la transaction"
+    },
+    "dashboard": {
+      "filtersLabel": "Filtres :",
+      "allYears": "Toutes les années",
+      "allMonths": "Tous les mois",
+      "refreshButton": "Actualiser",
+      "newTransactionButton": "Nouvelle transaction",
+      "transactionsTitle": "Transactions",
+      "showing": "Affichage de {shown} sur {total} transactions."
+    },
+    "form": {
+      "titleNew": "Nouvelle transaction",
+      "titleEdit": "Modifier la transaction",
+      "descriptionNew": "Enregistrez un nouveau revenu ou une dépense pour le club.",
+      "descriptionEdit": "Modifiez les données de la transaction financière.",
+      "categoryLabel": "Catégorie",
+      "categoryPlaceholder": "Sélectionnez une catégorie",
+      "categoryLoading": "Chargement des catégories...",
+      "dateLabel": "Date",
+      "amountLabel": "Montant",
+      "yearLabel": "Année",
+      "yearPlaceholder": "Année",
+      "monthLabel": "Mois",
+      "monthPlaceholder": "Mois",
+      "sectionLabel": "Section du club",
+      "sectionPlaceholder": "Sélectionnez une section",
+      "sectionEmpty": "Aucune section disponible",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Description de la transaction (optionnel)",
+      "cancelButton": "Annuler",
+      "saveButton": "Enregistrer les modifications",
+      "createButton": "Créer la transaction"
+    },
+    "table": {
+      "colDate": "Date",
+      "colDescription": "Description",
+      "colCategory": "Catégorie",
+      "colPeriod": "Période",
+      "colType": "Type",
+      "colAmount": "Montant",
+      "emptyTitle": "Aucune transaction",
+      "emptyDescription": "Aucune transaction financière trouvée pour les filtres sélectionnés.",
+      "actionsLabel": "Actions",
+      "actionEdit": "Modifier",
+      "actionDelete": "Supprimer",
+      "typeIncome": "Revenu",
+      "typeExpense": "Dépense"
+    },
+    "delete": {
+      "title": "Supprimer la transaction ?",
+      "descriptionPre": "Vous êtes sur le point de supprimer la transaction de",
+      "cannotUndo": "Cette action est irréversible.",
+      "descriptionFallback": "Cette action est irréversible.",
+      "cancelButton": "Annuler",
+      "confirmButton": "Supprimer"
+    },
+    "summary": {
+      "totalIncome": "Total des revenus",
+      "totalExpense": "Total des dépenses",
+      "balance": "Solde",
+      "movementsCount": "{count} transaction",
+      "movementsCountPlural": "{count} transactions",
+      "inPeriod": "sur la période",
+      "positiveBalance": "Solde positif",
+      "negativeBalance": "Solde négatif"
+    },
+    "months": {
+      "january": "Janvier",
+      "february": "Février",
+      "march": "Mars",
+      "april": "Avril",
+      "may": "Mai",
+      "june": "Juin",
+      "july": "Juillet",
+      "august": "Août",
+      "september": "Septembre",
+      "october": "Octobre",
+      "november": "Novembre",
+      "december": "Décembre"
+    },
+    "categoryType": {
+      "income": "Revenu",
+      "expense": "Dépense"
     }
   },
   "certifications": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1078,10 +1078,103 @@
       "transaction_deleted": "Movimento excluído com sucesso"
     },
     "validation": {
-      "section_required": "Selecione uma seção do clube"
+      "section_required": "Selecione uma seção do clube",
+      "year_invalid": "Insira um ano válido",
+      "year_range": "Ano inválido",
+      "month_invalid": "Insira um mês válido",
+      "month_range": "Mês inválido",
+      "amount_invalid": "Insira um valor válido",
+      "amount_positive": "O valor deve ser positivo",
+      "category_required": "Selecione uma categoria",
+      "date_required": "Insira a data"
     },
     "errors": {
-      "delete_transaction_failed": "Não foi possível excluir o movimento"
+      "delete_transaction_failed": "Não foi possível excluir o movimento",
+      "update_transaction_failed": "Não foi possível atualizar o movimento",
+      "create_transaction_failed": "Não foi possível criar o movimento"
+    },
+    "dashboard": {
+      "filtersLabel": "Filtros:",
+      "allYears": "Todos os anos",
+      "allMonths": "Todos os meses",
+      "refreshButton": "Atualizar",
+      "newTransactionButton": "Novo movimento",
+      "transactionsTitle": "Movimentos",
+      "showing": "Exibindo {shown} de {total} movimentos."
+    },
+    "form": {
+      "titleNew": "Novo movimento",
+      "titleEdit": "Editar movimento",
+      "descriptionNew": "Registre uma nova receita ou despesa do clube.",
+      "descriptionEdit": "Modifique os dados do movimento financeiro.",
+      "categoryLabel": "Categoria",
+      "categoryPlaceholder": "Selecione uma categoria",
+      "categoryLoading": "Carregando categorias...",
+      "dateLabel": "Data",
+      "amountLabel": "Valor",
+      "yearLabel": "Ano",
+      "yearPlaceholder": "Ano",
+      "monthLabel": "Mês",
+      "monthPlaceholder": "Mês",
+      "sectionLabel": "Seção do clube",
+      "sectionPlaceholder": "Selecione uma seção",
+      "sectionEmpty": "Nenhuma seção disponível",
+      "descriptionLabel": "Descrição",
+      "descriptionPlaceholder": "Descrição do movimento (opcional)",
+      "cancelButton": "Cancelar",
+      "saveButton": "Salvar alterações",
+      "createButton": "Criar movimento"
+    },
+    "table": {
+      "colDate": "Data",
+      "colDescription": "Descrição",
+      "colCategory": "Categoria",
+      "colPeriod": "Período",
+      "colType": "Tipo",
+      "colAmount": "Valor",
+      "emptyTitle": "Sem movimentos",
+      "emptyDescription": "Nenhum movimento financeiro encontrado para os filtros selecionados.",
+      "actionsLabel": "Ações",
+      "actionEdit": "Editar",
+      "actionDelete": "Excluir",
+      "typeIncome": "Receita",
+      "typeExpense": "Despesa"
+    },
+    "delete": {
+      "title": "Excluir movimento?",
+      "descriptionPre": "Você está prestes a excluir o movimento de",
+      "cannotUndo": "Esta ação não pode ser desfeita.",
+      "descriptionFallback": "Esta ação não pode ser desfeita.",
+      "cancelButton": "Cancelar",
+      "confirmButton": "Excluir"
+    },
+    "summary": {
+      "totalIncome": "Total de Receitas",
+      "totalExpense": "Total de Despesas",
+      "balance": "Saldo",
+      "movementsCount": "{count} movimento",
+      "movementsCountPlural": "{count} movimentos",
+      "inPeriod": "no período",
+      "positiveBalance": "Saldo positivo",
+      "negativeBalance": "Saldo negativo"
+    },
+    "months": {
+      "january": "Janeiro",
+      "february": "Fevereiro",
+      "march": "Março",
+      "april": "Abril",
+      "may": "Maio",
+      "june": "Junho",
+      "july": "Julho",
+      "august": "Agosto",
+      "september": "Setembro",
+      "october": "Outubro",
+      "november": "Novembro",
+      "december": "Dezembro"
+    },
+    "categoryType": {
+      "income": "Receita",
+      "expense": "Despesa"
     }
   },
   "certifications": {

--- a/src/components/finances/delete-transaction-dialog.tsx
+++ b/src/components/finances/delete-transaction-dialog.tsx
@@ -58,31 +58,33 @@ export function DeleteTransactionDialog({
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>¿Eliminar movimiento?</AlertDialogTitle>
+          <AlertDialogTitle>{t("delete.title")}</AlertDialogTitle>
           <AlertDialogDescription>
             {finance ? (
               <>
-                Estás por eliminar el movimiento de{" "}
+                {t("delete.descriptionPre")}{" "}
                 <strong className={isIncome ? "text-success" : "text-destructive"}>
                   {formatAmount(Math.abs(finance.amount))}
                 </strong>
                 {finance.description ? ` — ${finance.description}` : ""}.{" "}
-                Esta acción no se puede deshacer.
+                {t("delete.cannotUndo")}
               </>
             ) : (
-              "Esta acción no se puede deshacer."
+              t("delete.descriptionFallback")
             )}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isDeleting}>Cancelar</AlertDialogCancel>
+          <AlertDialogCancel disabled={isDeleting}>
+            {t("delete.cancelButton")}
+          </AlertDialogCancel>
           <AlertDialogAction
             onClick={handleDelete}
             disabled={isDeleting}
             className="bg-destructive text-white hover:bg-destructive/90"
           >
             {isDeleting && <Loader2 className="size-4 animate-spin" />}
-            Eliminar
+            {t("delete.confirmButton")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/src/components/finances/finances-dashboard.tsx
+++ b/src/components/finances/finances-dashboard.tsx
@@ -30,23 +30,24 @@ import {
 } from "@/lib/api/finances";
 import type { SortDirection } from "@/components/shared/sortable-header";
 import type { ClubSection } from "@/components/finances/transaction-form-dialog";
+import { useTranslations } from "next-intl";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const MONTHS = [
-  { value: 1, label: "Enero" },
-  { value: 2, label: "Febrero" },
-  { value: 3, label: "Marzo" },
-  { value: 4, label: "Abril" },
-  { value: 5, label: "Mayo" },
-  { value: 6, label: "Junio" },
-  { value: 7, label: "Julio" },
-  { value: 8, label: "Agosto" },
-  { value: 9, label: "Septiembre" },
-  { value: 10, label: "Octubre" },
-  { value: 11, label: "Noviembre" },
-  { value: 12, label: "Diciembre" },
-];
+const MONTH_KEYS = [
+  { value: 1, key: "january" },
+  { value: 2, key: "february" },
+  { value: 3, key: "march" },
+  { value: 4, key: "april" },
+  { value: 5, key: "may" },
+  { value: 6, key: "june" },
+  { value: 7, key: "july" },
+  { value: 8, key: "august" },
+  { value: 9, key: "september" },
+  { value: 10, key: "october" },
+  { value: 11, key: "november" },
+  { value: 12, key: "december" },
+] as const;
 
 const currentYear = new Date().getFullYear();
 const YEARS = Array.from({ length: 5 }, (_, i) => currentYear - 2 + i);
@@ -66,6 +67,8 @@ export function FinancesDashboard({
   clubName,
   sections,
 }: FinancesDashboardProps) {
+  const t = useTranslations("finances");
+
   // Filters
   const [year, setYear] = useState<number | undefined>(currentYear);
   const [month, setMonth] = useState<number | undefined>(undefined);
@@ -160,7 +163,7 @@ export function FinancesDashboard({
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex items-center gap-1.5 text-sm text-muted-foreground">
           <Filter className="size-4" />
-          <span>Filtros:</span>
+          <span>{t("dashboard.filtersLabel")}</span>
         </div>
 
         {/* Year filter */}
@@ -169,10 +172,10 @@ export function FinancesDashboard({
           onValueChange={(v) => setYear(v === "all" ? undefined : Number(v))}
         >
           <SelectTrigger className="h-8 w-[110px]">
-            <SelectValue placeholder="Año" />
+            <SelectValue placeholder={t("form.yearPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos los años</SelectItem>
+            <SelectItem value="all">{t("dashboard.allYears")}</SelectItem>
             {YEARS.map((y) => (
               <SelectItem key={y} value={y.toString()}>
                 {y}
@@ -187,13 +190,13 @@ export function FinancesDashboard({
           onValueChange={(v) => setMonth(v === "all" ? undefined : Number(v))}
         >
           <SelectTrigger className="h-8 w-[140px]">
-            <SelectValue placeholder="Mes" />
+            <SelectValue placeholder={t("form.monthPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos los meses</SelectItem>
-            {MONTHS.map((m) => (
+            <SelectItem value="all">{t("dashboard.allMonths")}</SelectItem>
+            {MONTH_KEYS.map((m) => (
               <SelectItem key={m.value} value={m.value.toString()}>
-                {m.label}
+                {t(`months.${m.key}`)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -209,12 +212,12 @@ export function FinancesDashboard({
             <RefreshCw
               className={`size-4 ${loadingSummary || loadingTable ? "animate-spin" : ""}`}
             />
-            Actualizar
+            {t("dashboard.refreshButton")}
           </Button>
 
           <Button size="sm" onClick={handleNewTransaction}>
             <Plus className="size-4" />
-            Nuevo movimiento
+            {t("dashboard.newTransactionButton")}
           </Button>
         </div>
       </div>
@@ -228,7 +231,7 @@ export function FinancesDashboard({
 
       {/* Transactions table */}
       <div className="space-y-3">
-        <h2 className="text-base font-semibold">Movimientos</h2>
+        <h2 className="text-base font-semibold">{t("dashboard.transactionsTitle")}</h2>
         {loadingTable ? (
           <TransactionsTableSkeleton />
         ) : (
@@ -245,7 +248,10 @@ export function FinancesDashboard({
         {/* Pagination info */}
         {result && result.total > result.data.length && (
           <p className="text-sm text-muted-foreground">
-            Mostrando {result.data.length} de {result.total} movimientos.
+            {t("dashboard.showing", {
+              shown: result.data.length,
+              total: result.total,
+            })}
           </p>
         )}
       </div>

--- a/src/components/finances/finances-summary-cards.tsx
+++ b/src/components/finances/finances-summary-cards.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { FinanceSummary } from "@/lib/api/finances";
 import { formatCurrency } from "@/lib/currency";
+import { useTranslations } from "next-intl";
 
 // ─── Amount formatter ─────────────────────────────────────────────────────────
 
@@ -42,35 +43,43 @@ interface FinancesSummaryCardsProps {
 }
 
 export function FinancesSummaryCards({ summary }: FinancesSummaryCardsProps) {
+  const t = useTranslations("finances");
   const isPositiveBalance = summary.balance >= 0;
+
+  const movementsSub =
+    summary.movement_count === 1
+      ? t("summary.movementsCount", { count: summary.movement_count })
+      : t("summary.movementsCountPlural", { count: summary.movement_count });
 
   const cards = [
     {
-      label: "Total Ingresos",
+      label: t("summary.totalIncome"),
       value: formatAmount(summary.total_income),
       icon: TrendingUp,
       iconClass: "text-success",
       iconBg: "bg-success/10",
       valueClass: "text-success",
-      sub: `${summary.movement_count} movimiento${summary.movement_count !== 1 ? "s" : ""}`,
+      sub: movementsSub,
     },
     {
-      label: "Total Egresos",
+      label: t("summary.totalExpense"),
       value: formatAmount(summary.total_expense),
       icon: TrendingDown,
       iconClass: "text-destructive",
       iconBg: "bg-destructive/10",
       valueClass: "text-destructive",
-      sub: "en el período",
+      sub: t("summary.inPeriod"),
     },
     {
-      label: "Balance",
+      label: t("summary.balance"),
       value: formatAmount(summary.balance),
       icon: Wallet,
       iconClass: isPositiveBalance ? "text-primary" : "text-destructive",
       iconBg: isPositiveBalance ? "bg-primary/10" : "bg-destructive/10",
       valueClass: isPositiveBalance ? "text-foreground" : "text-destructive",
-      sub: isPositiveBalance ? "Saldo positivo" : "Saldo negativo",
+      sub: isPositiveBalance
+        ? t("summary.positiveBalance")
+        : t("summary.negativeBalance"),
     },
   ];
 

--- a/src/components/finances/transaction-form-dialog.tsx
+++ b/src/components/finances/transaction-form-dialog.tsx
@@ -40,21 +40,21 @@ import {
 
 const formSchema = z.object({
   year: z.coerce
-    .number({ error: "Ingresá un año válido" })
-    .min(2000, "Año inválido")
-    .max(2100, "Año inválido"),
+    .number()
+    .min(2000)
+    .max(2100),
   month: z.coerce
-    .number({ error: "Ingresá un mes válido" })
-    .min(1, "Mes inválido")
-    .max(12, "Mes inválido"),
+    .number()
+    .min(1)
+    .max(12),
   amount: z.coerce
-    .number({ error: "Ingresá un monto válido" })
-    .positive("El monto debe ser positivo"),
+    .number()
+    .positive(),
   description: z.string().optional(),
   finance_category_id: z.coerce
-    .number({ error: "Seleccioná una categoría" })
-    .min(1, "Seleccioná una categoría"),
-  finance_date: z.string().min(1, "Ingresá la fecha"),
+    .number()
+    .min(1),
+  finance_date: z.string().min(1),
   club_type_id: z.coerce.number().optional(),
   club_section_id: z.coerce.number().optional(),
 });
@@ -63,20 +63,20 @@ type FormValues = z.infer<typeof formSchema>;
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const MONTHS = [
-  { value: 1, label: "Enero" },
-  { value: 2, label: "Febrero" },
-  { value: 3, label: "Marzo" },
-  { value: 4, label: "Abril" },
-  { value: 5, label: "Mayo" },
-  { value: 6, label: "Junio" },
-  { value: 7, label: "Julio" },
-  { value: 8, label: "Agosto" },
-  { value: 9, label: "Septiembre" },
-  { value: 10, label: "Octubre" },
-  { value: 11, label: "Noviembre" },
-  { value: 12, label: "Diciembre" },
-];
+const MONTH_KEYS = [
+  "january",
+  "february",
+  "march",
+  "april",
+  "may",
+  "june",
+  "july",
+  "august",
+  "september",
+  "october",
+  "november",
+  "december",
+] as const;
 
 const currentYear = new Date().getFullYear();
 const YEARS = Array.from({ length: 6 }, (_, i) => currentYear - 2 + i);
@@ -124,7 +124,7 @@ export function TransactionFormDialog({
       .then(setCategories)
       .catch(() => toast.error(t("toasts.categories_load_failed")))
       .finally(() => setLoadingCategories(false));
-  }, [open]);
+  }, [open, t]);
 
   const today = new Date().toISOString().split("T")[0];
 
@@ -209,23 +209,23 @@ export function TransactionFormDialog({
         err instanceof Error
           ? err.message
           : isEdit
-            ? "No se pudo actualizar el movimiento"
-            : "No se pudo crear el movimiento";
+            ? t("errors.update_transaction_failed")
+            : t("errors.create_transaction_failed");
       toast.error(message);
     } finally {
       setIsSubmitting(false);
     }
-  }
+  };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
-          <DialogTitle>{isEdit ? "Editar movimiento" : "Nuevo movimiento"}</DialogTitle>
+          <DialogTitle>
+            {isEdit ? t("form.titleEdit") : t("form.titleNew")}
+          </DialogTitle>
           <DialogDescription>
-            {isEdit
-              ? "Modificá los datos del movimiento financiero."
-              : "Registrá un nuevo ingreso o egreso del club."}
+            {isEdit ? t("form.descriptionEdit") : t("form.descriptionNew")}
           </DialogDescription>
         </DialogHeader>
 
@@ -233,7 +233,7 @@ export function TransactionFormDialog({
           {/* Categoría */}
           <div className="space-y-1.5">
             <Label htmlFor="finance_category_id">
-              Categoría{" "}
+              {t("form.categoryLabel")}{" "}
               <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Select
@@ -244,7 +244,9 @@ export function TransactionFormDialog({
               <SelectTrigger id="finance_category_id" aria-required="true">
                 <SelectValue
                   placeholder={
-                    loadingCategories ? "Cargando categorías..." : "Seleccioná una categoría"
+                    loadingCategories
+                      ? t("form.categoryLoading")
+                      : t("form.categoryPlaceholder")
                   }
                 />
               </SelectTrigger>
@@ -254,14 +256,17 @@ export function TransactionFormDialog({
                     key={cat.finance_category_id}
                     value={cat.finance_category_id.toString()}
                   >
-                    {cat.name} — {cat.type === 0 ? "Ingreso" : "Egreso"}
+                    {cat.name} —{" "}
+                    {cat.type === 0
+                      ? t("categoryType.income")
+                      : t("categoryType.expense")}
                   </SelectItem>
                 ))}
               </SelectContent>
             </Select>
             {errors.finance_category_id && (
               <p className="text-xs text-destructive">
-                {errors.finance_category_id.message}
+                {t("validation.category_required")}
               </p>
             )}
           </div>
@@ -269,7 +274,7 @@ export function TransactionFormDialog({
           {/* Fecha */}
           <div className="space-y-1.5">
             <Label htmlFor="finance_date">
-              Fecha{" "}
+              {t("form.dateLabel")}{" "}
               <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Input
@@ -279,14 +284,16 @@ export function TransactionFormDialog({
               {...register("finance_date")}
             />
             {errors.finance_date && (
-              <p className="text-xs text-destructive">{errors.finance_date.message}</p>
+              <p className="text-xs text-destructive">
+                {t("validation.date_required")}
+              </p>
             )}
           </div>
 
           {/* Monto */}
           <div className="space-y-1.5">
             <Label htmlFor="amount">
-              Monto{" "}
+              {t("form.amountLabel")}{" "}
               <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
             </Label>
             <Input
@@ -299,7 +306,9 @@ export function TransactionFormDialog({
               {...register("amount")}
             />
             {errors.amount && (
-              <p className="text-xs text-destructive">{errors.amount.message}</p>
+              <p className="text-xs text-destructive">
+                {t("validation.amount_positive")}
+              </p>
             )}
           </div>
 
@@ -307,7 +316,7 @@ export function TransactionFormDialog({
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
               <Label htmlFor="year">
-                Año{" "}
+                {t("form.yearLabel")}{" "}
                 <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
@@ -316,7 +325,7 @@ export function TransactionFormDialog({
                 disabled={isEdit}
               >
                 <SelectTrigger id="year" aria-required="true">
-                  <SelectValue placeholder="Año" />
+                  <SelectValue placeholder={t("form.yearPlaceholder")} />
                 </SelectTrigger>
                 <SelectContent>
                   {YEARS.map((y) => (
@@ -327,13 +336,15 @@ export function TransactionFormDialog({
                 </SelectContent>
               </Select>
               {errors.year && (
-                <p className="text-xs text-destructive">{errors.year.message}</p>
+                <p className="text-xs text-destructive">
+                  {t("validation.year_invalid")}
+                </p>
               )}
             </div>
 
             <div className="space-y-1.5">
               <Label htmlFor="month">
-                Mes{" "}
+                {t("form.monthLabel")}{" "}
                 <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
@@ -342,18 +353,20 @@ export function TransactionFormDialog({
                 disabled={isEdit}
               >
                 <SelectTrigger id="month" aria-required="true">
-                  <SelectValue placeholder="Mes" />
+                  <SelectValue placeholder={t("form.monthPlaceholder")} />
                 </SelectTrigger>
                 <SelectContent>
-                  {MONTHS.map((m) => (
-                    <SelectItem key={m.value} value={m.value.toString()}>
-                      {m.label}
+                  {MONTH_KEYS.map((key, index) => (
+                    <SelectItem key={key} value={String(index + 1)}>
+                      {t(`months.${key}`)}
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
               {errors.month && (
-                <p className="text-xs text-destructive">{errors.month.message}</p>
+                <p className="text-xs text-destructive">
+                  {t("validation.month_invalid")}
+                </p>
               )}
             </div>
           </div>
@@ -362,7 +375,7 @@ export function TransactionFormDialog({
           {!isEdit && (
             <div className="space-y-1.5">
               <Label htmlFor="club_section_id">
-                Sección del club{" "}
+                {t("form.sectionLabel")}{" "}
                 <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
@@ -379,7 +392,7 @@ export function TransactionFormDialog({
                 }}
               >
                 <SelectTrigger id="club_section_id" aria-required="true">
-                  <SelectValue placeholder="Seleccioná una sección" />
+                  <SelectValue placeholder={t("form.sectionPlaceholder")} />
                 </SelectTrigger>
                 <SelectContent>
                   {sections.length > 0 ? (
@@ -394,7 +407,7 @@ export function TransactionFormDialog({
                     ))
                   ) : (
                     <SelectItem value="0" disabled>
-                      No hay secciones disponibles
+                      {t("form.sectionEmpty")}
                     </SelectItem>
                   )}
                 </SelectContent>
@@ -404,10 +417,10 @@ export function TransactionFormDialog({
 
           {/* Descripción */}
           <div className="space-y-1.5">
-            <Label htmlFor="description">Descripción</Label>
+            <Label htmlFor="description">{t("form.descriptionLabel")}</Label>
             <Textarea
               id="description"
-              placeholder="Descripción del movimiento (opcional)"
+              placeholder={t("form.descriptionPlaceholder")}
               className="min-h-[80px] resize-none"
               {...register("description")}
             />
@@ -420,11 +433,11 @@ export function TransactionFormDialog({
               onClick={() => onOpenChange(false)}
               disabled={isSubmitting}
             >
-              Cancelar
+              {t("form.cancelButton")}
             </Button>
             <Button type="submit" disabled={isSubmitting || loadingCategories}>
               {isSubmitting && <Loader2 aria-hidden="true" className="size-4 animate-spin" />}
-              {isEdit ? "Guardar cambios" : "Crear movimiento"}
+              {isEdit ? t("form.saveButton") : t("form.createButton")}
             </Button>
           </DialogFooter>
         </form>

--- a/src/components/finances/transactions-table.tsx
+++ b/src/components/finances/transactions-table.tsx
@@ -27,6 +27,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { DollarSign } from "lucide-react";
 import type { Finance, FinanceSortField } from "@/lib/api/finances";
 import { formatCurrency } from "@/lib/currency";
+import { useTranslations } from "next-intl";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -46,32 +47,41 @@ function formatDate(dateStr: string): string {
   }
 }
 
-const MONTH_NAMES: Record<number, string> = {
-  1: "Enero",
-  2: "Febrero",
-  3: "Marzo",
-  4: "Abril",
-  5: "Mayo",
-  6: "Junio",
-  7: "Julio",
-  8: "Agosto",
-  9: "Septiembre",
-  10: "Octubre",
-  11: "Noviembre",
-  12: "Diciembre",
+const MONTH_KEYS: Record<number, string> = {
+  1: "january",
+  2: "february",
+  3: "march",
+  4: "april",
+  5: "may",
+  6: "june",
+  7: "july",
+  8: "august",
+  9: "september",
+  10: "october",
+  11: "november",
+  12: "december",
 };
 
 // ─── Skeleton ─────────────────────────────────────────────────────────────────
 
 export function TransactionsTableSkeleton() {
+  const t = useTranslations("finances");
+
   return (
     <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
       <Table>
         <TableHeader>
           <TableRow>
-            {["Fecha", "Descripción", "Categoría", "Tipo", "Monto", ""].map((h) => (
+            {[
+              t("table.colDate"),
+              t("table.colDescription"),
+              t("table.colCategory"),
+              t("table.colType"),
+              t("table.colAmount"),
+              "",
+            ].map((h, i) => (
               <TableHead
-                key={h}
+                key={i}
                 className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground"
               >
                 {h}
@@ -127,14 +137,24 @@ export function TransactionsTable({
   sortDirection,
   onSort,
 }: TransactionsTableProps) {
+  const t = useTranslations("finances");
+
   if (items.length === 0) {
     return (
       <EmptyState
         icon={DollarSign}
-        title="Sin movimientos"
-        description="No se encontraron movimientos financieros para los filtros seleccionados."
+        title={t("table.emptyTitle")}
+        description={t("table.emptyDescription")}
       />
     );
+  }
+
+  function monthName(month: number): string {
+    const key = MONTH_KEYS[month];
+    if (key) {
+      return t(`months.${key}` as Parameters<typeof t>[0]);
+    }
+    return String(month);
   }
 
   return (
@@ -158,11 +178,11 @@ export function TransactionsTable({
                 direction={sortDirection}
                 onSort={onSort}
               >
-                Fecha
+                {t("table.colDate")}
               </SortableHeader>
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Descripción
+              {t("table.colDescription")}
             </TableHead>
             <TableHead
               className="h-9 px-3"
@@ -180,14 +200,14 @@ export function TransactionsTable({
                 direction={sortDirection}
                 onSort={onSort}
               >
-                Categoría
+                {t("table.colCategory")}
               </SortableHeader>
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Período
+              {t("table.colPeriod")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Tipo
+              {t("table.colType")}
             </TableHead>
             <TableHead
               className="h-9 px-3 text-right"
@@ -206,7 +226,7 @@ export function TransactionsTable({
                 onSort={onSort}
                 align="right"
               >
-                Monto
+                {t("table.colAmount")}
               </SortableHeader>
             </TableHead>
             <TableHead className="h-9 w-12 px-3" />
@@ -232,11 +252,11 @@ export function TransactionsTable({
                   </span>
                 </TableCell>
                 <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground tabular-nums">
-                  {MONTH_NAMES[finance.month] ?? finance.month}/{finance.year}
+                  {monthName(finance.month)}/{finance.year}
                 </TableCell>
                 <TableCell className="px-3 py-2.5 align-middle">
                   <Badge variant={isIncome ? "success" : "destructive"}>
-                    {isIncome ? "Ingreso" : "Egreso"}
+                    {isIncome ? t("table.typeIncome") : t("table.typeExpense")}
                   </Badge>
                 </TableCell>
                 <TableCell className="px-3 py-2.5 align-middle text-right">
@@ -254,13 +274,13 @@ export function TransactionsTable({
                     <DropdownMenuTrigger asChild>
                       <Button variant="ghost" size="icon-sm">
                         <MoreHorizontal className="size-4" />
-                        <span className="sr-only">Acciones</span>
+                        <span className="sr-only">{t("table.actionsLabel")}</span>
                       </Button>
                     </DropdownMenuTrigger>
                     <DropdownMenuContent align="end">
                       <DropdownMenuItem onClick={() => onEdit(finance)}>
                         <Pencil className="size-4" />
-                        Editar
+                        {t("table.actionEdit")}
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
@@ -268,7 +288,7 @@ export function TransactionsTable({
                         onClick={() => onDelete(finance)}
                       >
                         <Trash2 className="size-4" />
-                        Eliminar
+                        {t("table.actionDelete")}
                       </DropdownMenuItem>
                     </DropdownMenuContent>
                   </DropdownMenu>


### PR DESCRIPTION
## Summary

Batch 2 of next-intl rollout. Expands the existing `finances` namespace (3 keys → ~80 keys) covering the full finances flow.

## Files

| File | Notes |
|---|---|
| `transaction-form-dialog.tsx` | Form labels, placeholders, validation errors. Zod schema strings removed from module scope; validation errors now render-time via `t("errors.*")`. MONTHS array → MONTH_KEYS + `t("months.*")`. |
| `transactions-table.tsx` | Column headers, empty state, dropdown actions, type badges. MONTH_NAMES record → MONTH_KEYS lookup. |
| `finances-dashboard.tsx` | Filter bar, refresh/new buttons, section title, pagination interpolation. |
| `finances-summary-cards.tsx` | Total labels + ICU plural movements count. |
| `delete-transaction-dialog.tsx` | Description split into `descriptionPre` + `cannotUndo` atomic keys to flank the styled `<strong>` JSX. |

## Sub-namespaces

| | Keys |
|---|---|
| `finances.dashboard.*` | 7 |
| `finances.form.*` | 20 |
| `finances.table.*` | 13 |
| `finances.delete.*` | 6 |
| `finances.summary.*` | 8 |
| `finances.months.*` | 12 |
| `finances.errors.*` | 2 |
| `finances.validation.*` | 8 |
| `finances.categoryType.*` | 2 |

## Out of scope

- Currency formatting (`Intl.NumberFormat("es-MX", currency: "ARS")`) — deferred to locale-routing PR
- Date formatting (`toLocaleDateString`) — same

## Caveat

en/fr/pt-BR best-effort. Native review flagged:
- `pt-BR.form.amountLabel` — `"Valor (ARS)"` (vs `Monto`)
- `pt-BR.table.actionDelete` — `"Excluir"` (vs `Deletar`)
- `fr.table.typeIncome/typeExpense` — `"Revenu"` / `"Dépense"` (verify accounting term)

## Test plan

- [ ] CI typecheck (#56) passes
- [ ] CI tests (#60) passes — 41/41
- [ ] `/dashboard/clubs/:id/finances` renders all flows in `es` without missing-key warnings
- [ ] Create + edit + delete transaction dialogs render correctly