### PR TITLE
fix(clubs): inline Pencil + DropdownMenu actions match honors (audit H5)

### DIFF
--- a/src/app/(dashboard)/dashboard/clubs/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/page.tsx
@@ -17,9 +17,11 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 import { DataTableShell } from "@/components/shared/data-table-shell";
 import { DataTablePagination } from "@/components/shared/data-table-pagination";
+import { ClubsTableActionsCell } from "@/components/clubs/clubs-table-actions-cell";
 import { apiRequest, ApiError } from "@/lib/api/client";
 import { requireAdminUser } from "@/lib/auth/session";
 import { hasPermission } from "@/lib/auth/permission-utils";
+import { CLUBS_UPDATE, CLUBS_DELETE } from "@/lib/auth/permissions";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -159,6 +161,8 @@ async function ClubsContent({
 }) {
   const user = await requireAdminUser();
   const canCreate = hasPermission(user, "clubs:create");
+  const canEdit = hasPermission(user, CLUBS_UPDATE);
+  const canDelete = hasPermission(user, CLUBS_DELETE);
   const result = await fetchClubs(query);
 
   if (!result.available) {
@@ -198,7 +202,11 @@ async function ClubsContent({
                 <TableHead className="hidden lg:table-cell">Distrito</TableHead>
                 <TableHead className="hidden lg:table-cell">Iglesia</TableHead>
                 <TableHead>Estado</TableHead>
-                <TableHead className="w-[100px]">Acciones</TableHead>
+                {(canEdit || canDelete) && (
+                  <TableHead className="sticky right-0 z-20 w-[100px] border-l bg-background">
+                    Acciones
+                  </TableHead>
+                )}
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -221,11 +229,15 @@ async function ClubsContent({
                         {club.active !== false ? "Activo" : "Inactivo"}
                       </Badge>
                     </TableCell>
-                    <TableCell>
-                      <Button variant="ghost" size="sm" asChild>
-                        <Link href={`/dashboard/clubs/${clubId}`}>Ver</Link>
-                      </Button>
-                    </TableCell>
+                    {(canEdit || canDelete) && (
+                      <TableCell className="sticky right-0 z-10 border-l bg-background">
+                        <ClubsTableActionsCell
+                          club={{ id: clubId ?? 0, name: club.name ?? "" }}
+                          canEdit={canEdit}
+                          canDelete={canDelete}
+                        />
+                      </TableCell>
+                    )}
                   </TableRow>
                 );
               })}

--- a/src/components/clubs/clubs-table-actions-cell.tsx
+++ b/src/components/clubs/clubs-table-actions-cell.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import Link from "next/link";
+import { useState } from "react";
+import { useFormStatus } from "react-dom";
+import { Loader2, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { deleteClubAction } from "@/lib/clubs/actions";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ClubActionItem {
+  id: number;
+  name: string;
+}
+
+interface ClubsTableActionsCellProps {
+  club: ClubActionItem;
+  canEdit: boolean;
+  canDelete: boolean;
+}
+
+// ─── Delete submit button ─────────────────────────────────────────────────────
+
+function DeleteButton() {
+  const { pending } = useFormStatus();
+  return (
+    <Button
+      type="submit"
+      disabled={pending}
+      className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+    >
+      {pending && <Loader2 className="size-4 animate-spin" />}
+      Eliminar
+    </Button>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ClubsTableActionsCell({
+  club,
+  canEdit,
+  canDelete,
+}: ClubsTableActionsCellProps) {
+  const [deleteItem, setDeleteItem] = useState<ClubActionItem | null>(null);
+
+  const editHref = `/dashboard/clubs/${club.id}?tab=edit`;
+
+  return (
+    <>
+      {/* Desktop: icon buttons */}
+      <div className="hidden gap-1 md:flex">
+        {canEdit && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8"
+            asChild
+            title="Editar"
+          >
+            <Link href={editHref} aria-label={`Editar ${club.name}`}>
+              <Pencil className="size-3.5" />
+            </Link>
+          </Button>
+        )}
+        {canDelete && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="size-8 text-destructive hover:text-destructive"
+            onClick={() => setDeleteItem(club)}
+            title="Eliminar"
+          >
+            <Trash2 className="size-3.5" />
+          </Button>
+        )}
+      </div>
+
+      {/* Mobile: DropdownMenu */}
+      <div className="md:hidden">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon" className="size-8" title="Acciones">
+              <MoreHorizontal className="size-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {canEdit && (
+              <DropdownMenuItem asChild>
+                <Link href={editHref}>
+                  <Pencil className="size-4" />
+                  Editar
+                </Link>
+              </DropdownMenuItem>
+            )}
+            {canDelete && (
+              <DropdownMenuItem
+                variant="destructive"
+                onSelect={() => setDeleteItem(club)}
+              >
+                <Trash2 className="size-4" />
+                Eliminar
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+
+      {/* AlertDialog for delete confirmation */}
+      {canDelete && (
+        <AlertDialog
+          open={!!deleteItem}
+          onOpenChange={(open) => {
+            if (!open) setDeleteItem(null);
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>¿Eliminar club?</AlertDialogTitle>
+              <AlertDialogDescription>
+                Esta acción eliminará de forma permanente el club{" "}
+                <span className="font-medium">&quot;{deleteItem?.name}&quot;</span>.
+                Esta operación no se puede deshacer.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancelar</AlertDialogCancel>
+              <form action={deleteClubAction}>
+                <input
+                  type="hidden"
+                  name="id"
+                  value={String(deleteItem?.id ?? "")}
+                />
+                <DeleteButton />
+              </form>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- New: `src/components/clubs/clubs-table-actions-cell.tsx` (158 lines, "use client")
- Desktop: Pencil icon button + Trash2 icon button (`hidden md:flex`)
- Mobile: DropdownMenu with Editar / Eliminar items (`md:hidden`)
- Wires `deleteClubAction` via AlertDialog + `useFormStatus` pending button
- Replaces single "Ver" Button cell in `clubs/page.tsx`

## Why
Audit H5. Clubs list exposed only "Ver" Button. Honors uses Pencil + DropdownMenu pattern (after PR #71). Inconsistent. Match Honors → better information scent + Fitts's Law improvement.

## Edit href
Points to `/dashboard/clubs/${id}?tab=edit` (no separate edit route exists; edit form lives inside detail page as a tab).

## Delete behavior
Hard delete labeled "Eliminar" — `deleteClubAction` is real delete (no soft-deactivate action exists). AlertDialog copy: "Esta operación no se puede deshacer" sets correct expectations. If soft-deactivate added later, only action import + dialog copy change.

## Mobile card
Untouched — full-row `<Link>` to detail. Matches Honors mobile pattern.

## Permissions
Gated via `CLUBS_UPDATE` / `CLUBS_DELETE` permission constants + super-admin bypass.

## Test plan
- [ ] `pnpm lint` clean (verified)
- [ ] Desktop: Pencil + Trash2 visible, Pencil → tab=edit, Trash2 → AlertDialog confirm
- [ ] Mobile: DropdownMenu trigger, items working
- [ ] Permission gates: non-canEdit hides Pencil, non-canDelete hides Trash2
- [ ] AlertDialog: Cancel cancels, Confirm fires deleteClubAction with pending state