### PR TITLE
feat(i18n): migrate clubs CRUD strings to next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -315,6 +315,48 @@
       "district": "District",
       "church": "Church",
       "ecclesiastical_year": "Ecclesiastical year"
+    },
+    "form": {
+      "labelName": "Name",
+      "labelDescription": "Description",
+      "labelAddress": "Address",
+      "labelLatitude": "Latitude",
+      "labelLongitude": "Longitude",
+      "coordinatesTitle": "Coordinates (optional)"
+    },
+    "create": {
+      "cardTitle": "Club data",
+      "submitButton": "Create club",
+      "placeholderName": "Club name",
+      "placeholderDescription": "Optional description",
+      "placeholderLocalField": "Select local field",
+      "placeholderDistrict": "Select district",
+      "placeholderChurch": "Select church",
+      "placeholderAddress": "Club address"
+    },
+    "edit": {
+      "cardTitle": "General information",
+      "submitButton": "Save changes",
+      "placeholderSelect": "Select",
+      "labelActive": "Active club"
+    },
+    "sections": {
+      "description": "A club can have sections for each club type (Adventurers, Pathfinders, Master Guides).",
+      "labelSoulsTarget": "Souls target",
+      "labelFee": "Membership fee",
+      "labelMeetingDay": "Meeting day",
+      "placeholderMeetingDay": "Select day",
+      "labelMeetingTime": "Meeting time",
+      "createButton": "Create section",
+      "notCreated": "Not created",
+      "cancelButton": "Cancel",
+      "addButton": "Add",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "infoType": "Type",
+      "infoSectionId": "Section ID",
+      "infoCuota": "Fee",
+      "infoMembers": "Members"
     }
   },
   "dashboardHub": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -315,6 +315,48 @@
       "district": "Distrito",
       "church": "Iglesia",
       "ecclesiastical_year": "Año eclesiástico"
+    },
+    "form": {
+      "labelName": "Nombre",
+      "labelDescription": "Descripción",
+      "labelAddress": "Dirección",
+      "labelLatitude": "Latitud",
+      "labelLongitude": "Longitud",
+      "coordinatesTitle": "Coordenadas (opcional)"
+    },
+    "create": {
+      "cardTitle": "Datos del club",
+      "submitButton": "Crear club",
+      "placeholderName": "Nombre del club",
+      "placeholderDescription": "Descripción opcional",
+      "placeholderLocalField": "Seleccionar campo local",
+      "placeholderDistrict": "Seleccionar distrito",
+      "placeholderChurch": "Seleccionar iglesia",
+      "placeholderAddress": "Dirección del club"
+    },
+    "edit": {
+      "cardTitle": "Información general",
+      "submitButton": "Guardar cambios",
+      "placeholderSelect": "Seleccionar",
+      "labelActive": "Club activo"
+    },
+    "sections": {
+      "description": "Un club puede tener secciones para cada tipo de club (Aventureros, Conquistadores, Guías Mayores).",
+      "labelSoulsTarget": "Meta de almas",
+      "labelFee": "Cuota de membresía",
+      "labelMeetingDay": "Día de reunión",
+      "placeholderMeetingDay": "Seleccionar día",
+      "labelMeetingTime": "Hora de reunión",
+      "createButton": "Crear sección",
+      "notCreated": "Sin crear",
+      "cancelButton": "Cancelar",
+      "addButton": "Agregar",
+      "statusActive": "Activa",
+      "statusInactive": "Inactiva",
+      "infoType": "Tipo",
+      "infoSectionId": "ID sección",
+      "infoCuota": "Cuota",
+      "infoMembers": "Miembros"
     }
   },
   "dashboardHub": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -315,6 +315,48 @@
       "district": "District",
       "church": "Église",
       "ecclesiastical_year": "Année ecclésiastique"
+    },
+    "form": {
+      "labelName": "Nom",
+      "labelDescription": "Description",
+      "labelAddress": "Adresse",
+      "labelLatitude": "Latitude",
+      "labelLongitude": "Longitude",
+      "coordinatesTitle": "Coordonnées (facultatif)"
+    },
+    "create": {
+      "cardTitle": "Données du club",
+      "submitButton": "Créer un club",
+      "placeholderName": "Nom du club",
+      "placeholderDescription": "Description facultative",
+      "placeholderLocalField": "Sélectionner un champ local",
+      "placeholderDistrict": "Sélectionner un district",
+      "placeholderChurch": "Sélectionner une église",
+      "placeholderAddress": "Adresse du club"
+    },
+    "edit": {
+      "cardTitle": "Informations générales",
+      "submitButton": "Enregistrer les modifications",
+      "placeholderSelect": "Sélectionner",
+      "labelActive": "Club actif"
+    },
+    "sections": {
+      "description": "Un club peut avoir des sections pour chaque type de club (Aventuriers, Éclaireurs, Guides Maîtres).",
+      "labelSoulsTarget": "Objectif d'âmes",
+      "labelFee": "Cotisation d'adhésion",
+      "labelMeetingDay": "Jour de réunion",
+      "placeholderMeetingDay": "Sélectionner un jour",
+      "labelMeetingTime": "Heure de réunion",
+      "createButton": "Créer une section",
+      "notCreated": "Non créée",
+      "cancelButton": "Annuler",
+      "addButton": "Ajouter",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "infoType": "Type",
+      "infoSectionId": "ID section",
+      "infoCuota": "Cotisation",
+      "infoMembers": "Membres"
     }
   },
   "dashboardHub": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -315,6 +315,48 @@
       "district": "Distrito",
       "church": "Igreja",
       "ecclesiastical_year": "Ano eclesiástico"
+    },
+    "form": {
+      "labelName": "Nome",
+      "labelDescription": "Descrição",
+      "labelAddress": "Endereço",
+      "labelLatitude": "Latitude",
+      "labelLongitude": "Longitude",
+      "coordinatesTitle": "Coordenadas (opcional)"
+    },
+    "create": {
+      "cardTitle": "Dados do clube",
+      "submitButton": "Criar clube",
+      "placeholderName": "Nome do clube",
+      "placeholderDescription": "Descrição opcional",
+      "placeholderLocalField": "Selecionar campo local",
+      "placeholderDistrict": "Selecionar distrito",
+      "placeholderChurch": "Selecionar igreja",
+      "placeholderAddress": "Endereço do clube"
+    },
+    "edit": {
+      "cardTitle": "Informações gerais",
+      "submitButton": "Salvar alterações",
+      "placeholderSelect": "Selecionar",
+      "labelActive": "Clube ativo"
+    },
+    "sections": {
+      "description": "Um clube pode ter seções para cada tipo de clube (Aventureiros, Desbravadores, Guias Máster).",
+      "labelSoulsTarget": "Meta de almas",
+      "labelFee": "Mensalidade",
+      "labelMeetingDay": "Dia de reunião",
+      "placeholderMeetingDay": "Selecionar dia",
+      "labelMeetingTime": "Horário de reunião",
+      "createButton": "Criar seção",
+      "notCreated": "Não criada",
+      "cancelButton": "Cancelar",
+      "addButton": "Adicionar",
+      "statusActive": "Ativa",
+      "statusInactive": "Inativa",
+      "infoType": "Tipo",
+      "infoSectionId": "ID seção",
+      "infoCuota": "Mensalidade",
+      "infoMembers": "Membros"
     }
   },
   "dashboardHub": {

--- a/src/components/clubs/club-sections-panel.tsx
+++ b/src/components/clubs/club-sections-panel.tsx
@@ -4,6 +4,7 @@ import { useState, useActionState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useFormStatus } from "react-dom";
 import { Plus, Users, CheckCircle, XCircle, Loader2, ChevronDown, ChevronUp } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -77,6 +78,7 @@ function CreateSectionForm({
   onSuccess: () => void;
 }) {
   const router = useRouter();
+  const t = useTranslations("clubs");
   const boundAction = createClubSectionAction.bind(null, clubId);
   const [state, action] = useActionState(boundAction, {} as ClubActionState);
 
@@ -97,20 +99,20 @@ function CreateSectionForm({
 
       <div className="grid gap-3 sm:grid-cols-2">
         <div className="space-y-1">
-          <Label htmlFor={`souls_${clubTypeId}`}>Meta de almas</Label>
+          <Label htmlFor={`souls_${clubTypeId}`}>{t("sections.labelSoulsTarget")}</Label>
           <Input id={`souls_${clubTypeId}`} name="souls_target" type="number" min="0" defaultValue="0" />
         </div>
 
         <div className="space-y-1">
-          <Label htmlFor={`fee_${clubTypeId}`}>Cuota de membresia</Label>
+          <Label htmlFor={`fee_${clubTypeId}`}>{t("sections.labelFee")}</Label>
           <Input id={`fee_${clubTypeId}`} name="fee" type="number" min="0" step="0.01" defaultValue="0" />
         </div>
 
         <div className="space-y-1">
-          <Label htmlFor={`day_${clubTypeId}`}>Dia de reunion</Label>
+          <Label htmlFor={`day_${clubTypeId}`}>{t("sections.labelMeetingDay")}</Label>
           <Select name="meeting_day">
             <SelectTrigger id={`day_${clubTypeId}`}>
-              <SelectValue placeholder="Seleccionar dia" />
+              <SelectValue placeholder={t("sections.placeholderMeetingDay")} />
             </SelectTrigger>
             <SelectContent>
               {DAYS_OF_WEEK.map((d) => (
@@ -121,7 +123,7 @@ function CreateSectionForm({
         </div>
 
         <div className="space-y-1">
-          <Label htmlFor={`time_${clubTypeId}`}>Hora de reunion</Label>
+          <Label htmlFor={`time_${clubTypeId}`}>{t("sections.labelMeetingTime")}</Label>
           <Input
             id={`time_${clubTypeId}`}
             name="meeting_time"
@@ -133,7 +135,7 @@ function CreateSectionForm({
       </div>
 
       <div className="flex justify-end">
-        <SubmitButton label="Crear seccion" />
+        <SubmitButton label={t("sections.createButton")} />
       </div>
     </form>
   );
@@ -146,6 +148,7 @@ interface ClubSectionsPanelProps {
 }
 
 export function ClubSectionsPanel({ clubId, sections, clubTypes }: ClubSectionsPanelProps) {
+  const t = useTranslations("clubs");
   const [openForms, setOpenForms] = useState<Set<number>>(new Set());
   const [refreshKey, setRefreshKey] = useState(0);
 
@@ -171,7 +174,7 @@ export function ClubSectionsPanel({ clubId, sections, clubTypes }: ClubSectionsP
   return (
     <div className="space-y-4" key={refreshKey}>
       <p className="text-sm text-muted-foreground">
-        Un club puede tener secciones para cada tipo de club (Aventureros, Conquistadores, Guias Mayores).
+        {t("sections.description")}
       </p>
 
       {typesToRender.map((clubType) => {
@@ -188,7 +191,7 @@ export function ClubSectionsPanel({ clubId, sections, clubTypes }: ClubSectionsP
                     <XCircle className="size-5 text-muted-foreground" />
                     <div>
                       <p className="text-sm font-medium">{label}</p>
-                      <p className="text-xs text-muted-foreground">Sin crear</p>
+                      <p className="text-xs text-muted-foreground">{t("sections.notCreated")}</p>
                     </div>
                   </div>
                   <Button
@@ -198,9 +201,9 @@ export function ClubSectionsPanel({ clubId, sections, clubTypes }: ClubSectionsP
                     type="button"
                   >
                     {isOpen ? (
-                      <><ChevronUp className="mr-2 size-4" />Cancelar</>
+                      <><ChevronUp className="mr-2 size-4" />{t("sections.cancelButton")}</>
                     ) : (
-                      <><Plus className="mr-2 size-4" />Agregar</>
+                      <><Plus className="mr-2 size-4" />{t("sections.addButton")}</>
                     )}
                   </Button>
                 </div>
@@ -234,22 +237,22 @@ export function ClubSectionsPanel({ clubId, sections, clubTypes }: ClubSectionsP
                 </CardTitle>
               </div>
               <Badge variant={section.active !== false ? "soft-success" : "outline"}>
-                {section.active !== false ? "Activa" : "Inactiva"}
+                {section.active !== false ? t("sections.statusActive") : t("sections.statusInactive")}
               </Badge>
             </CardHeader>
             <CardContent className="space-y-3">
               <div className="space-y-2">
-                <InfoRow label="Tipo" value={label} />
-                <InfoRow label="ID seccion" value={section.club_section_id} />
+                <InfoRow label={t("sections.infoType")} value={label} />
+                <InfoRow label={t("sections.infoSectionId")} value={section.club_section_id} />
                 {section.souls_target != null && (
-                  <InfoRow label="Meta de almas" value={section.souls_target} />
+                  <InfoRow label={t("sections.labelSoulsTarget")} value={section.souls_target} />
                 )}
                 {section.fee != null && (
-                  <InfoRow label="Cuota" value={formatCurrency(section.fee)} />
+                  <InfoRow label={t("sections.infoCuota")} value={formatCurrency(section.fee)} />
                 )}
                 {section.members_count != null && (
                   <InfoRow
-                    label="Miembros"
+                    label={t("sections.infoMembers")}
                     value={
                       <span className="flex items-center gap-1">
                         <Users className="size-3.5" />

--- a/src/components/clubs/create-club-form.tsx
+++ b/src/components/clubs/create-club-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from "react";
 import { useFormStatus } from "react-dom";
 import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -21,10 +22,11 @@ type SelectOption = { label: string; value: number };
 
 function SubmitButton() {
   const { pending } = useFormStatus();
+  const t = useTranslations("clubs");
   return (
     <Button type="submit" disabled={pending}>
       {pending && <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />}
-      Crear club
+      {t("create.submitButton")}
     </Button>
   );
 }
@@ -40,6 +42,7 @@ const initialState: ClubActionState = {};
 
 export function CreateClubForm({ localFields, districts, churches, formAction }: CreateClubFormProps) {
   const [state, action] = useActionState(formAction, initialState);
+  const t = useTranslations("clubs");
 
   return (
     <form action={action} className="space-y-6" noValidate>
@@ -55,12 +58,12 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Datos del club</CardTitle>
+          <CardTitle className="text-base">{t("create.cardTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2 sm:col-span-2">
             <Label htmlFor="name">
-              Nombre{" "}
+              {t("form.labelName")}{" "}
               <span className="text-destructive" aria-hidden="true">
                 *
               </span>
@@ -68,32 +71,32 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
             <Input
               id="name"
               name="name"
-              placeholder="Nombre del club"
+              placeholder={t("create.placeholderName")}
               required
               aria-required="true"
             />
           </div>
 
           <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="description">Descripción</Label>
+            <Label htmlFor="description">{t("form.labelDescription")}</Label>
             <Textarea
               id="description"
               name="description"
-              placeholder="Descripción opcional"
+              placeholder={t("create.placeholderDescription")}
               rows={3}
             />
           </div>
 
           <div className="space-y-2">
             <Label htmlFor="local_field_id">
-              Campo local{" "}
+              {t("fields.local_field")}{" "}
               <span className="text-destructive" aria-hidden="true">
                 *
               </span>
             </Label>
             <Select name="local_field_id" required>
               <SelectTrigger id="local_field_id" aria-required="true">
-                <SelectValue placeholder="Seleccionar campo local" />
+                <SelectValue placeholder={t("create.placeholderLocalField")} />
               </SelectTrigger>
               <SelectContent>
                 {localFields.map((opt) => (
@@ -107,14 +110,14 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
 
           <div className="space-y-2">
             <Label htmlFor="district_id">
-              Distrito{" "}
+              {t("fields.district")}{" "}
               <span className="text-destructive" aria-hidden="true">
                 *
               </span>
             </Label>
             <Select name="district_id" required>
               <SelectTrigger id="district_id" aria-required="true">
-                <SelectValue placeholder="Seleccionar distrito" />
+                <SelectValue placeholder={t("create.placeholderDistrict")} />
               </SelectTrigger>
               <SelectContent>
                 {districts.map((opt) => (
@@ -128,14 +131,14 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
 
           <div className="space-y-2">
             <Label htmlFor="church_id">
-              Iglesia{" "}
+              {t("fields.church")}{" "}
               <span className="text-destructive" aria-hidden="true">
                 *
               </span>
             </Label>
             <Select name="church_id" required>
               <SelectTrigger id="church_id" aria-required="true">
-                <SelectValue placeholder="Seleccionar iglesia" />
+                <SelectValue placeholder={t("create.placeholderChurch")} />
               </SelectTrigger>
               <SelectContent>
                 {churches.map((opt) => (
@@ -148,11 +151,11 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="address">Dirección</Label>
+            <Label htmlFor="address">{t("form.labelAddress")}</Label>
             <Input
               id="address"
               name="address"
-              placeholder="Dirección del club"
+              placeholder={t("create.placeholderAddress")}
             />
           </div>
         </CardContent>
@@ -160,11 +163,11 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Coordenadas (opcional)</CardTitle>
+          <CardTitle className="text-base">{t("form.coordinatesTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2">
-            <Label htmlFor="coordinates_lat">Latitud</Label>
+            <Label htmlFor="coordinates_lat">{t("form.labelLatitude")}</Label>
             <Input
               id="coordinates_lat"
               name="coordinates_lat"
@@ -174,7 +177,7 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="coordinates_lng">Longitud</Label>
+            <Label htmlFor="coordinates_lng">{t("form.labelLongitude")}</Label>
             <Input
               id="coordinates_lng"
               name="coordinates_lng"

--- a/src/components/clubs/edit-club-form.tsx
+++ b/src/components/clubs/edit-club-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from "react";
 import { useFormStatus } from "react-dom";
 import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -22,10 +23,11 @@ type SelectOption = { label: string; value: number };
 
 function SubmitButton() {
   const { pending } = useFormStatus();
+  const t = useTranslations("clubs");
   return (
     <Button type="submit" disabled={pending}>
       {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
-      Guardar cambios
+      {t("edit.submitButton")}
     </Button>
   );
 }
@@ -53,6 +55,7 @@ const initialState: ClubActionState = {};
 
 export function EditClubForm({ club, localFields, districts, churches, formAction }: EditClubFormProps) {
   const [state, action] = useActionState(formAction, initialState);
+  const t = useTranslations("clubs");
 
   const lat = club.coordinates?.lat ?? club.latitude;
   const lng = club.coordinates?.lng ?? club.longitude;
@@ -72,24 +75,24 @@ export function EditClubForm({ club, localFields, districts, churches, formActio
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Información general</CardTitle>
+          <CardTitle className="text-base">{t("edit.cardTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="name">Nombre <span className="text-destructive">*</span></Label>
+            <Label htmlFor="name">{t("form.labelName")} <span className="text-destructive">*</span></Label>
             <Input id="name" name="name" defaultValue={club.name ?? ""} required />
           </div>
 
           <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="description">Descripción</Label>
+            <Label htmlFor="description">{t("form.labelDescription")}</Label>
             <Textarea id="description" name="description" defaultValue={club.description ?? ""} rows={3} />
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="local_field_id">Campo local</Label>
+            <Label htmlFor="local_field_id">{t("fields.local_field")}</Label>
             <Select name="local_field_id" defaultValue={club.local_field_id ? String(club.local_field_id) : undefined}>
               <SelectTrigger>
-                <SelectValue placeholder="Seleccionar" />
+                <SelectValue placeholder={t("edit.placeholderSelect")} />
               </SelectTrigger>
               <SelectContent>
                 {localFields.map((opt) => (
@@ -100,10 +103,10 @@ export function EditClubForm({ club, localFields, districts, churches, formActio
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="district_id">Distrito</Label>
+            <Label htmlFor="district_id">{t("fields.district")}</Label>
             <Select name="district_id" defaultValue={club.district_id ? String(club.district_id) : undefined}>
               <SelectTrigger>
-                <SelectValue placeholder="Seleccionar" />
+                <SelectValue placeholder={t("edit.placeholderSelect")} />
               </SelectTrigger>
               <SelectContent>
                 {districts.map((opt) => (
@@ -114,10 +117,10 @@ export function EditClubForm({ club, localFields, districts, churches, formActio
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="church_id">Iglesia</Label>
+            <Label htmlFor="church_id">{t("fields.church")}</Label>
             <Select name="church_id" defaultValue={club.church_id ? String(club.church_id) : undefined}>
               <SelectTrigger>
-                <SelectValue placeholder="Seleccionar" />
+                <SelectValue placeholder={t("edit.placeholderSelect")} />
               </SelectTrigger>
               <SelectContent>
                 {churches.map((opt) => (
@@ -128,7 +131,7 @@ export function EditClubForm({ club, localFields, districts, churches, formActio
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="address">Dirección</Label>
+            <Label htmlFor="address">{t("form.labelAddress")}</Label>
             <Input id="address" name="address" defaultValue={club.address ?? ""} />
           </div>
 
@@ -142,22 +145,22 @@ export function EditClubForm({ club, localFields, districts, churches, formActio
                 if (hidden) hidden.value = checked ? "true" : "false";
               }}
             />
-            <Label htmlFor="active">Club activo</Label>
+            <Label htmlFor="active">{t("edit.labelActive")}</Label>
           </div>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Coordenadas (opcional)</CardTitle>
+          <CardTitle className="text-base">{t("form.coordinatesTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2">
-            <Label htmlFor="coordinates_lat">Latitud</Label>
+            <Label htmlFor="coordinates_lat">{t("form.labelLatitude")}</Label>
             <Input id="coordinates_lat" name="coordinates_lat" type="number" step="any" defaultValue={lat ?? ""} />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="coordinates_lng">Longitud</Label>
+            <Label htmlFor="coordinates_lng">{t("form.labelLongitude")}</Label>
             <Input id="coordinates_lng" name="coordinates_lng" type="number" step="any" defaultValue={lng ?? ""} />
           </div>
         </CardContent>


### PR DESCRIPTION
## Summary

Batch 3 of i18n rollout. Extends the existing `clubs` namespace with 42 new keys covering create + edit forms and the sections panel.

## Files

| File | Sub-namespace | Keys |
|---|---|---|
| `create-club-form.tsx` | `clubs.create.*` + reuses `clubs.fields.*` | 8 + shared |
| `edit-club-form.tsx` | `clubs.edit.*` | 4 |
| `club-sections-panel.tsx` | `clubs.sections.*` | 16 |
| (shared) | `clubs.form.*` | 6 |

## Out of scope

`SECTION_TYPE_LABELS` and `DAYS_OF_WEEK` module-level constants left hardcoded — same pattern as Zod schemas (run outside React context). Future refactor PR can move them inside components for `t()` access.

## Caveat

en/fr/pt-BR best-effort. Native review flagged:
- `fr.sections.description` — Aventuriers / Éclaireurs / Guides Maîtres (verify French Adventist terminology)
- `pt-BR.sections.description` — Aventureiros / Desbravadores / Guias Máster (verify local SDA terms)

## Test plan

- [ ] CI typecheck (#56) passes
- [ ] CI tests (#60) passes — 41/41
- [ ] `/dashboard/clubs/new` renders create form in `es` without missing-key warnings
- [ ] `/dashboard/clubs/[id]` renders edit form + sections panel correctly
- [ ] Section badge variant (`soft-success` for active) preserved from PR #66
- [ ] Section fee renders via `formatCurrency()` (PR #63 centralized currency)