### PR TITLE
fix(dashboard): KPI + quick-links hover align Ember motion (audit H6/M6/QL)

### DIFF
--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -232,7 +232,7 @@ function StatCard({
   const config = statCardConfig[colorIndex % statCardConfig.length];
 
   return (
-    <Card className="relative overflow-hidden transition-shadow hover:shadow-md">
+    <Card className="group relative overflow-hidden transition-all hover:border-primary/20 hover:shadow-md">
       <CardHeader className="flex flex-row items-start justify-between space-y-0 pb-3">
         <CardTitle className="text-sm font-medium text-muted-foreground">
           {title}
@@ -243,7 +243,7 @@ function StatCard({
             config.iconBg
           )}
         >
-          <Icon className={cn("size-4", config.iconColor)} />
+          <Icon className={cn("size-[18px]", config.iconColor)} />
         </div>
       </CardHeader>
       <CardContent>
@@ -651,7 +651,7 @@ export default async function DashboardPage() {
               statCardConfig[link.colorIndex % statCardConfig.length];
             return (
               <Link key={link.href} href={link.href}>
-                <Card className="group h-full transition-all hover:shadow-md hover:-translate-y-0.5">
+                <Card className="group h-full transition-all hover:border-primary/20 hover:shadow-md">
                   <CardContent className="flex items-center gap-3.5 p-4">
                     <div
                       className={cn(


### PR DESCRIPTION
## Summary
- KPI cards: add `group`, `transition-all`, `hover:border-primary/20`
- KPI icons: `size-4` (16px) → `size-[18px]` (spec) inside `size-9` container
- Quick links cards: remove undocumented `-translate-y-0.5`, add `hover:border-primary/20`

## Why
Audit H6-vis (KPI hover missing border tint) + M6-vis (icon undersized) + Quick links anti-pattern (undocumented motion). Ember motion vocabulary = border tint + shadow elevation. Translate belongs to marketing pages, not admin.

## Test plan
- [ ] `pnpm lint` clean (verified)
- [ ] Hover on dashboard KPI cards — border subtly orange + shadow
- [ ] Icon now feels balanced inside size-9 container
- [ ] Quick links cards no vertical bounce