### PR TITLE
fix(ui): catalog delete dialog AlertTriangle 20px (audit H5-vis)

### DIFF
--- a/src/components/catalogs/catalog-delete-dialog.tsx
+++ b/src/components/catalogs/catalog-delete-dialog.tsx
@@ -54,7 +54,7 @@ export function CatalogDeleteDialog({
       <AlertDialogContent className="sm:max-w-sm">
         <AlertDialogHeader>
           <div className="rounded-full bg-destructive/10 p-2.5 mx-auto mb-3 w-fit">
-            <AlertTriangle className="size-10 text-destructive" />
+            <AlertTriangle className="size-5 text-destructive" />
           </div>
           <AlertDialogTitle className="text-center">
             Eliminar {itemName}


### PR DESCRIPTION
## Summary
- `CatalogDeleteDialog` AlertTriangle: `size-10` (40px) → `size-5` (20px)
- Container `rounded-full bg-destructive/10 p-2.5 w-fit` unchanged

## Why
Audit H5-vis. 40px icon is 2.5x DESIGN-SYSTEM.md §6.2 spec for AlertDialogMedia destructive confirmations. Felt childish — Stripe/Linear use 20-24px with generous padding.

## Sibling note
`roles-table.tsx:196` has `size-8` inside `AlertDialogMedia` (different pattern: container is `size-16`, ratio is correct). Left untouched.

## Test plan
- [ ] `pnpm lint` clean
- [ ] Visual: trigger any catalog delete (countries, churches, etc.) — icon proportional to dialog title