### PR TITLE
feat(i18n): migrate investiture feature remaining files to next-intl

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -908,6 +908,111 @@
       "year_required": "Select an ecclesiastical year",
       "submission_deadline_required": "Enter the submission deadline",
       "investiture_date_required": "Enter the investiture date"
+    },
+    "configClient": {
+      "countSingular": "configuration",
+      "countPlural": "configurations",
+      "refresh": "Refresh",
+      "newConfig": "New configuration",
+      "errorRefresh": "Could not refresh configurations"
+    },
+    "configTable": {
+      "emptyTitle": "No configurations",
+      "emptyDescription": "No investiture configurations found. Create one to get started.",
+      "colLocalField": "Local Field",
+      "colYear": "Ecclesiastical Year",
+      "colSubmissionDeadline": "Submission Deadline",
+      "colInvestitureDate": "Investiture Date",
+      "colStatus": "Status",
+      "colActions": "Actions",
+      "statusActive": "Active",
+      "statusInactive": "Inactive",
+      "tooltipEdit": "Edit",
+      "tooltipDeactivate": "Deactivate",
+      "tooltipAlreadyInactive": "Already inactive",
+      "ariaEdit": "Edit configuration",
+      "ariaDeactivate": "Deactivate configuration",
+      "fieldFallback": "Field #{id}",
+      "yearFallback": "Year #{id}"
+    },
+    "client": {
+      "allYears": "All years",
+      "yearActive": "(active)",
+      "countSingular": "pending",
+      "countPlural": "pending",
+      "refresh": "Refresh",
+      "errorRefresh": "Could not refresh the list"
+    },
+    "pipeline": {
+      "refresh": "Refresh",
+      "errorRefresh": "Could not refresh the list",
+      "tabAll": "All",
+      "tabSubmitted": "Submitted",
+      "tabClubApproved": "Club approved",
+      "tabCoordinatorApproved": "Coord. approved",
+      "tabFieldApproved": "Field approved",
+      "tabInvested": "Invested",
+      "tabRejected": "Rejected"
+    },
+    "historyDialog": {
+      "title": "Investiture history",
+      "errorLoad": "Could not load history",
+      "emptyHistory": "No history yet.",
+      "system": "System",
+      "actionSubmitted": "Submitted",
+      "actionClubApproved": "Approved by director",
+      "actionCoordinatorApproved": "Approved by coordinator",
+      "actionFieldApproved": "Approved by field",
+      "actionInvested": "Invested",
+      "actionRejected": "Rejected"
+    },
+    "history": {
+      "emptyHistory": "No validation history yet.",
+      "system": "System",
+      "actionSubmitted": "Submitted for validation",
+      "actionApproved": "Approved",
+      "actionRejected": "Rejected",
+      "actionReinvestitureRequested": "Reinvestiture requested"
+    },
+    "pendingTable": {
+      "emptyTitle": "No pending",
+      "emptyDescription": "No investitures pending validation at this time.",
+      "colMember": "Member",
+      "colClass": "Class",
+      "colClub": "Club",
+      "colSubmitted": "Submitted",
+      "colStatus": "Status",
+      "colActions": "Actions",
+      "ariaHistory": "View history",
+      "ariaApprove": "Approve",
+      "ariaReject": "Reject",
+      "ariaMarkInvested": "Mark as invested",
+      "tooltipHistory": "View history",
+      "tooltipApprove": "Approve",
+      "tooltipReject": "Reject",
+      "tooltipMarkInvested": "Mark as invested",
+      "historyTitle": "Investiture history",
+      "errorLoadHistory": "Could not load history",
+      "enrollmentFallback": "Enrollment #{id}"
+    },
+    "statusBadge": {
+      "inProgress": "In progress",
+      "submittedForValidation": "Submitted",
+      "submitted": "Submitted",
+      "clubApproved": "Club approved",
+      "coordinatorApproved": "Coordinator approved",
+      "fieldApproved": "Field approved",
+      "approved": "Approved",
+      "rejected": "Rejected",
+      "invested": "Invested"
+    },
+    "pipelineStatusBadge": {
+      "submitted": "Submitted",
+      "clubApproved": "Club approved",
+      "coordinatorApproved": "Coordinator approved",
+      "fieldApproved": "Field approved",
+      "invested": "Invested",
+      "rejected": "Rejected"
     }
   },
   "evidence_review": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -908,6 +908,111 @@
       "year_required": "Seleccioná un año eclesiástico",
       "submission_deadline_required": "Ingresá la fecha límite de envío",
       "investiture_date_required": "Ingresá la fecha de investidura"
+    },
+    "configClient": {
+      "countSingular": "configuración",
+      "countPlural": "configuraciones",
+      "refresh": "Actualizar",
+      "newConfig": "Nueva configuración",
+      "errorRefresh": "No se pudieron actualizar las configuraciones"
+    },
+    "configTable": {
+      "emptyTitle": "Sin configuraciones",
+      "emptyDescription": "No hay configuraciones de investidura registradas. Creá una para comenzar.",
+      "colLocalField": "Campo Local",
+      "colYear": "Año Eclesiástico",
+      "colSubmissionDeadline": "Límite de Envío",
+      "colInvestitureDate": "Fecha de Investidura",
+      "colStatus": "Estado",
+      "colActions": "Acciones",
+      "statusActive": "Activo",
+      "statusInactive": "Inactivo",
+      "tooltipEdit": "Editar",
+      "tooltipDeactivate": "Desactivar",
+      "tooltipAlreadyInactive": "Ya inactivo",
+      "ariaEdit": "Editar configuración",
+      "ariaDeactivate": "Desactivar configuración",
+      "fieldFallback": "Campo #{id}",
+      "yearFallback": "Año #{id}"
+    },
+    "client": {
+      "allYears": "Todos los años",
+      "yearActive": "(activo)",
+      "countSingular": "pendiente",
+      "countPlural": "pendientes",
+      "refresh": "Actualizar",
+      "errorRefresh": "No se pudo actualizar la lista"
+    },
+    "pipeline": {
+      "refresh": "Actualizar",
+      "errorRefresh": "No se pudo actualizar la lista",
+      "tabAll": "Todos",
+      "tabSubmitted": "Enviados",
+      "tabClubApproved": "Aprobados club",
+      "tabCoordinatorApproved": "Aprobados coord.",
+      "tabFieldApproved": "Aprobados campo",
+      "tabInvested": "Investidos",
+      "tabRejected": "Rechazados"
+    },
+    "historyDialog": {
+      "title": "Historial de investidura",
+      "errorLoad": "No se pudo cargar el historial",
+      "emptyHistory": "No hay historial aún.",
+      "system": "Sistema",
+      "actionSubmitted": "Enviado",
+      "actionClubApproved": "Aprobado por director",
+      "actionCoordinatorApproved": "Aprobado por coordinación",
+      "actionFieldApproved": "Aprobado por campo",
+      "actionInvested": "Investido",
+      "actionRejected": "Rechazado"
+    },
+    "history": {
+      "emptyHistory": "No hay historial de validación aún.",
+      "system": "Sistema",
+      "actionSubmitted": "Enviado a validación",
+      "actionApproved": "Aprobado",
+      "actionRejected": "Rechazado",
+      "actionReinvestitureRequested": "Re-investidura solicitada"
+    },
+    "pendingTable": {
+      "emptyTitle": "Sin pendientes",
+      "emptyDescription": "No hay investiduras pendientes de validación en este momento.",
+      "colMember": "Miembro",
+      "colClass": "Clase",
+      "colClub": "Club",
+      "colSubmitted": "Enviado",
+      "colStatus": "Estado",
+      "colActions": "Acciones",
+      "ariaHistory": "Ver historial",
+      "ariaApprove": "Aprobar",
+      "ariaReject": "Rechazar",
+      "ariaMarkInvested": "Marcar como investido",
+      "tooltipHistory": "Ver historial",
+      "tooltipApprove": "Aprobar",
+      "tooltipReject": "Rechazar",
+      "tooltipMarkInvested": "Marcar como investido",
+      "historyTitle": "Historial de investidura",
+      "errorLoadHistory": "No se pudo cargar el historial",
+      "enrollmentFallback": "Inscripción #{id}"
+    },
+    "statusBadge": {
+      "inProgress": "En progreso",
+      "submittedForValidation": "Enviado",
+      "submitted": "Enviado",
+      "clubApproved": "Aprobado por club",
+      "coordinatorApproved": "Aprobado por coordinación",
+      "fieldApproved": "Aprobado por campo",
+      "approved": "Aprobado",
+      "rejected": "Rechazado",
+      "invested": "Investido"
+    },
+    "pipelineStatusBadge": {
+      "submitted": "Enviado",
+      "clubApproved": "Aprobado por club",
+      "coordinatorApproved": "Aprobado por coordinación",
+      "fieldApproved": "Aprobado por campo",
+      "invested": "Investido",
+      "rejected": "Rechazado"
     }
   },
   "evidence_review": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -908,6 +908,111 @@
       "year_required": "Sélectionnez une année ecclésiastique",
       "submission_deadline_required": "Saisissez la date limite de soumission",
       "investiture_date_required": "Saisissez la date de l'investiture"
+    },
+    "configClient": {
+      "countSingular": "configuration",
+      "countPlural": "configurations",
+      "refresh": "Actualiser",
+      "newConfig": "Nouvelle configuration",
+      "errorRefresh": "Impossible de mettre à jour les configurations"
+    },
+    "configTable": {
+      "emptyTitle": "Aucune configuration",
+      "emptyDescription": "Aucune configuration d'investiture enregistrée. Créez-en une pour commencer.",
+      "colLocalField": "Champ local",
+      "colYear": "Année ecclésiastique",
+      "colSubmissionDeadline": "Date limite d'envoi",
+      "colInvestitureDate": "Date d'investiture",
+      "colStatus": "Statut",
+      "colActions": "Actions",
+      "statusActive": "Actif",
+      "statusInactive": "Inactif",
+      "tooltipEdit": "Modifier",
+      "tooltipDeactivate": "Désactiver",
+      "tooltipAlreadyInactive": "Déjà inactif",
+      "ariaEdit": "Modifier la configuration",
+      "ariaDeactivate": "Désactiver la configuration",
+      "fieldFallback": "Champ #{id}",
+      "yearFallback": "Année #{id}"
+    },
+    "client": {
+      "allYears": "Toutes les années",
+      "yearActive": "(actif)",
+      "countSingular": "en attente",
+      "countPlural": "en attente",
+      "refresh": "Actualiser",
+      "errorRefresh": "Impossible de mettre à jour la liste"
+    },
+    "pipeline": {
+      "refresh": "Actualiser",
+      "errorRefresh": "Impossible de mettre à jour la liste",
+      "tabAll": "Tous",
+      "tabSubmitted": "Soumis",
+      "tabClubApproved": "Approuvés club",
+      "tabCoordinatorApproved": "Approuvés coord.",
+      "tabFieldApproved": "Approuvés terrain",
+      "tabInvested": "Investis",
+      "tabRejected": "Rejetés"
+    },
+    "historyDialog": {
+      "title": "Historique d'investiture",
+      "errorLoad": "Impossible de charger l'historique",
+      "emptyHistory": "Aucun historique pour le moment.",
+      "system": "Système",
+      "actionSubmitted": "Soumis",
+      "actionClubApproved": "Approuvé par le directeur",
+      "actionCoordinatorApproved": "Approuvé par la coordination",
+      "actionFieldApproved": "Approuvé par le terrain",
+      "actionInvested": "Investi",
+      "actionRejected": "Rejeté"
+    },
+    "history": {
+      "emptyHistory": "Aucun historique de validation pour le moment.",
+      "system": "Système",
+      "actionSubmitted": "Soumis pour validation",
+      "actionApproved": "Approuvé",
+      "actionRejected": "Rejeté",
+      "actionReinvestitureRequested": "Réinvestiture demandée"
+    },
+    "pendingTable": {
+      "emptyTitle": "Aucun en attente",
+      "emptyDescription": "Aucune investiture en attente de validation pour le moment.",
+      "colMember": "Membre",
+      "colClass": "Classe",
+      "colClub": "Club",
+      "colSubmitted": "Soumis",
+      "colStatus": "Statut",
+      "colActions": "Actions",
+      "ariaHistory": "Voir l'historique",
+      "ariaApprove": "Approuver",
+      "ariaReject": "Rejeter",
+      "ariaMarkInvested": "Marquer comme investi",
+      "tooltipHistory": "Voir l'historique",
+      "tooltipApprove": "Approuver",
+      "tooltipReject": "Rejeter",
+      "tooltipMarkInvested": "Marquer comme investi",
+      "historyTitle": "Historique d'investiture",
+      "errorLoadHistory": "Impossible de charger l'historique",
+      "enrollmentFallback": "Inscription #{id}"
+    },
+    "statusBadge": {
+      "inProgress": "En cours",
+      "submittedForValidation": "Soumis",
+      "submitted": "Soumis",
+      "clubApproved": "Approuvé par le club",
+      "coordinatorApproved": "Approuvé par la coordination",
+      "fieldApproved": "Approuvé par le terrain",
+      "approved": "Approuvé",
+      "rejected": "Rejeté",
+      "invested": "Investi"
+    },
+    "pipelineStatusBadge": {
+      "submitted": "Soumis",
+      "clubApproved": "Approuvé par le club",
+      "coordinatorApproved": "Approuvé par la coordination",
+      "fieldApproved": "Approuvé par le terrain",
+      "invested": "Investi",
+      "rejected": "Rejeté"
     }
   },
   "evidence_review": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -908,6 +908,111 @@
       "year_required": "Selecione um ano eclesiástico",
       "submission_deadline_required": "Insira a data-limite de envio",
       "investiture_date_required": "Insira a data da investidura"
+    },
+    "configClient": {
+      "countSingular": "configuração",
+      "countPlural": "configurações",
+      "refresh": "Atualizar",
+      "newConfig": "Nova configuração",
+      "errorRefresh": "Não foi possível atualizar as configurações"
+    },
+    "configTable": {
+      "emptyTitle": "Sem configurações",
+      "emptyDescription": "Nenhuma configuração de investidura registrada. Crie uma para começar.",
+      "colLocalField": "Campo Local",
+      "colYear": "Ano Eclesiástico",
+      "colSubmissionDeadline": "Prazo de Envio",
+      "colInvestitureDate": "Data de Investidura",
+      "colStatus": "Status",
+      "colActions": "Ações",
+      "statusActive": "Ativo",
+      "statusInactive": "Inativo",
+      "tooltipEdit": "Editar",
+      "tooltipDeactivate": "Desativar",
+      "tooltipAlreadyInactive": "Já inativo",
+      "ariaEdit": "Editar configuração",
+      "ariaDeactivate": "Desativar configuração",
+      "fieldFallback": "Campo #{id}",
+      "yearFallback": "Ano #{id}"
+    },
+    "client": {
+      "allYears": "Todos os anos",
+      "yearActive": "(ativo)",
+      "countSingular": "pendente",
+      "countPlural": "pendentes",
+      "refresh": "Atualizar",
+      "errorRefresh": "Não foi possível atualizar a lista"
+    },
+    "pipeline": {
+      "refresh": "Atualizar",
+      "errorRefresh": "Não foi possível atualizar a lista",
+      "tabAll": "Todos",
+      "tabSubmitted": "Enviados",
+      "tabClubApproved": "Aprovados clube",
+      "tabCoordinatorApproved": "Aprovados coord.",
+      "tabFieldApproved": "Aprovados campo",
+      "tabInvested": "Investidos",
+      "tabRejected": "Rejeitados"
+    },
+    "historyDialog": {
+      "title": "Histórico de investidura",
+      "errorLoad": "Não foi possível carregar o histórico",
+      "emptyHistory": "Sem histórico ainda.",
+      "system": "Sistema",
+      "actionSubmitted": "Enviado",
+      "actionClubApproved": "Aprovado pelo diretor",
+      "actionCoordinatorApproved": "Aprovado pela coordenação",
+      "actionFieldApproved": "Aprovado pelo campo",
+      "actionInvested": "Investido",
+      "actionRejected": "Rejeitado"
+    },
+    "history": {
+      "emptyHistory": "Sem histórico de validação ainda.",
+      "system": "Sistema",
+      "actionSubmitted": "Enviado para validação",
+      "actionApproved": "Aprovado",
+      "actionRejected": "Rejeitado",
+      "actionReinvestitureRequested": "Reinvestidura solicitada"
+    },
+    "pendingTable": {
+      "emptyTitle": "Sem pendentes",
+      "emptyDescription": "Não há investiduras pendentes de validação no momento.",
+      "colMember": "Membro",
+      "colClass": "Classe",
+      "colClub": "Clube",
+      "colSubmitted": "Enviado",
+      "colStatus": "Status",
+      "colActions": "Ações",
+      "ariaHistory": "Ver histórico",
+      "ariaApprove": "Aprovar",
+      "ariaReject": "Rejeitar",
+      "ariaMarkInvested": "Marcar como investido",
+      "tooltipHistory": "Ver histórico",
+      "tooltipApprove": "Aprovar",
+      "tooltipReject": "Rejeitar",
+      "tooltipMarkInvested": "Marcar como investido",
+      "historyTitle": "Histórico de investidura",
+      "errorLoadHistory": "Não foi possível carregar o histórico",
+      "enrollmentFallback": "Inscrição #{id}"
+    },
+    "statusBadge": {
+      "inProgress": "Em andamento",
+      "submittedForValidation": "Enviado",
+      "submitted": "Enviado",
+      "clubApproved": "Aprovado pelo clube",
+      "coordinatorApproved": "Aprovado pela coordenação",
+      "fieldApproved": "Aprovado pelo campo",
+      "approved": "Aprovado",
+      "rejected": "Rejeitado",
+      "invested": "Investido"
+    },
+    "pipelineStatusBadge": {
+      "submitted": "Enviado",
+      "clubApproved": "Aprovado pelo clube",
+      "coordinatorApproved": "Aprovado pela coordenação",
+      "fieldApproved": "Aprovado pelo campo",
+      "invested": "Investido",
+      "rejected": "Rejeitado"
     }
   },
   "evidence_review": {

--- a/src/components/investiture/config-client-page.tsx
+++ b/src/components/investiture/config-client-page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { toast } from "sonner";
 import { Plus, RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { ConfigTable } from "@/components/investiture/config-table";
 import { ConfigFormDialog } from "@/components/investiture/config-form-dialog";
@@ -19,6 +20,7 @@ interface ConfigClientPageProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function ConfigClientPage({ initialConfigs }: ConfigClientPageProps) {
+  const t = useTranslations("investiture");
   const [configs, setConfigs] = useState<InvestitureConfig[]>(initialConfigs);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -37,12 +39,12 @@ export function ConfigClientPage({ initialConfigs }: ConfigClientPageProps) {
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudieron actualizar las configuraciones";
+          : t("configClient.errorRefresh");
       toast.error(message);
     } finally {
       setIsRefreshing(false);
     }
-  }, []);
+  }, [t]);
 
   function openCreate() {
     setEditingConfig(null);
@@ -66,7 +68,9 @@ export function ConfigClientPage({ initialConfigs }: ConfigClientPageProps) {
         <div className="flex items-center gap-2">
           <p className="text-sm text-muted-foreground">
             <span className="font-medium text-foreground">{configs.length}</span>{" "}
-            {configs.length === 1 ? "configuración" : "configuraciones"}
+            {configs.length === 1
+              ? t("configClient.countSingular")
+              : t("configClient.countPlural")}
           </p>
           <Button
             variant="outline"
@@ -77,13 +81,13 @@ export function ConfigClientPage({ initialConfigs }: ConfigClientPageProps) {
             <RefreshCw
               className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
             />
-            Actualizar
+            {t("configClient.refresh")}
           </Button>
         </div>
 
         <Button size="sm" onClick={openCreate}>
           <Plus className="size-4" />
-          Nueva configuración
+          {t("configClient.newConfig")}
         </Button>
       </div>
 

--- a/src/components/investiture/config-table.tsx
+++ b/src/components/investiture/config-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Pencil, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableBody,
@@ -42,12 +43,14 @@ interface ConfigTableProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function ConfigTable({ configs, onEdit, onDelete }: ConfigTableProps) {
+  const t = useTranslations("investiture");
+
   if (configs.length === 0) {
     return (
       <EmptyState
         icon={Settings2}
-        title="Sin configuraciones"
-        description="No hay configuraciones de investidura registradas. Creá una para comenzar."
+        title={t("configTable.emptyTitle")}
+        description={t("configTable.emptyDescription")}
       />
     );
   }
@@ -58,22 +61,22 @@ export function ConfigTable({ configs, onEdit, onDelete }: ConfigTableProps) {
         <TableHeader>
           <TableRow>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Campo Local
+              {t("configTable.colLocalField")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Año Eclesiástico
+              {t("configTable.colYear")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Límite de Envío
+              {t("configTable.colSubmissionDeadline")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Fecha de Investidura
+              {t("configTable.colInvestitureDate")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Estado
+              {t("configTable.colStatus")}
             </TableHead>
             <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Acciones
+              {t("configTable.colActions")}
             </TableHead>
           </TableRow>
         </TableHeader>
@@ -81,10 +84,10 @@ export function ConfigTable({ configs, onEdit, onDelete }: ConfigTableProps) {
           {configs.map((config) => (
             <TableRow key={config.investiture_config_id} className="hover:bg-muted/30">
               <TableCell className="px-3 py-2.5 align-middle font-medium">
-                {config.local_fields?.name ?? `Campo #${config.local_field_id}`}
+                {config.local_fields?.name ?? t("configTable.fieldFallback", { id: config.local_field_id })}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
-                {config.ecclesiastical_years?.name ?? `Año #${config.ecclesiastical_year_id}`}
+                {config.ecclesiastical_years?.name ?? t("configTable.yearFallback", { id: config.ecclesiastical_year_id })}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
                 {formatDate(config.submission_deadline)}
@@ -95,10 +98,10 @@ export function ConfigTable({ configs, onEdit, onDelete }: ConfigTableProps) {
               <TableCell className="px-3 py-2.5 align-middle">
                 {config.active ? (
                   <Badge className="bg-success/10 text-success border-success/20">
-                    Activo
+                    {t("configTable.statusActive")}
                   </Badge>
                 ) : (
-                  <Badge variant="destructive">Inactivo</Badge>
+                  <Badge variant="destructive">{t("configTable.statusInactive")}</Badge>
                 )}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle">
@@ -109,12 +112,12 @@ export function ConfigTable({ configs, onEdit, onDelete }: ConfigTableProps) {
                         variant="ghost"
                         size="icon-sm"
                         onClick={() => onEdit(config)}
-                        aria-label="Editar configuración"
+                        aria-label={t("configTable.ariaEdit")}
                       >
                         <Pencil className="size-4" />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent>Editar</TooltipContent>
+                    <TooltipContent>{t("configTable.tooltipEdit")}</TooltipContent>
                   </Tooltip>
 
                   <Tooltip>
@@ -124,14 +127,16 @@ export function ConfigTable({ configs, onEdit, onDelete }: ConfigTableProps) {
                         size="icon-sm"
                         className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                         onClick={() => onDelete(config)}
-                        aria-label="Desactivar configuración"
+                        aria-label={t("configTable.ariaDeactivate")}
                         disabled={!config.active}
                       >
                         <Trash2 className="size-4" />
                       </Button>
                     </TooltipTrigger>
                     <TooltipContent>
-                      {config.active ? "Desactivar" : "Ya inactivo"}
+                      {config.active
+                        ? t("configTable.tooltipDeactivate")
+                        : t("configTable.tooltipAlreadyInactive")}
                     </TooltipContent>
                   </Tooltip>
                 </div>

--- a/src/components/investiture/history-timeline.tsx
+++ b/src/components/investiture/history-timeline.tsx
@@ -1,43 +1,9 @@
 "use client";
 
 import { CheckCircle2, XCircle, Send, RefreshCw, Clock } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import type { InvestitureHistoryEntry, InvestitureAction } from "@/lib/api/investiture";
-
-const actionConfig: Record<
-  InvestitureAction,
-  {
-    label: string;
-    icon: React.ElementType;
-    iconClassName: string;
-    dotClassName: string;
-  }
-> = {
-  SUBMITTED: {
-    label: "Enviado a validación",
-    icon: Send,
-    iconClassName: "text-warning",
-    dotClassName: "bg-warning/20 border-warning/40",
-  },
-  APPROVED: {
-    label: "Aprobado",
-    icon: CheckCircle2,
-    iconClassName: "text-success",
-    dotClassName: "bg-success/20 border-success/40",
-  },
-  REJECTED: {
-    label: "Rechazado",
-    icon: XCircle,
-    iconClassName: "text-destructive",
-    dotClassName: "bg-destructive/20 border-destructive/40",
-  },
-  REINVESTITURE_REQUESTED: {
-    label: "Re-investidura solicitada",
-    icon: RefreshCw,
-    iconClassName: "text-primary",
-    dotClassName: "bg-primary/20 border-primary/40",
-  },
-};
 
 function formatDate(isoDate: string): string {
   try {
@@ -53,14 +19,14 @@ function formatDate(isoDate: string): string {
   }
 }
 
-function getPerformerName(entry: InvestitureHistoryEntry): string {
+function getPerformerName(entry: InvestitureHistoryEntry, systemLabel: string): string {
   if (entry.performer?.first_name || entry.performer?.last_name) {
     return [entry.performer.first_name, entry.performer.last_name]
       .filter(Boolean)
       .join(" ");
   }
   if (entry.performed_by) return entry.performed_by;
-  return "Sistema";
+  return systemLabel;
 }
 
 interface HistoryTimelineProps {
@@ -68,11 +34,48 @@ interface HistoryTimelineProps {
 }
 
 export function HistoryTimeline({ entries }: HistoryTimelineProps) {
+  const t = useTranslations("investiture");
+
+  const actionConfig: Record<
+    InvestitureAction,
+    {
+      label: string;
+      icon: React.ElementType;
+      iconClassName: string;
+      dotClassName: string;
+    }
+  > = {
+    SUBMITTED: {
+      label: t("history.actionSubmitted"),
+      icon: Send,
+      iconClassName: "text-warning",
+      dotClassName: "bg-warning/20 border-warning/40",
+    },
+    APPROVED: {
+      label: t("history.actionApproved"),
+      icon: CheckCircle2,
+      iconClassName: "text-success",
+      dotClassName: "bg-success/20 border-success/40",
+    },
+    REJECTED: {
+      label: t("history.actionRejected"),
+      icon: XCircle,
+      iconClassName: "text-destructive",
+      dotClassName: "bg-destructive/20 border-destructive/40",
+    },
+    REINVESTITURE_REQUESTED: {
+      label: t("history.actionReinvestitureRequested"),
+      icon: RefreshCw,
+      iconClassName: "text-primary",
+      dotClassName: "bg-primary/20 border-primary/40",
+    },
+  };
+
   if (entries.length === 0) {
     return (
       <div className="flex items-center gap-2 rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
         <Clock className="size-4 shrink-0" />
-        <span>No hay historial de validación aún.</span>
+        <span>{t("history.emptyHistory")}</span>
       </div>
     );
   }
@@ -110,7 +113,7 @@ export function HistoryTimeline({ entries }: HistoryTimelineProps) {
             <div className={cn("pb-4", isLast && "pb-0")}>
               <p className="text-sm font-medium leading-tight">{config.label}</p>
               <p className="mt-0.5 text-xs text-muted-foreground">
-                {getPerformerName(entry)} &middot; {formatDate(entry.created_at)}
+                {getPerformerName(entry, t("history.system"))} &middot; {formatDate(entry.created_at)}
               </p>
               {entry.comments && (
                 <p className="mt-1.5 rounded-md bg-muted px-3 py-2 text-xs text-foreground">

--- a/src/components/investiture/investiture-client-page.tsx
+++ b/src/components/investiture/investiture-client-page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useMemo } from "react";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -29,6 +30,7 @@ export function InvestitureClientPage({
   initialEnrollments,
   years,
 }: InvestitureClientPageProps) {
+  const t = useTranslations("investiture");
   const [enrollments, setEnrollments] =
     useState<PendingEnrollment[]>(initialEnrollments);
   const [selectedYearId, setSelectedYearId] = useState<string>("all");
@@ -67,12 +69,12 @@ export function InvestitureClientPage({
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudo actualizar la lista";
+          : t("client.errorRefresh");
       toast.error(message);
     } finally {
       setIsRefreshing(false);
     }
-  }, [selectedYearId]);
+  }, [selectedYearId, t]);
 
   return (
     <div className="space-y-4">
@@ -82,10 +84,10 @@ export function InvestitureClientPage({
           {years.length > 0 && (
             <Select value={selectedYearId} onValueChange={setSelectedYearId}>
               <SelectTrigger className="w-52">
-                <SelectValue placeholder="Todos los años" />
+                <SelectValue placeholder={t("client.allYears")} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">Todos los años</SelectItem>
+                <SelectItem value="all">{t("client.allYears")}</SelectItem>
                 {years.map((year) => (
                   <SelectItem
                     key={year.ecclesiastical_year_id}
@@ -94,7 +96,7 @@ export function InvestitureClientPage({
                     {year.name}
                     {year.active && (
                       <span className="ml-1.5 text-xs text-muted-foreground">
-                        (activo)
+                        {t("client.yearActive")}
                       </span>
                     )}
                   </SelectItem>
@@ -110,8 +112,8 @@ export function InvestitureClientPage({
               {filteredEnrollments.length}
             </span>{" "}
             {filteredEnrollments.length === 1
-              ? "pendiente"
-              : "pendientes"}
+              ? t("client.countSingular")
+              : t("client.countPlural")}
           </p>
           <Button
             variant="outline"
@@ -122,7 +124,7 @@ export function InvestitureClientPage({
             <RefreshCw
               className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
             />
-            Actualizar
+            {t("client.refresh")}
           </Button>
         </div>
       </div>

--- a/src/components/investiture/investiture-status-badge.tsx
+++ b/src/components/investiture/investiture-status-badge.tsx
@@ -1,18 +1,8 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { StatusBadge, type StatusIntent } from "@/components/ui/status-badge";
 import type { InvestitureStatus } from "@/lib/api/investiture";
-
-const statusMap: Record<InvestitureStatus, { label: string; intent: StatusIntent }> = {
-  IN_PROGRESS: { label: "En progreso", intent: "neutral" },
-  SUBMITTED_FOR_VALIDATION: { label: "Enviado", intent: "warning" },
-  SUBMITTED: { label: "Enviado", intent: "warning" },
-  CLUB_APPROVED: { label: "Aprobado por club", intent: "progress-1" },
-  COORDINATOR_APPROVED: { label: "Aprobado por coordinación", intent: "progress-2" },
-  FIELD_APPROVED: { label: "Aprobado por campo", intent: "progress-3" },
-  APPROVED: { label: "Aprobado", intent: "success" },
-  REJECTED: { label: "Rechazado", intent: "destructive" },
-  INVESTED: { label: "Investido", intent: "primary" },
-  INVESTIDO: { label: "Investido", intent: "primary" },
-};
 
 interface InvestitureStatusBadgeProps {
   status: InvestitureStatus;
@@ -20,6 +10,21 @@ interface InvestitureStatusBadgeProps {
 }
 
 export function InvestitureStatusBadge({ status, className }: InvestitureStatusBadgeProps) {
+  const t = useTranslations("investiture");
+
+  const statusMap: Record<InvestitureStatus, { label: string; intent: StatusIntent }> = {
+    IN_PROGRESS: { label: t("statusBadge.inProgress"), intent: "neutral" },
+    SUBMITTED_FOR_VALIDATION: { label: t("statusBadge.submittedForValidation"), intent: "warning" },
+    SUBMITTED: { label: t("statusBadge.submitted"), intent: "warning" },
+    CLUB_APPROVED: { label: t("statusBadge.clubApproved"), intent: "progress-1" },
+    COORDINATOR_APPROVED: { label: t("statusBadge.coordinatorApproved"), intent: "progress-2" },
+    FIELD_APPROVED: { label: t("statusBadge.fieldApproved"), intent: "progress-3" },
+    APPROVED: { label: t("statusBadge.approved"), intent: "success" },
+    REJECTED: { label: t("statusBadge.rejected"), intent: "destructive" },
+    INVESTED: { label: t("statusBadge.invested"), intent: "primary" },
+    INVESTIDO: { label: t("statusBadge.invested"), intent: "primary" },
+  };
+
   const config = statusMap[status] ?? { label: status, intent: "neutral" as StatusIntent };
   return <StatusBadge intent={config.intent} label={config.label} className={className} />;
 }

--- a/src/components/investiture/pending-table.tsx
+++ b/src/components/investiture/pending-table.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import { CheckCircle2, XCircle, Award, History, ClipboardList } from "lucide-react";
 import {
   Table,
@@ -35,11 +36,11 @@ import { ApiError } from "@/lib/api/client";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-function getMemberName(enrollment: PendingEnrollment): string {
+function getMemberName(enrollment: PendingEnrollment, fallback: string): string {
   const u = enrollment.user;
-  if (!u) return `Inscripción #${enrollment.enrollment_id}`;
+  if (!u) return fallback;
   const full = [u.first_name, u.last_name].filter(Boolean).join(" ");
-  return full || u.email || `Inscripción #${enrollment.enrollment_id}`;
+  return full || u.email || fallback;
 }
 
 function formatDate(iso?: string | null): string {
@@ -73,6 +74,7 @@ type DialogState =
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
+  const t = useTranslations("investiture");
   const [dialog, setDialog] = useState<DialogState>(null);
   const [historyEntries, setHistoryEntries] = useState<InvestitureHistoryEntry[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
@@ -88,7 +90,7 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudo cargar el historial";
+          : t("pendingTable.errorLoadHistory");
       toast.error(message);
     } finally {
       setLoadingHistory(false);
@@ -104,14 +106,19 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
     return (
       <EmptyState
         icon={ClipboardList}
-        title="Sin pendientes"
-        description="No hay investiduras pendientes de validación en este momento."
+        title={t("pendingTable.emptyTitle")}
+        description={t("pendingTable.emptyDescription")}
       />
     );
   }
 
   const activeEnrollment = dialog?.enrollment ?? null;
-  const memberName = activeEnrollment ? getMemberName(activeEnrollment) : "";
+  const memberName = activeEnrollment
+    ? getMemberName(
+        activeEnrollment,
+        t("pendingTable.enrollmentFallback", { id: activeEnrollment.enrollment_id }),
+      )
+    : "";
 
   return (
     <>
@@ -120,28 +127,31 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
           <TableHeader>
             <TableRow>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Miembro
+                {t("pendingTable.colMember")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Clase
+                {t("pendingTable.colClass")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Club
+                {t("pendingTable.colClub")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Enviado
+                {t("pendingTable.colSubmitted")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Estado
+                {t("pendingTable.colStatus")}
               </TableHead>
               <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Acciones
+                {t("pendingTable.colActions")}
               </TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             {enrollments.map((enrollment) => {
-              const name = getMemberName(enrollment);
+              const name = getMemberName(
+                enrollment,
+                t("pendingTable.enrollmentFallback", { id: enrollment.enrollment_id }),
+              );
               const isSubmitted =
                 enrollment.investiture_status === "SUBMITTED_FOR_VALIDATION";
               const isApproved = enrollment.investiture_status === "APPROVED";
@@ -177,12 +187,12 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
                             variant="ghost"
                             size="icon-sm"
                             onClick={() => openHistory(enrollment)}
-                            aria-label="Ver historial"
+                            aria-label={t("pendingTable.ariaHistory")}
                           >
                             <History className="size-4" />
                           </Button>
                         </TooltipTrigger>
-                        <TooltipContent>Ver historial</TooltipContent>
+                        <TooltipContent>{t("pendingTable.tooltipHistory")}</TooltipContent>
                       </Tooltip>
 
                       {/* Approve — only for SUBMITTED */}
@@ -200,12 +210,12 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
                                   action: "APPROVED",
                                 })
                               }
-                              aria-label="Aprobar"
+                              aria-label={t("pendingTable.ariaApprove")}
                             >
                               <CheckCircle2 className="size-4" />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>Aprobar</TooltipContent>
+                          <TooltipContent>{t("pendingTable.tooltipApprove")}</TooltipContent>
                         </Tooltip>
                       )}
 
@@ -224,12 +234,12 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
                                   action: "REJECTED",
                                 })
                               }
-                              aria-label="Rechazar"
+                              aria-label={t("pendingTable.ariaReject")}
                             >
                               <XCircle className="size-4" />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>Rechazar</TooltipContent>
+                          <TooltipContent>{t("pendingTable.tooltipReject")}</TooltipContent>
                         </Tooltip>
                       )}
 
@@ -244,12 +254,12 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
                               onClick={() =>
                                 setDialog({ type: "investido", enrollment })
                               }
-                              aria-label="Marcar como investido"
+                              aria-label={t("pendingTable.ariaMarkInvested")}
                             >
                               <Award className="size-4" />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>Marcar como investido</TooltipContent>
+                          <TooltipContent>{t("pendingTable.tooltipMarkInvested")}</TooltipContent>
                         </Tooltip>
                       )}
                     </div>
@@ -303,7 +313,7 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
       >
         <DialogContent className="sm:max-w-lg">
           <DialogHeader>
-            <DialogTitle>Historial de investidura</DialogTitle>
+            <DialogTitle>{t("pendingTable.historyTitle")}</DialogTitle>
             {activeEnrollment && (
               <p className="text-sm text-muted-foreground">
                 {memberName} &middot;{" "}

--- a/src/components/investiture/pipeline-client-page.tsx
+++ b/src/components/investiture/pipeline-client-page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { PipelineTable, type UserRole } from "@/components/investiture/pipeline-table";
@@ -17,16 +18,6 @@ import { ApiError } from "@/lib/api/client";
 
 type TabKey = PipelineStatus | "ALL";
 
-const TABS: { key: TabKey; label: string }[] = [
-  { key: "ALL", label: "Todos" },
-  { key: "SUBMITTED", label: "Enviados" },
-  { key: "CLUB_APPROVED", label: "Aprobados club" },
-  { key: "COORDINATOR_APPROVED", label: "Aprobados coord." },
-  { key: "FIELD_APPROVED", label: "Aprobados campo" },
-  { key: "INVESTED", label: "Investidos" },
-  { key: "REJECTED", label: "Rechazados" },
-];
-
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 interface PipelineClientPageProps {
@@ -40,6 +31,18 @@ export function PipelineClientPage({
   initialEnrollments,
   userRole,
 }: PipelineClientPageProps) {
+  const t = useTranslations("investiture");
+
+  const TABS: { key: TabKey; label: string }[] = [
+    { key: "ALL", label: t("pipeline.tabAll") },
+    { key: "SUBMITTED", label: t("pipeline.tabSubmitted") },
+    { key: "CLUB_APPROVED", label: t("pipeline.tabClubApproved") },
+    { key: "COORDINATOR_APPROVED", label: t("pipeline.tabCoordinatorApproved") },
+    { key: "FIELD_APPROVED", label: t("pipeline.tabFieldApproved") },
+    { key: "INVESTED", label: t("pipeline.tabInvested") },
+    { key: "REJECTED", label: t("pipeline.tabRejected") },
+  ];
+
   const [activeTab, setActiveTab] = useState<TabKey>("ALL");
   const [enrollments, setEnrollments] =
     useState<PipelineEnrollment[]>(initialEnrollments);
@@ -66,14 +69,14 @@ export function PipelineClientPage({
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudo actualizar la lista";
+          : t("pipeline.errorRefresh");
       toast.error(message);
     } finally {
       if (isMounted.current) {
         setIsRefreshing(false);
       }
     }
-  }, [activeTab]);
+  }, [activeTab, t]);
 
   // Reload data on tab change (server returns all on initial load)
   useEffect(() => {
@@ -104,7 +107,7 @@ export function PipelineClientPage({
           <RefreshCw
             className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
-          Actualizar
+          {t("pipeline.refresh")}
         </Button>
       </div>
 

--- a/src/components/investiture/pipeline-history-dialog.tsx
+++ b/src/components/investiture/pipeline-history-dialog.tsx
@@ -9,6 +9,7 @@ import {
   Send,
   Award,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useQuery } from "@tanstack/react-query";
 import {
   Dialog,
@@ -37,71 +38,25 @@ function formatDate(iso: string): string {
   }
 }
 
-function getPerformerName(entry: PipelineHistoryEntry): string {
+function getPerformerName(
+  entry: PipelineHistoryEntry,
+  systemLabel: string,
+): string {
   if (entry.performer?.first_name || entry.performer?.last_name) {
     return [entry.performer.first_name, entry.performer.last_name]
       .filter(Boolean)
       .join(" ");
   }
   if (entry.performed_by) return entry.performed_by;
-  return "Sistema";
+  return systemLabel;
 }
 
-const actionConfig: Record<
-  string,
-  { label: string; icon: React.ElementType; iconClass: string; dotClass: string }
-> = {
-  SUBMITTED: {
-    label: "Enviado",
-    icon: Send,
-    iconClass: "text-warning",
-    dotClass: "bg-warning/20 border-warning/40",
-  },
-  CLUB_APPROVED: {
-    label: "Aprobado por director",
-    icon: CheckCircle2,
-    iconClass: "text-[var(--chart-1)]",
-    dotClass:
-      "bg-[color-mix(in_oklch,var(--chart-1)_20%,transparent)] border-[color-mix(in_oklch,var(--chart-1)_40%,transparent)]",
-  },
-  COORDINATOR_APPROVED: {
-    label: "Aprobado por coordinación",
-    icon: CheckCircle2,
-    iconClass: "text-[var(--chart-2)]",
-    dotClass:
-      "bg-[color-mix(in_oklch,var(--chart-2)_20%,transparent)] border-[color-mix(in_oklch,var(--chart-2)_40%,transparent)]",
-  },
-  FIELD_APPROVED: {
-    label: "Aprobado por campo",
-    icon: CheckCircle2,
-    iconClass: "text-[var(--chart-3)]",
-    dotClass:
-      "bg-[color-mix(in_oklch,var(--chart-3)_20%,transparent)] border-[color-mix(in_oklch,var(--chart-3)_40%,transparent)]",
-  },
-  INVESTED: {
-    label: "Investido",
-    icon: Award,
-    iconClass: "text-primary",
-    dotClass: "bg-primary/20 border-primary/40",
-  },
-  REJECTED: {
-    label: "Rechazado",
-    icon: XCircle,
-    iconClass: "text-destructive",
-    dotClass: "bg-destructive/20 border-destructive/40",
-  },
+type ActionEntryConfig = {
+  label: string;
+  icon: React.ElementType;
+  iconClass: string;
+  dotClass: string;
 };
-
-function getConfig(action: string) {
-  return (
-    actionConfig[action] ?? {
-      label: action,
-      icon: Clock,
-      iconClass: "text-muted-foreground",
-      dotClass: "bg-muted border-border",
-    }
-  );
-}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -125,6 +80,50 @@ export function PipelineHistoryDialog({
   memberName,
   onOpenChange,
 }: PipelineHistoryDialogProps) {
+  const t = useTranslations("investiture");
+
+  const actionConfig: Record<string, ActionEntryConfig> = {
+    SUBMITTED: {
+      label: t("historyDialog.actionSubmitted"),
+      icon: Send,
+      iconClass: "text-warning",
+      dotClass: "bg-warning/20 border-warning/40",
+    },
+    CLUB_APPROVED: {
+      label: t("historyDialog.actionClubApproved"),
+      icon: CheckCircle2,
+      iconClass: "text-[var(--chart-1)]",
+      dotClass:
+        "bg-[color-mix(in_oklch,var(--chart-1)_20%,transparent)] border-[color-mix(in_oklch,var(--chart-1)_40%,transparent)]",
+    },
+    COORDINATOR_APPROVED: {
+      label: t("historyDialog.actionCoordinatorApproved"),
+      icon: CheckCircle2,
+      iconClass: "text-[var(--chart-2)]",
+      dotClass:
+        "bg-[color-mix(in_oklch,var(--chart-2)_20%,transparent)] border-[color-mix(in_oklch,var(--chart-2)_40%,transparent)]",
+    },
+    FIELD_APPROVED: {
+      label: t("historyDialog.actionFieldApproved"),
+      icon: CheckCircle2,
+      iconClass: "text-[var(--chart-3)]",
+      dotClass:
+        "bg-[color-mix(in_oklch,var(--chart-3)_20%,transparent)] border-[color-mix(in_oklch,var(--chart-3)_40%,transparent)]",
+    },
+    INVESTED: {
+      label: t("historyDialog.actionInvested"),
+      icon: Award,
+      iconClass: "text-primary",
+      dotClass: "bg-primary/20 border-primary/40",
+    },
+    REJECTED: {
+      label: t("historyDialog.actionRejected"),
+      icon: XCircle,
+      iconClass: "text-destructive",
+      dotClass: "bg-destructive/20 border-destructive/40",
+    },
+  };
+
   // Pipeline history is append-only — once fetched it never changes.
   const { data: entries = [], isLoading: loading } = useQuery({
     queryKey: pipelineHistoryQueryKey(enrollmentId),
@@ -135,7 +134,7 @@ export function PipelineHistoryDialog({
         const message =
           error instanceof ApiError
             ? error.message
-            : "No se pudo cargar el historial";
+            : t("historyDialog.errorLoad");
         toast.error(message);
         throw error;
       }
@@ -151,7 +150,7 @@ export function PipelineHistoryDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <History className="size-5 text-muted-foreground" />
-            Historial de investidura
+            {t("historyDialog.title")}
           </DialogTitle>
           <p className="text-sm text-muted-foreground">{memberName}</p>
         </DialogHeader>
@@ -166,12 +165,17 @@ export function PipelineHistoryDialog({
           ) : entries.length === 0 ? (
             <div className="flex items-center gap-2 rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
               <Clock className="size-4 shrink-0" />
-              <span>No hay historial aún.</span>
+              <span>{t("historyDialog.emptyHistory")}</span>
             </div>
           ) : (
             <ol className="relative space-y-0">
               {entries.map((entry, idx) => {
-                const config = getConfig(entry.action);
+                const config = actionConfig[entry.action] ?? {
+                  label: entry.action,
+                  icon: Clock,
+                  iconClass: "text-muted-foreground",
+                  dotClass: "bg-muted border-border",
+                };
                 const Icon = config.icon;
                 const isLast = idx === entries.length - 1;
 
@@ -193,7 +197,7 @@ export function PipelineHistoryDialog({
                         {config.label}
                       </p>
                       <p className="mt-0.5 text-xs text-muted-foreground">
-                        {getPerformerName(entry)} &middot; {formatDate(entry.created_at)}
+                        {getPerformerName(entry, t("historyDialog.system"))} &middot; {formatDate(entry.created_at)}
                       </p>
                       {entry.reason && (
                         <p className="mt-1.5 rounded-md bg-muted px-3 py-2 text-xs text-foreground">

--- a/src/components/investiture/pipeline-status-badge.tsx
+++ b/src/components/investiture/pipeline-status-badge.tsx
@@ -1,14 +1,8 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { StatusBadge, type StatusIntent } from "@/components/ui/status-badge";
 import type { PipelineStatus } from "@/lib/api/investiture";
-
-const statusMap: Record<PipelineStatus, { label: string; intent: StatusIntent }> = {
-  SUBMITTED: { label: "Enviado", intent: "warning" },
-  CLUB_APPROVED: { label: "Aprobado por club", intent: "progress-1" },
-  COORDINATOR_APPROVED: { label: "Aprobado por coordinación", intent: "progress-2" },
-  FIELD_APPROVED: { label: "Aprobado por campo", intent: "progress-3" },
-  INVESTED: { label: "Investido", intent: "primary" },
-  REJECTED: { label: "Rechazado", intent: "destructive" },
-};
 
 interface PipelineStatusBadgeProps {
   status: PipelineStatus;
@@ -16,6 +10,17 @@ interface PipelineStatusBadgeProps {
 }
 
 export function PipelineStatusBadge({ status, className }: PipelineStatusBadgeProps) {
+  const t = useTranslations("investiture");
+
+  const statusMap: Record<PipelineStatus, { label: string; intent: StatusIntent }> = {
+    SUBMITTED: { label: t("pipelineStatusBadge.submitted"), intent: "warning" },
+    CLUB_APPROVED: { label: t("pipelineStatusBadge.clubApproved"), intent: "progress-1" },
+    COORDINATOR_APPROVED: { label: t("pipelineStatusBadge.coordinatorApproved"), intent: "progress-2" },
+    FIELD_APPROVED: { label: t("pipelineStatusBadge.fieldApproved"), intent: "progress-3" },
+    INVESTED: { label: t("pipelineStatusBadge.invested"), intent: "primary" },
+    REJECTED: { label: t("pipelineStatusBadge.rejected"), intent: "destructive" },
+  };
+
   const config = statusMap[status] ?? { label: status, intent: "neutral" as StatusIntent };
   return <StatusBadge intent={config.intent} label={config.label} className={className} />;
 }


### PR DESCRIPTION
## Summary

Batch 4 of i18n rollout. Extends the existing `investiture` namespace with ~76 new keys covering 9 components (status badges, list pages, tables, history dialogs).

| File | Sub-namespace | Keys |
|---|---|---|
| `config-client-page.tsx` | `investiture.configClient.*` | 5 |
| `config-table.tsx` | `investiture.configTable.*` | 14 |
| `investiture-client-page.tsx` | `investiture.client.*` | 6 |
| `pipeline-client-page.tsx` | `investiture.pipeline.*` | 8 |
| `pipeline-history-dialog.tsx` | `investiture.historyDialog.*` | 9 |
| `history-timeline.tsx` | `investiture.history.*` | 6 |
| `pending-table.tsx` | `investiture.pendingTable.*` | 13 |
| `investiture-status-badge.tsx` | `investiture.statusBadge.*` | 9 |
| `pipeline-status-badge.tsx` | `investiture.pipelineStatusBadge.*` | 6 |

## Patterns reinforced

- Module-level constants holding UI strings (`TABS`, `actionConfig`, `statusMap`) moved INSIDE component body for `useTranslations` hook access.
- Status badges: added `'use client'` directive since they now consume the hook.
- `getMemberName` helper accepts `fallback: string` parameter for translatable empty value.

## Test plan

- [ ] CI typecheck (#56) passes
- [ ] CI tests (#60) passes — 41/41
- [ ] `/dashboard/investiture/config` + `/pipeline` + main view render in `es` without missing-key warnings
- [ ] Status badges (investiture + pipeline) render with translated labels
- [ ] History timeline + history dialog render with translated action labels