### PR TITLE
fix(sidebar): nav icons use 18px per design system (audit H3-vis)

### DIFF
--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -61,9 +61,9 @@ function NavItemWithChildren({ item, pathname }: { item: NavItem; pathname: stri
       <SidebarMenuItem>
         <CollapsibleTrigger asChild>
           <SidebarMenuButton tooltip={title} isActive={isActive}>
-            <item.icon className="size-4 shrink-0" />
+            <item.icon className="h-[18px] w-[18px] shrink-0" />
             <span className="truncate">{title}</span>
-            <ChevronRight className="ml-auto size-4 shrink-0 transition-transform group-data-[state=open]/collapsible:rotate-90" />
+            <ChevronRight className="ml-auto h-[18px] w-[18px] shrink-0 transition-transform group-data-[state=open]/collapsible:rotate-90" />
           </SidebarMenuButton>
         </CollapsibleTrigger>
         <CollapsibleContent>
@@ -96,7 +96,7 @@ function NavItemSimple({ item, pathname }: { item: NavItem; pathname: string }) 
     <SidebarMenuItem>
       <SidebarMenuButton asChild tooltip={title} isActive={isActive}>
         <Link href={item.url}>
-          <item.icon className="size-4 shrink-0" />
+          <item.icon className="h-[18px] w-[18px] shrink-0" />
           <span className="truncate">{title}</span>
         </Link>
       </SidebarMenuButton>


### PR DESCRIPTION
## Summary
- `NavItemWithChildren` + `NavItemSimple` icons: `size-4` (16px) → `h-[18px] w-[18px]`
- ChevronRight in collapsible trigger: same fix

## Why
Audit H3-vis. DESIGN-SYSTEM.md §8.2 specifies 18px for sidebar nav icons. Pre-fix `size-4` = 12.5% reduction; icons felt thin and distant from labels on warm-stone sidebar.

## Untouched (intentional)
`User` + `LogOut` icons in dropdown menu chrome (lines 183/197) — those are dropdown UI, not nav.

## Test plan
- [ ] `pnpm lint` clean (verified)
- [ ] Visual: sidebar icons feel proportional to labels
- [ ] ChevronRight rotation animation still works on collapsible groups