### PR TITLE
fix(theme): WCAG-compliant disabled tokens for dark mode (audit H8)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -30,6 +30,9 @@
   --color-input: var(--input);
   --color-border: var(--border);
 
+  --color-disabled-bg: var(--disabled-bg);
+  --color-disabled-foreground: var(--disabled-foreground);
+
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
   --color-success: var(--success);
@@ -107,6 +110,9 @@
   --input: oklch(0.91 0.008 75);
   --ring: oklch(0.66 0.21 42 / 0.4);
 
+  --disabled-bg: oklch(0.95 0 0);
+  --disabled-foreground: oklch(0.6 0 0);
+
   --chart-1: oklch(0.66 0.21 42);
   --chart-2: oklch(0.58 0.14 235);
   --chart-3: oklch(0.56 0.15 152);
@@ -155,6 +161,9 @@
   --border: oklch(1 0 0 / 0.08);
   --input: oklch(1 0 0 / 0.10);
   --ring: oklch(0.72 0.19 42 / 0.5);
+
+  --disabled-bg: oklch(0.25 0.012 60);
+  --disabled-foreground: oklch(0.55 0.012 60);
 
   --chart-1: oklch(0.72 0.19 42);
   --chart-2: oklch(0.68 0.14 235);


### PR DESCRIPTION
## Summary
- Add `--disabled-bg` + `--disabled-foreground` OKLCH tokens for light + dark themes
- Wire to Tailwind v4 via `@theme inline`: `bg-disabled-bg`, `text-disabled-foreground` utilities
- shadcn `disabled:opacity-50` defaults untouched — tokens are opt-in for components needing WCAG-grade disabled state

## Why
Audit H8. Dark mode `--border: oklch(1 0 0 / 0.08)` (8% white alpha) + opacity-50 disabled = sub-3:1 contrast on Card, fails WCAG 1.4.11 (Non-text Contrast).

## Contrast (calculated)
| Mode | Pair | Ratio |
|------|------|-------|
| Light | foreground `oklch(0.6 0 0)` ~#8a8a8a vs bg `oklch(0.95 0 0)` ~#f2f2f2 | ~3.4:1 ✅ |
| Dark | foreground `oklch(0.55 0.012 60)` ~#7e7873 vs bg `oklch(0.25 0.012 60)` ~#3a3632 | ~3.2:1 ✅ |

Both exceed WCAG SC 1.4.11 (3:1 for UI components).

## Test plan
- [ ] `pnpm lint` clean (verified, 6 pre-existing errors unrelated)
- [ ] Toggle dark mode, inspect any page with disabled Button/Input — opt-in tokens render with separation against Card
- [ ] Lighthouse / axe-core a11y scan