### PR TITLE
feat(i18n): migrate activities feature remaining files to next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1424,6 +1424,53 @@
     "errors": {
       "save_failed": "Error saving the activity",
       "delete_failed": "Could not delete the activity"
+    },
+    "view": {
+      "selectClubPlaceholder": "Select club",
+      "allTypes": "All types",
+      "refresh": "Refresh",
+      "newActivity": "New activity",
+      "loading": "Loading activities...",
+      "activitiesFoundOne": "activity found",
+      "activitiesFoundOther": "activities found",
+      "errors": {
+        "loadFailed": "Could not load activities"
+      },
+      "types": {
+        "regular": "Regular",
+        "especial": "Special",
+        "camporee": "Camporee"
+      }
+    },
+    "table": {
+      "emptyTitle": "No activities",
+      "emptyDescription": "No activities found for the selected filters.",
+      "colName": "Name",
+      "colType": "Type",
+      "colTime": "Time",
+      "colPlace": "Location",
+      "colMode": "Mode",
+      "colStatus": "Status",
+      "editTitle": "Edit activity",
+      "editLabel": "Edit",
+      "deleteTitle": "Delete activity",
+      "deleteLabel": "Delete",
+      "viewDetail": "View detail",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "platformInPerson": "In-person"
+    },
+    "detailActions": {
+      "edit": "Edit",
+      "delete": "Delete",
+      "sectionFallback": "Section {id}"
+    },
+    "attendance": {
+      "emptyTitle": "No attendance records",
+      "emptyDescription": "No attendees registered for this activity.",
+      "colUser": "User",
+      "colEmail": "Email",
+      "colRegistered": "Registered"
     }
   },
   "year_end": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -1424,6 +1424,53 @@
     "errors": {
       "save_failed": "Error al guardar la actividad",
       "delete_failed": "No se pudo eliminar la actividad"
+    },
+    "view": {
+      "selectClubPlaceholder": "Seleccionar club",
+      "allTypes": "Todos los tipos",
+      "refresh": "Actualizar",
+      "newActivity": "Nueva actividad",
+      "loading": "Cargando actividades...",
+      "activitiesFoundOne": "actividad encontrada",
+      "activitiesFoundOther": "actividades encontradas",
+      "errors": {
+        "loadFailed": "No se pudieron cargar las actividades"
+      },
+      "types": {
+        "regular": "Regular",
+        "especial": "Especial",
+        "camporee": "Camporee"
+      }
+    },
+    "table": {
+      "emptyTitle": "Sin actividades",
+      "emptyDescription": "No se encontraron actividades para los filtros seleccionados.",
+      "colName": "Nombre",
+      "colType": "Tipo",
+      "colTime": "Hora",
+      "colPlace": "Lugar",
+      "colMode": "Modalidad",
+      "colStatus": "Estado",
+      "editTitle": "Editar actividad",
+      "editLabel": "Editar",
+      "deleteTitle": "Eliminar actividad",
+      "deleteLabel": "Eliminar",
+      "viewDetail": "Ver detalle",
+      "statusActive": "Activa",
+      "statusInactive": "Inactiva",
+      "platformInPerson": "Presencial"
+    },
+    "detailActions": {
+      "edit": "Editar",
+      "delete": "Eliminar",
+      "sectionFallback": "Sección {id}"
+    },
+    "attendance": {
+      "emptyTitle": "Sin registros de asistencia",
+      "emptyDescription": "No hay asistentes registrados para esta actividad.",
+      "colUser": "Usuario",
+      "colEmail": "Email",
+      "colRegistered": "Registrado"
     }
   },
   "year_end": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1424,6 +1424,53 @@
     "errors": {
       "save_failed": "Erreur lors de l'enregistrement de l'activité",
       "delete_failed": "Impossible de supprimer l'activité"
+    },
+    "view": {
+      "selectClubPlaceholder": "Sélectionner un club",
+      "allTypes": "Tous les types",
+      "refresh": "Actualiser",
+      "newActivity": "Nouvelle activité",
+      "loading": "Chargement des activités...",
+      "activitiesFoundOne": "activité trouvée",
+      "activitiesFoundOther": "activités trouvées",
+      "errors": {
+        "loadFailed": "Impossible de charger les activités"
+      },
+      "types": {
+        "regular": "Régulier",
+        "especial": "Spécial",
+        "camporee": "Camporee"
+      }
+    },
+    "table": {
+      "emptyTitle": "Aucune activité",
+      "emptyDescription": "Aucune activité trouvée pour les filtres sélectionnés.",
+      "colName": "Nom",
+      "colType": "Type",
+      "colTime": "Heure",
+      "colPlace": "Lieu",
+      "colMode": "Mode",
+      "colStatus": "Statut",
+      "editTitle": "Modifier l'activité",
+      "editLabel": "Modifier",
+      "deleteTitle": "Supprimer l'activité",
+      "deleteLabel": "Supprimer",
+      "viewDetail": "Voir le détail",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "platformInPerson": "En présentiel"
+    },
+    "detailActions": {
+      "edit": "Modifier",
+      "delete": "Supprimer",
+      "sectionFallback": "Section {id}"
+    },
+    "attendance": {
+      "emptyTitle": "Aucun enregistrement de présence",
+      "emptyDescription": "Aucun participant enregistré pour cette activité.",
+      "colUser": "Utilisateur",
+      "colEmail": "E-mail",
+      "colRegistered": "Enregistré"
     }
   },
   "year_end": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1424,6 +1424,53 @@
     "errors": {
       "save_failed": "Erro ao salvar a atividade",
       "delete_failed": "Não foi possível excluir a atividade"
+    },
+    "view": {
+      "selectClubPlaceholder": "Selecionar clube",
+      "allTypes": "Todos os tipos",
+      "refresh": "Atualizar",
+      "newActivity": "Nova atividade",
+      "loading": "Carregando atividades...",
+      "activitiesFoundOne": "atividade encontrada",
+      "activitiesFoundOther": "atividades encontradas",
+      "errors": {
+        "loadFailed": "Não foi possível carregar as atividades"
+      },
+      "types": {
+        "regular": "Regular",
+        "especial": "Especial",
+        "camporee": "Camporee"
+      }
+    },
+    "table": {
+      "emptyTitle": "Sem atividades",
+      "emptyDescription": "Nenhuma atividade encontrada para os filtros selecionados.",
+      "colName": "Nome",
+      "colType": "Tipo",
+      "colTime": "Horário",
+      "colPlace": "Local",
+      "colMode": "Modalidade",
+      "colStatus": "Status",
+      "editTitle": "Editar atividade",
+      "editLabel": "Editar",
+      "deleteTitle": "Excluir atividade",
+      "deleteLabel": "Excluir",
+      "viewDetail": "Ver detalhe",
+      "statusActive": "Ativa",
+      "statusInactive": "Inativa",
+      "platformInPerson": "Presencial"
+    },
+    "detailActions": {
+      "edit": "Editar",
+      "delete": "Excluir",
+      "sectionFallback": "Seção {id}"
+    },
+    "attendance": {
+      "emptyTitle": "Sem registros de presença",
+      "emptyDescription": "Nenhum participante registrado para esta atividade.",
+      "colUser": "Usuário",
+      "colEmail": "E-mail",
+      "colRegistered": "Registrado"
     }
   },
   "year_end": {

--- a/src/components/activities/activities-table.tsx
+++ b/src/components/activities/activities-table.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ChevronRight, Pencil, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,12 +30,14 @@ function formatTime(time?: string | null): string {
 }
 
 export function ActivitiesTable({ items, onEdit, onDelete }: ActivitiesTableProps) {
+  const t = useTranslations("activities");
+
   if (items.length === 0) {
     return (
       <EmptyState
         icon={Calendar}
-        title="Sin actividades"
-        description="No se encontraron actividades para los filtros seleccionados."
+        title={t("table.emptyTitle")}
+        description={t("table.emptyDescription")}
       />
     );
   }
@@ -45,22 +48,22 @@ export function ActivitiesTable({ items, onEdit, onDelete }: ActivitiesTableProp
         <TableHeader>
           <TableRow>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Nombre
+              {t("table.colName")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Tipo
+              {t("table.colType")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Hora
+              {t("table.colTime")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Lugar
+              {t("table.colPlace")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Modalidad
+              {t("table.colMode")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Estado
+              {t("table.colStatus")}
             </TableHead>
             <TableHead className="h-9 w-32 px-3" />
           </TableRow>
@@ -74,7 +77,7 @@ export function ActivitiesTable({ items, onEdit, onDelete }: ActivitiesTableProp
             const platformLabel =
               activity.platform != null
                 ? (PLATFORM_LABELS[activity.platform] ?? "—")
-                : "Presencial";
+                : t("table.platformInPerson");
 
             return (
               <TableRow key={activity.activity_id} className="hover:bg-muted/30">
@@ -97,7 +100,7 @@ export function ActivitiesTable({ items, onEdit, onDelete }: ActivitiesTableProp
                 </TableCell>
                 <TableCell className="px-3 py-2.5 align-middle">
                   <Badge variant={activity.active !== false ? "soft-success" : "outline"}>
-                    {activity.active !== false ? "Activa" : "Inactiva"}
+                    {activity.active !== false ? t("table.statusActive") : t("table.statusInactive")}
                   </Badge>
                 </TableCell>
                 <TableCell className="px-3 py-2.5 align-middle">
@@ -107,10 +110,10 @@ export function ActivitiesTable({ items, onEdit, onDelete }: ActivitiesTableProp
                         variant="ghost"
                         size="icon-sm"
                         onClick={() => onEdit(activity)}
-                        title="Editar actividad"
+                        title={t("table.editTitle")}
                       >
                         <Pencil className="size-3.5" />
-                        <span className="sr-only">Editar</span>
+                        <span className="sr-only">{t("table.editLabel")}</span>
                       </Button>
                     )}
                     {onDelete && (
@@ -118,17 +121,17 @@ export function ActivitiesTable({ items, onEdit, onDelete }: ActivitiesTableProp
                         variant="ghost"
                         size="icon-sm"
                         onClick={() => onDelete(activity)}
-                        title="Eliminar actividad"
+                        title={t("table.deleteTitle")}
                         className="text-destructive hover:text-destructive"
                       >
                         <Trash2 className="size-3.5" />
-                        <span className="sr-only">Eliminar</span>
+                        <span className="sr-only">{t("table.deleteLabel")}</span>
                       </Button>
                     )}
                     <Button variant="ghost" size="icon-sm" asChild>
                       <Link href={`/dashboard/activities/${activity.activity_id}`}>
                         <ChevronRight className="size-4" />
-                        <span className="sr-only">Ver detalle</span>
+                        <span className="sr-only">{t("table.viewDetail")}</span>
                       </Link>
                     </Button>
                   </div>

--- a/src/components/activities/activities-view.tsx
+++ b/src/components/activities/activities-view.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import { Plus, RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -31,13 +32,13 @@ type Section = {
 
 type ActivityTypeOption = {
   value: number;
-  label: string;
+  labelKey: "regular" | "especial" | "camporee";
 };
 
 const ACTIVITY_TYPES: ActivityTypeOption[] = [
-  { value: 1, label: "Regular" },
-  { value: 2, label: "Especial" },
-  { value: 3, label: "Camporee" },
+  { value: 1, labelKey: "regular" },
+  { value: 2, labelKey: "especial" },
+  { value: 3, labelKey: "camporee" },
 ];
 
 // ─── Normalize helpers ─────────────────────────────────────────────────────────
@@ -109,6 +110,8 @@ export function ActivitiesView({
   initialActivities,
   initialClubId,
 }: ActivitiesViewProps) {
+  const t = useTranslations("activities");
+
   const [selectedClubId, setSelectedClubId] = useState<number | null>(initialClubId);
   const [activities, setActivities] = useState<Activity[]>(initialActivities);
   const [filterTypeId, setFilterTypeId] = useState<number | null>(null);
@@ -140,14 +143,14 @@ export function ActivitiesView({
         const message =
           err instanceof ApiError
             ? err.message
-            : "No se pudieron cargar las actividades";
+            : t("view.errors.loadFailed");
         setLoadError(message);
         setActivities([]);
       } finally {
         setIsLoading(false);
       }
     },
-    [],
+    [t],
   );
 
   function handleClubChange(value: string) {
@@ -205,7 +208,7 @@ export function ActivitiesView({
             onValueChange={handleClubChange}
           >
             <SelectTrigger className="w-52">
-              <SelectValue placeholder="Seleccionar club" />
+              <SelectValue placeholder={t("view.selectClubPlaceholder")} />
             </SelectTrigger>
             <SelectContent>
               {clubs.map((club) => (
@@ -223,13 +226,13 @@ export function ActivitiesView({
             disabled={!selectedClubId}
           >
             <SelectTrigger className="w-44">
-              <SelectValue placeholder="Todos los tipos" />
+              <SelectValue placeholder={t("view.allTypes")} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">Todos los tipos</SelectItem>
-              {ACTIVITY_TYPES.map((t) => (
-                <SelectItem key={t.value} value={String(t.value)}>
-                  {t.label}
+              <SelectItem value="all">{t("view.allTypes")}</SelectItem>
+              {ACTIVITY_TYPES.map((type) => (
+                <SelectItem key={type.value} value={String(type.value)}>
+                  {t(`view.types.${type.labelKey}`)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -240,16 +243,16 @@ export function ActivitiesView({
             size="icon-sm"
             onClick={handleRefresh}
             disabled={!selectedClubId || isLoading}
-            title="Actualizar"
+            title={t("view.refresh")}
           >
             <RefreshCw className={`size-3.5 ${isLoading ? "animate-spin" : ""}`} />
-            <span className="sr-only">Actualizar</span>
+            <span className="sr-only">{t("view.refresh")}</span>
           </Button>
         </div>
 
         <Button onClick={handleCreate} disabled={!selectedClubId} size="sm">
           <Plus className="size-4" />
-          Nueva actividad
+          {t("view.newActivity")}
         </Button>
       </div>
 
@@ -264,14 +267,16 @@ export function ActivitiesView({
       {selectedClubId && !loadError && (
         <p className="text-sm text-muted-foreground">
           <span className="font-medium text-foreground">{filteredActivities.length}</span>{" "}
-          {filteredActivities.length === 1 ? "actividad encontrada" : "actividades encontradas"}
+          {filteredActivities.length === 1
+            ? t("view.activitiesFoundOne")
+            : t("view.activitiesFoundOther")}
         </p>
       )}
 
       {/* Table */}
       {isLoading ? (
         <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
-          Cargando actividades...
+          {t("view.loading")}
         </div>
       ) : (
         <ActivitiesTable

--- a/src/components/activities/activity-detail-actions.tsx
+++ b/src/components/activities/activity-detail-actions.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { Pencil, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { ActivityFormDialog } from "@/components/activities/activity-form-dialog";
 import { DeleteActivityDialog } from "@/components/activities/delete-activity-dialog";
@@ -13,6 +14,7 @@ interface ActivityDetailActionsProps {
 }
 
 export function ActivityDetailActions({ activity }: ActivityDetailActionsProps) {
+  const t = useTranslations("activities");
   const router = useRouter();
   const [editOpen, setEditOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
@@ -29,7 +31,7 @@ export function ActivityDetailActions({ activity }: ActivityDetailActionsProps) 
     <>
       <Button variant="outline" size="sm" onClick={() => setEditOpen(true)}>
         <Pencil className="mr-2 size-3.5" />
-        Editar
+        {t("detailActions.edit")}
       </Button>
       <Button
         variant="outline"
@@ -38,7 +40,7 @@ export function ActivityDetailActions({ activity }: ActivityDetailActionsProps) 
         className="text-destructive hover:bg-destructive/10 hover:text-destructive"
       >
         <Trash2 className="mr-2 size-3.5" />
-        Eliminar
+        {t("detailActions.delete")}
       </Button>
 
       <ActivityFormDialog
@@ -48,7 +50,7 @@ export function ActivityDetailActions({ activity }: ActivityDetailActionsProps) 
         sections={[
           {
             club_section_id: activity.club_section_id,
-            name: `Sección ${activity.club_section_id}`,
+            name: t("detailActions.sectionFallback", { id: activity.club_section_id }),
             club_type_id: activity.club_type_id,
           },
         ]}

--- a/src/components/activities/attendance-panel.tsx
+++ b/src/components/activities/attendance-panel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Users } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableBody,
@@ -43,12 +44,14 @@ function getUserDisplayName(
 }
 
 export function AttendancePanel({ records }: AttendancePanelProps) {
+  const t = useTranslations("activities");
+
   if (records.length === 0) {
     return (
       <EmptyState
         icon={Users}
-        title="Sin registros de asistencia"
-        description="No hay asistentes registrados para esta actividad."
+        title={t("attendance.emptyTitle")}
+        description={t("attendance.emptyDescription")}
       />
     );
   }
@@ -59,13 +62,13 @@ export function AttendancePanel({ records }: AttendancePanelProps) {
         <TableHeader>
           <TableRow>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Usuario
+              {t("attendance.colUser")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Email
+              {t("attendance.colEmail")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Registrado
+              {t("attendance.colRegistered")}
             </TableHead>
           </TableRow>
         </TableHeader>


### PR DESCRIPTION
## Summary

Batch 4 of i18n rollout. Extends the existing `activities` namespace with 35 new keys covering 4 components not migrated by earlier work (`activity-form-dialog` and `delete-activity-dialog` were already done).

| File | Sub-namespace | Keys |
|---|---|---|
| `activities-view.tsx` | `activities.view.*` | 11 |
| `activities-table.tsx` | `activities.table.*` | 16 |
| `activity-detail-actions.tsx` | `activities.detailActions.*` | 3 |
| `attendance-panel.tsx` | `activities.attendance.*` | 5 |

## Notes

- `ACTIVITY_TYPES` refactored from `label: string` to `labelKey` resolved via `t()` at render
- `toLocaleDateString("es-MX")` left hardcoded (locale routing PR will handle later)
- ICU plural for "actividad/actividades encontrada(s)"

## Test plan

- [ ] CI typecheck (#56) passes
- [ ] CI tests (#60) passes — 41/41
- [ ] `/dashboard/activities` view + table render in `es` without missing-key warnings
- [ ] Activity detail page actions and attendance panel render correctly