### PR TITLE
fix(ui): remove redundant mr-2 from icons inside Button (audit H4-vis)

### DIFF
--- a/src/app/(dashboard)/dashboard/achievements/_components/achievement-categories-crud-page.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/achievement-categories-crud-page.tsx
@@ -98,7 +98,7 @@ function DeleteButton() {
       onClick={() => setPending(true)}
       disabled={pending}
     >
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       Eliminar
     </Button>
   );
@@ -202,7 +202,7 @@ export function AchievementCategoriesCrudPage({
         description="Categorías y logros del sistema de recompensas."
       >
         <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 size-4" />
+          <Plus className="size-4" />
           Nueva categoría
         </Button>
       </PageHeader>
@@ -262,7 +262,7 @@ export function AchievementCategoriesCrudPage({
           >
             {!hasActiveFilters && (
               <Button onClick={() => setCreateOpen(true)}>
-                <Plus className="mr-2 size-4" />
+                <Plus className="size-4" />
                 Nueva categoría
               </Button>
             )}

--- a/src/app/(dashboard)/dashboard/achievements/_components/achievement-form.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/achievement-form.tsx
@@ -97,7 +97,7 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {label}
     </Button>
   );

--- a/src/app/(dashboard)/dashboard/achievements/_components/achievements-crud-page.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/achievements-crud-page.tsx
@@ -147,7 +147,7 @@ function DeleteButton() {
       onClick={() => setPending(true)}
       disabled={pending}
     >
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       Eliminar
     </Button>
   );
@@ -275,7 +275,7 @@ export function AchievementsCrudPage({
         </div>
         <Button asChild>
           <Link href={`/dashboard/achievements/${categoryId}/new`}>
-            <Plus className="mr-2 size-4" />
+            <Plus className="size-4" />
             Nuevo logro
           </Link>
         </Button>
@@ -377,7 +377,7 @@ export function AchievementsCrudPage({
             {!hasActiveFilters && (
               <Button asChild>
                 <Link href={`/dashboard/achievements/${categoryId}/new`}>
-                  <Plus className="mr-2 size-4" />
+                  <Plus className="size-4" />
                   Nuevo logro
                 </Link>
               </Button>

--- a/src/app/(dashboard)/dashboard/achievements/_components/category-form-dialog.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/category-form-dialog.tsx
@@ -45,7 +45,7 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {label}
     </Button>
   );

--- a/src/app/(dashboard)/dashboard/activities/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/activities/[id]/page.tsx
@@ -163,7 +163,7 @@ export default async function ActivityDetailPage({ params }: { params: Params })
       <PageHeader title={activity.name} description="Detalle de actividad">
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/activities">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/camporees/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/camporees/[id]/page.tsx
@@ -203,7 +203,7 @@ export default async function CamporeeDetailPage({ params }: { params: Params })
       <PageHeader title={camporee.name} description="Detalle del camporee">
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/camporees">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/catalogs/geography/local-fields/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/local-fields/[id]/page.tsx
@@ -87,7 +87,7 @@ export default async function LocalFieldDetailPage({
       <PageHeader title={fieldName}>
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/catalogs/geography/local-fields">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/catalogs/geography/unions/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/unions/[id]/page.tsx
@@ -87,7 +87,7 @@ export default async function UnionDetailPage({
       <PageHeader title={unionName}>
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/catalogs/geography/unions">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/catalogs/honor-categories/[categoryId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/honor-categories/[categoryId]/page.tsx
@@ -147,7 +147,7 @@ export default async function HonorCategoryDetailPage({ params }: { params: Para
       <PageHeader title="Detalle de categoría de especialidad">
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/catalogs/honor-categories">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/certifications/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/certifications/[id]/page.tsx
@@ -211,7 +211,7 @@ export default async function CertificationDetailPage({ params }: { params: Para
       <PageHeader title={name} description="Detalle de certificación">
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/certifications">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/classes/[classId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/classes/[classId]/page.tsx
@@ -194,7 +194,7 @@ export default async function ClassDetailPage({ params }: { params: Params }) {
       <PageHeader title={name} description="Detalle de clase progresiva">
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/classes">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
@@ -149,7 +149,7 @@ export default async function ClubDetailPage({
           </form>
           <Button variant="outline" size="sm" asChild>
             <Link href="/dashboard/clubs">
-              <ArrowLeft className="mr-2 size-4" />
+              <ArrowLeft className="size-4" />
               Volver
             </Link>
           </Button>

--- a/src/app/(dashboard)/dashboard/clubs/[id]/units/[unitId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/[id]/units/[unitId]/page.tsx
@@ -79,7 +79,7 @@ export default async function EditUnitPage({ params }: { params: Params }) {
       >
         <Button variant="outline" size="sm" asChild>
           <Link href={`/dashboard/clubs/${clubId}`}>
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver al club
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/clubs/[id]/units/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/[id]/units/new/page.tsx
@@ -50,7 +50,7 @@ export default async function NewUnitPage({ params }: { params: Params }) {
       <PageHeader title="Nueva unidad" description={`Agregar una nueva unidad a ${clubName}`}>
         <Button variant="outline" size="sm" asChild>
           <Link href={`/dashboard/clubs/${clubId}`}>
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver al club
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/clubs/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/new/page.tsx
@@ -21,7 +21,7 @@ export default async function NewClubPage() {
       <PageHeader title="Crear club">
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/clubs">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/clubs/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/page.tsx
@@ -176,7 +176,7 @@ async function ClubsContent({
         {canCreate && (
           <Button asChild>
             <Link href="/dashboard/clubs/new">
-              <Plus className="mr-2 size-4" />
+              <Plus className="size-4" />
               Crear club
             </Link>
           </Button>
@@ -353,7 +353,7 @@ export default async function ClubsPage({
         {canCreate && (
           <Button asChild>
             <Link href="/dashboard/clubs/new">
-              <Plus className="mr-2 size-4" />
+              <Plus className="size-4" />
               Crear club
             </Link>
           </Button>

--- a/src/app/(dashboard)/dashboard/honors/[honorId]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/[honorId]/edit/page.tsx
@@ -70,7 +70,7 @@ export default async function EditHonorPage({ params }: { params: Params }) {
       >
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/honors">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/honors/[honorId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/[honorId]/page.tsx
@@ -318,7 +318,7 @@ export default async function HonorDetailPage({ params }: { params: Params }) {
       <PageHeader title="Detalle de especialidad">
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/honors">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/honors/[honorId]/requirements/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/[honorId]/requirements/page.tsx
@@ -96,7 +96,7 @@ export default function HonorRequirementsPage() {
       >
         <Button variant="outline" size="sm" asChild>
           <Link href={backHref}>
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/honors/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/new/page.tsx
@@ -31,7 +31,7 @@ export default async function NewHonorPage() {
       >
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/honors">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/honors/requirements/review/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/requirements/review/page.tsx
@@ -305,7 +305,7 @@ export default function ReviewPage() {
         {/* Back + header row */}
         <div className="flex items-center gap-3">
           <Button variant="outline" size="sm" onClick={closeSplit}>
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver a la lista
           </Button>
           <div className="flex-1">

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/[id]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/[id]/edit/page.tsx
@@ -56,7 +56,7 @@ export default async function EditWeightsPage({ params }: EditWeightsPageProps) 
       >
         <Button variant="outline" size="sm" asChild>
           <Link href={BACK_HREF}>
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/new/page.tsx
@@ -29,7 +29,7 @@ export default async function NewWeightsPage() {
       >
         <Button variant="outline" size="sm" asChild>
           <Link href={BACK_HREF}>
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/member-rankings/[enrollmentId]/breakdown/page.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/[enrollmentId]/breakdown/page.tsx
@@ -94,7 +94,7 @@ export default async function MemberBreakdownPage({
       >
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/member-rankings">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver a rankings
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/section-rankings/[sectionId]/members/page.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/[sectionId]/members/page.tsx
@@ -72,7 +72,7 @@ export default async function SectionMembersPage({
       >
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/section-rankings">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver a secciones
           </Link>
         </Button>

--- a/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
@@ -298,7 +298,7 @@ export default async function UserDetailPage({ params }: { params: Params }) {
       <PageHeader title="Detalle de usuario">
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/users">
-            <ArrowLeft className="mr-2 size-4" />
+            <ArrowLeft className="size-4" />
             Volver
           </Link>
         </Button>

--- a/src/components/camporees/camporee-approval-dialog.tsx
+++ b/src/components/camporees/camporee-approval-dialog.tsx
@@ -151,7 +151,7 @@ export function CamporeeApprovalDialog({
               variant={isReject ? "destructive" : "default"}
               disabled={isPending}
             >
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               {isReject ? "Rechazar" : "Aprobar"}
             </Button>
           </DialogFooter>

--- a/src/components/camporees/camporee-clubs-tab.tsx
+++ b/src/components/camporees/camporee-clubs-tab.tsx
@@ -74,7 +74,7 @@ export function CamporeeClubsTab({
             <span className="sr-only">Actualizar</span>
           </Button>
           <Button size="sm" onClick={() => setEnrollOpen(true)}>
-            <PlusCircle className="mr-2 size-4" />
+            <PlusCircle className="size-4" />
             Inscribir club
           </Button>
         </div>

--- a/src/components/camporees/camporee-members-tab.tsx
+++ b/src/components/camporees/camporee-members-tab.tsx
@@ -88,7 +88,7 @@ export function CamporeeMembersTab({
             <span className="sr-only">Actualizar</span>
           </Button>
           <Button size="sm" onClick={() => setRegisterOpen(true)}>
-            <UserPlus className="mr-2 size-4" />
+            <UserPlus className="size-4" />
             Registrar miembro
           </Button>
         </div>

--- a/src/components/camporees/camporee-payments-tab.tsx
+++ b/src/components/camporees/camporee-payments-tab.tsx
@@ -94,7 +94,7 @@ export function CamporeePaymentsTab({
             <span className="sr-only">Actualizar</span>
           </Button>
           <Button size="sm" onClick={handleNewPayment}>
-            <PlusCircle className="mr-2 size-4" />
+            <PlusCircle className="size-4" />
             Registrar pago
           </Button>
         </div>

--- a/src/components/camporees/camporees-view.tsx
+++ b/src/components/camporees/camporees-view.tsx
@@ -108,7 +108,7 @@ export function CampoReesView({ initialCamporees }: CampoReesViewProps) {
           </Button>
         </div>
         <Button size="sm" onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 size-4" />
+          <Plus className="size-4" />
           {t("list.newCamporee")}
         </Button>
       </div>

--- a/src/components/camporees/union-camporees-view.tsx
+++ b/src/components/camporees/union-camporees-view.tsx
@@ -115,7 +115,7 @@ export function UnionCampoReesView({ initialCamporees, unions }: UnionCampoReesV
           </Button>
         </div>
         <Button size="sm" onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 size-4" />
+          <Plus className="size-4" />
           {t("unionList.newCamporee")}
         </Button>
       </div>

--- a/src/components/catalogs/honor-categories-crud-page.tsx
+++ b/src/components/catalogs/honor-categories-crud-page.tsx
@@ -128,7 +128,7 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {label}
     </Button>
   );
@@ -138,7 +138,7 @@ function DeleteButton() {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       Eliminar
     </Button>
   );
@@ -331,7 +331,7 @@ export function HonorCategoriesCrudPage({
       <PageHeader title="Categorías de especialidades" description="Catálogo de categorías para especialidades.">
         {canCreate && (
           <Button onClick={() => handleCreateDialogChange(true)}>
-            <Plus className="mr-2 size-4" />
+            <Plus className="size-4" />
             Crear categoría
           </Button>
         )}
@@ -385,7 +385,7 @@ export function HonorCategoriesCrudPage({
           >
             {canCreate && !hasActiveFilters && (
               <Button onClick={() => handleCreateDialogChange(true)}>
-                <Plus className="mr-2 size-4" />
+                <Plus className="size-4" />
                 Crear categoría
               </Button>
             )}

--- a/src/components/catalogs/phase-e-catalog-crud-page.tsx
+++ b/src/components/catalogs/phase-e-catalog-crud-page.tsx
@@ -119,7 +119,7 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {label}
     </Button>
   );
@@ -133,7 +133,7 @@ function DeleteButton() {
       disabled={pending}
       className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
     >
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       Eliminar
     </Button>
   );
@@ -356,7 +356,7 @@ export function PhaseECatalogCrudPage({
       <PageHeader title={title} description={description}>
         {canCreate && (
           <Button onClick={() => handleCreateOpen(true)}>
-            <Plus className="mr-2 size-4" />
+            <Plus className="size-4" />
             Crear {entityLabel.toLowerCase()}
           </Button>
         )}
@@ -417,7 +417,7 @@ export function PhaseECatalogCrudPage({
           >
             {canCreate && !hasActiveFilters && (
               <Button onClick={() => handleCreateOpen(true)}>
-                <Plus className="mr-2 size-4" />
+                <Plus className="size-4" />
                 Crear {entityLabel.toLowerCase()}
               </Button>
             )}

--- a/src/components/clubs/club-sections-panel.tsx
+++ b/src/components/clubs/club-sections-panel.tsx
@@ -62,7 +62,7 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" size="sm" disabled={pending}>
-      {pending ? <Loader2 className="mr-2 size-4 animate-spin" /> : <Plus className="mr-2 size-4" />}
+      {pending ? <Loader2 className="size-4 animate-spin" /> : <Plus className="size-4" />}
       {label}
     </Button>
   );
@@ -201,9 +201,9 @@ export function ClubSectionsPanel({ clubId, sections, clubTypes }: ClubSectionsP
                     type="button"
                   >
                     {isOpen ? (
-                      <><ChevronUp className="mr-2 size-4" />{t("sections.cancelButton")}</>
+                      <><ChevronUp className="size-4" />{t("sections.cancelButton")}</>
                     ) : (
-                      <><Plus className="mr-2 size-4" />{t("sections.addButton")}</>
+                      <><Plus className="size-4" />{t("sections.addButton")}</>
                     )}
                   </Button>
                 </div>

--- a/src/components/clubs/create-club-form.tsx
+++ b/src/components/clubs/create-club-form.tsx
@@ -25,7 +25,7 @@ function SubmitButton() {
   const t = useTranslations("clubs");
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />}
+      {pending && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
       {t("create.submitButton")}
     </Button>
   );

--- a/src/components/clubs/edit-club-form.tsx
+++ b/src/components/clubs/edit-club-form.tsx
@@ -26,7 +26,7 @@ function SubmitButton() {
   const t = useTranslations("clubs");
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {t("edit.submitButton")}
     </Button>
   );

--- a/src/components/evidence-review/evidence-approve-dialog.tsx
+++ b/src/components/evidence-review/evidence-approve-dialog.tsx
@@ -107,7 +107,7 @@ export function EvidenceApproveDialog({
             disabled={isSubmitting}
             className="bg-success hover:bg-success/90 text-success-foreground"
           >
-            {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
+            {isSubmitting && <Loader2 className="size-4 animate-spin" />}
             Aprobar
           </Button>
         </DialogFooter>

--- a/src/components/evidence-review/evidence-bulk-action-bar.tsx
+++ b/src/components/evidence-review/evidence-bulk-action-bar.tsx
@@ -224,7 +224,7 @@ export function EvidenceBulkActionBar({
               disabled={isApproving}
               className="bg-success hover:bg-success/90 text-success-foreground"
             >
-              {isApproving && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isApproving && <Loader2 className="size-4 animate-spin" />}
               Confirmar aprobación
             </Button>
           </DialogFooter>
@@ -278,7 +278,7 @@ export function EvidenceBulkActionBar({
               </Button>
               <Button type="submit" variant="destructive" disabled={isRejecting}>
                 {isRejecting && (
-                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  <Loader2 className="size-4 animate-spin" />
                 )}
                 Rechazar
               </Button>

--- a/src/components/evidence-review/evidence-reject-dialog.tsx
+++ b/src/components/evidence-review/evidence-reject-dialog.tsx
@@ -132,7 +132,7 @@ export function EvidenceRejectDialog({
               Cancelar
             </Button>
             <Button type="submit" variant="destructive" disabled={isSubmitting}>
-              {isSubmitting && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isSubmitting && <Loader2 className="size-4 animate-spin" />}
               Rechazar
             </Button>
           </DialogFooter>

--- a/src/components/evidence-review/evidence-review-client-page.tsx
+++ b/src/components/evidence-review/evidence-review-client-page.tsx
@@ -104,7 +104,7 @@ export function EvidenceReviewClientPage({
           disabled={isRefreshing}
         >
           <RefreshCw
-            className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`}
+            className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
           Actualizar
         </Button>

--- a/src/components/honors/honor-form.tsx
+++ b/src/components/honors/honor-form.tsx
@@ -29,7 +29,7 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" aria-hidden="true" />}
+      {pending && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
       {label}
     </Button>
   );

--- a/src/components/honors/honors-crud-page.tsx
+++ b/src/components/honors/honors-crud-page.tsx
@@ -174,7 +174,7 @@ function DeleteButton() {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       Eliminar
     </Button>
   );
@@ -343,7 +343,7 @@ export function HonorsCrudPage({
         {canCreate && (
           <Button asChild>
             <Link href="/dashboard/honors/new">
-              <Plus className="mr-2 size-4" />
+              <Plus className="size-4" />
               Crear especialidad
             </Link>
           </Button>
@@ -447,7 +447,7 @@ export function HonorsCrudPage({
             {canCreate && !hasActiveFilters && (
               <Button asChild>
                 <Link href="/dashboard/honors/new">
-                  <Plus className="mr-2 size-4" />
+                  <Plus className="size-4" />
                   Crear especialidad
                 </Link>
               </Button>

--- a/src/components/honors/requirements-tree.tsx
+++ b/src/components/honors/requirements-tree.tsx
@@ -239,11 +239,11 @@ function RequirementRow({
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
                 <DropdownMenuItem onClick={() => onEdit(node)}>
-                  <Pencil className="mr-2 size-4" />
+                  <Pencil className="size-4" />
                   Editar
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => onAddSubItem(node)}>
-                  <Plus className="mr-2 size-4" />
+                  <Plus className="size-4" />
                   Agregar sub-requisito
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
@@ -251,7 +251,7 @@ function RequirementRow({
                   onClick={() => onDelete(node)}
                   className="text-destructive focus:text-destructive"
                 >
-                  <Trash2 className="mr-2 size-4" />
+                  <Trash2 className="size-4" />
                   Eliminar
                 </DropdownMenuItem>
               </DropdownMenuContent>

--- a/src/components/investiture/bulk-action-bar.tsx
+++ b/src/components/investiture/bulk-action-bar.tsx
@@ -259,7 +259,7 @@ export function BulkActionBar({
               disabled={isApproving}
               className="bg-success hover:bg-success/90 text-success-foreground"
             >
-              {isApproving && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isApproving && <Loader2 className="size-4 animate-spin" />}
               Confirmar aprobación
             </Button>
           </DialogFooter>
@@ -313,7 +313,7 @@ export function BulkActionBar({
               </Button>
               <Button type="submit" variant="destructive" disabled={isRejecting}>
                 {isRejecting && (
-                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  <Loader2 className="size-4 animate-spin" />
                 )}
                 Rechazar
               </Button>

--- a/src/components/investiture/config-client-page.tsx
+++ b/src/components/investiture/config-client-page.tsx
@@ -75,14 +75,14 @@ export function ConfigClientPage({ initialConfigs }: ConfigClientPageProps) {
             disabled={isRefreshing}
           >
             <RefreshCw
-              className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`}
+              className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
             />
             Actualizar
           </Button>
         </div>
 
         <Button size="sm" onClick={openCreate}>
-          <Plus className="mr-2 size-4" />
+          <Plus className="size-4" />
           Nueva configuración
         </Button>
       </div>

--- a/src/components/investiture/investido-dialog.tsx
+++ b/src/components/investiture/investido-dialog.tsx
@@ -122,7 +122,7 @@ export function InvestidoDialog({
               Cancelar
             </Button>
             <Button type="submit" disabled={isPending}>
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               Confirmar investidura
             </Button>
           </DialogFooter>

--- a/src/components/investiture/investiture-client-page.tsx
+++ b/src/components/investiture/investiture-client-page.tsx
@@ -120,7 +120,7 @@ export function InvestitureClientPage({
             disabled={isRefreshing}
           >
             <RefreshCw
-              className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`}
+              className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
             />
             Actualizar
           </Button>

--- a/src/components/investiture/pipeline-client-page.tsx
+++ b/src/components/investiture/pipeline-client-page.tsx
@@ -102,7 +102,7 @@ export function PipelineClientPage({
           disabled={isRefreshing}
         >
           <RefreshCw
-            className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`}
+            className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
           Actualizar
         </Button>

--- a/src/components/investiture/pipeline-reject-dialog.tsx
+++ b/src/components/investiture/pipeline-reject-dialog.tsx
@@ -124,7 +124,7 @@ export function PipelineRejectDialog({
               Cancelar
             </Button>
             <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               Rechazar
             </Button>
           </DialogFooter>

--- a/src/components/investiture/validate-dialog.tsx
+++ b/src/components/investiture/validate-dialog.tsx
@@ -155,7 +155,7 @@ export function ValidateDialog({
               variant={isApprove ? "default" : "destructive"}
               disabled={isPending}
             >
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               {isApprove ? "Aprobar" : "Rechazar"}
             </Button>
           </DialogFooter>

--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -78,7 +78,7 @@ export function AppHeader() {
           <DropdownMenuContent align="end" className="w-48" sideOffset={6}>
             <DropdownMenuItem asChild>
               <Link href={`/dashboard/users/${user?.id ?? ""}`}>
-                <User className="mr-2 size-4" />
+                <User className="size-4" />
                 Mi perfil
               </Link>
             </DropdownMenuItem>
@@ -91,7 +91,7 @@ export function AppHeader() {
                 }}
                 aria-label="Cerrar sesión"
               >
-                <LogOut className="mr-2 size-4" />
+                <LogOut className="size-4" />
                 Cerrar sesión
               </button>
             </DropdownMenuItem>

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -179,7 +179,7 @@ function SidebarUserFooter() {
             >
               <DropdownMenuItem asChild>
                 <Link href={`/dashboard/users/${user?.id ?? ""}`}>
-                  <User className="mr-2 size-4" />
+                  <User className="size-4" />
                   Mi perfil
                 </Link>
               </DropdownMenuItem>
@@ -194,7 +194,7 @@ function SidebarUserFooter() {
                   }}
                   aria-label="Cerrar sesión"
                 >
-                  <LogOut className="mr-2 size-4" />
+                  <LogOut className="size-4" />
                   Cerrar sesión
                 </button>
               </DropdownMenuItem>

--- a/src/components/layout/locale-switcher.tsx
+++ b/src/components/layout/locale-switcher.tsx
@@ -33,7 +33,7 @@ export function LocaleSwitcherMenu() {
   return (
     <DropdownMenuSub>
       <DropdownMenuSubTrigger>
-        <Globe className="mr-2 size-4" />
+        <Globe className="size-4" />
         <span>{currentLocale.label}</span>
       </DropdownMenuSubTrigger>
       <DropdownMenuPortal>

--- a/src/components/member-of-month/evaluate-dialog.tsx
+++ b/src/components/member-of-month/evaluate-dialog.tsx
@@ -168,7 +168,7 @@ export function EvaluateMemberOfMonthDialog({
             <Button type="submit" disabled={isSubmitting}>
               {isSubmitting ? (
                 <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  <Loader2 className="size-4 animate-spin" />
                   Evaluando...
                 </>
               ) : (

--- a/src/components/membership/membership-reject-dialog.tsx
+++ b/src/components/membership/membership-reject-dialog.tsx
@@ -134,7 +134,7 @@ export function MembershipRejectDialog({
               Cancelar
             </Button>
             <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               Rechazar
             </Button>
           </DialogFooter>

--- a/src/components/membership/pending-members-table.tsx
+++ b/src/components/membership/pending-members-table.tsx
@@ -156,7 +156,7 @@ export function PendingMembersTable({
           disabled={isRefreshing}
         >
           <RefreshCw
-            className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`}
+            className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
           Actualizar
         </Button>

--- a/src/components/notifications/notification-forms.tsx
+++ b/src/components/notifications/notification-forms.tsx
@@ -26,7 +26,7 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending} className="w-full sm:w-auto">
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {label}
     </Button>
   );

--- a/src/components/rbac/permissions-table.tsx
+++ b/src/components/rbac/permissions-table.tsx
@@ -41,7 +41,7 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {label}
     </Button>
   );
@@ -51,7 +51,7 @@ function DeleteButton() {
   const { pending } = useFormStatus();
   return (
     <AlertDialogAction type="submit" disabled={pending} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       Eliminar
     </AlertDialogAction>
   );
@@ -85,7 +85,7 @@ export function PermissionsTable({ items, createAction, updateAction, deleteActi
     <>
       <div className="flex justify-end">
         <Button onClick={() => setCreateOpen(true)}>
-          <Plus className="mr-2 size-4" />
+          <Plus className="size-4" />
           Crear permiso
         </Button>
       </div>
@@ -93,7 +93,7 @@ export function PermissionsTable({ items, createAction, updateAction, deleteActi
       {items.length === 0 ? (
         <EmptyState icon={Key} title="Sin permisos" description="No se encontraron permisos registrados.">
           <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="mr-2 size-4" />
+            <Plus className="size-4" />
             Crear permiso
           </Button>
         </EmptyState>

--- a/src/components/rbac/role-form.tsx
+++ b/src/components/rbac/role-form.tsx
@@ -206,19 +206,19 @@ export function CreateRoleForm({ allPermissions }: CreateRoleFormProps) {
         <div className="flex items-center justify-end gap-3">
           <Button type="button" variant="outline" asChild>
             <Link href={ROLES_PATH}>
-              <ArrowLeft className="mr-2 size-4" />
+              <ArrowLeft className="size-4" />
               Cancelar
             </Link>
           </Button>
           <Button type="submit" disabled={isPending}>
             {isPending ? (
               <>
-                <Loader2 className="mr-2 size-4 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
                 Creando...
               </>
             ) : (
               <>
-                <Save className="mr-2 size-4" />
+                <Save className="size-4" />
                 Crear rol
               </>
             )}
@@ -395,19 +395,19 @@ export function EditRoleForm({ role, allPermissions }: EditRoleFormProps) {
         <div className="flex items-center justify-end gap-3">
           <Button type="button" variant="outline" asChild>
             <Link href={ROLES_PATH}>
-              <ArrowLeft className="mr-2 size-4" />
+              <ArrowLeft className="size-4" />
               Cancelar
             </Link>
           </Button>
           <Button type="submit" disabled={isPending}>
             {isPending ? (
               <>
-                <Loader2 className="mr-2 size-4 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
                 Guardando...
               </>
             ) : (
               <>
-                <Save className="mr-2 size-4" />
+                <Save className="size-4" />
                 Guardar cambios
               </>
             )}

--- a/src/components/rbac/roles-table.tsx
+++ b/src/components/rbac/roles-table.tsx
@@ -220,7 +220,7 @@ function DeactivateDialog({ role, open, onClose, onSuccess }: DeactivateDialogPr
           {isBlocked ? (
             <Button variant="outline" asChild>
               <Link href="/dashboard/rbac/user-permissions">
-                <Users className="mr-2 size-4" />
+                <Users className="size-4" />
                 Ver usuarios asignados
               </Link>
             </Button>

--- a/src/components/rbac/user-permissions-panel.tsx
+++ b/src/components/rbac/user-permissions-panel.tsx
@@ -269,7 +269,7 @@ export function UserPermissionsPanel({
               onClick={handleAssign}
               disabled={isPending || !selectedPermId}
             >
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               Asignar permiso
             </Button>
           </DialogFooter>
@@ -303,7 +303,7 @@ export function UserPermissionsPanel({
                 disabled={isPending}
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               >
-                {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {isPending && <Loader2 className="size-4 animate-spin" />}
                 Remover
               </AlertDialogAction>
             </AlertDialogFooter>

--- a/src/components/rbac/user-permissions-search.tsx
+++ b/src/components/rbac/user-permissions-search.tsx
@@ -81,9 +81,9 @@ export function UserPermissionsSearch({ allPermissions }: UserPermissionsSearchP
             </div>
             <Button onClick={handleSearch} disabled={isPending || !userIdInput.trim()}>
               {isPending ? (
-                <Loader2 className="mr-2 size-4 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
               ) : (
-                <Search className="mr-2 size-4" />
+                <Search className="size-4" />
               )}
               Buscar
             </Button>

--- a/src/components/rbac/user-roles-panel.tsx
+++ b/src/components/rbac/user-roles-panel.tsx
@@ -286,7 +286,7 @@ export function UserRolesPanel({
               onClick={handleAssign}
               disabled={isPending || !selectedRoleId}
             >
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               Asignar rol
             </Button>
           </DialogFooter>
@@ -320,7 +320,7 @@ export function UserRolesPanel({
                 disabled={isPending}
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               >
-                {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {isPending && <Loader2 className="size-4 animate-spin" />}
                 Remover
               </AlertDialogAction>
             </AlertDialogFooter>

--- a/src/components/requests/assignments-client-page.tsx
+++ b/src/components/requests/assignments-client-page.tsx
@@ -85,7 +85,7 @@ export function AssignmentsClientPage({ initialRequests }: AssignmentsClientPage
           disabled={isRefreshing}
         >
           <RefreshCw
-            className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`}
+            className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
           Actualizar
         </Button>

--- a/src/components/requests/request-review-dialog.tsx
+++ b/src/components/requests/request-review-dialog.tsx
@@ -149,7 +149,7 @@ export function RequestReviewDialog({
               variant={isApprove ? "default" : "destructive"}
               disabled={isPending}
             >
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               {isApprove ? "Aprobar" : "Rechazar"}
             </Button>
           </DialogFooter>

--- a/src/components/requests/transfers-client-page.tsx
+++ b/src/components/requests/transfers-client-page.tsx
@@ -85,7 +85,7 @@ export function TransfersClientPage({ initialRequests }: TransfersClientPageProp
           disabled={isRefreshing}
         >
           <RefreshCw
-            className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`}
+            className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
           Actualizar
         </Button>

--- a/src/components/resources/resource-categories-crud-page.tsx
+++ b/src/components/resources/resource-categories-crud-page.tsx
@@ -112,7 +112,7 @@ function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {label}
     </Button>
   );
@@ -126,7 +126,7 @@ function DeleteButton() {
       disabled={pending}
       className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
     >
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       Eliminar
     </Button>
   );
@@ -287,7 +287,7 @@ export function ResourceCategoriesCrudPage({
               setCreateActiveChecked(true);
             }}
           >
-            <Plus className="mr-2 size-4" />
+            <Plus className="size-4" />
             Crear categoría
           </Button>
         )}
@@ -355,7 +355,7 @@ export function ResourceCategoriesCrudPage({
                   setCreateActiveChecked(true);
                 }}
               >
-                <Plus className="mr-2 size-4" />
+                <Plus className="size-4" />
                 Crear categoría
               </Button>
             )}

--- a/src/components/resources/resources-crud-page.tsx
+++ b/src/components/resources/resources-crud-page.tsx
@@ -303,7 +303,7 @@ function SubmitButton({ label, extraDisabled }: { label: string; extraDisabled?:
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending || extraDisabled}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {label}
     </Button>
   );
@@ -317,7 +317,7 @@ function DeleteButton() {
       variant="destructive"
       disabled={pending}
     >
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       Eliminar
     </Button>
   );
@@ -855,7 +855,7 @@ export function ResourcesCrudPage({
       >
         {canCreate && (
           <Button onClick={() => setCreateOpen(true)}>
-            <Plus className="mr-2 size-4" />
+            <Plus className="size-4" />
             Subir recurso
           </Button>
         )}
@@ -1018,7 +1018,7 @@ export function ResourcesCrudPage({
           >
             {canCreate && !hasActiveFilters && (
               <Button onClick={() => setCreateOpen(true)}>
-                <Plus className="mr-2 size-4" />
+                <Plus className="size-4" />
                 Subir recurso
               </Button>
             )}

--- a/src/components/scoring-categories/scoring-category-delete-dialog.tsx
+++ b/src/components/scoring-categories/scoring-category-delete-dialog.tsx
@@ -77,7 +77,7 @@ export function ScoringCategoryDeleteDialog({
           >
             {isDeleting ? (
               <>
-                <Loader2 className="mr-2 size-4 animate-spin" />
+                <Loader2 className="size-4 animate-spin" />
                 Eliminando...
               </>
             ) : (

--- a/src/components/scoring-categories/scoring-category-dialog.tsx
+++ b/src/components/scoring-categories/scoring-category-dialog.tsx
@@ -193,7 +193,7 @@ export function ScoringCategoryDialog({
             <Button type="submit" disabled={isSubmitting}>
               {isSubmitting ? (
                 <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  <Loader2 className="size-4 animate-spin" />
                   Guardando...
                 </>
               ) : isEdit ? (

--- a/src/components/system-config/system-config-client-page.tsx
+++ b/src/components/system-config/system-config-client-page.tsx
@@ -79,7 +79,7 @@ export function SystemConfigClientPage({ initialConfigs }: SystemConfigClientPag
           disabled={isRefreshing}
         >
           <RefreshCw
-            className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`}
+            className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
           Actualizar
         </Button>

--- a/src/components/system-config/system-config-edit-dialog.tsx
+++ b/src/components/system-config/system-config-edit-dialog.tsx
@@ -138,7 +138,7 @@ export function SystemConfigEditDialog({
               Cancelar
             </Button>
             <Button type="submit" disabled={isPending}>
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               Guardar
             </Button>
           </DialogFooter>

--- a/src/components/units/unit-form.tsx
+++ b/src/components/units/unit-form.tsx
@@ -26,7 +26,7 @@ function SubmitButton({ mode }: { mode: "create" | "edit" }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending}>
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {pending
         ? mode === "create"
           ? "Creando..."

--- a/src/components/units/units-tab.tsx
+++ b/src/components/units/units-tab.tsx
@@ -182,7 +182,7 @@ export function UnitsTab({ clubId, localFieldId }: UnitsTabProps) {
 export function UnitsTabLoading() {
   return (
     <div className="flex items-center justify-center py-12 text-muted-foreground">
-      <Loader2 className="mr-2 size-4 animate-spin" />
+      <Loader2 className="size-4 animate-spin" />
       <span className="text-sm">Cargando unidades...</span>
     </div>
   );

--- a/src/components/units/weekly-records-panel.tsx
+++ b/src/components/units/weekly-records-panel.tsx
@@ -259,7 +259,7 @@ function AddRecordDialog({
             <Button type="submit" disabled={isSubmitting}>
               {isSubmitting ? (
                 <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  <Loader2 className="size-4 animate-spin" />
                   Guardando...
                 </>
               ) : (
@@ -492,7 +492,7 @@ export function WeeklyRecordsPanel({
   if (recordsLoading) {
     return (
       <div className="flex items-center justify-center py-8 text-muted-foreground">
-        <Loader2 className="mr-2 size-4 animate-spin" />
+        <Loader2 className="size-4 animate-spin" />
         <span className="text-sm">Cargando registros...</span>
       </div>
     );

--- a/src/components/users/post-registration-tab.tsx
+++ b/src/components/users/post-registration-tab.tsx
@@ -203,9 +203,9 @@ function OverrideButton({
         className="mt-3"
       >
         {isPending ? (
-          <Loader2 className="mr-2 size-4 animate-spin" />
+          <Loader2 className="size-4 animate-spin" />
         ) : (
-          <ShieldAlert className="mr-2 size-4" />
+          <ShieldAlert className="size-4" />
         )}
         {t("postRegistration.force_complete_button")}
       </Button>
@@ -234,7 +234,7 @@ function OverrideButton({
               disabled={isPending}
               onClick={handleConfirm}
             >
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               {t("postRegistration.force_confirming")}
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/src/components/users/user-approval-actions.tsx
+++ b/src/components/users/user-approval-actions.tsx
@@ -30,7 +30,7 @@ function SubmitButton({ variant }: { variant: "approve" | "reject" }) {
       disabled={pending}
       variant={isApprove ? "default" : "destructive"}
     >
-      {pending && <Loader2 className="mr-2 size-4 animate-spin" />}
+      {pending && <Loader2 className="size-4 animate-spin" />}
       {isApprove ? t("approval.actionApprove") : t("approval.actionReject")}
     </Button>
   );
@@ -95,7 +95,7 @@ export function UserApprovalActions({ userId, currentApproval }: UserApprovalAct
             setDialogOpen(true);
           }}
         >
-          <CheckCircle className="mr-2 size-4" />
+          <CheckCircle className="size-4" />
           {t("approval.actionApprove")}
         </Button>
         <Button
@@ -106,7 +106,7 @@ export function UserApprovalActions({ userId, currentApproval }: UserApprovalAct
             setDialogOpen(true);
           }}
         >
-          <XCircle className="mr-2 size-4" />
+          <XCircle className="size-4" />
           {t("approval.actionReject")}
         </Button>
       </div>

--- a/src/components/validation/validation-client-page.tsx
+++ b/src/components/validation/validation-client-page.tsx
@@ -137,7 +137,7 @@ export function ValidationClientPage({
             disabled={isRefreshing}
           >
             <RefreshCw
-              className={`mr-2 size-4 ${isRefreshing ? "animate-spin" : ""}`}
+              className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
             />
             Actualizar
           </Button>

--- a/src/components/validation/validation-review-dialog.tsx
+++ b/src/components/validation/validation-review-dialog.tsx
@@ -163,7 +163,7 @@ export function ValidationReviewDialog({
               variant={isApprove ? "default" : "destructive"}
               disabled={isPending}
             >
-              {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isPending && <Loader2 className="size-4 animate-spin" />}
               {isApprove ? "Aprobar" : "Rechazar"}
             </Button>
           </DialogFooter>

--- a/src/components/year-end/year-end-client-page.tsx
+++ b/src/components/year-end/year-end-client-page.tsx
@@ -209,7 +209,7 @@ export function YearEndClientPage({ ecclesiasticalYears }: YearEndClientPageProp
               onClick={handlePreview}
               disabled={!selectedYearId || isPreviewing}
             >
-              <Search className="mr-2 size-4" />
+              <Search className="size-4" />
               {isPreviewing ? "Cargando..." : "Vista previa"}
             </Button>
           </div>
@@ -274,7 +274,7 @@ export function YearEndClientPage({ ecclesiasticalYears }: YearEndClientPageProp
                 onClick={() => setConfirmOpen(true)}
                 disabled={isClosing}
               >
-                <AlertTriangle className="mr-2 size-4" />
+                <AlertTriangle className="size-4" />
                 Cerrar año
               </Button>
             </div>


### PR DESCRIPTION
## Summary
- Sweep 126 instances of `mr-2 size-4` across 78 source files
- Pattern: `<Plus|Loader2|ArrowLeft|... className="mr-2 size-4">` → `<... className="size-4">`
- `buttonVariants` base already includes `gap-2` (8px) — `mr-2` was doubling icon-to-text gap to 16px

## Why
Audit H4-vis. Buttons felt loose, especially in side-by-side bulk action bars. `gap-2` handles spacing; `mr-2` was redundant.

## Verification
- `buttonVariants` (button.tsx:8) — `gap-2` ✅
- `DropdownMenuItem` / `DropdownMenuSubTrigger` — `gap-2` ✅
- `AlertDialogAction` / `AlertDialogCancel` render as `<Button asChild>` — inherit `gap-2` ✅

## Skipped (intentional)
- `locale-switcher.tsx:43`: `<span className="mr-2">{flag}</span>` — emoji standalone span (not SVG icon), manually spacing flag emoji from text. `gap-2` doesn't apply because span has multiple children. Left untouched.

## Test plan
- [ ] `pnpm lint` clean (verified, 6 pre-existing errors unrelated)
- [ ] Visual: bulk action bars (investiture, members), submit buttons with loaders, "Volver" buttons — icon-text gap is now 8px (was 16px)
- [ ] Dropdown menu items with leading icons — proper spacing
- [ ] Loaders inside SubmitButton during pending — icon adjacent to label, not floating