### PR TITLE
fix(ui): ModuleListPage wraps table in DataTableShell (audit H2-vis)

### DIFF
--- a/src/components/shared/module-list-page.tsx
+++ b/src/components/shared/module-list-page.tsx
@@ -11,6 +11,7 @@ import {
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { DataTableShell } from "@/components/shared/data-table-shell";
 import { getTranslations } from "next-intl/server";
 import { apiRequest, ApiError } from "@/lib/api/client";
 import { requireAdminUser } from "@/lib/auth/session";
@@ -107,7 +108,7 @@ export async function ModuleListPage({
       )}
 
       {available && items.length > 0 && (
-        <div className="rounded-md border">
+        <DataTableShell>
           <Table>
             <TableHeader>
               <TableRow>
@@ -148,7 +149,7 @@ export async function ModuleListPage({
               })}
             </TableBody>
           </Table>
-        </div>
+        </DataTableShell>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- `module-list-page.tsx:110` wrapper: `<div className="rounded-md border">` → `<DataTableShell>`
- Import added for shared shell component

## Why
Audit H2-vis. Generic `ModuleListPage` had pre-Ember geometry. Future consumers will inherit canonical Ember table shell (rounded-xl, border-border/60, bg-card, shadow-xs) automatically.

## Note
No actual consumers grep'd in current codebase — `ModuleListPage` is intended generic backbone. Fix is forward-looking; ensures any catalog page that adopts it renders with correct shell from day one.

## Test plan
- [ ] `pnpm lint` clean (verified)
- [ ] When new catalog page consumes ModuleListPage, renders with rounded-xl shell