### PR TITLE
fix(ui): TableHead base applies design-system §5.4 typography (audit H1-vis)

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -70,7 +70,7 @@ function TableHead({ className, ...props }: React.ComponentProps<"th">) {
     <th
       data-slot="table-head"
       className={cn(
-        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        "h-11 bg-muted/40 px-3 text-left align-middle text-xs font-medium uppercase tracking-wider text-muted-foreground whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
- Update base `TableHead` default classes in `src/components/ui/table.tsx`
- Drop `text-foreground h-10 px-2` → add `h-11 bg-muted/40 px-3 text-xs uppercase tracking-wider text-muted-foreground`
- Keep `text-left align-middle whitespace-nowrap` + checkbox slot utilities

## Why
Audit H1-vis. DESIGN-SYSTEM.md §5.4 specifies table headers as `text-xs uppercase tracking-wider text-muted-foreground`. Pre-fix base used full opacity foreground + no uppercase = headers indistinguishable from body text. CatalogCrudPage already applied this inline — push to base so all consumers inherit.

## Conflict sweep
Zero callers pass conflicting `text-foreground` or `h-10` → no breakage.

## Redundancy follow-up (out of scope, harmless)
~16 components repeat the full spec inline. Most use `h-9` (intentional dense override — keep). A few (~3) repeat full spec without `h-9` and become purely redundant — safe cleanup pass for Sprint 3:
- `catalog-crud-page.tsx` TH_BASE constant
- `honors/requirements-tree.tsx`
- `users/sessions-tab.tsx`
- `member-rankings/*`

`cn()` merges work correctly; no immediate breakage.

## Test plan
- [ ] `pnpm lint` clean (verified, 52 pre-existing unrelated)
- [ ] Visual: clubs list, users list, module-list-page consumers — headers now uppercase + muted + bg-muted/40
- [ ] Spot-check tables with explicit `h-9` overrides (evidence-review, classes, membership) — still render at h-9 (intentional)