### PR TITLE
feat(i18n): batch 6 — certifications, classes, inventory, member-of-month, membership

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1707,7 +1707,17 @@
       "evaluation_completed": "Evaluation completed"
     },
     "errors": {
-      "evaluation_failed": "Could not complete the evaluation"
+      "evaluation_failed": "Could not complete the evaluation",
+      "load_history_failed": "Could not load history"
+    },
+    "history": {
+      "title": "Member of the Month — History",
+      "description": "Winners history for {sectionName}",
+      "tie": "Tie",
+      "empty_title": "No history",
+      "empty_description": "No member of the month data yet.",
+      "pagination_label": "Page {page} of {total}",
+      "points": "{count} pts"
     }
   },
   "reports": {
@@ -2021,6 +2031,28 @@
     "toasts": {
       "progress_load_failed": "Could not load the user's progress",
       "progress_update_failed": "Could not update the progress"
+    },
+    "list": {
+      "empty_title": "No certifications",
+      "empty_description": "No certifications have been registered.",
+      "col_name": "Name",
+      "col_description": "Description",
+      "col_duration": "Duration",
+      "col_modules": "Modules",
+      "col_status": "Status",
+      "view_detail": "View detail",
+      "status_active": "Active",
+      "status_inactive": "Inactive",
+      "duration_weeks": "{count} wks."
+    },
+    "tree": {
+      "no_modules": "This certification has no registered modules.",
+      "sections_count": "{count, plural, one {# section} other {# sections}}",
+      "modules_count": "{count, plural, one {# module} other {# modules}}",
+      "no_sections": "No sections registered.",
+      "required": "Required",
+      "expand_all": "Expand all",
+      "collapse_all": "Collapse all"
     }
   },
   "activities": {
@@ -2098,7 +2130,54 @@
     },
     "errors": {
       "delete_failed": "Could not delete the item",
-      "save_item_failed": "Error saving the item"
+      "save_item_failed": "Error saving the item",
+      "load_history_failed": "Could not load history",
+      "load_items_failed": "Could not load inventory items"
+    },
+    "table": {
+      "col_name": "Name",
+      "col_description": "Description",
+      "col_category": "Category",
+      "col_amount": "Quantity",
+      "col_status": "Status",
+      "empty_title": "No inventory items",
+      "empty_description": "No items found for the selected filters.",
+      "category_fallback": "Category {id}"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "actions": {
+      "view_history": "View history",
+      "history_sr": "History",
+      "edit_item": "Edit item",
+      "edit_sr": "Edit",
+      "delete_item": "Delete item",
+      "delete_sr": "Delete"
+    },
+    "history": {
+      "dialog_title": "Change history",
+      "loading": "Loading history...",
+      "empty": "This item has no change history yet.",
+      "action_create": "Created",
+      "action_update": "Updated",
+      "action_delete": "Deleted",
+      "performed_by_system": "System",
+      "field_name": "Name",
+      "field_description": "Description",
+      "field_amount": "Quantity",
+      "field_category": "Category",
+      "field_active": "Status"
+    },
+    "view": {
+      "select_club_placeholder": "Select club",
+      "all_categories": "All categories",
+      "refresh_title": "Refresh",
+      "refresh_sr": "Refresh",
+      "new_item": "New item",
+      "loading": "Loading inventory...",
+      "items_found_label": "{count, plural, =0 {items found} one {item found} other {items found}}"
     }
   },
   "units_admin": {
@@ -2201,6 +2280,86 @@
       "deletingLabel": "Deleting...",
       "overrideDeleted": "Override deleted",
       "overrideDeleteError": "Error deleting the override"
+    }
+  },
+  "classes": {
+    "list": {
+      "empty_title": "No classes registered",
+      "empty_description": "No progressive classes were found in the catalog.",
+      "col_order": "Order",
+      "col_name": "Name",
+      "col_club_type": "Club type",
+      "col_modules": "Modules",
+      "col_status": "Status",
+      "view_detail": "View detail for {name}"
+    },
+    "tree": {
+      "no_modules": "This class has no registered modules.",
+      "sections_count": "{count, plural, one {# section} other {# sections}}",
+      "modules_count": "{count, plural, one {# module} other {# modules}}",
+      "no_sections": "No sections registered.",
+      "expand_all": "Expand all",
+      "collapse_all": "Collapse all",
+      "section_fallback": "Section {id}",
+      "module_fallback": "Module {id}",
+      "status_inactive": "Inactive"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
+    }
+  },
+  "membership": {
+    "pending": {
+      "description": "Membership requests pending approval. Users who register in the app remain in pending status until a club director or leader approves their entry.",
+      "no_active_sections_title": "No active sections",
+      "no_active_sections_description": "This club has no active sections. Create a section to manage membership requests.",
+      "section_label": "Section",
+      "section_placeholder": "Select section",
+      "section_fallback": "Section {id}",
+      "load_error": "Could not load membership requests."
+    },
+    "table": {
+      "count_one": "{count} pending request",
+      "count_other": "{count} pending requests",
+      "refresh": "Refresh",
+      "refresh_error": "Could not refresh the list",
+      "col_member": "Member",
+      "col_role": "Role",
+      "col_requested": "Requested",
+      "col_expires": "Expires",
+      "col_actions": "Actions",
+      "empty_title": "No pending requests",
+      "empty_description": "There are no pending membership requests for this section.",
+      "aria_approve": "Approve membership",
+      "aria_reject": "Reject membership",
+      "tooltip_approve": "Approve",
+      "tooltip_reject": "Reject"
+    },
+    "dialogs": {
+      "reject": {
+        "title": "Reject membership request",
+        "description": "The membership request for {userName} will be rejected. You may optionally provide a reason.",
+        "reason_label": "Rejection reason (optional)",
+        "reason_placeholder": "Describe the reason for rejection...",
+        "cancel": "Cancel",
+        "confirm": "Reject",
+        "confirming": "Rejecting..."
+      }
+    },
+    "client": {
+      "section_label": "Club section",
+      "section_placeholder": "Select section",
+      "load_error_permission": "You do not have permission to view requests for this section.",
+      "load_error_generic": "Could not load membership requests."
+    },
+    "toasts": {
+      "approved": "Membership approved for {name}",
+      "rejected": "Membership request rejected for {name}"
+    },
+    "errors": {
+      "approve": "An error occurred while approving the request",
+      "reject": "An error occurred while rejecting the request"
     }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1707,7 +1707,17 @@
       "evaluation_completed": "Evaluación completada"
     },
     "errors": {
-      "evaluation_failed": "No se pudo completar la evaluación"
+      "evaluation_failed": "No se pudo completar la evaluación",
+      "load_history_failed": "No se pudo cargar el historial"
+    },
+    "history": {
+      "title": "Miembro del Mes — Historial",
+      "description": "Historial de ganadores en {sectionName}",
+      "tie": "Empate",
+      "empty_title": "Sin historial",
+      "empty_description": "No hay datos de miembro del mes aún.",
+      "pagination_label": "Página {page} de {total}",
+      "points": "{count} pts"
     }
   },
   "reports": {
@@ -2021,6 +2031,28 @@
     "toasts": {
       "progress_load_failed": "No se pudo cargar el progreso del usuario",
       "progress_update_failed": "No se pudo actualizar el progreso"
+    },
+    "list": {
+      "empty_title": "No hay certificaciones",
+      "empty_description": "No se encontraron certificaciones registradas.",
+      "col_name": "Nombre",
+      "col_description": "Descripción",
+      "col_duration": "Duración",
+      "col_modules": "Módulos",
+      "col_status": "Estado",
+      "view_detail": "Ver detalle",
+      "status_active": "Activo",
+      "status_inactive": "Inactivo",
+      "duration_weeks": "{count} sem."
+    },
+    "tree": {
+      "no_modules": "Esta certificación no tiene módulos registrados.",
+      "sections_count": "{count, plural, one {# sección} other {# secciones}}",
+      "modules_count": "{count, plural, one {# módulo} other {# módulos}}",
+      "no_sections": "Sin secciones registradas.",
+      "required": "Requerido",
+      "expand_all": "Expandir todos",
+      "collapse_all": "Colapsar todos"
     }
   },
   "activities": {
@@ -2098,7 +2130,54 @@
     },
     "errors": {
       "delete_failed": "No se pudo eliminar el ítem",
-      "save_item_failed": "Error al guardar el ítem"
+      "save_item_failed": "Error al guardar el ítem",
+      "load_history_failed": "No se pudo cargar el historial",
+      "load_items_failed": "No se pudieron cargar los ítems del inventario"
+    },
+    "table": {
+      "col_name": "Nombre",
+      "col_description": "Descripción",
+      "col_category": "Categoría",
+      "col_amount": "Cantidad",
+      "col_status": "Estado",
+      "empty_title": "Sin ítems de inventario",
+      "empty_description": "No se encontraron ítems para los filtros seleccionados.",
+      "category_fallback": "Categoría {id}"
+    },
+    "status": {
+      "active": "Activo",
+      "inactive": "Inactivo"
+    },
+    "actions": {
+      "view_history": "Ver historial",
+      "history_sr": "Historial",
+      "edit_item": "Editar ítem",
+      "edit_sr": "Editar",
+      "delete_item": "Eliminar ítem",
+      "delete_sr": "Eliminar"
+    },
+    "history": {
+      "dialog_title": "Historial de cambios",
+      "loading": "Cargando historial...",
+      "empty": "Este ítem no tiene historial de cambios aún.",
+      "action_create": "Creación",
+      "action_update": "Actualización",
+      "action_delete": "Eliminación",
+      "performed_by_system": "Sistema",
+      "field_name": "Nombre",
+      "field_description": "Descripción",
+      "field_amount": "Cantidad",
+      "field_category": "Categoría",
+      "field_active": "Estado"
+    },
+    "view": {
+      "select_club_placeholder": "Seleccionar club",
+      "all_categories": "Todas las categorías",
+      "refresh_title": "Actualizar",
+      "refresh_sr": "Actualizar",
+      "new_item": "Nuevo ítem",
+      "loading": "Cargando inventario...",
+      "items_found_label": "{count, plural, =0 {ítems encontrados} one {ítem encontrado} other {ítems encontrados}}"
     }
   },
   "units_admin": {
@@ -2201,6 +2280,86 @@
       "deletingLabel": "Eliminando...",
       "overrideDeleted": "Override eliminado",
       "overrideDeleteError": "Error al eliminar el override"
+    }
+  },
+  "classes": {
+    "list": {
+      "empty_title": "No hay clases registradas",
+      "empty_description": "No se encontraron clases progresivas en el catálogo.",
+      "col_order": "Orden",
+      "col_name": "Nombre",
+      "col_club_type": "Tipo de club",
+      "col_modules": "Módulos",
+      "col_status": "Estado",
+      "view_detail": "Ver detalle de {name}"
+    },
+    "tree": {
+      "no_modules": "Esta clase no tiene módulos registrados.",
+      "sections_count": "{count, plural, one {# sección} other {# secciones}}",
+      "modules_count": "{count, plural, one {# módulo} other {# módulos}}",
+      "no_sections": "Sin secciones registradas.",
+      "expand_all": "Expandir todos",
+      "collapse_all": "Colapsar todos",
+      "section_fallback": "Sección {id}",
+      "module_fallback": "Módulo {id}",
+      "status_inactive": "Inactivo"
+    },
+    "status": {
+      "active": "Activo",
+      "inactive": "Inactivo"
+    }
+  },
+  "membership": {
+    "pending": {
+      "description": "Solicitudes de membresía pendientes de aprobación. Los usuarios que se registran en la app quedan en estado pendiente hasta que un director o líder del club apruebe su ingreso.",
+      "no_active_sections_title": "Sin secciones activas",
+      "no_active_sections_description": "Este club no tiene secciones activas. Crea una sección para poder gestionar solicitudes de membresía.",
+      "section_label": "Sección",
+      "section_placeholder": "Seleccionar sección",
+      "section_fallback": "Sección {id}",
+      "load_error": "No se pudieron cargar las solicitudes de membresía."
+    },
+    "table": {
+      "count_one": "{count} solicitud pendiente",
+      "count_other": "{count} solicitudes pendientes",
+      "refresh": "Actualizar",
+      "refresh_error": "No se pudo actualizar la lista",
+      "col_member": "Miembro",
+      "col_role": "Rol",
+      "col_requested": "Fecha solicitud",
+      "col_expires": "Expira",
+      "col_actions": "Acciones",
+      "empty_title": "Sin solicitudes pendientes",
+      "empty_description": "No hay solicitudes de membresía pendientes para esta sección.",
+      "aria_approve": "Aprobar membresía",
+      "aria_reject": "Rechazar membresía",
+      "tooltip_approve": "Aprobar",
+      "tooltip_reject": "Rechazar"
+    },
+    "dialogs": {
+      "reject": {
+        "title": "Rechazar solicitud de membresía",
+        "description": "Se rechazará la solicitud de membresía de {userName}. Opcionalmente puedes indicar un motivo.",
+        "reason_label": "Motivo de rechazo (opcional)",
+        "reason_placeholder": "Describe el motivo del rechazo...",
+        "cancel": "Cancelar",
+        "confirm": "Rechazar",
+        "confirming": "Rechazando..."
+      }
+    },
+    "client": {
+      "section_label": "Sección de club",
+      "section_placeholder": "Seleccionar sección",
+      "load_error_permission": "No tienes permisos para ver solicitudes de esta sección.",
+      "load_error_generic": "No se pudieron cargar las solicitudes."
+    },
+    "toasts": {
+      "approved": "Membresía aprobada para {name}",
+      "rejected": "Solicitud de membresía rechazada para {name}"
+    },
+    "errors": {
+      "approve": "Ocurrió un error al aprobar la solicitud",
+      "reject": "Ocurrió un error al rechazar la solicitud"
     }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1707,7 +1707,17 @@
       "evaluation_completed": "Évaluation terminée"
     },
     "errors": {
-      "evaluation_failed": "Impossible de terminer l'évaluation"
+      "evaluation_failed": "Impossible de terminer l'évaluation",
+      "load_history_failed": "Impossible de charger l’historique"
+    },
+    "history": {
+      "title": "Membre du Mois — Historique",
+      "description": "Historique des gagnants pour {sectionName}",
+      "tie": "Égalité",
+      "empty_title": "Aucun historique",
+      "empty_description": "Aucune donnée de membre du mois pour l’instant.",
+      "pagination_label": "Page {page} sur {total}",
+      "points": "{count} pts"
     }
   },
   "reports": {
@@ -2021,6 +2031,28 @@
     "toasts": {
       "progress_load_failed": "Impossible de charger la progression de l'utilisateur",
       "progress_update_failed": "Impossible de mettre à jour la progression"
+    },
+    "list": {
+      "empty_title": "Aucune certification",
+      "empty_description": "Aucune certification enregistrée n'a été trouvée.",
+      "col_name": "Nom",
+      "col_description": "Description",
+      "col_duration": "Durée",
+      "col_modules": "Modules",
+      "col_status": "Statut",
+      "view_detail": "Voir le détail",
+      "status_active": "Actif",
+      "status_inactive": "Inactif",
+      "duration_weeks": "{count} sem."
+    },
+    "tree": {
+      "no_modules": "Cette certification n'a aucun module enregistré.",
+      "sections_count": "{count, plural, one {# section} other {# sections}}",
+      "modules_count": "{count, plural, one {# module} other {# modules}}",
+      "no_sections": "Aucune section enregistrée.",
+      "required": "Requis",
+      "expand_all": "Tout développer",
+      "collapse_all": "Tout réduire"
     }
   },
   "activities": {
@@ -2098,7 +2130,54 @@
     },
     "errors": {
       "delete_failed": "Impossible de supprimer l'élément",
-      "save_item_failed": "Erreur lors de l'enregistrement de l'élément"
+      "save_item_failed": "Erreur lors de l'enregistrement de l'élément",
+      "load_history_failed": "Impossible de charger l'historique",
+      "load_items_failed": "Impossible de charger les articles d'inventaire"
+    },
+    "table": {
+      "col_name": "Nom",
+      "col_description": "Description",
+      "col_category": "Catégorie",
+      "col_amount": "Quantité",
+      "col_status": "Statut",
+      "empty_title": "Aucun article d'inventaire",
+      "empty_description": "Aucun article trouvé pour les filtres sélectionnés.",
+      "category_fallback": "Catégorie {id}"
+    },
+    "status": {
+      "active": "Actif",
+      "inactive": "Inactif"
+    },
+    "actions": {
+      "view_history": "Voir l'historique",
+      "history_sr": "Historique",
+      "edit_item": "Modifier l'article",
+      "edit_sr": "Modifier",
+      "delete_item": "Supprimer l'article",
+      "delete_sr": "Supprimer"
+    },
+    "history": {
+      "dialog_title": "Historique des modifications",
+      "loading": "Chargement de l'historique ...",
+      "empty": "Cet article n'a pas encore d'historique de modifications.",
+      "action_create": "Création",
+      "action_update": "Mise à jour",
+      "action_delete": "Suppression",
+      "performed_by_system": "Système",
+      "field_name": "Nom",
+      "field_description": "Description",
+      "field_amount": "Quantité",
+      "field_category": "Catégorie",
+      "field_active": "Statut"
+    },
+    "view": {
+      "select_club_placeholder": "Sélectionner un club",
+      "all_categories": "Toutes les catégories",
+      "refresh_title": "Actualiser",
+      "refresh_sr": "Actualiser",
+      "new_item": "Nouvel article",
+      "loading": "Chargement de l'inventaire ...",
+      "items_found_label": "{count, plural, =0 {article trouvé} one {article trouvé} other {articles trouvés}}"
     }
   },
   "units_admin": {
@@ -2201,6 +2280,86 @@
       "deletingLabel": "Suppression...",
       "overrideDeleted": "Remplacement supprimé",
       "overrideDeleteError": "Erreur lors de la suppression du remplacement"
+    }
+  },
+  "classes": {
+    "list": {
+      "empty_title": "Aucune classe enregistrée",
+      "empty_description": "Aucune classe progressive n'a été trouvée dans le catalogue.",
+      "col_order": "Ordre",
+      "col_name": "Nom",
+      "col_club_type": "Type de club",
+      "col_modules": "Modules",
+      "col_status": "Statut",
+      "view_detail": "Voir le détail de {name}"
+    },
+    "tree": {
+      "no_modules": "Cette classe n'a aucun module enregistré.",
+      "sections_count": "{count, plural, one {# section} other {# sections}}",
+      "modules_count": "{count, plural, one {# module} other {# modules}}",
+      "no_sections": "Aucune section enregistrée.",
+      "expand_all": "Tout développer",
+      "collapse_all": "Tout réduire",
+      "section_fallback": "Section {id}",
+      "module_fallback": "Module {id}",
+      "status_inactive": "Inactif"
+    },
+    "status": {
+      "active": "Actif",
+      "inactive": "Inactif"
+    }
+  },
+  "membership": {
+    "pending": {
+      "description": "Demandes d’adhésion en attente d’approbation. Les utilisateurs qui s’inscrivent dans l’application restent en attente jusqu’à ce qu’un directeur ou responsable de club approuve leur entrée.",
+      "no_active_sections_title": "Aucune section active",
+      "no_active_sections_description": "Ce club n’a pas de sections actives. Créez une section pour gérer les demandes d’adhésion.",
+      "section_label": "Section",
+      "section_placeholder": "Sélectionner une section",
+      "section_fallback": "Section {id}",
+      "load_error": "Impossible de charger les demandes d’adhésion."
+    },
+    "table": {
+      "count_one": "{count} demande en attente",
+      "count_other": "{count} demandes en attente",
+      "refresh": "Actualiser",
+      "refresh_error": "Impossible d’actualiser la liste",
+      "col_member": "Membre",
+      "col_role": "Rôle",
+      "col_requested": "Demande",
+      "col_expires": "Expire",
+      "col_actions": "Actions",
+      "empty_title": "Aucune demande en attente",
+      "empty_description": "Il n’y a pas de demandes d’adhésion en attente pour cette section.",
+      "aria_approve": "Approuver l’adhésion",
+      "aria_reject": "Refuser l’adhésion",
+      "tooltip_approve": "Approuver",
+      "tooltip_reject": "Refuser"
+    },
+    "dialogs": {
+      "reject": {
+        "title": "Refuser la demande d’adhésion",
+        "description": "La demande d’adhésion de {userName} sera refusée. Vous pouvez indiquer un motif de manière optionnelle.",
+        "reason_label": "Motif du refus (optionnel)",
+        "reason_placeholder": "Décrivez le motif du refus ...",
+        "cancel": "Annuler",
+        "confirm": "Refuser",
+        "confirming": "Refus en cours ..."
+      }
+    },
+    "client": {
+      "section_label": "Section du club",
+      "section_placeholder": "Sélectionner une section",
+      "load_error_permission": "Vous n’avez pas la permission de voir les demandes de cette section.",
+      "load_error_generic": "Impossible de charger les demandes d’adhésion."
+    },
+    "toasts": {
+      "approved": "Adhésion approuvée pour {name}",
+      "rejected": "Demande d’adhésion refusée pour {name}"
+    },
+    "errors": {
+      "approve": "Une erreur s’est produite lors de l’approbation de la demande",
+      "reject": "Une erreur s’est produite lors du refus de la demande"
     }
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1707,7 +1707,17 @@
       "evaluation_completed": "Avaliação concluída"
     },
     "errors": {
-      "evaluation_failed": "Não foi possível concluir a avaliação"
+      "evaluation_failed": "Não foi possível concluir a avaliação",
+      "load_history_failed": "Não foi possível carregar o histórico"
+    },
+    "history": {
+      "title": "Membro do Mês — Histórico",
+      "description": "Histórico de vencedores em {sectionName}",
+      "tie": "Empate",
+      "empty_title": "Sem histórico",
+      "empty_description": "Nenhum dado de membro do mês ainda.",
+      "pagination_label": "Página {page} de {total}",
+      "points": "{count} pts"
     }
   },
   "reports": {
@@ -2021,6 +2031,28 @@
     "toasts": {
       "progress_load_failed": "Não foi possível carregar o progresso do usuário",
       "progress_update_failed": "Não foi possível atualizar o progresso"
+    },
+    "list": {
+      "empty_title": "Nenhuma certificação",
+      "empty_description": "Nenhuma certificação registrada foi encontrada.",
+      "col_name": "Nome",
+      "col_description": "Descrição",
+      "col_duration": "Duração",
+      "col_modules": "Módulos",
+      "col_status": "Status",
+      "view_detail": "Ver detalhe",
+      "status_active": "Ativo",
+      "status_inactive": "Inativo",
+      "duration_weeks": "{count} sem."
+    },
+    "tree": {
+      "no_modules": "Esta certificação não possui módulos registrados.",
+      "sections_count": "{count, plural, one {# seção} other {# seções}}",
+      "modules_count": "{count, plural, one {# módulo} other {# módulos}}",
+      "no_sections": "Nenhuma seção registrada.",
+      "required": "Obrigatório",
+      "expand_all": "Expandir todos",
+      "collapse_all": "Recolher todos"
     }
   },
   "activities": {
@@ -2098,7 +2130,54 @@
     },
     "errors": {
       "delete_failed": "Não foi possível excluir o item",
-      "save_item_failed": "Erro ao salvar o item"
+      "save_item_failed": "Erro ao salvar o item",
+      "load_history_failed": "Não foi possível carregar o histórico",
+      "load_items_failed": "Não foi possível carregar os itens do inventário"
+    },
+    "table": {
+      "col_name": "Nome",
+      "col_description": "Descrição",
+      "col_category": "Categoria",
+      "col_amount": "Quantidade",
+      "col_status": "Status",
+      "empty_title": "Nenhum item de inventário",
+      "empty_description": "Nenhum item encontrado para os filtros selecionados.",
+      "category_fallback": "Categoria {id}"
+    },
+    "status": {
+      "active": "Ativo",
+      "inactive": "Inativo"
+    },
+    "actions": {
+      "view_history": "Ver histórico",
+      "history_sr": "Histórico",
+      "edit_item": "Editar item",
+      "edit_sr": "Editar",
+      "delete_item": "Excluir item",
+      "delete_sr": "Excluir"
+    },
+    "history": {
+      "dialog_title": "Histórico de alterações",
+      "loading": "Carregando histórico...",
+      "empty": "Este item ainda não possui histórico de alterações.",
+      "action_create": "Criação",
+      "action_update": "Atualização",
+      "action_delete": "Exclusão",
+      "performed_by_system": "Sistema",
+      "field_name": "Nome",
+      "field_description": "Descrição",
+      "field_amount": "Quantidade",
+      "field_category": "Categoria",
+      "field_active": "Status"
+    },
+    "view": {
+      "select_club_placeholder": "Selecionar clube",
+      "all_categories": "Todas as categorias",
+      "refresh_title": "Atualizar",
+      "refresh_sr": "Atualizar",
+      "new_item": "Novo item",
+      "loading": "Carregando inventário...",
+      "items_found_label": "{count, plural, =0 {itens encontrados} one {item encontrado} other {itens encontrados}}"
     }
   },
   "units_admin": {
@@ -2201,6 +2280,86 @@
       "deletingLabel": "Excluindo...",
       "overrideDeleted": "Substituição excluída",
       "overrideDeleteError": "Erro ao excluir a substituição"
+    }
+  },
+  "classes": {
+    "list": {
+      "empty_title": "Nenhuma classe registrada",
+      "empty_description": "Nenhuma classe progressiva foi encontrada no catálogo.",
+      "col_order": "Ordem",
+      "col_name": "Nome",
+      "col_club_type": "Tipo de clube",
+      "col_modules": "Módulos",
+      "col_status": "Status",
+      "view_detail": "Ver detalhe de {name}"
+    },
+    "tree": {
+      "no_modules": "Esta classe não possui módulos registrados.",
+      "sections_count": "{count, plural, one {# seção} other {# seções}}",
+      "modules_count": "{count, plural, one {# módulo} other {# módulos}}",
+      "no_sections": "Nenhuma seção registrada.",
+      "expand_all": "Expandir todos",
+      "collapse_all": "Recolher todos",
+      "section_fallback": "Seção {id}",
+      "module_fallback": "Módulo {id}",
+      "status_inactive": "Inativo"
+    },
+    "status": {
+      "active": "Ativo",
+      "inactive": "Inativo"
+    }
+  },
+  "membership": {
+    "pending": {
+      "description": "Solicitações de adesão pendentes de aprovação. Os usuários que se cadastram no aplicativo ficam com status pendente até que um diretor ou líder do clube aprove sua entrada.",
+      "no_active_sections_title": "Sem seções ativas",
+      "no_active_sections_description": "Este clube não possui seções ativas. Crie uma seção para gerenciar as solicitações de adesão.",
+      "section_label": "Seção",
+      "section_placeholder": "Selecionar seção",
+      "section_fallback": "Seção {id}",
+      "load_error": "Não foi possível carregar as solicitações de adesão."
+    },
+    "table": {
+      "count_one": "{count} solicitação pendente",
+      "count_other": "{count} solicitações pendentes",
+      "refresh": "Atualizar",
+      "refresh_error": "Não foi possível atualizar a lista",
+      "col_member": "Membro",
+      "col_role": "Função",
+      "col_requested": "Data da solicitação",
+      "col_expires": "Expira",
+      "col_actions": "Ações",
+      "empty_title": "Sem solicitações pendentes",
+      "empty_description": "Não há solicitações de adesão pendentes para esta seção.",
+      "aria_approve": "Aprovar adesão",
+      "aria_reject": "Rejeitar adesão",
+      "tooltip_approve": "Aprovar",
+      "tooltip_reject": "Rejeitar"
+    },
+    "dialogs": {
+      "reject": {
+        "title": "Rejeitar solicitação de adesão",
+        "description": "A solicitação de adesão de {userName} será rejeitada. Opcionalmente, você pode indicar um motivo.",
+        "reason_label": "Motivo da rejeição (opcional)",
+        "reason_placeholder": "Descreva o motivo da rejeição...",
+        "cancel": "Cancelar",
+        "confirm": "Rejeitar",
+        "confirming": "Rejeitando..."
+      }
+    },
+    "client": {
+      "section_label": "Seção do clube",
+      "section_placeholder": "Selecionar seção",
+      "load_error_permission": "Você não tem permissão para ver as solicitações desta seção.",
+      "load_error_generic": "Não foi possível carregar as solicitações."
+    },
+    "toasts": {
+      "approved": "Adesão aprovada para {name}",
+      "rejected": "Solicitação de adesão rejeitada para {name}"
+    },
+    "errors": {
+      "approve": "Ocorreu um erro ao aprovar a solicitação",
+      "reject": "Ocorreu um erro ao rejeitar a solicitação"
     }
   }
 }

--- a/src/components/certifications/certification-modules-tree.tsx
+++ b/src/components/certifications/certification-modules-tree.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { ChevronDown, ChevronRight, BookOpen, FileText } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -28,6 +29,7 @@ interface ModuleNodeProps {
 }
 
 function ModuleNode({ mod, defaultOpen = false }: ModuleNodeProps) {
+  const t = useTranslations("certifications.tree");
   const [open, setOpen] = useState(defaultOpen);
   const sectionCount = mod.sections?.length ?? 0;
 
@@ -48,7 +50,7 @@ function ModuleNode({ mod, defaultOpen = false }: ModuleNodeProps) {
           )}
         </div>
         <Badge variant="secondary" className="shrink-0">
-          {sectionCount} {sectionCount === 1 ? "sección" : "secciones"}
+          {t("sections_count", { count: sectionCount })}
         </Badge>
         {open ? (
           <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
@@ -60,7 +62,7 @@ function ModuleNode({ mod, defaultOpen = false }: ModuleNodeProps) {
       {open && (
         <div className="border-t border-border px-4 py-3">
           {sectionCount === 0 ? (
-            <p className="text-sm text-muted-foreground">Sin secciones registradas.</p>
+            <p className="text-sm text-muted-foreground">{t("no_sections")}</p>
           ) : (
             <ul className="space-y-2">
               {mod.sections.map((section) => (
@@ -77,7 +79,7 @@ function ModuleNode({ mod, defaultOpen = false }: ModuleNodeProps) {
                   </div>
                   {section.is_required && (
                     <Badge variant="secondary" className="shrink-0 text-xs">
-                      Requerido
+                      {t("required")}
                     </Badge>
                   )}
                 </li>
@@ -95,6 +97,7 @@ interface CertificationModulesTreeProps {
 }
 
 export function CertificationModulesTree({ modules }: CertificationModulesTreeProps) {
+  const t = useTranslations("certifications.tree");
   const [allOpen, setAllOpen] = useState(false);
   const [key, setKey] = useState(0);
 
@@ -106,7 +109,7 @@ export function CertificationModulesTree({ modules }: CertificationModulesTreePr
   if (modules.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
-        Esta certificación no tiene módulos registrados.
+        {t("no_modules")}
       </p>
     );
   }
@@ -115,10 +118,10 @@ export function CertificationModulesTree({ modules }: CertificationModulesTreePr
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          {modules.length} {modules.length === 1 ? "módulo" : "módulos"}
+          {t("modules_count", { count: modules.length })}
         </p>
         <Button variant="ghost" size="sm" onClick={toggleAll}>
-          {allOpen ? "Colapsar todos" : "Expandir todos"}
+          {allOpen ? t("collapse_all") : t("expand_all")}
         </Button>
       </div>
       <div

--- a/src/components/certifications/certifications-list.tsx
+++ b/src/components/certifications/certifications-list.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ChevronRight, ShieldCheck } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -28,12 +29,14 @@ interface CertificationsListProps {
 }
 
 export function CertificationsList({ items }: CertificationsListProps) {
+  const t = useTranslations("certifications.list");
+
   if (items.length === 0) {
     return (
       <EmptyState
         icon={ShieldCheck}
-        title="No hay certificaciones"
-        description="No se encontraron certificaciones registradas."
+        title={t("empty_title")}
+        description={t("empty_description")}
       />
     );
   }
@@ -44,19 +47,19 @@ export function CertificationsList({ items }: CertificationsListProps) {
         <TableHeader>
           <TableRow>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Nombre
+              {t("col_name")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Descripción
+              {t("col_description")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Duración
+              {t("col_duration")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Módulos
+              {t("col_modules")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Estado
+              {t("col_status")}
             </TableHead>
             <TableHead className="h-9 w-12 px-3" />
           </TableRow>
@@ -74,7 +77,7 @@ export function CertificationsList({ items }: CertificationsListProps) {
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums">
                 {cert.duration_weeks != null
-                  ? `${cert.duration_weeks} sem.`
+                  ? t("duration_weeks", { count: cert.duration_weeks })
                   : "—"}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums">
@@ -82,14 +85,14 @@ export function CertificationsList({ items }: CertificationsListProps) {
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle">
                 <Badge variant={cert.active !== false ? "soft-success" : "outline"}>
-                  {cert.active !== false ? "Activo" : "Inactivo"}
+                  {cert.active !== false ? t("status_active") : t("status_inactive")}
                 </Badge>
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle">
                 <Button variant="ghost" size="icon-sm" asChild>
                   <Link href={`/dashboard/certifications/${cert.certification_id}`}>
                     <ChevronRight className="size-4" />
-                    <span className="sr-only">Ver detalle</span>
+                    <span className="sr-only">{t("view_detail")}</span>
                   </Link>
                 </Button>
               </TableCell>

--- a/src/components/classes/class-module-tree.tsx
+++ b/src/components/classes/class-module-tree.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { ChevronDown, ChevronRight, BookOpen, FileText, ListChecks } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -14,7 +15,8 @@ interface SectionNodeProps {
 }
 
 function SectionNode({ section }: SectionNodeProps) {
-  const title = section.title ?? section.name ?? `Sección ${section.section_id}`;
+  const t = useTranslations("classes.tree");
+  const title = section.title ?? section.name ?? t("section_fallback", { id: section.section_id });
   const requirementsCount = section.requirements?.length ?? 0;
 
   return (
@@ -41,7 +43,7 @@ function SectionNode({ section }: SectionNodeProps) {
       </div>
       {section.active === false && (
         <Badge variant="outline" className="shrink-0 text-xs">
-          Inactivo
+          {t("status_inactive")}
         </Badge>
       )}
     </li>
@@ -56,10 +58,11 @@ interface ModuleNodeProps {
 }
 
 function ModuleNode({ mod, defaultOpen = false }: ModuleNodeProps) {
+  const t = useTranslations("classes.tree");
   const [open, setOpen] = useState(defaultOpen);
   const sections = mod.sections ?? [];
   const sectionCount = sections.length > 0 ? sections.length : (mod.sections_count ?? 0);
-  const title = mod.title ?? mod.name ?? `Módulo ${mod.module_id}`;
+  const title = mod.title ?? mod.name ?? t("module_fallback", { id: mod.module_id });
 
   return (
     <div className="rounded-lg border border-border bg-card">
@@ -78,7 +81,7 @@ function ModuleNode({ mod, defaultOpen = false }: ModuleNodeProps) {
           )}
         </div>
         <Badge variant="secondary" className="shrink-0">
-          {sectionCount} {sectionCount === 1 ? "sección" : "secciones"}
+          {t("sections_count", { count: sectionCount })}
         </Badge>
         {open ? (
           <ChevronDown className="size-4 shrink-0 text-muted-foreground" />
@@ -90,7 +93,7 @@ function ModuleNode({ mod, defaultOpen = false }: ModuleNodeProps) {
       {open && (
         <div className="border-t border-border px-4 py-3">
           {sections.length === 0 ? (
-            <p className="text-sm text-muted-foreground">Sin secciones registradas.</p>
+            <p className="text-sm text-muted-foreground">{t("no_sections")}</p>
           ) : (
             <ul className="space-y-2">
               {sections.map((section) => (
@@ -111,6 +114,7 @@ interface ClassModuleTreeProps {
 }
 
 export function ClassModuleTree({ modules }: ClassModuleTreeProps) {
+  const t = useTranslations("classes.tree");
   const [allOpen, setAllOpen] = useState(false);
   const [key, setKey] = useState(0);
 
@@ -122,7 +126,7 @@ export function ClassModuleTree({ modules }: ClassModuleTreeProps) {
   if (modules.length === 0) {
     return (
       <p className="text-sm text-muted-foreground">
-        Esta clase no tiene módulos registrados.
+        {t("no_modules")}
       </p>
     );
   }
@@ -131,10 +135,10 @@ export function ClassModuleTree({ modules }: ClassModuleTreeProps) {
     <div className="space-y-3">
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          {modules.length} {modules.length === 1 ? "módulo" : "módulos"}
+          {t("modules_count", { count: modules.length })}
         </p>
         <Button variant="ghost" size="sm" onClick={toggleAll}>
-          {allOpen ? "Colapsar todos" : "Expandir todos"}
+          {allOpen ? t("collapse_all") : t("expand_all")}
         </Button>
       </div>
       <div key={key} className={cn("space-y-2")}>

--- a/src/components/classes/class-status-badge.tsx
+++ b/src/components/classes/class-status-badge.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 
 interface ClassStatusBadgeProps {
@@ -5,9 +8,10 @@ interface ClassStatusBadgeProps {
 }
 
 export function ClassStatusBadge({ active }: ClassStatusBadgeProps) {
+  const t = useTranslations("classes.status");
   return (
     <Badge variant={active ? "soft-success" : "outline"}>
-      {active ? "Activo" : "Inactivo"}
+      {active ? t("active") : t("inactive")}
     </Badge>
   );
 }

--- a/src/components/classes/classes-list.tsx
+++ b/src/components/classes/classes-list.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ChevronRight, GraduationCap } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,12 +32,14 @@ interface ClassesListProps {
 }
 
 export function ClassesList({ items }: ClassesListProps) {
+  const t = useTranslations("classes.list");
+
   if (items.length === 0) {
     return (
       <EmptyState
         icon={GraduationCap}
-        title="No hay clases registradas"
-        description="No se encontraron clases progresivas en el catálogo."
+        title={t("empty_title")}
+        description={t("empty_description")}
       />
     );
   }
@@ -47,19 +50,19 @@ export function ClassesList({ items }: ClassesListProps) {
         <TableHeader>
           <TableRow>
             <TableHead className="h-9 w-16 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Orden
+              {t("col_order")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Nombre
+              {t("col_name")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Tipo de club
+              {t("col_club_type")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Módulos
+              {t("col_modules")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Estado
+              {t("col_status")}
             </TableHead>
             <TableHead className="h-9 w-12 px-3" />
           </TableRow>
@@ -93,7 +96,7 @@ export function ClassesList({ items }: ClassesListProps) {
                 <Button variant="ghost" size="icon-sm" asChild>
                   <Link href={`/dashboard/classes/${cls.class_id}`}>
                     <ChevronRight className="size-4" />
-                    <span className="sr-only">Ver detalle de {cls.name}</span>
+                    <span className="sr-only">{t("view_detail", { name: cls.name })}</span>
                   </Link>
                 </Button>
               </TableCell>

--- a/src/components/inventory/inventory-history-dialog.tsx
+++ b/src/components/inventory/inventory-history-dialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { PlusCircle, Pencil, Trash2, Clock } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -13,12 +14,11 @@ import { Badge } from "@/components/ui/badge";
 import { getInventoryHistory } from "@/lib/api/inventory";
 import type { InventoryHistoryEntry, InventoryAction } from "@/lib/api/inventory";
 
-// ─── Action config ──────────────────────────────────────────────────────────────
+// ─── Action config (visual/structural constants — labels resolved via t() inside component) ──
 
-const actionConfig: Record<
+const ACTION_META: Record<
   InventoryAction,
   {
-    label: string;
     badgeVariant: "success" | "default" | "destructive" | "secondary";
     icon: React.ElementType;
     iconClassName: string;
@@ -26,21 +26,18 @@ const actionConfig: Record<
   }
 > = {
   CREATE: {
-    label: "Creación",
     badgeVariant: "success",
     icon: PlusCircle,
     iconClassName: "text-success",
     dotClassName: "bg-success/20 border-success/40",
   },
   UPDATE: {
-    label: "Actualización",
     badgeVariant: "default",
     icon: Pencil,
     iconClassName: "text-primary",
     dotClassName: "bg-primary/20 border-primary/40",
   },
   DELETE: {
-    label: "Eliminación",
     badgeVariant: "destructive",
     icon: Trash2,
     iconClassName: "text-destructive",
@@ -64,25 +61,32 @@ function formatDate(isoDate: string): string {
   }
 }
 
-function getPerformerName(entry: InventoryHistoryEntry): string {
+function getPerformerName(
+  entry: InventoryHistoryEntry,
+  systemLabel: string,
+): string {
   if (entry.performed_by?.name || entry.performed_by?.paternal_last_name) {
     return [entry.performed_by.name, entry.performed_by.paternal_last_name]
       .filter(Boolean)
       .join(" ");
   }
-  return "Sistema";
+  return systemLabel;
 }
 
-function formatFieldName(field: string | null): string {
+function getFieldLabel(
+  field: string | null,
+  t: ReturnType<typeof useTranslations<"inventory">>,
+): string {
   if (!field) return "";
-  const labels: Record<string, string> = {
-    name: "Nombre",
-    description: "Descripción",
-    amount: "Cantidad",
-    inventory_category_id: "Categoría",
-    active: "Estado",
+  const keyMap: Record<string, string> = {
+    name: "history.field_name",
+    description: "history.field_description",
+    amount: "history.field_amount",
+    inventory_category_id: "history.field_category",
+    active: "history.field_active",
   };
-  return labels[field] ?? field;
+  const key = keyMap[field];
+  return key ? t(key as Parameters<typeof t>[0]) : field;
 }
 
 // ─── Timeline ───────────────────────────────────────────────────────────────────
@@ -92,28 +96,41 @@ interface HistoryTimelineProps {
 }
 
 function HistoryTimeline({ entries }: HistoryTimelineProps) {
+  const t = useTranslations("inventory");
+
   if (entries.length === 0) {
     return (
       <div className="flex items-center gap-2 rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
         <Clock className="size-4 shrink-0" />
-        <span>Este ítem no tiene historial de cambios aún.</span>
+        <span>{t("history.empty")}</span>
       </div>
     );
   }
 
+  const actionLabelMap: Record<InventoryAction, string> = {
+    CREATE: t("history.action_create"),
+    UPDATE: t("history.action_update"),
+    DELETE: t("history.action_delete"),
+  };
+
+  const systemLabel = t("history.performed_by_system");
+
   return (
     <ol className="relative space-y-0">
       {entries.map((entry, idx) => {
-        const config = actionConfig[entry.action] ?? {
-          label: entry.action,
-          badgeVariant: "secondary" as const,
-          icon: Clock,
-          iconClassName: "text-muted-foreground",
-          dotClassName: "bg-muted border-border",
-        };
+        const meta = ACTION_META[entry.action];
+        const config = meta
+          ? { ...meta, label: actionLabelMap[entry.action] }
+          : {
+              label: entry.action,
+              badgeVariant: "secondary" as const,
+              icon: Clock,
+              iconClassName: "text-muted-foreground",
+              dotClassName: "bg-muted border-border",
+            };
         const Icon = config.icon;
         const isLast = idx === entries.length - 1;
-        const fieldLabel = formatFieldName(entry.field_changed);
+        const fieldLabel = getFieldLabel(entry.field_changed, t);
 
         return (
           <li key={entry.history_id} className="flex gap-3">
@@ -144,7 +161,7 @@ function HistoryTimeline({ entries }: HistoryTimelineProps) {
               </div>
 
               <p className="mt-0.5 text-xs text-muted-foreground">
-                {getPerformerName(entry)} &middot; {formatDate(entry.created_at)}
+                {getPerformerName(entry, systemLabel)} &middot; {formatDate(entry.created_at)}
               </p>
 
               {/* old → new values (UPDATE only) */}
@@ -189,6 +206,7 @@ export function InventoryHistoryDialog({
   inventoryId,
   itemName,
 }: InventoryHistoryDialogProps) {
+  const t = useTranslations("inventory");
   const [entries, setEntries] = useState<InventoryHistoryEntry[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -213,7 +231,7 @@ export function InventoryHistoryDialog({
           setError(
             err instanceof Error
               ? err.message
-              : "No se pudo cargar el historial",
+              : t("errors.load_history_failed"),
           );
         }
       })
@@ -224,14 +242,14 @@ export function InventoryHistoryDialog({
     return () => {
       cancelled = true;
     };
-  }, [open, inventoryId]);
+  }, [open, inventoryId, t]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
         <DialogHeader>
           <DialogTitle>
-            Historial de cambios
+            {t("history.dialog_title")}
             {itemName && (
               <span className="ml-1.5 text-sm font-normal text-muted-foreground">
                 — {itemName}
@@ -243,7 +261,7 @@ export function InventoryHistoryDialog({
         <div className="pt-2">
           {isLoading ? (
             <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
-              Cargando historial...
+              {t("history.loading")}
             </div>
           ) : error ? (
             <div className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive">

--- a/src/components/inventory/inventory-table.tsx
+++ b/src/components/inventory/inventory-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Package, Pencil, Trash2, History } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -27,6 +28,7 @@ interface InventoryTableProps {
 // ─── Component ─────────────────────────────────────────────────────────────────
 
 export function InventoryTable({ items, onEdit, onDelete }: InventoryTableProps) {
+  const t = useTranslations("inventory");
   const [historyOpen, setHistoryOpen] = useState(false);
   const [historyItem, setHistoryItem] = useState<InventoryItem | null>(null);
 
@@ -39,8 +41,8 @@ export function InventoryTable({ items, onEdit, onDelete }: InventoryTableProps)
     return (
       <EmptyState
         icon={Package}
-        title="Sin ítems de inventario"
-        description="No se encontraron ítems para los filtros seleccionados."
+        title={t("table.empty_title")}
+        description={t("table.empty_description")}
       />
     );
   }
@@ -51,19 +53,19 @@ export function InventoryTable({ items, onEdit, onDelete }: InventoryTableProps)
         <TableHeader>
           <TableRow>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Nombre
+              {t("table.col_name")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Descripción
+              {t("table.col_description")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Categoría
+              {t("table.col_category")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
-              Cantidad
+              {t("table.col_amount")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Estado
+              {t("table.col_status")}
             </TableHead>
             <TableHead className="h-9 w-32 px-3" />
           </TableRow>
@@ -71,7 +73,8 @@ export function InventoryTable({ items, onEdit, onDelete }: InventoryTableProps)
         <TableBody>
           {items.map((item) => {
             const categoryName =
-              item.inventory_category?.name ?? `Categoría ${item.inventory_category_id}`;
+              item.inventory_category?.name ??
+              t("table.category_fallback", { id: item.inventory_category_id });
 
             return (
               <TableRow key={item.inventory_id} className="hover:bg-muted/30">
@@ -91,7 +94,7 @@ export function InventoryTable({ items, onEdit, onDelete }: InventoryTableProps)
                 </TableCell>
                 <TableCell className="px-3 py-2.5 align-middle">
                   <Badge variant={item.active !== false ? "soft-success" : "outline"}>
-                    {item.active !== false ? "Activo" : "Inactivo"}
+                    {item.active !== false ? t("status.active") : t("status.inactive")}
                   </Badge>
                 </TableCell>
                 <TableCell className="px-3 py-2.5 align-middle">
@@ -100,20 +103,20 @@ export function InventoryTable({ items, onEdit, onDelete }: InventoryTableProps)
                       variant="ghost"
                       size="icon-sm"
                       onClick={() => handleHistory(item)}
-                      title="Ver historial"
+                      title={t("actions.view_history")}
                     >
                       <History className="size-3.5" />
-                      <span className="sr-only">Historial</span>
+                      <span className="sr-only">{t("actions.history_sr")}</span>
                     </Button>
                     {onEdit && (
                       <Button
                         variant="ghost"
                         size="icon-sm"
                         onClick={() => onEdit(item)}
-                        title="Editar ítem"
+                        title={t("actions.edit_item")}
                       >
                         <Pencil className="size-3.5" />
-                        <span className="sr-only">Editar</span>
+                        <span className="sr-only">{t("actions.edit_sr")}</span>
                       </Button>
                     )}
                     {onDelete && (
@@ -121,11 +124,11 @@ export function InventoryTable({ items, onEdit, onDelete }: InventoryTableProps)
                         variant="ghost"
                         size="icon-sm"
                         onClick={() => onDelete(item)}
-                        title="Eliminar ítem"
+                        title={t("actions.delete_item")}
                         className="text-destructive hover:text-destructive"
                       >
                         <Trash2 className="size-3.5" />
-                        <span className="sr-only">Eliminar</span>
+                        <span className="sr-only">{t("actions.delete_sr")}</span>
                       </Button>
                     )}
                   </div>

--- a/src/components/inventory/inventory-view.tsx
+++ b/src/components/inventory/inventory-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { Plus, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -93,6 +94,7 @@ export function InventoryView({
   initialItems,
   initialClubId,
 }: InventoryViewProps) {
+  const t = useTranslations("inventory");
   const [selectedClubId, setSelectedClubId] = useState<number | null>(initialClubId);
   const [items, setItems] = useState<InventoryItem[]>(initialItems);
   const [filterCategoryId, setFilterCategoryId] = useState<number | null>(null);
@@ -132,14 +134,14 @@ export function InventoryView({
         const message =
           err instanceof ApiError
             ? err.message
-            : "No se pudieron cargar los ítems del inventario";
+            : t("errors.load_items_failed");
         setLoadError(message);
         setItems([]);
       } finally {
         setIsLoading(false);
       }
     },
-    [clubs],
+    [clubs, t],
   );
 
   function handleClubChange(value: string) {
@@ -195,7 +197,7 @@ export function InventoryView({
             onValueChange={handleClubChange}
           >
             <SelectTrigger className="w-52">
-              <SelectValue placeholder="Seleccionar club" />
+              <SelectValue placeholder={t("view.select_club_placeholder")} />
             </SelectTrigger>
             <SelectContent>
               {clubs.map((club) => (
@@ -213,10 +215,10 @@ export function InventoryView({
             disabled={!selectedClubId}
           >
             <SelectTrigger className="w-48">
-              <SelectValue placeholder="Todas las categorías" />
+              <SelectValue placeholder={t("view.all_categories")} />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="all">Todas las categorías</SelectItem>
+              <SelectItem value="all">{t("view.all_categories")}</SelectItem>
               {categories.map((cat) => (
                 <SelectItem
                   key={cat.inventory_category_id}
@@ -233,10 +235,10 @@ export function InventoryView({
             size="icon-sm"
             onClick={handleRefresh}
             disabled={!selectedClubId || isLoading}
-            title="Actualizar"
+            title={t("view.refresh_title")}
           >
             <RefreshCw className={`size-3.5 ${isLoading ? "animate-spin" : ""}`} />
-            <span className="sr-only">Actualizar</span>
+            <span className="sr-only">{t("view.refresh_sr")}</span>
           </Button>
         </div>
 
@@ -248,7 +250,7 @@ export function InventoryView({
           )}
           <Button onClick={handleCreate} disabled={!selectedClubId} size="sm">
             <Plus className="size-4" />
-            Nuevo ítem
+            {t("view.new_item")}
           </Button>
         </div>
       </div>
@@ -264,14 +266,14 @@ export function InventoryView({
       {selectedClubId && !loadError && (
         <p className="text-sm text-muted-foreground">
           <span className="font-medium text-foreground">{items.length}</span>{" "}
-          {items.length === 1 ? "ítem encontrado" : "ítems encontrados"}
+          {t("view.items_found_label", { count: items.length })}
         </p>
       )}
 
       {/* Table */}
       {isLoading ? (
         <div className="flex h-40 items-center justify-center text-sm text-muted-foreground">
-          Cargando inventario...
+          {t("view.loading")}
         </div>
       ) : (
         <InventoryTable

--- a/src/components/member-of-month/history-sheet.tsx
+++ b/src/components/member-of-month/history-sheet.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { Trophy, ChevronLeft, ChevronRight } from "lucide-react";
 import { toast } from "sonner";
 import { useQuery } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -25,7 +26,15 @@ const PAGE_LIMIT = 12;
 
 // ─── History item ─────────────────────────────────────────────────────────────
 
-function HistoryEntry({ item }: { item: MemberOfMonthHistoryItem }) {
+type TranslationFn = ReturnType<typeof useTranslations<"member_of_month">>;
+
+function HistoryEntry({
+  item,
+  t,
+}: {
+  item: MemberOfMonthHistoryItem;
+  t: TranslationFn;
+}) {
   return (
     <div className="rounded-lg border bg-card px-4 py-3">
       {/* Period header */}
@@ -36,7 +45,7 @@ function HistoryEntry({ item }: { item: MemberOfMonthHistoryItem }) {
         </span>
         {item.members.length > 1 && (
           <Badge variant="warning" className="text-[10px]">
-            Empate
+            {t("history.tie")}
           </Badge>
         )}
       </div>
@@ -68,7 +77,7 @@ function HistoryEntry({ item }: { item: MemberOfMonthHistoryItem }) {
                 <p className="truncate text-sm font-medium">{member.name}</p>
               </div>
               <span className="shrink-0 text-sm font-semibold tabular-nums text-muted-foreground">
-                {member.total_points} pts
+                {t("history.points", { count: member.total_points })}
               </span>
             </div>
           );
@@ -122,6 +131,7 @@ export function MemberOfMonthHistorySheet({
   sectionId,
   sectionName,
 }: MemberOfMonthHistorySheetProps) {
+  const t = useTranslations("member_of_month");
   const [page, setPage] = useState(1);
 
   const { data, isLoading: loading } = useQuery({
@@ -131,7 +141,7 @@ export function MemberOfMonthHistorySheet({
         return await getMemberOfMonthHistory(clubId, sectionId, page, PAGE_LIMIT);
       } catch (err: unknown) {
         const message =
-          err instanceof Error ? err.message : "No se pudo cargar el historial";
+          err instanceof Error ? err.message : t("errors.load_history_failed");
         toast.error(message);
         throw err;
       }
@@ -162,11 +172,10 @@ export function MemberOfMonthHistorySheet({
         <SheetHeader>
           <SheetTitle className="flex items-center gap-2">
             <Trophy className="size-4 text-warning" />
-            Miembro del Mes — Historial
+            {t("history.title")}
           </SheetTitle>
           <SheetDescription>
-            Historial de ganadores en{" "}
-            <strong>{sectionName}</strong>
+            {t("history.description", { sectionName })}
           </SheetDescription>
         </SheetHeader>
 
@@ -176,14 +185,14 @@ export function MemberOfMonthHistorySheet({
           ) : items.length === 0 ? (
             <div className="flex flex-col items-center justify-center py-12 text-center">
               <Trophy className="size-10 text-muted-foreground/30" />
-              <p className="mt-3 text-sm font-medium">Sin historial</p>
+              <p className="mt-3 text-sm font-medium">{t("history.empty_title")}</p>
               <p className="mt-1 text-xs text-muted-foreground">
-                No hay datos de miembro del mes aún.
+                {t("history.empty_description")}
               </p>
             </div>
           ) : (
             items.map((item, idx) => (
-              <HistoryEntry key={`${item.year}-${item.month}-${idx}`} item={item} />
+              <HistoryEntry key={`${item.year}-${item.month}-${idx}`} item={item} t={t} />
             ))
           )}
         </div>
@@ -192,7 +201,7 @@ export function MemberOfMonthHistorySheet({
         {total > PAGE_LIMIT && (
           <div className="mt-4 flex items-center justify-between border-t pt-4">
             <span className="text-xs text-muted-foreground">
-              Página {page} de {totalPages}
+              {t("history.pagination_label", { page, total: totalPages })}
             </span>
             <div className="flex gap-1">
               <Button

--- a/src/components/membership/membership-reject-dialog.tsx
+++ b/src/components/membership/membership-reject-dialog.tsx
@@ -6,6 +6,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
 import { XCircle, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Dialog,
   DialogContent,
@@ -58,6 +59,7 @@ export function MembershipRejectDialog({
   onOpenChange,
   onSuccess,
 }: MembershipRejectDialogProps) {
+  const t = useTranslations("membership");
   const [isPending, setIsPending] = useState(false);
   const userName = getUserName(request.users);
 
@@ -75,7 +77,7 @@ export function MembershipRejectDialog({
         values.reason || undefined,
       );
 
-      toast.success(`Solicitud de membresía rechazada para ${userName}`);
+      toast.success(t("toasts.rejected", { name: userName }));
       form.reset();
       onOpenChange(false);
       onSuccess();
@@ -83,7 +85,7 @@ export function MembershipRejectDialog({
       const message =
         error instanceof ApiError
           ? error.message
-          : "Ocurrió un error al rechazar la solicitud";
+          : t("errors.reject");
       toast.error(message);
     } finally {
       setIsPending(false);
@@ -103,21 +105,19 @@ export function MembershipRejectDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <XCircle className="size-5 text-destructive" />
-            Rechazar solicitud de membresía
+            {t("dialogs.reject.title")}
           </DialogTitle>
           <DialogDescription>
-            Se rechazará la solicitud de membresía de{" "}
-            <span className="font-medium text-foreground">{userName}</span>.
-            Opcionalmente puedes indicar un motivo.
+            {t("dialogs.reject.description", { userName })}
           </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="reject-reason">Motivo de rechazo (opcional)</Label>
+            <Label htmlFor="reject-reason">{t("dialogs.reject.reason_label")}</Label>
             <Textarea
               id="reject-reason"
-              placeholder="Describe el motivo del rechazo..."
+              placeholder={t("dialogs.reject.reason_placeholder")}
               rows={3}
               {...form.register("reason")}
               disabled={isPending}
@@ -131,11 +131,11 @@ export function MembershipRejectDialog({
               onClick={() => handleClose(false)}
               disabled={isPending}
             >
-              Cancelar
+              {t("dialogs.reject.cancel")}
             </Button>
             <Button type="submit" variant="destructive" disabled={isPending}>
               {isPending && <Loader2 className="size-4 animate-spin" />}
-              Rechazar
+              {isPending ? t("dialogs.reject.confirming") : t("dialogs.reject.confirm")}
             </Button>
           </DialogFooter>
         </form>

--- a/src/components/membership/membership-requests-client-page.tsx
+++ b/src/components/membership/membership-requests-client-page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { toast } from "sonner";
 import { UserPlus } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Select,
   SelectContent,
@@ -36,6 +37,7 @@ interface MembershipRequestsClientPageProps {
 export function MembershipRequestsClientPage({
   sections,
 }: MembershipRequestsClientPageProps) {
+  const t = useTranslations("membership");
   const [selectedSectionId, setSelectedSectionId] = useState<number>(
     sections[0]?.club_section_id ?? 0,
   );
@@ -51,19 +53,19 @@ export function MembershipRequestsClientPage({
       setRequests(data);
     } catch (error) {
       if (error instanceof ApiError && (error.status === 403 || error.status === 401)) {
-        setLoadError("No tienes permisos para ver solicitudes de esta sección.");
+        setLoadError(t("client.load_error_permission"));
       } else {
         const message =
           error instanceof ApiError
             ? error.message
-            : "No se pudieron cargar las solicitudes.";
+            : t("client.load_error_generic");
         setLoadError(message);
       }
       setRequests([]);
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     if (selectedSectionId) {
@@ -75,13 +77,13 @@ export function MembershipRequestsClientPage({
     <div className="space-y-4">
       {/* Section selector */}
       <div className="max-w-md space-y-1.5">
-        <Label htmlFor="section-select">Sección de club</Label>
+        <Label htmlFor="section-select">{t("client.section_label")}</Label>
         <Select
           value={String(selectedSectionId)}
           onValueChange={(value) => setSelectedSectionId(Number(value))}
         >
           <SelectTrigger id="section-select">
-            <SelectValue placeholder="Seleccionar sección" />
+            <SelectValue placeholder={t("client.section_placeholder")} />
           </SelectTrigger>
           <SelectContent>
             {sections.map((section) => (

--- a/src/components/membership/pending-members-panel.tsx
+++ b/src/components/membership/pending-members-panel.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { UserPlus } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
 import {
   Select,
   SelectContent,
@@ -35,6 +36,7 @@ interface PendingMembersPanelProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function PendingMembersPanel({ sections }: PendingMembersPanelProps) {
+  const t = useTranslations("membership");
   const activeSections = sections.filter((s) => s.active !== false && s.club_section_id);
 
   const [selectedSectionId, setSelectedSectionId] = useState<number | null>(
@@ -56,41 +58,43 @@ export function PendingMembersPanel({ sections }: PendingMembersPanelProps) {
     queryError instanceof Error
       ? queryError.message
       : queryError
-        ? "No se pudieron cargar las solicitudes de membresía."
+        ? t("pending.load_error")
         : null;
 
   if (activeSections.length === 0) {
     return (
       <EmptyState
         icon={UserPlus}
-        title="Sin secciones activas"
-        description="Este club no tiene secciones activas. Crea una sección para poder gestionar solicitudes de membresía."
+        title={t("pending.no_active_sections_title")}
+        description={t("pending.no_active_sections_description")}
       />
     );
   }
 
   const getSectionLabel = (section: Section): string => {
-    return section.name ?? section.club_type?.name ?? `Sección ${section.club_section_id}`;
+    return (
+      section.name ??
+      section.club_type?.name ??
+      t("pending.section_fallback", { id: section.club_section_id ?? "?" })
+    );
   };
 
   return (
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">
-        Solicitudes de membresía pendientes de aprobación. Los usuarios que se
-        registran en la app quedan en estado pendiente hasta que un director o
-        líder del club apruebe su ingreso.
+        {t("pending.description")}
       </p>
 
       {/* Section selector */}
       {activeSections.length > 1 && (
         <div className="max-w-xs space-y-1.5">
-          <Label htmlFor="section-select">Sección</Label>
+          <Label htmlFor="section-select">{t("pending.section_label")}</Label>
           <Select
             value={String(selectedSectionId)}
             onValueChange={(value) => setSelectedSectionId(Number(value))}
           >
             <SelectTrigger id="section-select">
-              <SelectValue placeholder="Seleccionar sección" />
+              <SelectValue placeholder={t("pending.section_placeholder")} />
             </SelectTrigger>
             <SelectContent>
               {activeSections.map((section) => (

--- a/src/components/membership/pending-members-table.tsx
+++ b/src/components/membership/pending-members-table.tsx
@@ -10,6 +10,7 @@ import {
   UserPlus,
   Clock,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableBody,
@@ -99,6 +100,7 @@ export function PendingMembersTable({
   clubSectionId,
   initialRequests,
 }: PendingMembersTableProps) {
+  const t = useTranslations("membership");
   const [requests, setRequests] = useState<MembershipRequest[]>(initialRequests);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [processingId, setProcessingId] = useState<string | null>(null);
@@ -113,26 +115,24 @@ export function PendingMembersTable({
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudo actualizar la lista";
+          : t("table.refresh_error");
       toast.error(message);
     } finally {
       setIsRefreshing(false);
     }
-  }, [clubSectionId]);
+  }, [clubSectionId, t]);
 
   const handleApprove = async (req: MembershipRequest) => {
     setProcessingId(req.assignment_id);
     try {
       await approveMembershipRequest(clubSectionId, req.assignment_id);
-      toast.success(
-        `Membresía aprobada para ${getUserName(req.users)}`,
-      );
+      toast.success(t("toasts.approved", { name: getUserName(req.users) }));
       await refresh();
     } catch (error) {
       const message =
         error instanceof ApiError
           ? error.message
-          : "Ocurrió un error al aprobar la solicitud";
+          : t("errors.approve");
       toast.error(message);
     } finally {
       setProcessingId(null);
@@ -144,10 +144,10 @@ export function PendingMembersTable({
       {/* Toolbar */}
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          <span className="font-medium text-foreground">{requests.length}</span>{" "}
-          {requests.length === 1
-            ? "solicitud pendiente"
-            : "solicitudes pendientes"}
+          {t(
+            requests.length === 1 ? "table.count_one" : "table.count_other",
+            { count: requests.length },
+          )}
         </p>
         <Button
           variant="outline"
@@ -158,7 +158,7 @@ export function PendingMembersTable({
           <RefreshCw
             className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
-          Actualizar
+          {t("table.refresh")}
         </Button>
       </div>
 
@@ -166,8 +166,8 @@ export function PendingMembersTable({
       {requests.length === 0 ? (
         <EmptyState
           icon={UserPlus}
-          title="Sin solicitudes pendientes"
-          description="No hay solicitudes de membresía pendientes para esta sección."
+          title={t("table.empty_title")}
+          description={t("table.empty_description")}
         />
       ) : (
         /* Table */
@@ -176,19 +176,19 @@ export function PendingMembersTable({
             <TableHeader>
               <TableRow>
                 <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Miembro
+                  {t("table.col_member")}
                 </TableHead>
                 <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Rol
+                  {t("table.col_role")}
                 </TableHead>
                 <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Fecha solicitud
+                  {t("table.col_requested")}
                 </TableHead>
                 <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Expira
+                  {t("table.col_expires")}
                 </TableHead>
                 <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                  Acciones
+                  {t("table.col_actions")}
                 </TableHead>
               </TableRow>
             </TableHeader>
@@ -259,12 +259,12 @@ export function PendingMembersTable({
                               className="text-success hover:bg-success/10 hover:text-success"
                               onClick={() => handleApprove(req)}
                               disabled={isProcessing || isRefreshing}
-                              aria-label="Aprobar membresía"
+                              aria-label={t("table.aria_approve")}
                             >
                               <CheckCircle2 className="size-4" />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>Aprobar</TooltipContent>
+                          <TooltipContent>{t("table.tooltip_approve")}</TooltipContent>
                         </Tooltip>
 
                         <Tooltip>
@@ -275,12 +275,12 @@ export function PendingMembersTable({
                               className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                               onClick={() => setRejectDialog(req)}
                               disabled={isProcessing || isRefreshing}
-                              aria-label="Rechazar membresía"
+                              aria-label={t("table.aria_reject")}
                             >
                               <XCircle className="size-4" />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>Rechazar</TooltipContent>
+                          <TooltipContent>{t("table.tooltip_reject")}</TooltipContent>
                         </Tooltip>
                       </div>
                     </TableCell>


### PR DESCRIPTION
## Summary

next-intl batch 6 — single PR combining 3 parallel agent worktrees.

- **certifications** (extended +18 keys): certifications-list, certification-modules-tree
- **classes** (new ns, +19 keys): classes-list, class-module-tree, class-status-badge
- **inventory** (extended +37 keys): inventory-table, inventory-history-dialog, inventory-view
- **member_of_month** (extended +8 keys): history-sheet
- **membership** (new ns, +37 keys): pending-members-panel, pending-members-table, membership-reject-dialog, membership-requests-client-page

13 component files + 4 messages JSONs. ~119 new keys per locale, 4 locales (`es`, `en`, `fr`, `pt-BR`) all in sync. Cumulative i18n project: ~1231 keys across 14 namespaces.

## Patterns applied

- Status badges with module-level `statusMap` → label resolved via `t()` inside component, `'use client'` added where needed (`class-status-badge`)
- Module-level `actionConfig` split: visual constants (badge variant, icon, classNames) stay at module level, label map moves inside component body (`inventory-history-dialog`)
- Sub-components receiving `t` as prop where hooks can't be called (`history-sheet` `HistoryEntry`)
- Helper fns accept fallback string or typed `t` (`inventory` `getFieldLabel`, `getPerformerName`)
- ICU plural for `sections_count`, `modules_count`, `items_found_label`
- `_one`/`_other` key-selection pattern for membership table count (matches `users.sessions` pattern)
- TypeScript guard `?? "?"` for nullable id passed to `t()` interpolation (`pending-members-panel`)

## Test plan

- [x] All 3 sub-agents branched from `origin/development` HEAD `1dea191` cleanly (CRITICAL header verification)
- [x] No file overlap between 3 worktrees (0 merge conflicts)
- [x] Python deep-merge produced 4 locale JSONs in sync (`certifications=20, classes=19, inventory=42, member_of_month=10, membership=37` per locale)
- [x] `pnpm typecheck` produces no new errors (6 pre-existing `vitest` module errors on `origin/development` baseline are unchanged)
- [x] All 4 `messages/*.json` parse as valid JSON
- [ ] Manual smoke: locale switcher across the 5 features
- [ ] fr/pt-BR translation review (deferred — accumulated across 14 PRs i18n)