### PR TITLE
feat(honors): migrate CRUD from Dialog to dedicated pages (audit C2)

### DIFF
--- a/src/app/(dashboard)/dashboard/honors/[honorId]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/[honorId]/edit/page.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/shared/page-header";
+import { HonorForm } from "@/components/honors/honor-form";
+import { ApiError } from "@/lib/api/client";
+import { getHonorById } from "@/lib/api/honors";
+import { requireAdminUser } from "@/lib/auth/session";
+import { extractRoles, SUPER_ADMIN_ROLE } from "@/lib/auth/roles";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import { HONORS_UPDATE } from "@/lib/auth/permissions";
+import { updateHonorAction } from "@/lib/honors/actions";
+import { loadHonorCatalogOptions } from "@/lib/honors/catalogs";
+
+type Params = Promise<{ honorId: string }>;
+
+function pickHonorRecord(payload: unknown): Record<string, unknown> | null {
+  if (!payload || typeof payload !== "object") return null;
+  const root = payload as Record<string, unknown>;
+  if (root.honor_id !== undefined || root.id !== undefined) {
+    return root;
+  }
+  const nested = root.data;
+  if (nested && typeof nested === "object") {
+    return nested as Record<string, unknown>;
+  }
+  return null;
+}
+
+export default async function EditHonorPage({ params }: { params: Params }) {
+  const { honorId: rawHonorId } = await params;
+  const honorId = Number(rawHonorId);
+  if (!Number.isFinite(honorId) || honorId <= 0) {
+    notFound();
+  }
+
+  const user = await requireAdminUser();
+  const roleSet = new Set(extractRoles(user));
+  const isSuperAdmin = roleSet.has(SUPER_ADMIN_ROLE);
+  const canEdit = isSuperAdmin || hasAnyPermission(user, [HONORS_UPDATE]);
+
+  if (!canEdit) {
+    notFound();
+  }
+
+  let honor: Record<string, unknown> | null = null;
+  try {
+    const payload = await getHonorById(honorId);
+    honor = pickHonorRecord(payload);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      notFound();
+    }
+    throw error;
+  }
+
+  if (!honor) {
+    notFound();
+  }
+
+  const { categoryOptions, clubTypeOptions } = await loadHonorCatalogOptions();
+  const boundUpdateAction = updateHonorAction.bind(null, honorId);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Editar especialidad"
+        description="Modifica los datos de la especialidad."
+      >
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/dashboard/honors">
+            <ArrowLeft className="mr-2 size-4" />
+            Volver
+          </Link>
+        </Button>
+      </PageHeader>
+
+      <HonorForm
+        mode="edit"
+        initialItem={honor}
+        categoryOptions={categoryOptions}
+        clubTypeOptions={clubTypeOptions}
+        formAction={boundUpdateAction}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/honors/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/new/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/shared/page-header";
+import { HonorForm } from "@/components/honors/honor-form";
+import { requireAdminUser } from "@/lib/auth/session";
+import { extractRoles, SUPER_ADMIN_ROLE } from "@/lib/auth/roles";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import { HONORS_CREATE } from "@/lib/auth/permissions";
+import { createHonorAction } from "@/lib/honors/actions";
+import { loadHonorCatalogOptions } from "@/lib/honors/catalogs";
+
+export default async function NewHonorPage() {
+  const user = await requireAdminUser();
+  const roleSet = new Set(extractRoles(user));
+  const isSuperAdmin = roleSet.has(SUPER_ADMIN_ROLE);
+  const canCreate = isSuperAdmin || hasAnyPermission(user, [HONORS_CREATE]);
+
+  if (!canCreate) {
+    notFound();
+  }
+
+  const { categoryOptions, clubTypeOptions } = await loadHonorCatalogOptions();
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Crear especialidad"
+        description="Registra una nueva especialidad en el catálogo."
+      >
+        <Button variant="outline" size="sm" asChild>
+          <Link href="/dashboard/honors">
+            <ArrowLeft className="mr-2 size-4" />
+            Volver
+          </Link>
+        </Button>
+      </PageHeader>
+
+      <HonorForm
+        mode="create"
+        categoryOptions={categoryOptions}
+        clubTypeOptions={clubTypeOptions}
+        formAction={createHonorAction}
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/honors/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/page.tsx
@@ -7,11 +7,7 @@ import { hasAnyPermission } from "@/lib/auth/permission-utils";
 import { HONORS_CREATE, HONORS_UPDATE } from "@/lib/auth/permissions";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 import { HonorsCrudPage } from "@/components/honors/honors-crud-page";
-import {
-  createHonorAction,
-  deactivateHonorAction,
-  updateHonorAction,
-} from "@/lib/honors/actions";
+import { deactivateHonorAction } from "@/lib/honors/actions";
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 type SelectOption = { label: string; value: number };
@@ -443,8 +439,6 @@ export default async function HonorsPage({
         canCreate={canCreate}
         canEdit={canEdit}
         canDelete={canDelete}
-        createAction={createHonorAction}
-        updateActionBase={updateHonorAction}
         deactivateAction={deactivateHonorAction}
       />
     </div>

--- a/src/components/honors/honor-form-fields.tsx
+++ b/src/components/honors/honor-form-fields.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { SelectOption } from "@/lib/honors/catalogs";
+
+type HonorRecord = Record<string, unknown>;
+
+function toPositiveNumber(value: unknown): number | null {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+function toText(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+interface HonorFormFieldsProps {
+  item?: HonorRecord | null;
+  categoryOptions: SelectOption[];
+  clubTypeOptions: SelectOption[];
+}
+
+export function HonorFormFields({ item, categoryOptions, clubTypeOptions }: HonorFormFieldsProps) {
+  const currentCategoryId = toPositiveNumber(item?.honors_category_id ?? item?.category_id);
+  const currentClubTypeId = toPositiveNumber(item?.club_type_id);
+  const currentSkillLevel = toPositiveNumber(item?.skill_level) ?? 1;
+  const currentMasterHonor = toPositiveNumber(item?.master_honors);
+  const isActive = item ? item.active !== false : true;
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Datos de la especialidad</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="honor_name">
+              Nombre <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="honor_name"
+              name="name"
+              defaultValue={toText(item?.name) ?? ""}
+              placeholder="Nombre de la especialidad"
+              required
+              aria-required="true"
+            />
+          </div>
+
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="honor_description">Descripción</Label>
+            <Textarea
+              id="honor_description"
+              name="description"
+              rows={3}
+              defaultValue={toText(item?.description) ?? ""}
+              placeholder="Descripción opcional"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="honors_category_id">Categoría</Label>
+            <Select
+              name="honors_category_id"
+              defaultValue={currentCategoryId ? String(currentCategoryId) : undefined}
+            >
+              <SelectTrigger id="honors_category_id">
+                <SelectValue placeholder="Seleccionar categoría" />
+              </SelectTrigger>
+              <SelectContent>
+                {categoryOptions.map((option) => (
+                  <SelectItem key={option.value} value={String(option.value)}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="club_type_id">Tipo de club</Label>
+            <Select
+              name="club_type_id"
+              defaultValue={currentClubTypeId ? String(currentClubTypeId) : undefined}
+            >
+              <SelectTrigger id="club_type_id">
+                <SelectValue placeholder="Seleccionar club" />
+              </SelectTrigger>
+              <SelectContent>
+                {clubTypeOptions.map((option) => (
+                  <SelectItem key={option.value} value={String(option.value)}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="skill_level">Nivel</Label>
+            <Input
+              id="skill_level"
+              name="skill_level"
+              type="number"
+              min={1}
+              defaultValue={String(currentSkillLevel)}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="master_honors">Master honor</Label>
+            <Input
+              id="master_honors"
+              name="master_honors"
+              type="number"
+              min={1}
+              defaultValue={currentMasterHonor ? String(currentMasterHonor) : ""}
+            />
+          </div>
+
+          <div className="flex items-center gap-2 sm:col-span-2">
+            <input type="hidden" name="active" defaultValue={isActive ? "on" : ""} />
+            <Checkbox
+              id="active"
+              defaultChecked={isActive}
+              onCheckedChange={(checked) => {
+                const hidden = document.querySelector<HTMLInputElement>(
+                  'input[type="hidden"][name="active"]',
+                );
+                if (hidden) {
+                  hidden.value = checked ? "on" : "";
+                }
+              }}
+            />
+            <Label htmlFor="active">Especialidad activa</Label>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Recursos (opcional)</CardTitle>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="honor_image">Imagen (URL relativa o archivo)</Label>
+            <Input
+              id="honor_image"
+              name="honor_image"
+              defaultValue={toText(item?.honor_image ?? item?.patch_image) ?? ""}
+              placeholder="Especialidades/acolchado.png"
+            />
+          </div>
+
+          <div className="space-y-2 sm:col-span-2">
+            <Label htmlFor="material_url">Material (PDF)</Label>
+            <Input
+              id="material_url"
+              name="material_url"
+              defaultValue={toText(item?.material_url ?? item?.material_honor) ?? ""}
+              placeholder="Especialidades/Material/acolchado.pdf"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="year">Año</Label>
+            <Input
+              id="year"
+              name="year"
+              defaultValue={toText(item?.year) ?? ""}
+              placeholder="2026"
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/src/components/honors/honor-form.tsx
+++ b/src/components/honors/honor-form.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { HonorFormFields } from "@/components/honors/honor-form-fields";
+import type { SelectOption } from "@/lib/honors/catalogs";
+import type { HonorActionState } from "@/lib/honors/actions";
+
+type HonorRecord = Record<string, unknown>;
+type HonorFormAction = (
+  prevState: HonorActionState,
+  formData: FormData,
+) => Promise<HonorActionState>;
+
+interface HonorFormProps {
+  mode: "create" | "edit";
+  initialItem?: HonorRecord | null;
+  categoryOptions: SelectOption[];
+  clubTypeOptions: SelectOption[];
+  formAction: HonorFormAction;
+}
+
+const initialState: HonorActionState = {};
+
+function SubmitButton({ label }: { label: string }) {
+  const { pending } = useFormStatus();
+  return (
+    <Button type="submit" disabled={pending}>
+      {pending && <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />}
+      {label}
+    </Button>
+  );
+}
+
+export function HonorForm({
+  mode,
+  initialItem,
+  categoryOptions,
+  clubTypeOptions,
+  formAction,
+}: HonorFormProps) {
+  const [state, action] = useActionState(formAction, initialState);
+  const submitLabel = mode === "create" ? "Crear especialidad" : "Guardar cambios";
+
+  return (
+    <form action={action} className="space-y-6" noValidate>
+      {state.error && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {state.error}
+        </div>
+      )}
+
+      <HonorFormFields
+        item={initialItem}
+        categoryOptions={categoryOptions}
+        clubTypeOptions={clubTypeOptions}
+      />
+
+      <div className="flex justify-end gap-2">
+        <Button variant="outline" asChild>
+          <Link href="/dashboard/honors">Cancelar</Link>
+        </Button>
+        <SubmitButton label={submitLabel} />
+      </div>
+    </form>
+  );
+}

--- a/src/components/honors/honors-crud-page.tsx
+++ b/src/components/honors/honors-crud-page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useActionState, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useFormStatus } from "react-dom";
@@ -16,8 +17,6 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Textarea } from "@/components/ui/textarea";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -25,14 +24,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
 import {
   AlertDialog,
   AlertDialogCancel,
@@ -66,11 +57,6 @@ type HonorRecord = Record<string, unknown>;
 type SelectOption = { label: string; value: number };
 type NavigationMode = "push" | "replace";
 type HonorFormAction = (prevState: HonorActionState, formData: FormData) => Promise<HonorActionState>;
-type HonorUpdateAction = (
-  honorId: number,
-  prevState: HonorActionState,
-  formData: FormData,
-) => Promise<HonorActionState>;
 
 const HONOR_IMAGE_KEYS = [
   "patch_image",
@@ -106,8 +92,6 @@ interface HonorsCrudPageProps {
   canCreate: boolean;
   canEdit: boolean;
   canDelete: boolean;
-  createAction: HonorFormAction;
-  updateActionBase: HonorUpdateAction;
   deactivateAction: HonorFormAction;
 }
 
@@ -186,21 +170,6 @@ function resolveClubTypeName(item: HonorRecord, clubTypeById: Map<number, string
   return clubTypeById.get(id) ?? `#${id}`;
 }
 
-function getDefaultCheckboxValue(item?: HonorRecord | null): boolean {
-  if (!item) return true;
-  return item.active !== false;
-}
-
-function SubmitButton({ label }: { label: string }) {
-  const { pending } = useFormStatus();
-  return (
-    <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
-      {label}
-    </Button>
-  );
-}
-
 function DeleteButton() {
   const { pending } = useFormStatus();
   return (
@@ -208,141 +177,6 @@ function DeleteButton() {
       {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
       Eliminar
     </Button>
-  );
-}
-
-type HonorFormFieldsProps = {
-  item?: HonorRecord | null;
-  categoryOptions: SelectOption[];
-  clubTypeOptions: SelectOption[];
-  activeChecked: boolean;
-  onActiveChange: (checked: boolean) => void;
-};
-
-function HonorFormFields({
-  item,
-  categoryOptions,
-  clubTypeOptions,
-  activeChecked,
-  onActiveChange,
-}: HonorFormFieldsProps) {
-  const currentCategoryId = toPositiveNumber(item?.honors_category_id ?? item?.category_id);
-  const currentClubTypeId = toPositiveNumber(item?.club_type_id);
-  const currentSkillLevel = toPositiveNumber(item?.skill_level) ?? 1;
-  const currentMasterHonor = toPositiveNumber(item?.master_honors);
-
-  return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <Label htmlFor="honor_name">
-          Nombre <span className="text-destructive">*</span>
-        </Label>
-        <Input id="honor_name" name="name" defaultValue={toText(item?.name) ?? ""} required />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="honor_description">Descripción</Label>
-        <Textarea
-          id="honor_description"
-          name="description"
-          rows={3}
-          defaultValue={toText(item?.description) ?? ""}
-        />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="honor_image">Imagen (URL o archivo)</Label>
-        <Input
-          id="honor_image"
-          name="honor_image"
-          defaultValue={toText(item?.honor_image ?? item?.patch_image) ?? ""}
-          placeholder="Especialidades/acolchado.png"
-        />
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="material_url">Material (PDF)</Label>
-        <Input
-          id="material_url"
-          name="material_url"
-          defaultValue={toText(item?.material_url ?? item?.material_honor) ?? ""}
-          placeholder="Especialidades/Material/acolchado.pdf"
-        />
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div className="space-y-2">
-          <Label>Categoría</Label>
-          <Select name="honors_category_id" defaultValue={currentCategoryId ? String(currentCategoryId) : undefined}>
-            <SelectTrigger>
-              <SelectValue placeholder="Seleccionar categoría" />
-            </SelectTrigger>
-            <SelectContent>
-              {categoryOptions.map((option) => (
-                <SelectItem key={option.value} value={String(option.value)}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
-        <div className="space-y-2">
-          <Label>Tipo de club</Label>
-          <Select name="club_type_id" defaultValue={currentClubTypeId ? String(currentClubTypeId) : undefined}>
-            <SelectTrigger>
-              <SelectValue placeholder="Seleccionar club" />
-            </SelectTrigger>
-            <SelectContent>
-              {clubTypeOptions.map((option) => (
-                <SelectItem key={option.value} value={String(option.value)}>
-                  {option.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-3">
-        <div className="space-y-2">
-          <Label htmlFor="skill_level">Nivel</Label>
-          <Input
-            id="skill_level"
-            name="skill_level"
-            type="number"
-            min={1}
-            defaultValue={String(currentSkillLevel)}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="master_honors">Master honor</Label>
-          <Input
-            id="master_honors"
-            name="master_honors"
-            type="number"
-            min={1}
-            defaultValue={currentMasterHonor ? String(currentMasterHonor) : ""}
-          />
-        </div>
-
-        <div className="space-y-2">
-          <Label htmlFor="year">Año</Label>
-          <Input id="year" name="year" defaultValue={toText(item?.year) ?? ""} />
-        </div>
-      </div>
-
-      <div className="flex items-center gap-2">
-        <input type="hidden" name="active" value={activeChecked ? "on" : ""} />
-        <Checkbox
-          id="active"
-          checked={activeChecked}
-          onCheckedChange={(checked) => onActiveChange(!!checked)}
-        />
-        <Label htmlFor="active">Activo</Label>
-      </div>
-    </div>
   );
 }
 
@@ -354,8 +188,6 @@ export function HonorsCrudPage({
   canCreate,
   canEdit,
   canDelete,
-  createAction,
-  updateActionBase,
   deactivateAction,
 }: HonorsCrudPageProps) {
   const router = useRouter();
@@ -365,11 +197,7 @@ export function HonorsCrudPage({
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const latestParamsRef = useRef(searchParamsString);
 
-  const [createOpen, setCreateOpen] = useState(false);
-  const [editItem, setEditItem] = useState<HonorRecord | null>(null);
   const [deleteItem, setDeleteItem] = useState<HonorRecord | null>(null);
-  const [createActiveChecked, setCreateActiveChecked] = useState(true);
-  const [editActiveChecked, setEditActiveChecked] = useState(true);
 
   const categoryNameById = useMemo(() => {
     const map = new Map<number, string>();
@@ -387,23 +215,7 @@ export function HonorsCrudPage({
     return map;
   }, [clubTypeOptions]);
 
-  const [createState, createFormAction] = useActionState<HonorActionState, FormData>(createAction, {});
   const [deleteState, deleteFormAction] = useActionState<HonorActionState, FormData>(deactivateAction, {});
-
-  const editId = editItem ? pickHonorId(editItem) : null;
-  const boundUpdateAction = editItem && editId
-    ? updateActionBase.bind(null, editId)
-    : async (): Promise<HonorActionState> => ({ error: "No se pudo identificar la especialidad." });
-  const [updateState, updateFormAction] = useActionState<HonorActionState, FormData>(boundUpdateAction, {});
-
-  const handleCreateDialogChange = (open: boolean) => {
-    setCreateOpen(open);
-    if (open) setCreateActiveChecked(true);
-  };
-
-  const handleEditDialogChange = (open: boolean) => {
-    if (!open) setEditItem(null);
-  };
 
   useEffect(() => {
     latestParamsRef.current = searchParamsString;
@@ -529,9 +341,11 @@ export function HonorsCrudPage({
     <div className="space-y-6">
       <PageHeader title="Especialidades" description="Catálogo de especialidades.">
         {canCreate && (
-          <Button onClick={() => handleCreateDialogChange(true)}>
-            <Plus className="mr-2 size-4" />
-            Crear especialidad
+          <Button asChild>
+            <Link href="/dashboard/honors/new">
+              <Plus className="mr-2 size-4" />
+              Crear especialidad
+            </Link>
           </Button>
         )}
       </PageHeader>
@@ -633,9 +447,11 @@ export function HonorsCrudPage({
             description={hasActiveFilters ? "No hay especialidades que coincidan con los filtros." : "No se encontraron registros."}
           >
             {canCreate && !hasActiveFilters && (
-              <Button onClick={() => handleCreateDialogChange(true)}>
-                <Plus className="mr-2 size-4" />
-                Crear especialidad
+              <Button asChild>
+                <Link href="/dashboard/honors/new">
+                  <Plus className="mr-2 size-4" />
+                  Crear especialidad
+                </Link>
               </Button>
             )}
           </EmptyState>
@@ -666,6 +482,7 @@ export function HonorsCrudPage({
                     const clubTypeName = resolveClubTypeName(item, clubTypeById);
                     const skillLevel = toPositiveNumber(item.skill_level);
                     const rowKey = honorId ? `honor-${honorId}` : `honor-row-${(safePage - 1) * safeLimit + idx}`;
+                    const editHref = honorId ? `/dashboard/honors/${honorId}/edit` : null;
 
                     return (
                       <TableRow key={rowKey}>
@@ -687,19 +504,17 @@ export function HonorsCrudPage({
                         {(canEdit || canDelete) && (
                           <TableCell className="sticky right-0 z-10 border-l bg-background">
                             <div className="hidden gap-1 md:flex">
-                              {canEdit && (
+                              {canEdit && editHref && (
                                 <Button
                                   variant="ghost"
                                   size="icon"
                                   className="size-8"
-                                  disabled={!honorId}
-                                  onClick={() => {
-                                    setEditItem(item);
-                                    setEditActiveChecked(getDefaultCheckboxValue(item));
-                                  }}
+                                  asChild
                                   title="Editar"
                                 >
-                                  <Pencil className="size-3.5" />
+                                  <Link href={editHref} aria-label={`Editar ${honorName}`}>
+                                    <Pencil className="size-3.5" />
+                                  </Link>
                                 </Button>
                               )}
                               {canDelete && (
@@ -723,16 +538,12 @@ export function HonorsCrudPage({
                                   </Button>
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent align="end">
-                                  {canEdit && (
-                                    <DropdownMenuItem
-                                      disabled={!honorId}
-                                      onSelect={() => {
-                                        setEditItem(item);
-                                        setEditActiveChecked(getDefaultCheckboxValue(item));
-                                      }}
-                                    >
-                                      <Pencil className="size-4" />
-                                      Editar
+                                  {canEdit && editHref && (
+                                    <DropdownMenuItem asChild>
+                                      <Link href={editHref}>
+                                        <Pencil className="size-4" />
+                                        Editar
+                                      </Link>
                                     </DropdownMenuItem>
                                   )}
                                   {canDelete && (
@@ -767,66 +578,6 @@ export function HonorsCrudPage({
           </>
         )}
       </div>
-
-      {canCreate && (
-        <Dialog open={createOpen} onOpenChange={handleCreateDialogChange}>
-          <DialogContent className="max-w-2xl">
-            <DialogHeader>
-              <DialogTitle>Crear especialidad</DialogTitle>
-              <DialogDescription>Completa los campos necesarios para registrar la especialidad.</DialogDescription>
-            </DialogHeader>
-            <form action={createFormAction} className="space-y-4">
-              {createState.error && (
-                <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                  {createState.error}
-                </div>
-              )}
-              <HonorFormFields
-                categoryOptions={categoryOptions}
-                clubTypeOptions={clubTypeOptions}
-                activeChecked={createActiveChecked}
-                onActiveChange={setCreateActiveChecked}
-              />
-              <DialogFooter>
-                <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>
-                  Cancelar
-                </Button>
-                <SubmitButton label="Crear" />
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-      )}
-
-      {canEdit && editItem && editId && (
-        <Dialog open={!!editItem} onOpenChange={handleEditDialogChange}>
-          <DialogContent className="max-w-2xl">
-            <DialogHeader>
-              <DialogTitle>Editar especialidad</DialogTitle>
-            </DialogHeader>
-            <form action={updateFormAction} className="space-y-4">
-              {updateState.error && (
-                <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                  {updateState.error}
-                </div>
-              )}
-              <HonorFormFields
-                item={editItem}
-                categoryOptions={categoryOptions}
-                clubTypeOptions={clubTypeOptions}
-                activeChecked={editActiveChecked}
-                onActiveChange={setEditActiveChecked}
-              />
-              <DialogFooter>
-                <Button type="button" variant="outline" onClick={() => setEditItem(null)}>
-                  Cancelar
-                </Button>
-                <SubmitButton label="Guardar cambios" />
-              </DialogFooter>
-            </form>
-          </DialogContent>
-        </Dialog>
-      )}
 
       {canDelete && deleteItem && (
         <AlertDialog open={!!deleteItem} onOpenChange={(open) => { if (!open) setDeleteItem(null); }}>

--- a/src/lib/honors/catalogs.ts
+++ b/src/lib/honors/catalogs.ts
@@ -1,0 +1,110 @@
+import { listClubTypes } from "@/lib/api/catalogs";
+import { listHonorCategories } from "@/lib/api/honors";
+
+export type SelectOption = { label: string; value: number };
+type GenericRecord = Record<string, unknown>;
+
+const CATALOGS_CACHE_TTL_MS = 5 * 60 * 1000;
+const EMPTY_ARRAY: unknown[] = [];
+
+let cachedHonorCategories: { value: unknown; fetchedAt: number } | null = null;
+let cachedClubTypes: { value: unknown; fetchedAt: number } | null = null;
+
+function toPositiveNumber(value: unknown): number | null {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return null;
+  }
+  return parsed;
+}
+
+function toNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function normalizeArrayPayload(payload: unknown): GenericRecord[] {
+  if (Array.isArray(payload)) return payload as GenericRecord[];
+  if (payload && typeof payload === "object" && Array.isArray((payload as { data?: unknown[] }).data)) {
+    return ((payload as { data: unknown[] }).data).filter(
+      (item): item is GenericRecord => Boolean(item) && typeof item === "object",
+    );
+  }
+  return [];
+}
+
+export async function getHonorCategoriesPayload() {
+  const now = Date.now();
+  if (cachedHonorCategories && now - cachedHonorCategories.fetchedAt < CATALOGS_CACHE_TTL_MS) {
+    return cachedHonorCategories.value;
+  }
+
+  try {
+    const payload = await listHonorCategories();
+    cachedHonorCategories = { value: payload, fetchedAt: now };
+    return payload;
+  } catch {
+    if (cachedHonorCategories) {
+      return cachedHonorCategories.value;
+    }
+    return EMPTY_ARRAY;
+  }
+}
+
+export async function getClubTypesPayload() {
+  const now = Date.now();
+  if (cachedClubTypes && now - cachedClubTypes.fetchedAt < CATALOGS_CACHE_TTL_MS) {
+    return cachedClubTypes.value;
+  }
+
+  try {
+    const payload = await listClubTypes();
+    cachedClubTypes = { value: payload, fetchedAt: now };
+    return payload;
+  } catch {
+    if (cachedClubTypes) {
+      return cachedClubTypes.value;
+    }
+    return EMPTY_ARRAY;
+  }
+}
+
+export function buildCategoryOptions(payload: unknown): SelectOption[] {
+  const options: SelectOption[] = [];
+  for (const category of normalizeArrayPayload(payload)) {
+    const id = toPositiveNumber(category.honor_category_id ?? category.category_id);
+    const name = toNonEmptyString(category.name);
+    if (id && name) {
+      options.push({ value: id, label: name });
+    }
+  }
+  return options;
+}
+
+export function buildClubTypeOptions(payload: unknown): SelectOption[] {
+  const options: SelectOption[] = [];
+  for (const clubType of normalizeArrayPayload(payload)) {
+    const id = toPositiveNumber(clubType.club_type_id);
+    const name = toNonEmptyString(clubType.name);
+    if (id && name) {
+      options.push({ value: id, label: name });
+    }
+  }
+  return options;
+}
+
+export async function loadHonorCatalogOptions(): Promise<{
+  categoryOptions: SelectOption[];
+  clubTypeOptions: SelectOption[];
+}> {
+  const [categoriesPayload, clubTypesPayload] = await Promise.all([
+    getHonorCategoriesPayload(),
+    getClubTypesPayload(),
+  ]);
+
+  return {
+    categoryOptions: buildCategoryOptions(categoriesPayload),
+    clubTypeOptions: buildClubTypeOptions(clubTypesPayload),
+  };
+}


### PR DESCRIPTION
## Summary
- New routes: `/dashboard/honors/new`, `/dashboard/honors/[honorId]/edit`
- Extract `HonorFormFields` to dedicated module
- Add `HonorForm` wrapper supporting `mode: "create" | "edit"`
- Add shared `lib/honors/catalogs.ts` (catalog options loader for new + edit pages)
- List page: replace Dialog triggers with `<Link>`, remove related state and `useActionState` for create/update
- Delete AlertDialog unchanged (correct per DESIGN-SYSTEM.md §6.2)
- Server actions in `lib/honors/actions.ts` unchanged

## Why
Audit C2. Dialog with 8+ fields + crossed selects violates DESIGN-SYSTEM.md §6.1 — dedicated pages required for complex forms. Mirrors `clubs/new` pattern.

## SDD artifacts (engram)
- `sdd/honors-crud-pages-migration/explore`
- `sdd/honors-crud-pages-migration/proposal`
- `sdd/honors-crud-pages-migration/spec` (12/13 PASS, 1 PARTIAL accepted)
- `sdd/honors-crud-pages-migration/design`
- `sdd/honors-crud-pages-migration/tasks` (16 tasks, 14 done + 2 deferred manual smoke)
- `sdd/honors-crud-pages-migration/apply-progress`
- `sdd/honors-crud-pages-migration/verify-report` (PASS WITH WARNINGS)

## Files (7)
- new: `src/lib/honors/catalogs.ts`
- new: `src/components/honors/honor-form-fields.tsx`
- new: `src/components/honors/honor-form.tsx`
- new: `src/app/(dashboard)/dashboard/honors/new/page.tsx`
- new: `src/app/(dashboard)/dashboard/honors/[honorId]/edit/page.tsx`
- modified: `src/components/honors/honors-crud-page.tsx` (-249 lines, 862→613)
- modified: `src/app/(dashboard)/dashboard/honors/page.tsx` (drop createAction/updateActionBase props)

## Justified deviations
1. **Active checkbox**: `defaultChecked` + uncontrolled `onCheckedChange` querySelector update (mirrors `clubs/edit-club-form.tsx` exactly) instead of design's "hidden input + state". Functionally identical, codebase consistent.
2. **Permission denial**: `notFound()` vs spec's "redirect to /dashboard/honors". UX equivalent — user sees 404 instead of bouncing back. Lower-risk re race conditions.
3. **Extra file** `lib/honors/catalogs.ts`: Tasks 2.1 marked "create if needed". Created to share catalog loader between `/new` and `/[id]/edit`. Existing `honors/page.tsx` cache helpers untouched (consolidation deferred).

## Test plan
- [ ] `pnpm lint` clean (verified)
- [ ] **Manual browser smoke** (deferred from Phase 4.2):
  - [ ] `/dashboard/honors/new` renders, submits valid record, redirects to list
  - [ ] `/dashboard/honors/new` invalid form (empty name) shows form-level error banner with `role="alert"`
  - [ ] `/dashboard/honors/[id]/edit` pre-fills 8 fields from server record
  - [ ] Edit submit redirects to list with revalidated data
  - [ ] List page Pencil → navigates to `/edit` (desktop + mobile DropdownMenu)
  - [ ] List "Crear especialidad" button visible only when `canCreate`
  - [ ] Delete AlertDialog still works (unchanged behavior)
  - [ ] Permissions: non-canCreate user `/new` shows 404; non-canEdit `/edit` shows 404