### PR TITLE
fix(honors): filter bar responsive grid (audit H4)

### DIFF
--- a/src/components/honors/honors-crud-page.tsx
+++ b/src/components/honors/honors-crud-page.tsx
@@ -356,9 +356,8 @@ export function HonorsCrudPage({
             <h3 className="text-sm font-semibold tracking-wide text-foreground">Filtros</h3>
             <span className="text-xs text-muted-foreground">Refina el listado por campo</span>
           </div>
-          <div className="overflow-x-auto pb-1">
-            <div className="flex min-w-max items-end gap-4">
-              <div className="w-[280px] space-y-1">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
+              <div className="space-y-1">
                 <Label htmlFor="honors-filter-name">Nombre</Label>
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
@@ -372,7 +371,7 @@ export function HonorsCrudPage({
                 </div>
               </div>
 
-              <div className="w-[210px] space-y-1">
+              <div className="space-y-1">
                 <Label htmlFor="honors-filter-category">Categoría</Label>
                 <Select value={currentCategoryFilter} onValueChange={(value) => updateParam("categoryId", value)}>
                   <SelectTrigger id="honors-filter-category" className="bg-background">
@@ -389,7 +388,7 @@ export function HonorsCrudPage({
                 </Select>
               </div>
 
-              <div className="w-[210px] space-y-1">
+              <div className="space-y-1">
                 <Label htmlFor="honors-filter-club-type">Tipo de club</Label>
                 <Select value={currentClubTypeFilter} onValueChange={(value) => updateParam("clubTypeId", value)}>
                   <SelectTrigger id="honors-filter-club-type" className="bg-background">
@@ -406,7 +405,7 @@ export function HonorsCrudPage({
                 </Select>
               </div>
 
-              <div className="w-[170px] space-y-1">
+              <div className="space-y-1">
                 <Label htmlFor="honors-filter-level">Nivel</Label>
                 <Select value={currentLevelFilter} onValueChange={(value) => updateParam("skillLevel", value)}>
                   <SelectTrigger id="honors-filter-level" className="bg-background">
@@ -423,7 +422,7 @@ export function HonorsCrudPage({
                 </Select>
               </div>
 
-              <div className="w-[170px] space-y-1">
+              <div className="space-y-1">
                 <Label htmlFor="honors-filter-status">Estado</Label>
                 <Select value={currentStatusFilter} onValueChange={(value) => updateParam("active", value)}>
                   <SelectTrigger id="honors-filter-status" className="bg-background">
@@ -436,7 +435,6 @@ export function HonorsCrudPage({
                   </SelectContent>
                 </Select>
               </div>
-            </div>
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
- Replace `overflow-x-auto pb-1` + `flex min-w-max items-end gap-4` with `grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5`
- Drop fixed widths `w-[280px]`, `w-[210px]` × 2, `w-[170px]` × 2 from individual filter items — grid columns handle sizing

## Why
Audit H4. 5 filters in `min-w-max` = ~1080px width hidden behind invisible scrollbar on tablets (1024px). Estado + Nivel filters never seen by tablet users. NN Group: hidden controls = ignored controls.

## Breakpoints
- `<sm` (<640px): 1 column, stack
- `sm` (640-1023): 2 cols
- `lg` (1024-1279): 3 cols — Estado + Nivel finally visible
- `xl` (≥1280): 5 cols single row

## Test plan
- [ ] `pnpm lint` clean (verified, 6 pre-existing unrelated errors)
- [ ] Resize browser between breakpoints — no horizontal scroll
- [ ] Tablet 1024px: 3 columns visible, no clipping