### PR TITLE
fix(layout): dedupe user menu, sidebar canonical (audit H3 UX)

### DIFF
--- a/src/components/layout/app-header.tsx
+++ b/src/components/layout/app-header.tsx
@@ -3,46 +3,8 @@
 import { SidebarTrigger } from "@/components/ui/sidebar";
 import { AppBreadcrumbs } from "@/components/layout/app-breadcrumbs";
 import { ThemeToggle } from "@/components/layout/theme-toggle";
-import { useAuth } from "@/lib/auth/auth-context";
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
-import { LogOut, User } from "lucide-react";
-import Link from "next/link";
-import { useQueryClient } from "@tanstack/react-query";
-
-function getInitials(name?: string | null, email?: string | null): string {
-  if (name) {
-    return name
-      .split(" ")
-      .map((n) => n[0])
-      .join("")
-      .toUpperCase()
-      .slice(0, 2);
-  }
-  return (email?.[0] ?? "A").toUpperCase();
-}
-
-const LOGOUT_URL = "/api/auth/logout?next=/login";
 
 export function AppHeader() {
-  const { user } = useAuth();
-  const queryClient = useQueryClient();
-  const displayName = user?.name ?? user?.email ?? "Admin";
-  const photoUrl =
-    user?.picture_url ??
-    user?.user_image ??
-    user?.avatar_url ??
-    user?.photo_url ??
-    user?.profile_picture_url ??
-    (typeof user?.profile_picture === "string" ? user.profile_picture : null) ??
-    null;
-
   return (
     <header className="flex h-14 shrink-0 items-center gap-2 border-b px-4">
       <SidebarTrigger className="-ml-1" />
@@ -52,51 +14,9 @@ export function AppHeader() {
 
       <AppBreadcrumbs />
 
-      {/* Right side: theme toggle + user avatar */}
+      {/* Right side: theme toggle. Future: <ActiveContextChip /> once active club / ecclesiastical year data source exists. */}
       <div className="ml-auto flex items-center gap-1.5">
         <ThemeToggle />
-        <div className="h-4 w-px bg-border" />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              className="flex items-center gap-2 rounded-lg px-2 py-1.5 text-sm transition-colors hover:bg-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              aria-label="Menú de usuario"
-            >
-              <Avatar className="size-7">
-                {photoUrl && (
-                  <AvatarImage src={photoUrl} alt={displayName} />
-                )}
-                <AvatarFallback className="text-xs font-medium">
-                  {getInitials(user?.name, user?.email)}
-                </AvatarFallback>
-              </Avatar>
-              <span className="hidden max-w-32 truncate text-sm font-medium sm:block">
-                {displayName}
-              </span>
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end" className="w-48" sideOffset={6}>
-            <DropdownMenuItem asChild>
-              <Link href={`/dashboard/users/${user?.id ?? ""}`}>
-                <User className="size-4" />
-                Mi perfil
-              </Link>
-            </DropdownMenuItem>
-            <DropdownMenuSeparator />
-            <DropdownMenuItem asChild>
-              <button
-                onClick={() => {
-                  queryClient.clear();
-                  window.location.href = LOGOUT_URL;
-                }}
-                aria-label="Cerrar sesión"
-              >
-                <LogOut className="size-4" />
-                Cerrar sesión
-              </button>
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
     </header>
   );


### PR DESCRIPTION
## Summary
- Strip avatar dropdown from `app-header.tsx` (was lines 59-99)
- Sidebar footer becomes canonical user menu (already has Mi perfil + locale switcher + Cerrar sesión)
- Header right slot: ThemeToggle only (cleaner)
- `app-header.tsx`: 105 → 23 lines

## Why
Audit H3 UX. Avatar dropdown duplicated in header AND sidebar footer with diverging content (locale only in sidebar). Violates Nielsen heuristic 4 (consistency). Pick one canonical (sidebar = fuller version), drop the other. Frees header for future affordances.

## ActiveContextChip — DEFERRED
Investigation: no viable data source for "club activo + año eclesiástico":
- `AuthorizationSnapshot.active_assignment` carries only opaque `assignment_id` UUID
- `AuthUser` types lack `club_name` / `ecclesiastical_year`
- No context provider, store, or cookie carries resolved values

Header right slot reserved with comment for future implementor.

## Removed imports
`useAuth`, `Avatar/AvatarFallback/AvatarImage`, 5 DropdownMenu primitives, `LogOut`/`User` icons, `Link`, `useQueryClient`, `getInitials`, `LOGOUT_URL`, vertical divider.

## Test plan
- [ ] `pnpm lint` clean (verified)
- [ ] Header renders: SidebarTrigger | breadcrumbs | ... | ThemeToggle. No avatar.
- [ ] Sidebar footer: Mi perfil + locale + Cerrar sesión work as before
- [ ] Logout flow intact (sidebar footer triggers it)