### PR TITLE
feat(i18n): batch 7 — shared, units, validation, requests, evidence-review, system-config

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1280,6 +1280,51 @@
     "validation": {
       "reason_required": "The rejection reason is required",
       "reason_max": "Maximum 1000 characters"
+    },
+    "table": {
+      "col_member": "Member",
+      "col_type": "Type",
+      "col_section": "Section / Honor",
+      "col_files": "Files",
+      "col_submitted": "Submitted",
+      "col_status": "Status",
+      "col_actions": "Actions",
+      "select_all": "Select all",
+      "select_row": "Select {name}",
+      "action_view_files": "View files",
+      "action_view_history": "View history",
+      "action_approve": "Approve",
+      "action_reject": "Reject",
+      "empty_title": "No pending evidence",
+      "empty_description": "There is no evidence pending review in this state."
+    },
+    "typeBadge": {
+      "folder": "Folder",
+      "class": "Class",
+      "honor": "Honor"
+    },
+    "statusBadge": {
+      "no_submit": "Not submitted",
+      "submitted": "Submitted",
+      "validated": "Validated",
+      "rejected": "Rejected"
+    },
+    "client": {
+      "tab_all": "All",
+      "tab_folders": "Folders",
+      "tab_classes": "Classes",
+      "tab_honors": "Honors",
+      "btn_refresh": "Refresh",
+      "error_refresh": "Could not refresh the list"
+    },
+    "history": {
+      "title": "Validation history",
+      "empty": "No validation history yet.",
+      "system": "System",
+      "action_approved": "Approved",
+      "action_rejected": "Rejected",
+      "action_submitted": "Submitted for review",
+      "error_load": "Could not load history"
     }
   },
   "users": {
@@ -1648,7 +1693,57 @@
   },
   "validation_admin": {
     "errors": {
-      "unexpected": "An unexpected error occurred"
+      "unexpected": "An unexpected error occurred",
+      "loadHistory": "Could not load validation history",
+      "refresh": "Could not refresh the list"
+    },
+    "status": {
+      "PENDING": "Pending",
+      "APPROVED": "Approved",
+      "REJECTED": "Rejected",
+      "NEEDS_REVISION": "Needs Revision"
+    },
+    "table": {
+      "columns": {
+        "member": "Member",
+        "class": "Class",
+        "honor": "Honor",
+        "section": "Section",
+        "submitted": "Submitted",
+        "status": "Status",
+        "actions": "Actions"
+      },
+      "empty": {
+        "title": "No pending items",
+        "description": "There are no pending validations at this time."
+      },
+      "actions": {
+        "viewHistory": "View history",
+        "approve": "Approve",
+        "reject": "Reject"
+      }
+    },
+    "history": {
+      "title": "Validation history",
+      "empty": "No validation history yet.",
+      "performer": {
+        "system": "System"
+      },
+      "actions": {
+        "APPROVED": "Approved",
+        "REJECTED": "Rejected"
+      }
+    },
+    "client": {
+      "filters": {
+        "allSections": "All sections"
+      },
+      "count": "{count, plural, one {# pending} other {# pending}}",
+      "refresh": "Refresh",
+      "tabs": {
+        "class": "Classes",
+        "honor": "Honors"
+      }
     }
   },
   "scoring_categories": {
@@ -1836,7 +1931,81 @@
   },
   "requests": {
     "errors": {
-      "unexpected": "An unexpected error occurred"
+      "unexpected": "An unexpected error occurred",
+      "refresh": "Could not refresh the list"
+    },
+    "status": {
+      "PENDING": "Pending",
+      "APPROVED": "Approved",
+      "REJECTED": "Rejected"
+    },
+    "client": {
+      "count": "{count, plural, one {# request} other {# requests}}",
+      "refresh": "Refresh",
+      "tabs": {
+        "all": "All",
+        "pending": "Pending",
+        "approved": "Approved",
+        "rejected": "Rejected"
+      }
+    },
+    "transfers": {
+      "table": {
+        "columns": {
+          "requester": "Requester",
+          "from": "From",
+          "to": "To",
+          "reason": "Reason",
+          "status": "Status",
+          "date": "Date",
+          "actions": "Actions"
+        },
+        "empty": {
+          "title": "No requests",
+          "description": "There are no transfer requests in this status."
+        },
+        "actions": {
+          "approve": "Approve",
+          "reject": "Reject",
+          "approveAriaLabel": "Approve transfer",
+          "rejectAriaLabel": "Reject transfer"
+        }
+      },
+      "dialog": {
+        "approveTitle": "Approve transfer",
+        "rejectTitle": "Reject transfer",
+        "approveDescription": "The transfer request from {name} will be approved.",
+        "rejectDescription": "The request from {name} will be rejected. A reason is required."
+      }
+    },
+    "assignments": {
+      "table": {
+        "columns": {
+          "targetUser": "Target user",
+          "section": "Section",
+          "roleToAssign": "Role to assign",
+          "requestedBy": "Requested by",
+          "status": "Status",
+          "date": "Date",
+          "actions": "Actions"
+        },
+        "empty": {
+          "title": "No requests",
+          "description": "There are no role assignment requests in this status."
+        },
+        "actions": {
+          "approve": "Approve",
+          "reject": "Reject",
+          "approveAriaLabel": "Approve assignment",
+          "rejectAriaLabel": "Reject assignment"
+        }
+      },
+      "dialog": {
+        "approveTitle": "Approve role assignment",
+        "rejectTitle": "Reject role assignment",
+        "approveDescription": "The role assignment for {name} will be approved.",
+        "rejectDescription": "The assignment request for {name} will be rejected. A reason is required."
+      }
     }
   },
   "insurance": {
@@ -2198,16 +2367,87 @@
       "member_removed": "Member removed from the unit",
       "weekly_record_created": "Weekly record created",
       "unit_deactivated": "Unit deactivated successfully"
+    },
+    "memberCombobox": {
+      "searchPlaceholder": "Search by name...",
+      "loading": "Loading members...",
+      "empty": "No members available.",
+      "clearSelection": "Clear selection",
+      "loadError": "Could not load members"
+    },
+    "unitForm": {
+      "generalData": "Unit data",
+      "leaders": "Unit leaders",
+      "requiredHint": "Fields marked with",
+      "requiredHintSuffix": "are required.",
+      "name": "Name",
+      "namePlaceholder": "E.g. Eagles Unit",
+      "clubType": "Club type",
+      "captain": "Captain",
+      "captainPlaceholder": "Select captain...",
+      "secretary": "Secretary",
+      "secretaryPlaceholder": "Select secretary...",
+      "advisor": "Advisor",
+      "advisorPlaceholder": "Select advisor...",
+      "substituteAdvisor": "Substitute advisor",
+      "substituteAdvisorOptional": "(optional)",
+      "substituteAdvisorPlaceholder": "Select substitute advisor (optional)...",
+      "submitCreate": "Create unit",
+      "submitEdit": "Save changes",
+      "submittingCreate": "Creating...",
+      "submittingEdit": "Saving...",
+      "clubTypeAdventurers": "Adventurers",
+      "clubTypePathfinders": "Pathfinders",
+      "clubTypeMasterGuides": "Master Guides"
     }
   },
   "system_config": {
     "errors": {
       "unexpected": "An unexpected error occurred"
+    },
+    "table": {
+      "col_key": "Key",
+      "col_value": "Value",
+      "col_description": "Description",
+      "col_type": "Type",
+      "col_actions": "Actions",
+      "action_edit": "Edit value",
+      "action_edit_key": "Edit {key}",
+      "no_description": "—",
+      "no_type": "—",
+      "empty_title": "No configurations",
+      "empty_description": "There are no system configuration entries registered."
+    },
+    "client": {
+      "entry_count": "{count, plural, one {# entry} other {# entries}}",
+      "btn_refresh": "Refresh",
+      "error_refresh": "Could not refresh the configuration"
     }
   },
   "shared": {
     "errors": {
       "unexpected": "Unexpected error"
+    },
+    "pagination": {
+      "showing": "Showing {from}–{to} of {total} records",
+      "perPage": "Per page",
+      "pageOf": "Page {page} of {totalPages}",
+      "prevPage": "Previous page",
+      "nextPage": "Next page"
+    },
+    "sortable": {
+      "sortBy": "Sort by {field}",
+      "sortedAscending": "Sorted by {field} ascending. Click to reverse.",
+      "sortedDescending": "Sorted by {field} descending. Click to reverse."
+    },
+    "pageHeader": {
+      "breadcrumbNav": "Breadcrumb navigation"
+    },
+    "errorBanner": {
+      "forbidden": "Access denied",
+      "missing": "Not available",
+      "rateLimited": "Rate limit reached",
+      "goToLogin": "Go to login"
     }
   },
   "translations": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -1280,6 +1280,51 @@
     "validation": {
       "reason_required": "El motivo de rechazo es obligatorio",
       "reason_max": "Máximo 1000 caracteres"
+    },
+    "table": {
+      "col_member": "Miembro",
+      "col_type": "Tipo",
+      "col_section": "Sección / Honor",
+      "col_files": "Archivos",
+      "col_submitted": "Enviado",
+      "col_status": "Estado",
+      "col_actions": "Acciones",
+      "select_all": "Seleccionar todo",
+      "select_row": "Seleccionar {name}",
+      "action_view_files": "Ver archivos",
+      "action_view_history": "Ver historial",
+      "action_approve": "Aprobar",
+      "action_reject": "Rechazar",
+      "empty_title": "Sin evidencias pendientes",
+      "empty_description": "No hay evidencias pendientes de revisión en este estado."
+    },
+    "typeBadge": {
+      "folder": "Carpeta",
+      "class": "Clase",
+      "honor": "Honor"
+    },
+    "statusBadge": {
+      "no_submit": "Sin enviar",
+      "submitted": "Enviado",
+      "validated": "Validado",
+      "rejected": "Rechazado"
+    },
+    "client": {
+      "tab_all": "Todos",
+      "tab_folders": "Carpetas",
+      "tab_classes": "Clases",
+      "tab_honors": "Honores",
+      "btn_refresh": "Actualizar",
+      "error_refresh": "No se pudo actualizar la lista"
+    },
+    "history": {
+      "title": "Historial de validación",
+      "empty": "No hay historial de validación aún.",
+      "system": "Sistema",
+      "action_approved": "Aprobado",
+      "action_rejected": "Rechazado",
+      "action_submitted": "Enviado a revisión",
+      "error_load": "No se pudo cargar el historial"
     }
   },
   "users": {
@@ -1648,7 +1693,57 @@
   },
   "validation_admin": {
     "errors": {
-      "unexpected": "Ocurrió un error inesperado"
+      "unexpected": "Ocurrió un error inesperado",
+      "loadHistory": "No se pudo cargar el historial",
+      "refresh": "No se pudo actualizar la lista"
+    },
+    "status": {
+      "PENDING": "Pendiente",
+      "APPROVED": "Aprobado",
+      "REJECTED": "Rechazado",
+      "NEEDS_REVISION": "Revisión"
+    },
+    "table": {
+      "columns": {
+        "member": "Miembro",
+        "class": "Clase",
+        "honor": "Especialidad",
+        "section": "Sección",
+        "submitted": "Enviado",
+        "status": "Estado",
+        "actions": "Acciones"
+      },
+      "empty": {
+        "title": "Sin pendientes",
+        "description": "No hay validaciones pendientes en este momento."
+      },
+      "actions": {
+        "viewHistory": "Ver historial",
+        "approve": "Aprobar",
+        "reject": "Rechazar"
+      }
+    },
+    "history": {
+      "title": "Historial de validación",
+      "empty": "No hay historial de validación aún.",
+      "performer": {
+        "system": "Sistema"
+      },
+      "actions": {
+        "APPROVED": "Aprobado",
+        "REJECTED": "Rechazado"
+      }
+    },
+    "client": {
+      "filters": {
+        "allSections": "Todas las secciones"
+      },
+      "count": "{count, plural, one {# pendiente} other {# pendientes}}",
+      "refresh": "Actualizar",
+      "tabs": {
+        "class": "Clases",
+        "honor": "Especialidades"
+      }
     }
   },
   "scoring_categories": {
@@ -1836,7 +1931,81 @@
   },
   "requests": {
     "errors": {
-      "unexpected": "Ocurrió un error inesperado"
+      "unexpected": "Ocurrió un error inesperado",
+      "refresh": "No se pudo actualizar la lista"
+    },
+    "status": {
+      "PENDING": "Pendiente",
+      "APPROVED": "Aprobado",
+      "REJECTED": "Rechazado"
+    },
+    "client": {
+      "count": "{count, plural, one {# solicitud} other {# solicitudes}}",
+      "refresh": "Actualizar",
+      "tabs": {
+        "all": "Todas",
+        "pending": "Pendientes",
+        "approved": "Aprobadas",
+        "rejected": "Rechazadas"
+      }
+    },
+    "transfers": {
+      "table": {
+        "columns": {
+          "requester": "Solicitante",
+          "from": "Desde",
+          "to": "Hacia",
+          "reason": "Motivo",
+          "status": "Estado",
+          "date": "Fecha",
+          "actions": "Acciones"
+        },
+        "empty": {
+          "title": "Sin solicitudes",
+          "description": "No hay solicitudes de transferencia en este estado."
+        },
+        "actions": {
+          "approve": "Aprobar",
+          "reject": "Rechazar",
+          "approveAriaLabel": "Aprobar transferencia",
+          "rejectAriaLabel": "Rechazar transferencia"
+        }
+      },
+      "dialog": {
+        "approveTitle": "Aprobar transferencia",
+        "rejectTitle": "Rechazar transferencia",
+        "approveDescription": "Se aprobará la solicitud de transferencia de {name}.",
+        "rejectDescription": "Se rechazará la solicitud de {name}. El motivo es obligatorio."
+      }
+    },
+    "assignments": {
+      "table": {
+        "columns": {
+          "targetUser": "Usuario destino",
+          "section": "Sección",
+          "roleToAssign": "Rol a asignar",
+          "requestedBy": "Solicitado por",
+          "status": "Estado",
+          "date": "Fecha",
+          "actions": "Acciones"
+        },
+        "empty": {
+          "title": "Sin solicitudes",
+          "description": "No hay solicitudes de asignación de rol en este estado."
+        },
+        "actions": {
+          "approve": "Aprobar",
+          "reject": "Rechazar",
+          "approveAriaLabel": "Aprobar asignación",
+          "rejectAriaLabel": "Rechazar asignación"
+        }
+      },
+      "dialog": {
+        "approveTitle": "Aprobar asignación de rol",
+        "rejectTitle": "Rechazar asignación de rol",
+        "approveDescription": "Se aprobará la asignación de rol para {name}.",
+        "rejectDescription": "Se rechazará la solicitud de asignación para {name}. El motivo es obligatorio."
+      }
     }
   },
   "insurance": {
@@ -2198,16 +2367,87 @@
       "member_removed": "Miembro removido de la unidad",
       "weekly_record_created": "Registro semanal creado",
       "unit_deactivated": "Unidad desactivada correctamente"
+    },
+    "memberCombobox": {
+      "searchPlaceholder": "Buscar por nombre...",
+      "loading": "Cargando miembros...",
+      "empty": "Sin miembros disponibles.",
+      "clearSelection": "Limpiar selección",
+      "loadError": "No se pudieron cargar los miembros"
+    },
+    "unitForm": {
+      "generalData": "Datos de la unidad",
+      "leaders": "Líderes de la unidad",
+      "requiredHint": "Los campos marcados con",
+      "requiredHintSuffix": "son obligatorios.",
+      "name": "Nombre",
+      "namePlaceholder": "Ej. Unidad Aguilas",
+      "clubType": "Tipo de club",
+      "captain": "Capitán",
+      "captainPlaceholder": "Seleccionar capitán...",
+      "secretary": "Secretario",
+      "secretaryPlaceholder": "Seleccionar secretario...",
+      "advisor": "Consejero",
+      "advisorPlaceholder": "Seleccionar consejero...",
+      "substituteAdvisor": "Consejero suplente",
+      "substituteAdvisorOptional": "(opcional)",
+      "substituteAdvisorPlaceholder": "Seleccionar consejero suplente (opcional)...",
+      "submitCreate": "Crear unidad",
+      "submitEdit": "Guardar cambios",
+      "submittingCreate": "Creando...",
+      "submittingEdit": "Guardando...",
+      "clubTypeAdventurers": "Aventureros",
+      "clubTypePathfinders": "Conquistadores",
+      "clubTypeMasterGuides": "Guías Mayores"
     }
   },
   "system_config": {
     "errors": {
       "unexpected": "Ocurrió un error inesperado"
+    },
+    "table": {
+      "col_key": "Clave",
+      "col_value": "Valor",
+      "col_description": "Descripción",
+      "col_type": "Tipo",
+      "col_actions": "Acciones",
+      "action_edit": "Editar valor",
+      "action_edit_key": "Editar {key}",
+      "no_description": "—",
+      "no_type": "—",
+      "empty_title": "Sin configuraciones",
+      "empty_description": "No hay entradas de configuración del sistema registradas."
+    },
+    "client": {
+      "entry_count": "{count, plural, one {# entrada} other {# entradas}}",
+      "btn_refresh": "Actualizar",
+      "error_refresh": "No se pudo actualizar la configuración"
     }
   },
   "shared": {
     "errors": {
       "unexpected": "Error inesperado"
+    },
+    "pagination": {
+      "showing": "Mostrando {from}–{to} de {total} registros",
+      "perPage": "Por página",
+      "pageOf": "Página {page} de {totalPages}",
+      "prevPage": "Página anterior",
+      "nextPage": "Página siguiente"
+    },
+    "sortable": {
+      "sortBy": "Ordenar por {field}",
+      "sortedAscending": "Ordenado por {field} ascendente. Click para invertir.",
+      "sortedDescending": "Ordenado por {field} descendente. Click para invertir."
+    },
+    "pageHeader": {
+      "breadcrumbNav": "Navegación de rutas"
+    },
+    "errorBanner": {
+      "forbidden": "Acceso denegado",
+      "missing": "No disponible",
+      "rateLimited": "Límite de solicitudes",
+      "goToLogin": "Ir a login"
     }
   },
   "translations": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1280,6 +1280,51 @@
     "validation": {
       "reason_required": "Le motif de rejet est obligatoire",
       "reason_max": "Maximum 1000 caractères"
+    },
+    "table": {
+      "col_member": "Membre",
+      "col_type": "Type",
+      "col_section": "Section / Honneur",
+      "col_files": "Fichiers",
+      "col_submitted": "Envoyé",
+      "col_status": "Statut",
+      "col_actions": "Actions",
+      "select_all": "Tout sélectionner",
+      "select_row": "Sélectionner {name}",
+      "action_view_files": "Voir les fichiers",
+      "action_view_history": "Voir l'historique",
+      "action_approve": "Approuver",
+      "action_reject": "Rejeter",
+      "empty_title": "Aucune preuve en attente",
+      "empty_description": "Il n'y a aucune preuve en attente de révision dans cet état."
+    },
+    "typeBadge": {
+      "folder": "Dossier",
+      "class": "Classe",
+      "honor": "Honneur"
+    },
+    "statusBadge": {
+      "no_submit": "Non envoyé",
+      "submitted": "Envoyé",
+      "validated": "Validé",
+      "rejected": "Rejeté"
+    },
+    "client": {
+      "tab_all": "Tous",
+      "tab_folders": "Dossiers",
+      "tab_classes": "Classes",
+      "tab_honors": "Honneurs",
+      "btn_refresh": "Actualiser",
+      "error_refresh": "Impossible de mettre à jour la liste"
+    },
+    "history": {
+      "title": "Historique de validation",
+      "empty": "Il n'y a pas encore d'historique de validation.",
+      "system": "Système",
+      "action_approved": "Approuvé",
+      "action_rejected": "Rejeté",
+      "action_submitted": "Envoyé en révision",
+      "error_load": "Impossible de charger l'historique"
     }
   },
   "users": {
@@ -1648,7 +1693,57 @@
   },
   "validation_admin": {
     "errors": {
-      "unexpected": "Une erreur inattendue s'est produite"
+      "unexpected": "Une erreur inattendue s'est produite",
+      "loadHistory": "Impossible de charger l'historique de validation",
+      "refresh": "Impossible de rafraîchir la liste"
+    },
+    "status": {
+      "PENDING": "En attente",
+      "APPROVED": "Approuvé",
+      "REJECTED": "Rejeté",
+      "NEEDS_REVISION": "À réviser"
+    },
+    "table": {
+      "columns": {
+        "member": "Membre",
+        "class": "Classe",
+        "honor": "Spécialité",
+        "section": "Section",
+        "submitted": "Soumis",
+        "status": "Statut",
+        "actions": "Actions"
+      },
+      "empty": {
+        "title": "Aucun élément en attente",
+        "description": "Il n'y a aucune validation en attente pour le moment."
+      },
+      "actions": {
+        "viewHistory": "Voir l'historique",
+        "approve": "Approuver",
+        "reject": "Rejeter"
+      }
+    },
+    "history": {
+      "title": "Historique de validation",
+      "empty": "Aucun historique de validation pour le moment.",
+      "performer": {
+        "system": "Système"
+      },
+      "actions": {
+        "APPROVED": "Approuvé",
+        "REJECTED": "Rejeté"
+      }
+    },
+    "client": {
+      "filters": {
+        "allSections": "Toutes les sections"
+      },
+      "count": "{count, plural, one {# en attente} other {# en attente}}",
+      "refresh": "Actualiser",
+      "tabs": {
+        "class": "Classes",
+        "honor": "Spécialités"
+      }
     }
   },
   "scoring_categories": {
@@ -1836,7 +1931,81 @@
   },
   "requests": {
     "errors": {
-      "unexpected": "Une erreur inattendue s'est produite"
+      "unexpected": "Une erreur inattendue s'est produite",
+      "refresh": "Impossible de rafraîchir la liste"
+    },
+    "status": {
+      "PENDING": "En attente",
+      "APPROVED": "Approuvé",
+      "REJECTED": "Rejeté"
+    },
+    "client": {
+      "count": "{count, plural, one {# demande} other {# demandes}}",
+      "refresh": "Actualiser",
+      "tabs": {
+        "all": "Toutes",
+        "pending": "En attente",
+        "approved": "Approuvées",
+        "rejected": "Rejetées"
+      }
+    },
+    "transfers": {
+      "table": {
+        "columns": {
+          "requester": "Demandeur",
+          "from": "De",
+          "to": "Vers",
+          "reason": "Motif",
+          "status": "Statut",
+          "date": "Date",
+          "actions": "Actions"
+        },
+        "empty": {
+          "title": "Aucune demande",
+          "description": "Il n'y a aucune demande de transfert dans cet état."
+        },
+        "actions": {
+          "approve": "Approuver",
+          "reject": "Rejeter",
+          "approveAriaLabel": "Approuver le transfert",
+          "rejectAriaLabel": "Rejeter le transfert"
+        }
+      },
+      "dialog": {
+        "approveTitle": "Approuver le transfert",
+        "rejectTitle": "Rejeter le transfert",
+        "approveDescription": "La demande de transfert de {name} sera approuvée.",
+        "rejectDescription": "La demande de {name} sera rejetée. Un motif est obligatoire."
+      }
+    },
+    "assignments": {
+      "table": {
+        "columns": {
+          "targetUser": "Utilisateur cible",
+          "section": "Section",
+          "roleToAssign": "Rôle à assigner",
+          "requestedBy": "Demandé par",
+          "status": "Statut",
+          "date": "Date",
+          "actions": "Actions"
+        },
+        "empty": {
+          "title": "Aucune demande",
+          "description": "Il n'y a aucune demande d'attribution de rôle dans cet état."
+        },
+        "actions": {
+          "approve": "Approuver",
+          "reject": "Rejeter",
+          "approveAriaLabel": "Approuver l'attribution",
+          "rejectAriaLabel": "Rejeter l'attribution"
+        }
+      },
+      "dialog": {
+        "approveTitle": "Approuver l'attribution de rôle",
+        "rejectTitle": "Rejeter l'attribution de rôle",
+        "approveDescription": "L'attribution de rôle pour {name} sera approuvée.",
+        "rejectDescription": "La demande d'attribution pour {name} sera rejetée. Un motif est obligatoire."
+      }
     }
   },
   "insurance": {
@@ -2198,16 +2367,87 @@
       "member_removed": "Membre retiré de l'unité",
       "weekly_record_created": "Registre hebdomadaire créé",
       "unit_deactivated": "Unité désactivée avec succès"
+    },
+    "memberCombobox": {
+      "searchPlaceholder": "Rechercher par nom...",
+      "loading": "Chargement des membres...",
+      "empty": "Aucun membre disponible.",
+      "clearSelection": "Effacer la sélection",
+      "loadError": "Impossible de charger les membres"
+    },
+    "unitForm": {
+      "generalData": "Données de l'unité",
+      "leaders": "Leaders de l'unité",
+      "requiredHint": "Les champs marqués avec",
+      "requiredHintSuffix": "sont obligatoires.",
+      "name": "Nom",
+      "namePlaceholder": "Ex. Unité Aigles",
+      "clubType": "Type de club",
+      "captain": "Capitaine",
+      "captainPlaceholder": "Sélectionner le capitaine...",
+      "secretary": "Secrétaire",
+      "secretaryPlaceholder": "Sélectionner le secrétaire...",
+      "advisor": "Conseiller",
+      "advisorPlaceholder": "Sélectionner le conseiller...",
+      "substituteAdvisor": "Conseiller suppléant",
+      "substituteAdvisorOptional": "(facultatif)",
+      "substituteAdvisorPlaceholder": "Sélectionner le conseiller suppléant (facultatif)...",
+      "submitCreate": "Créer l'unité",
+      "submitEdit": "Enregistrer les modifications",
+      "submittingCreate": "Création en cours...",
+      "submittingEdit": "Enregistrement...",
+      "clubTypeAdventurers": "Aventuriers",
+      "clubTypePathfinders": "Conquistadores",
+      "clubTypeMasterGuides": "Guides Majeurs"
     }
   },
   "system_config": {
     "errors": {
       "unexpected": "Une erreur inattendue s'est produite"
+    },
+    "table": {
+      "col_key": "Clé",
+      "col_value": "Valeur",
+      "col_description": "Description",
+      "col_type": "Type",
+      "col_actions": "Actions",
+      "action_edit": "Modifier la valeur",
+      "action_edit_key": "Modifier {key}",
+      "no_description": "—",
+      "no_type": "—",
+      "empty_title": "Aucune configuration",
+      "empty_description": "Il n'y a aucune entrée de configuration système enregistrée."
+    },
+    "client": {
+      "entry_count": "{count, plural, one {# entrée} other {# entrées}}",
+      "btn_refresh": "Actualiser",
+      "error_refresh": "Impossible de mettre à jour la configuration"
     }
   },
   "shared": {
     "errors": {
       "unexpected": "Erreur inattendue"
+    },
+    "pagination": {
+      "showing": "Affichage {from}–{to} sur {total} enregistrements",
+      "perPage": "Par page",
+      "pageOf": "Page {page} sur {totalPages}",
+      "prevPage": "Page précédente",
+      "nextPage": "Page suivante"
+    },
+    "sortable": {
+      "sortBy": "Trier par {field}",
+      "sortedAscending": "Trié par {field} croissant. Cliquez pour inverser.",
+      "sortedDescending": "Trié par {field} décroissant. Cliquez pour inverser."
+    },
+    "pageHeader": {
+      "breadcrumbNav": "Navigation fil d'Ariane"
+    },
+    "errorBanner": {
+      "forbidden": "Accès refusé",
+      "missing": "Non disponible",
+      "rateLimited": "Limite de requêtes atteinte",
+      "goToLogin": "Aller à la connexion"
     }
   },
   "translations": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1280,6 +1280,51 @@
     "validation": {
       "reason_required": "O motivo da rejeição é obrigatório",
       "reason_max": "Máximo de 1000 caracteres"
+    },
+    "table": {
+      "col_member": "Membro",
+      "col_type": "Tipo",
+      "col_section": "Seção / Honra",
+      "col_files": "Arquivos",
+      "col_submitted": "Enviado",
+      "col_status": "Estado",
+      "col_actions": "Ações",
+      "select_all": "Selecionar tudo",
+      "select_row": "Selecionar {name}",
+      "action_view_files": "Ver arquivos",
+      "action_view_history": "Ver histórico",
+      "action_approve": "Aprovar",
+      "action_reject": "Rejeitar",
+      "empty_title": "Sem evidências pendentes",
+      "empty_description": "Não há evidências pendentes de revisão neste estado."
+    },
+    "typeBadge": {
+      "folder": "Pasta",
+      "class": "Classe",
+      "honor": "Honra"
+    },
+    "statusBadge": {
+      "no_submit": "Não enviado",
+      "submitted": "Enviado",
+      "validated": "Validado",
+      "rejected": "Rejeitado"
+    },
+    "client": {
+      "tab_all": "Todos",
+      "tab_folders": "Pastas",
+      "tab_classes": "Classes",
+      "tab_honors": "Honras",
+      "btn_refresh": "Atualizar",
+      "error_refresh": "Não foi possível atualizar a lista"
+    },
+    "history": {
+      "title": "Histórico de validação",
+      "empty": "Nenhum histórico de validação ainda.",
+      "system": "Sistema",
+      "action_approved": "Aprovado",
+      "action_rejected": "Rejeitado",
+      "action_submitted": "Enviado para revisão",
+      "error_load": "Não foi possível carregar o histórico"
     }
   },
   "users": {
@@ -1648,7 +1693,57 @@
   },
   "validation_admin": {
     "errors": {
-      "unexpected": "Ocorreu um erro inesperado"
+      "unexpected": "Ocorreu um erro inesperado",
+      "loadHistory": "Não foi possível carregar o histórico de validação",
+      "refresh": "Não foi possível atualizar a lista"
+    },
+    "status": {
+      "PENDING": "Pendente",
+      "APPROVED": "Aprovado",
+      "REJECTED": "Rejeitado",
+      "NEEDS_REVISION": "Revisão"
+    },
+    "table": {
+      "columns": {
+        "member": "Membro",
+        "class": "Classe",
+        "honor": "Especialidade",
+        "section": "Seção",
+        "submitted": "Enviado",
+        "status": "Status",
+        "actions": "Ações"
+      },
+      "empty": {
+        "title": "Sem pendências",
+        "description": "Não há validações pendentes no momento."
+      },
+      "actions": {
+        "viewHistory": "Ver histórico",
+        "approve": "Aprovar",
+        "reject": "Rejeitar"
+      }
+    },
+    "history": {
+      "title": "Histórico de validação",
+      "empty": "Nenhum histórico de validação ainda.",
+      "performer": {
+        "system": "Sistema"
+      },
+      "actions": {
+        "APPROVED": "Aprovado",
+        "REJECTED": "Rejeitado"
+      }
+    },
+    "client": {
+      "filters": {
+        "allSections": "Todas as seções"
+      },
+      "count": "{count, plural, one {# pendente} other {# pendentes}}",
+      "refresh": "Atualizar",
+      "tabs": {
+        "class": "Classes",
+        "honor": "Especialidades"
+      }
     }
   },
   "scoring_categories": {
@@ -1836,7 +1931,81 @@
   },
   "requests": {
     "errors": {
-      "unexpected": "Ocorreu um erro inesperado"
+      "unexpected": "Ocorreu um erro inesperado",
+      "refresh": "Não foi possível atualizar a lista"
+    },
+    "status": {
+      "PENDING": "Pendente",
+      "APPROVED": "Aprovado",
+      "REJECTED": "Rejeitado"
+    },
+    "client": {
+      "count": "{count, plural, one {# solicitação} other {# solicitações}}",
+      "refresh": "Atualizar",
+      "tabs": {
+        "all": "Todas",
+        "pending": "Pendentes",
+        "approved": "Aprovadas",
+        "rejected": "Rejeitadas"
+      }
+    },
+    "transfers": {
+      "table": {
+        "columns": {
+          "requester": "Solicitante",
+          "from": "De",
+          "to": "Para",
+          "reason": "Motivo",
+          "status": "Status",
+          "date": "Data",
+          "actions": "Ações"
+        },
+        "empty": {
+          "title": "Sem solicitações",
+          "description": "Não há solicitações de transferência neste estado."
+        },
+        "actions": {
+          "approve": "Aprovar",
+          "reject": "Rejeitar",
+          "approveAriaLabel": "Aprovar transferência",
+          "rejectAriaLabel": "Rejeitar transferência"
+        }
+      },
+      "dialog": {
+        "approveTitle": "Aprovar transferência",
+        "rejectTitle": "Rejeitar transferência",
+        "approveDescription": "A solicitação de transferência de {name} será aprovada.",
+        "rejectDescription": "A solicitação de {name} será rejeitada. O motivo é obrigatório."
+      }
+    },
+    "assignments": {
+      "table": {
+        "columns": {
+          "targetUser": "Usuário alvo",
+          "section": "Seção",
+          "roleToAssign": "Função a atribuir",
+          "requestedBy": "Solicitado por",
+          "status": "Status",
+          "date": "Data",
+          "actions": "Ações"
+        },
+        "empty": {
+          "title": "Sem solicitações",
+          "description": "Não há solicitações de atribuição de função neste estado."
+        },
+        "actions": {
+          "approve": "Aprovar",
+          "reject": "Rejeitar",
+          "approveAriaLabel": "Aprovar atribuição",
+          "rejectAriaLabel": "Rejeitar atribuição"
+        }
+      },
+      "dialog": {
+        "approveTitle": "Aprovar atribuição de função",
+        "rejectTitle": "Rejeitar atribuição de função",
+        "approveDescription": "A atribuição de função para {name} será aprovada.",
+        "rejectDescription": "A solicitação de atribuição para {name} será rejeitada. O motivo é obrigatório."
+      }
     }
   },
   "insurance": {
@@ -2198,16 +2367,87 @@
       "member_removed": "Membro removido da unidade",
       "weekly_record_created": "Registro semanal criado",
       "unit_deactivated": "Unidade desativada com sucesso"
+    },
+    "memberCombobox": {
+      "searchPlaceholder": "Buscar por nome...",
+      "loading": "Carregando membros...",
+      "empty": "Sem membros disponíveis.",
+      "clearSelection": "Limpar seleção",
+      "loadError": "Não foi possível carregar os membros"
+    },
+    "unitForm": {
+      "generalData": "Dados da unidade",
+      "leaders": "Líderes da unidade",
+      "requiredHint": "Os campos marcados com",
+      "requiredHintSuffix": "são obrigatórios.",
+      "name": "Nome",
+      "namePlaceholder": "Ex. Unidade Águias",
+      "clubType": "Tipo de clube",
+      "captain": "Capitão",
+      "captainPlaceholder": "Selecionar capitão...",
+      "secretary": "Secretário",
+      "secretaryPlaceholder": "Selecionar secretário...",
+      "advisor": "Conselheiro",
+      "advisorPlaceholder": "Selecionar conselheiro...",
+      "substituteAdvisor": "Conselheiro substituto",
+      "substituteAdvisorOptional": "(opcional)",
+      "substituteAdvisorPlaceholder": "Selecionar conselheiro substituto (opcional)...",
+      "submitCreate": "Criar unidade",
+      "submitEdit": "Salvar alterações",
+      "submittingCreate": "Criando...",
+      "submittingEdit": "Salvando...",
+      "clubTypeAdventurers": "Aventureiros",
+      "clubTypePathfinders": "Conquistadores",
+      "clubTypeMasterGuides": "Guias Maiores"
     }
   },
   "system_config": {
     "errors": {
       "unexpected": "Ocorreu um erro inesperado"
+    },
+    "table": {
+      "col_key": "Chave",
+      "col_value": "Valor",
+      "col_description": "Descrição",
+      "col_type": "Tipo",
+      "col_actions": "Ações",
+      "action_edit": "Editar valor",
+      "action_edit_key": "Editar {key}",
+      "no_description": "—",
+      "no_type": "—",
+      "empty_title": "Sem configurações",
+      "empty_description": "Não há entradas de configuração do sistema registradas."
+    },
+    "client": {
+      "entry_count": "{count, plural, one {# entrada} other {# entradas}}",
+      "btn_refresh": "Atualizar",
+      "error_refresh": "Não foi possível atualizar a configuração"
     }
   },
   "shared": {
     "errors": {
       "unexpected": "Erro inesperado"
+    },
+    "pagination": {
+      "showing": "Mostrando {from}–{to} de {total} registros",
+      "perPage": "Por página",
+      "pageOf": "Página {page} de {totalPages}",
+      "prevPage": "Página anterior",
+      "nextPage": "Próxima página"
+    },
+    "sortable": {
+      "sortBy": "Ordenar por {field}",
+      "sortedAscending": "Ordenado por {field} crescente. Clique para inverter.",
+      "sortedDescending": "Ordenado por {field} decrescente. Clique para inverter."
+    },
+    "pageHeader": {
+      "breadcrumbNav": "Navegação de breadcrumb"
+    },
+    "errorBanner": {
+      "forbidden": "Acesso negado",
+      "missing": "Não disponível",
+      "rateLimited": "Limite de requisições atingido",
+      "goToLogin": "Ir para login"
     }
   },
   "translations": {

--- a/src/components/evidence-review/evidence-history-dialog.tsx
+++ b/src/components/evidence-review/evidence-history-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { History, Clock, CheckCircle2, XCircle, Send } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
@@ -14,7 +15,6 @@ import { cn } from "@/lib/utils";
 import {
   getEvidenceHistory,
   type EvidenceType,
-  type EvidenceHistoryEntry,
 } from "@/lib/api/evidence-review";
 import { ApiError } from "@/lib/api/client";
 
@@ -34,45 +34,35 @@ function formatDate(iso: string): string {
   }
 }
 
-const actionConfig: Record<
+// Action intent data (no user-facing strings here — labels resolved via t() below)
+const actionIntentMap: Record<
   string,
   {
-    label: string;
+    labelKey: "action_approved" | "action_rejected" | "action_submitted";
     icon: React.ElementType;
     iconClass: string;
     dotClass: string;
   }
 > = {
   APPROVED: {
-    label: "Aprobado",
+    labelKey: "action_approved",
     icon: CheckCircle2,
     iconClass: "text-success",
     dotClass: "bg-success/20 border-success/40",
   },
   REJECTED: {
-    label: "Rechazado",
+    labelKey: "action_rejected",
     icon: XCircle,
     iconClass: "text-destructive",
     dotClass: "bg-destructive/20 border-destructive/40",
   },
   SUBMITTED: {
-    label: "Enviado a revisión",
+    labelKey: "action_submitted",
     icon: Send,
     iconClass: "text-warning",
     dotClass: "bg-warning/20 border-warning/40",
   },
 };
-
-function getConfig(action: string) {
-  return (
-    actionConfig[action] ?? {
-      label: action,
-      icon: Clock,
-      iconClass: "text-muted-foreground",
-      dotClass: "bg-muted border-border",
-    }
-  );
-}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -98,6 +88,8 @@ export function EvidenceHistoryDialog({
   memberName,
   onOpenChange,
 }: EvidenceHistoryDialogProps) {
+  const t = useTranslations("evidence_review.history");
+
   // Evidence history is append-only — once fetched it never changes.
   const { data: entries = [], isLoading: loading } = useQuery({
     queryKey: evidenceHistoryQueryKey(type, id),
@@ -108,7 +100,7 @@ export function EvidenceHistoryDialog({
         const message =
           error instanceof ApiError
             ? error.message
-            : "No se pudo cargar el historial";
+            : t("error_load");
         toast.error(message);
         throw error;
       }
@@ -124,7 +116,7 @@ export function EvidenceHistoryDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <History className="size-5 text-muted-foreground" />
-            Historial de validación
+            {t("title")}
           </DialogTitle>
           <p className="text-sm text-muted-foreground">{memberName}</p>
         </DialogHeader>
@@ -139,13 +131,18 @@ export function EvidenceHistoryDialog({
           ) : entries.length === 0 ? (
             <div className="flex items-center gap-2 rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
               <Clock className="size-4 shrink-0" />
-              <span>No hay historial de validación aún.</span>
+              <span>{t("empty")}</span>
             </div>
           ) : (
             <ol className="relative space-y-0">
               {entries.map((entry, idx) => {
-                const config = getConfig(entry.action);
-                const Icon = config.icon;
+                const intent = actionIntentMap[entry.action];
+                const Icon = intent?.icon ?? Clock;
+                const iconClass = intent?.iconClass ?? "text-muted-foreground";
+                const dotClass = intent?.dotClass ?? "bg-muted border-border";
+                const label = intent
+                  ? t(intent.labelKey)
+                  : entry.action;
                 const isLast = idx === entries.length - 1;
 
                 return (
@@ -154,10 +151,10 @@ export function EvidenceHistoryDialog({
                       <div
                         className={cn(
                           "flex size-7 shrink-0 items-center justify-center rounded-full border",
-                          config.dotClass,
+                          dotClass,
                         )}
                       >
-                        <Icon className={cn("size-3.5", config.iconClass)} />
+                        <Icon className={cn("size-3.5", iconClass)} />
                       </div>
                       {!isLast && (
                         <div className="mt-1 w-px flex-1 bg-border" />
@@ -165,10 +162,10 @@ export function EvidenceHistoryDialog({
                     </div>
                     <div className={cn("pb-4", isLast && "pb-0")}>
                       <p className="text-sm font-medium leading-tight">
-                        {config.label}
+                        {label}
                       </p>
                       <p className="mt-0.5 text-xs text-muted-foreground">
-                        {entry.performed_by_name ?? "Sistema"} &middot;{" "}
+                        {entry.performed_by_name ?? t("system")} &middot;{" "}
                         {formatDate(entry.created_at)}
                       </p>
                       {entry.comment && (

--- a/src/components/evidence-review/evidence-review-client-page.tsx
+++ b/src/components/evidence-review/evidence-review-client-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -13,16 +14,9 @@ import {
 } from "@/lib/api/evidence-review";
 import { ApiError } from "@/lib/api/client";
 
-// ─── Tab config ───────────────────────────────────────────────────────────────
+// ─── Types ────────────────────────────────────────────────────────────────────
 
 type TabKey = EvidenceType | "all";
-
-const TABS: { key: TabKey; label: string }[] = [
-  { key: "all", label: "Todos" },
-  { key: "folder", label: "Carpetas" },
-  { key: "class", label: "Clases" },
-  { key: "honor", label: "Honores" },
-];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -42,6 +36,16 @@ interface EvidenceReviewClientPageProps {
 export function EvidenceReviewClientPage({
   initialItems,
 }: EvidenceReviewClientPageProps) {
+  const t = useTranslations("evidence_review.client");
+
+  // TABS defined inside component so labels go through t()
+  const TABS: { key: TabKey; label: string }[] = [
+    { key: "all",    label: t("tab_all") },
+    { key: "folder", label: t("tab_folders") },
+    { key: "class",  label: t("tab_classes") },
+    { key: "honor",  label: t("tab_honors") },
+  ];
+
   const [activeTab, setActiveTab] = useState<TabKey>("all");
   const [items, setItems] = useState<EvidenceItem[]>(initialItems);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -66,14 +70,14 @@ export function EvidenceReviewClientPage({
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudo actualizar la lista";
+          : t("error_refresh");
       toast.error(message);
     } finally {
       if (isMounted.current) {
         setIsRefreshing(false);
       }
     }
-  }, [activeTab]);
+  }, [activeTab, t]);
 
   // Reload data when tab changes
   useEffect(() => {
@@ -106,7 +110,7 @@ export function EvidenceReviewClientPage({
           <RefreshCw
             className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
-          Actualizar
+          {t("btn_refresh")}
         </Button>
       </div>
 

--- a/src/components/evidence-review/evidence-review-table.tsx
+++ b/src/components/evidence-review/evidence-review-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   CheckCircle2,
   XCircle,
@@ -77,8 +78,11 @@ function RowActions({
   onDetail,
   onHistory,
 }: RowActionsProps) {
+  const t = useTranslations("evidence_review.table");
   const [isApproving, setIsApproving] = useState(false);
   const pending = isPending(item.status, item.type);
+
+  void setIsApproving;
 
   return (
     <div className="flex items-center justify-end gap-1">
@@ -89,12 +93,12 @@ function RowActions({
             variant="ghost"
             size="icon-sm"
             onClick={onDetail}
-            aria-label="Ver archivos"
+            aria-label={t("action_view_files")}
           >
             <Eye className="size-4" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>Ver archivos</TooltipContent>
+        <TooltipContent>{t("action_view_files")}</TooltipContent>
       </Tooltip>
 
       {/* History */}
@@ -104,12 +108,12 @@ function RowActions({
             variant="ghost"
             size="icon-sm"
             onClick={onHistory}
-            aria-label="Ver historial"
+            aria-label={t("action_view_history")}
           >
             <History className="size-4" />
           </Button>
         </TooltipTrigger>
-        <TooltipContent>Ver historial</TooltipContent>
+        <TooltipContent>{t("action_view_history")}</TooltipContent>
       </Tooltip>
 
       {/* Approve — only when pending */}
@@ -122,7 +126,7 @@ function RowActions({
               className="text-success hover:bg-success/10 hover:text-success"
               onClick={onApprove}
               disabled={isApproving}
-              aria-label="Aprobar"
+              aria-label={t("action_approve")}
             >
               {isApproving ? (
                 <Loader2 className="size-4 animate-spin" />
@@ -131,7 +135,7 @@ function RowActions({
               )}
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Aprobar</TooltipContent>
+          <TooltipContent>{t("action_approve")}</TooltipContent>
         </Tooltip>
       )}
 
@@ -144,12 +148,12 @@ function RowActions({
               size="icon-sm"
               className="text-destructive hover:bg-destructive/10 hover:text-destructive"
               onClick={onReject}
-              aria-label="Rechazar"
+              aria-label={t("action_reject")}
             >
               <XCircle className="size-4" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Rechazar</TooltipContent>
+          <TooltipContent>{t("action_reject")}</TooltipContent>
         </Tooltip>
       )}
     </div>
@@ -164,6 +168,7 @@ interface EvidenceReviewTableProps {
 }
 
 export function EvidenceReviewTable({ items, onRefresh }: EvidenceReviewTableProps) {
+  const t = useTranslations("evidence_review.table");
   const [dialog, setDialog] = useState<DialogState>(null);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
@@ -221,8 +226,8 @@ export function EvidenceReviewTable({ items, onRefresh }: EvidenceReviewTablePro
     return (
       <EmptyState
         icon={FileSearch}
-        title="Sin evidencias pendientes"
-        description="No hay evidencias pendientes de revisión en este estado."
+        title={t("empty_title")}
+        description={t("empty_description")}
       />
     );
   }
@@ -241,30 +246,30 @@ export function EvidenceReviewTable({ items, onRefresh }: EvidenceReviewTablePro
                   <Checkbox
                     checked={allSelected ? true : someSelected ? "indeterminate" : false}
                     onCheckedChange={(checked) => toggleSelectAll(!!checked)}
-                    aria-label="Seleccionar todo"
+                    aria-label={t("select_all")}
                   />
                 )}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Miembro
+                {t("col_member")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Tipo
+                {t("col_type")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Sección / Honor
+                {t("col_section")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Archivos
+                {t("col_files")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Enviado
+                {t("col_submitted")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Estado
+                {t("col_status")}
               </TableHead>
               <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Acciones
+                {t("col_actions")}
               </TableHead>
             </TableRow>
           </TableHeader>
@@ -285,7 +290,7 @@ export function EvidenceReviewTable({ items, onRefresh }: EvidenceReviewTablePro
                       <Checkbox
                         checked={isSelected}
                         onCheckedChange={() => toggleRow(item.id, selectable)}
-                        aria-label={`Seleccionar ${item.member_name}`}
+                        aria-label={t("select_row", { name: item.member_name })}
                       />
                     ) : (
                       <span className="inline-block size-4" />

--- a/src/components/evidence-review/evidence-status-badge.tsx
+++ b/src/components/evidence-review/evidence-status-badge.tsx
@@ -1,28 +1,31 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { StatusBadge, type StatusIntent } from "@/components/ui/status-badge";
 import type { EvidenceType } from "@/lib/api/evidence-review";
 
-type IntentConfig = { label: string; intent: StatusIntent };
+type IntentConfig = { labelKey: string; intent: StatusIntent };
 
 // Backend enum evidence_validation_enum: PENDING | SUBMITTED | VALIDATED | REJECTED
 // Applies to folders_section_records.status AND class_section_progress.status
-const folderClassStatusMap: Record<string, IntentConfig> = {
-  PENDING: { label: "Sin enviar", intent: "neutral" },
-  SUBMITTED: { label: "Enviado", intent: "info" },
-  VALIDATED: { label: "Validado", intent: "success" },
-  REJECTED: { label: "Rechazado", intent: "destructive" },
-  pendiente: { label: "Enviado", intent: "info" },
-  validado: { label: "Validado", intent: "success" },
-  rechazado: { label: "Rechazado", intent: "destructive" },
+const folderClassIntentMap: Record<string, IntentConfig> = {
+  PENDING:   { labelKey: "no_submit",  intent: "neutral" },
+  SUBMITTED: { labelKey: "submitted",  intent: "info" },
+  VALIDATED: { labelKey: "validated",  intent: "success" },
+  REJECTED:  { labelKey: "rejected",   intent: "destructive" },
+  pendiente: { labelKey: "submitted",  intent: "info" },
+  validado:  { labelKey: "validated",  intent: "success" },
+  rechazado: { labelKey: "rejected",   intent: "destructive" },
 };
 
-const honorStatusMap: Record<string, IntentConfig> = {
-  PENDING: { label: "Sin enviar", intent: "neutral" },
-  SUBMITTED: { label: "Enviado", intent: "info" },
-  VALIDATED: { label: "Validado", intent: "success" },
-  REJECTED: { label: "Rechazado", intent: "destructive" },
-  in_progress: { label: "Enviado", intent: "info" },
-  validated: { label: "Validado", intent: "success" },
-  rejected: { label: "Rechazado", intent: "destructive" },
+const honorIntentMap: Record<string, IntentConfig> = {
+  PENDING:     { labelKey: "no_submit",  intent: "neutral" },
+  SUBMITTED:   { labelKey: "submitted",  intent: "info" },
+  VALIDATED:   { labelKey: "validated",  intent: "success" },
+  REJECTED:    { labelKey: "rejected",   intent: "destructive" },
+  in_progress: { labelKey: "submitted",  intent: "info" },
+  validated:   { labelKey: "validated",  intent: "success" },
+  rejected:    { labelKey: "rejected",   intent: "destructive" },
 };
 
 interface EvidenceStatusBadgeProps {
@@ -32,7 +35,10 @@ interface EvidenceStatusBadgeProps {
 }
 
 export function EvidenceStatusBadge({ status, type, className }: EvidenceStatusBadgeProps) {
-  const configMap = type === "honor" ? honorStatusMap : folderClassStatusMap;
-  const config = configMap[status] ?? { label: status, intent: "neutral" as StatusIntent };
-  return <StatusBadge intent={config.intent} label={config.label} className={className} />;
+  const t = useTranslations("evidence_review.statusBadge");
+  const configMap = type === "honor" ? honorIntentMap : folderClassIntentMap;
+  const config = configMap[status];
+  const label = config ? t(config.labelKey as "no_submit" | "submitted" | "validated" | "rejected") : status;
+  const intent: StatusIntent = config?.intent ?? "neutral";
+  return <StatusBadge intent={intent} label={label} className={className} />;
 }

--- a/src/components/evidence-review/evidence-type-badge.tsx
+++ b/src/components/evidence-review/evidence-type-badge.tsx
@@ -1,10 +1,13 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { StatusBadge, type StatusIntent } from "@/components/ui/status-badge";
 import type { EvidenceType } from "@/lib/api/evidence-review";
 
-const typeMap: Record<EvidenceType, { label: string; intent: StatusIntent }> = {
-  folder: { label: "Carpeta", intent: "primary" },
-  class: { label: "Clase", intent: "neutral" },
-  honor: { label: "Honor", intent: "success" },
+const typeIntentMap: Record<EvidenceType, StatusIntent> = {
+  folder: "primary",
+  class: "neutral",
+  honor: "success",
 };
 
 interface EvidenceTypeBadgeProps {
@@ -13,6 +16,8 @@ interface EvidenceTypeBadgeProps {
 }
 
 export function EvidenceTypeBadge({ type, className }: EvidenceTypeBadgeProps) {
-  const config = typeMap[type] ?? { label: type, intent: "neutral" as StatusIntent };
-  return <StatusBadge intent={config.intent} label={config.label} className={className} />;
+  const t = useTranslations("evidence_review.typeBadge");
+  const intent = typeIntentMap[type] ?? ("neutral" as StatusIntent);
+  const label = type in typeIntentMap ? t(type as EvidenceType) : type;
+  return <StatusBadge intent={intent} label={label} className={className} />;
 }

--- a/src/components/requests/assignments-client-page.tsx
+++ b/src/components/requests/assignments-client-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef, useEffect } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,7 @@ interface AssignmentsClientPageProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function AssignmentsClientPage({ initialRequests }: AssignmentsClientPageProps) {
+  const t = useTranslations("requests");
   const [activeTab, setActiveTab] = useState<StatusTab>("PENDING");
   const [requests, setRequests] = useState<AssignmentRequest[]>(initialRequests);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -43,12 +45,12 @@ export function AssignmentsClientPage({ initialRequests }: AssignmentsClientPage
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudo actualizar la lista";
+          : t("errors.refresh");
       toast.error(message);
     } finally {
       setIsRefreshing(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     if (isInitialMount.current) {
@@ -75,8 +77,7 @@ export function AssignmentsClientPage({ initialRequests }: AssignmentsClientPage
       {/* Toolbar */}
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          <span className="font-medium text-foreground">{filteredRequests.length}</span>{" "}
-          {filteredRequests.length === 1 ? "solicitud" : "solicitudes"}
+          {t("client.count", { count: filteredRequests.length })}
         </p>
         <Button
           variant="outline"
@@ -87,7 +88,7 @@ export function AssignmentsClientPage({ initialRequests }: AssignmentsClientPage
           <RefreshCw
             className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
-          Actualizar
+          {t("client.refresh")}
         </Button>
       </div>
 
@@ -96,19 +97,19 @@ export function AssignmentsClientPage({ initialRequests }: AssignmentsClientPage
         <div className="overflow-x-auto border-b border-border">
           <TabsList variant="line" className="gap-4">
             <TabsTrigger value="ALL" className="whitespace-nowrap">
-              Todas
+              {t("client.tabs.all")}
               {tabBadge(requests.length)}
             </TabsTrigger>
             <TabsTrigger value="PENDING" className="whitespace-nowrap">
-              Pendientes
+              {t("client.tabs.pending")}
               {tabBadge(pendingCount)}
             </TabsTrigger>
             <TabsTrigger value="APPROVED" className="whitespace-nowrap">
-              Aprobadas
+              {t("client.tabs.approved")}
               {tabBadge(approvedCount)}
             </TabsTrigger>
             <TabsTrigger value="REJECTED" className="whitespace-nowrap">
-              Rechazadas
+              {t("client.tabs.rejected")}
               {tabBadge(rejectedCount)}
             </TabsTrigger>
           </TabsList>

--- a/src/components/requests/assignments-table.tsx
+++ b/src/components/requests/assignments-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { CheckCircle2, XCircle, UserCog } from "lucide-react";
 import {
   Table,
@@ -58,14 +59,15 @@ interface AssignmentsTableProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function AssignmentsTable({ requests, onRefresh }: AssignmentsTableProps) {
+  const t = useTranslations("requests");
   const [dialog, setDialog] = useState<DialogState>(null);
 
   if (requests.length === 0) {
     return (
       <EmptyState
         icon={UserCog}
-        title="Sin solicitudes"
-        description="No hay solicitudes de asignación de rol en este estado."
+        title={t("assignments.table.empty.title")}
+        description={t("assignments.table.empty.description")}
       />
     );
   }
@@ -85,25 +87,25 @@ export function AssignmentsTable({ requests, onRefresh }: AssignmentsTableProps)
           <TableHeader>
             <TableRow>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Usuario destino
+                {t("assignments.table.columns.targetUser")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Sección
+                {t("assignments.table.columns.section")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Rol a asignar
+                {t("assignments.table.columns.roleToAssign")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Solicitado por
+                {t("assignments.table.columns.requestedBy")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Estado
+                {t("assignments.table.columns.status")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Fecha
+                {t("assignments.table.columns.date")}
               </TableHead>
               <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Acciones
+                {t("assignments.table.columns.actions")}
               </TableHead>
             </TableRow>
           </TableHeader>
@@ -141,12 +143,12 @@ export function AssignmentsTable({ requests, onRefresh }: AssignmentsTableProps)
                                 size="icon-sm"
                                 className="text-success hover:bg-success/10 hover:text-success"
                                 onClick={() => setDialog({ request: req, action: "approved" })}
-                                aria-label="Aprobar asignación"
+                                aria-label={t("assignments.table.actions.approveAriaLabel")}
                               >
                                 <CheckCircle2 className="size-4" />
                               </Button>
                             </TooltipTrigger>
-                            <TooltipContent>Aprobar</TooltipContent>
+                            <TooltipContent>{t("assignments.table.actions.approve")}</TooltipContent>
                           </Tooltip>
 
                           <Tooltip>
@@ -156,12 +158,12 @@ export function AssignmentsTable({ requests, onRefresh }: AssignmentsTableProps)
                                 size="icon-sm"
                                 className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                                 onClick={() => setDialog({ request: req, action: "rejected" })}
-                                aria-label="Rechazar asignación"
+                                aria-label={t("assignments.table.actions.rejectAriaLabel")}
                               >
                                 <XCircle className="size-4" />
                               </Button>
                             </TooltipTrigger>
-                            <TooltipContent>Rechazar</TooltipContent>
+                            <TooltipContent>{t("assignments.table.actions.reject")}</TooltipContent>
                           </Tooltip>
                         </>
                       )}
@@ -180,13 +182,13 @@ export function AssignmentsTable({ requests, onRefresh }: AssignmentsTableProps)
           action={dialog.action}
           title={
             dialog.action === "approved"
-              ? "Aprobar asignación de rol"
-              : "Rechazar asignación de rol"
+              ? t("assignments.dialog.approveTitle")
+              : t("assignments.dialog.rejectTitle")
           }
           description={
             dialog.action === "approved"
-              ? `Se aprobará la asignación de rol para ${targetName}.`
-              : `Se rechazará la solicitud de asignación para ${targetName}. El motivo es obligatorio.`
+              ? t("assignments.dialog.approveDescription", { name: targetName })
+              : t("assignments.dialog.rejectDescription", { name: targetName })
           }
           onOpenChange={(open) => { if (!open) setDialog(null); }}
           onSubmit={handleReview}

--- a/src/components/requests/request-status-badge.tsx
+++ b/src/components/requests/request-status-badge.tsx
@@ -1,11 +1,8 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { StatusBadge, type StatusIntent } from "@/components/ui/status-badge";
 import type { RequestStatus } from "@/lib/api/requests";
-
-const statusMap: Record<RequestStatus, { label: string; intent: StatusIntent }> = {
-  PENDING: { label: "Pendiente", intent: "warning" },
-  APPROVED: { label: "Aprobado", intent: "success" },
-  REJECTED: { label: "Rechazado", intent: "destructive" },
-};
 
 interface RequestStatusBadgeProps {
   status: RequestStatus | string;
@@ -13,6 +10,14 @@ interface RequestStatusBadgeProps {
 }
 
 export function RequestStatusBadge({ status, className }: RequestStatusBadgeProps) {
+  const t = useTranslations("requests");
+
+  const statusMap: Record<RequestStatus, { label: string; intent: StatusIntent }> = {
+    PENDING: { label: t("status.PENDING"), intent: "warning" },
+    APPROVED: { label: t("status.APPROVED"), intent: "success" },
+    REJECTED: { label: t("status.REJECTED"), intent: "destructive" },
+  };
+
   const config = statusMap[status as RequestStatus] ?? {
     label: status,
     intent: "neutral" as StatusIntent,

--- a/src/components/requests/transfers-client-page.tsx
+++ b/src/components/requests/transfers-client-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -24,6 +25,7 @@ interface TransfersClientPageProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function TransfersClientPage({ initialRequests }: TransfersClientPageProps) {
+  const t = useTranslations("requests");
   const [activeTab, setActiveTab] = useState<StatusTab>("PENDING");
   const [requests, setRequests] = useState<TransferRequest[]>(initialRequests);
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -43,12 +45,12 @@ export function TransfersClientPage({ initialRequests }: TransfersClientPageProp
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudo actualizar la lista";
+          : t("errors.refresh");
       toast.error(message);
     } finally {
       setIsRefreshing(false);
     }
-  }, []);
+  }, [t]);
 
   useEffect(() => {
     if (isInitialMount.current) {
@@ -75,8 +77,7 @@ export function TransfersClientPage({ initialRequests }: TransfersClientPageProp
       {/* Toolbar */}
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          <span className="font-medium text-foreground">{filteredRequests.length}</span>{" "}
-          {filteredRequests.length === 1 ? "solicitud" : "solicitudes"}
+          {t("client.count", { count: filteredRequests.length })}
         </p>
         <Button
           variant="outline"
@@ -87,7 +88,7 @@ export function TransfersClientPage({ initialRequests }: TransfersClientPageProp
           <RefreshCw
             className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
-          Actualizar
+          {t("client.refresh")}
         </Button>
       </div>
 
@@ -96,19 +97,19 @@ export function TransfersClientPage({ initialRequests }: TransfersClientPageProp
         <div className="overflow-x-auto border-b border-border">
           <TabsList variant="line" className="gap-4">
             <TabsTrigger value="ALL" className="whitespace-nowrap">
-              Todas
+              {t("client.tabs.all")}
               {tabBadge(requests.length)}
             </TabsTrigger>
             <TabsTrigger value="PENDING" className="whitespace-nowrap">
-              Pendientes
+              {t("client.tabs.pending")}
               {tabBadge(pendingCount)}
             </TabsTrigger>
             <TabsTrigger value="APPROVED" className="whitespace-nowrap">
-              Aprobadas
+              {t("client.tabs.approved")}
               {tabBadge(approvedCount)}
             </TabsTrigger>
             <TabsTrigger value="REJECTED" className="whitespace-nowrap">
-              Rechazadas
+              {t("client.tabs.rejected")}
               {tabBadge(rejectedCount)}
             </TabsTrigger>
           </TabsList>

--- a/src/components/requests/transfers-table.tsx
+++ b/src/components/requests/transfers-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { CheckCircle2, XCircle, ArrowRightLeft } from "lucide-react";
 import {
   Table,
@@ -58,14 +59,15 @@ interface TransfersTableProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function TransfersTable({ requests, onRefresh }: TransfersTableProps) {
+  const t = useTranslations("requests");
   const [dialog, setDialog] = useState<DialogState>(null);
 
   if (requests.length === 0) {
     return (
       <EmptyState
         icon={ArrowRightLeft}
-        title="Sin solicitudes"
-        description="No hay solicitudes de transferencia en este estado."
+        title={t("transfers.table.empty.title")}
+        description={t("transfers.table.empty.description")}
       />
     );
   }
@@ -85,25 +87,25 @@ export function TransfersTable({ requests, onRefresh }: TransfersTableProps) {
           <TableHeader>
             <TableRow>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Solicitante
+                {t("transfers.table.columns.requester")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Desde
+                {t("transfers.table.columns.from")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Hacia
+                {t("transfers.table.columns.to")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Motivo
+                {t("transfers.table.columns.reason")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Estado
+                {t("transfers.table.columns.status")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Fecha
+                {t("transfers.table.columns.date")}
               </TableHead>
               <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Acciones
+                {t("transfers.table.columns.actions")}
               </TableHead>
             </TableRow>
           </TableHeader>
@@ -143,12 +145,12 @@ export function TransfersTable({ requests, onRefresh }: TransfersTableProps) {
                                 size="icon-sm"
                                 className="text-success hover:bg-success/10 hover:text-success"
                                 onClick={() => setDialog({ request: req, action: "approved" })}
-                                aria-label="Aprobar transferencia"
+                                aria-label={t("transfers.table.actions.approveAriaLabel")}
                               >
                                 <CheckCircle2 className="size-4" />
                               </Button>
                             </TooltipTrigger>
-                            <TooltipContent>Aprobar</TooltipContent>
+                            <TooltipContent>{t("transfers.table.actions.approve")}</TooltipContent>
                           </Tooltip>
 
                           <Tooltip>
@@ -158,12 +160,12 @@ export function TransfersTable({ requests, onRefresh }: TransfersTableProps) {
                                 size="icon-sm"
                                 className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                                 onClick={() => setDialog({ request: req, action: "rejected" })}
-                                aria-label="Rechazar transferencia"
+                                aria-label={t("transfers.table.actions.rejectAriaLabel")}
                               >
                                 <XCircle className="size-4" />
                               </Button>
                             </TooltipTrigger>
-                            <TooltipContent>Rechazar</TooltipContent>
+                            <TooltipContent>{t("transfers.table.actions.reject")}</TooltipContent>
                           </Tooltip>
                         </>
                       )}
@@ -182,13 +184,13 @@ export function TransfersTable({ requests, onRefresh }: TransfersTableProps) {
           action={dialog.action}
           title={
             dialog.action === "approved"
-              ? "Aprobar transferencia"
-              : "Rechazar transferencia"
+              ? t("transfers.dialog.approveTitle")
+              : t("transfers.dialog.rejectTitle")
           }
           description={
             dialog.action === "approved"
-              ? `Se aprobará la solicitud de transferencia de ${requesterName}.`
-              : `Se rechazará la solicitud de ${requesterName}. El motivo es obligatorio.`
+              ? t("transfers.dialog.approveDescription", { name: requesterName })
+              : t("transfers.dialog.rejectDescription", { name: requesterName })
           }
           onOpenChange={(open) => { if (!open) setDialog(null); }}
           onSubmit={handleReview}

--- a/src/components/shared/data-table-pagination.tsx
+++ b/src/components/shared/data-table-pagination.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useSearchParams, useRouter } from "next/navigation";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import {
   Select,
@@ -26,6 +27,7 @@ export function DataTablePagination({
   limit,
   limitOptions = [20, 50, 100],
 }: DataTablePaginationProps) {
+  const t = useTranslations("shared.pagination");
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -47,11 +49,11 @@ export function DataTablePagination({
   return (
     <div className="flex flex-col items-center justify-between gap-4 sm:flex-row">
       <p className="text-sm text-muted-foreground">
-        Mostrando {from}–{to} de {total} registros
+        {t("showing", { from, to, total })}
       </p>
       <div className="flex items-center gap-4">
         <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground">Por página</span>
+          <span className="text-sm text-muted-foreground">{t("perPage")}</span>
           <Select defaultValue={String(limit)} onValueChange={handleLimitChange}>
             <SelectTrigger className="h-8 w-[70px]">
               <SelectValue />
@@ -65,14 +67,14 @@ export function DataTablePagination({
         </div>
         <div className="flex items-center gap-1">
           <span className="text-sm text-muted-foreground">
-            Página {page} de {totalPages}
+            {t("pageOf", { page, totalPages })}
           </span>
           <Button
             variant="outline"
             size="icon"
             className="size-8"
             disabled={page <= 1}
-            aria-label="Página anterior"
+            aria-label={t("prevPage")}
             onClick={() => router.push(buildHref(page - 1))}
           >
             <ChevronLeft className="size-4" />
@@ -82,7 +84,7 @@ export function DataTablePagination({
             size="icon"
             className="size-8"
             disabled={page >= totalPages}
-            aria-label="Página siguiente"
+            aria-label={t("nextPage")}
             onClick={() => router.push(buildHref(page + 1))}
           >
             <ChevronRight className="size-4" />

--- a/src/components/shared/endpoint-error-banner.tsx
+++ b/src/components/shared/endpoint-error-banner.tsx
@@ -1,14 +1,18 @@
+"use client";
+
 import Link from "next/link";
 import { AlertCircle, ShieldOff, Clock, ServerOff } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
 type EndpointState = "forbidden" | "missing" | "rate-limited";
+type ErrorBannerLabelKey = "forbidden" | "missing" | "rateLimited";
 
-const stateConfig: Record<EndpointState, { icon: React.ElementType; label: string; variant: "destructive" | "secondary" | "outline" }> = {
-  forbidden: { icon: ShieldOff, label: "Acceso denegado", variant: "destructive" },
-  missing: { icon: ServerOff, label: "No disponible", variant: "secondary" },
-  "rate-limited": { icon: Clock, label: "Límite de solicitudes", variant: "outline" },
+const stateConfig: Record<EndpointState, { icon: React.ElementType; labelKey: ErrorBannerLabelKey; variant: "destructive" | "secondary" | "outline" }> = {
+  forbidden: { icon: ShieldOff, labelKey: "forbidden", variant: "destructive" },
+  missing: { icon: ServerOff, labelKey: "missing", variant: "secondary" },
+  "rate-limited": { icon: Clock, labelKey: "rateLimited", variant: "outline" },
 };
 
 interface EndpointErrorBannerProps {
@@ -18,6 +22,7 @@ interface EndpointErrorBannerProps {
 }
 
 export function EndpointErrorBanner({ state, detail, showLoginLink }: EndpointErrorBannerProps) {
+  const t = useTranslations("shared.errorBanner");
   const config = stateConfig[state];
   const Icon = config.icon;
 
@@ -29,13 +34,13 @@ export function EndpointErrorBanner({ state, detail, showLoginLink }: EndpointEr
           <div className="flex items-center gap-2">
             <Badge variant={config.variant} className="gap-1">
               <Icon className="size-3" />
-              {config.label}
+              {t(config.labelKey)}
             </Badge>
           </div>
           <p className="text-sm text-muted-foreground">{detail}</p>
           {showLoginLink && (
             <Button variant="outline" size="sm" asChild>
-              <Link href="/login">Ir a login</Link>
+              <Link href="/login">{t("goToLogin")}</Link>
             </Button>
           )}
         </div>

--- a/src/components/shared/sortable-header.tsx
+++ b/src/components/shared/sortable-header.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
 import type { ReactNode } from "react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 
 export type SortDirection = "asc" | "desc";
@@ -25,6 +26,8 @@ export function SortableHeader<TField extends string>({
   align = "left",
   className,
 }: SortableHeaderProps<TField>) {
+  const t = useTranslations("shared.sortable");
+
   const isActive = activeField === field;
   const nextDirection: SortDirection =
     isActive && direction === "asc" ? "desc" : "asc";
@@ -35,15 +38,17 @@ export function SortableHeader<TField extends string>({
       ? ArrowUp
       : ArrowDown;
 
+  const ariaLabel = isActive
+    ? direction === "asc"
+      ? t("sortedAscending", { field })
+      : t("sortedDescending", { field })
+    : t("sortBy", { field });
+
   return (
     <button
       type="button"
       onClick={() => onSort(field, nextDirection)}
-      aria-label={
-        isActive
-          ? `Ordenado por ${field} ${direction === "asc" ? "ascendente" : "descendente"}. Click para invertir.`
-          : `Ordenar por ${field}`
-      }
+      aria-label={ariaLabel}
       className={cn(
         "inline-flex h-7 items-center gap-1.5 rounded-md px-1.5 text-xs font-medium uppercase tracking-wider text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
         align === "right" && "ml-auto",

--- a/src/components/system-config/system-config-client-page.tsx
+++ b/src/components/system-config/system-config-client-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -36,6 +37,7 @@ interface SystemConfigClientPageProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function SystemConfigClientPage({ initialConfigs }: SystemConfigClientPageProps) {
+  const t = useTranslations("system_config.client");
   const [configs, setConfigs] = useState<SystemConfig[]>(initialConfigs);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [editingConfig, setEditingConfig] = useState<SystemConfig | null>(null);
@@ -50,12 +52,12 @@ export function SystemConfigClientPage({ initialConfigs }: SystemConfigClientPag
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudo actualizar la configuración";
+          : t("error_refresh");
       toast.error(message);
     } finally {
       setIsRefreshing(false);
     }
-  }, []);
+  }, [t]);
 
   function openEdit(config: SystemConfig) {
     setEditingConfig(config);
@@ -69,8 +71,7 @@ export function SystemConfigClientPage({ initialConfigs }: SystemConfigClientPag
       {/* Toolbar */}
       <div className="flex items-center justify-between">
         <p className="text-sm text-muted-foreground">
-          <span className="font-medium text-foreground">{configs.length}</span>{" "}
-          {configs.length === 1 ? "entrada" : "entradas"}
+          {t("entry_count", { count: configs.length })}
         </p>
         <Button
           variant="outline"
@@ -81,7 +82,7 @@ export function SystemConfigClientPage({ initialConfigs }: SystemConfigClientPag
           <RefreshCw
             className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
           />
-          Actualizar
+          {t("btn_refresh")}
         </Button>
       </div>
 

--- a/src/components/system-config/system-config-table.tsx
+++ b/src/components/system-config/system-config-table.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Pencil, Settings2 } from "lucide-react";
 import {
   Table,
@@ -36,12 +37,14 @@ interface SystemConfigTableProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function SystemConfigTable({ configs, onEdit }: SystemConfigTableProps) {
+  const t = useTranslations("system_config.table");
+
   if (configs.length === 0) {
     return (
       <EmptyState
         icon={Settings2}
-        title="Sin configuraciones"
-        description="No hay entradas de configuración del sistema registradas."
+        title={t("empty_title")}
+        description={t("empty_description")}
       />
     );
   }
@@ -52,19 +55,19 @@ export function SystemConfigTable({ configs, onEdit }: SystemConfigTableProps) {
         <TableHeader>
           <TableRow>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Clave
+              {t("col_key")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Valor
+              {t("col_value")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Descripción
+              {t("col_description")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Tipo
+              {t("col_type")}
             </TableHead>
             <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Acciones
+              {t("col_actions")}
             </TableHead>
           </TableRow>
         </TableHeader>
@@ -83,7 +86,7 @@ export function SystemConfigTable({ configs, onEdit }: SystemConfigTableProps) {
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle max-w-64">
                 <span className="line-clamp-2 text-sm text-muted-foreground">
-                  {config.description ?? "—"}
+                  {config.description ?? t("no_description")}
                 </span>
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle">
@@ -92,7 +95,7 @@ export function SystemConfigTable({ configs, onEdit }: SystemConfigTableProps) {
                     {config.value_type}
                   </Badge>
                 ) : (
-                  <span className="text-sm text-muted-foreground">—</span>
+                  <span className="text-sm text-muted-foreground">{t("no_type")}</span>
                 )}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle">
@@ -103,12 +106,12 @@ export function SystemConfigTable({ configs, onEdit }: SystemConfigTableProps) {
                         variant="ghost"
                         size="icon-sm"
                         onClick={() => onEdit(config)}
-                        aria-label={`Editar ${config.key}`}
+                        aria-label={t("action_edit_key", { key: config.key })}
                       >
                         <Pencil className="size-4" />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent>Editar valor</TooltipContent>
+                    <TooltipContent>{t("action_edit")}</TooltipContent>
                   </Tooltip>
                 </div>
               </TableCell>

--- a/src/components/units/member-combobox.tsx
+++ b/src/components/units/member-combobox.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Check, ChevronsUpDown, X, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -39,7 +40,7 @@ export interface MemberComboboxProps {
   value: string;
   /** Called with the selected user_id, or empty string when cleared */
   onChange: (userId: string) => void;
-  /** Placeholder text shown when nothing is selected */
+  /** Placeholder text shown when nothing is selected. Defaults to the translated "searchPlaceholder" key. */
   placeholder?: string;
   /** Whether the combobox is disabled */
   disabled?: boolean;
@@ -57,12 +58,13 @@ export function MemberCombobox({
   clubId,
   value,
   onChange,
-  placeholder = "Seleccionar miembro...",
+  placeholder,
   disabled = false,
   excludeUserIds,
   members: externalMembers,
   onMembersLoaded,
 }: MemberComboboxProps) {
+  const t = useTranslations("units_admin.memberCombobox");
   const [open, setOpen] = useState(false);
   // Delay enabling the query until the popover is opened at least once,
   // and only when no external list was provided.
@@ -87,7 +89,7 @@ export function MemberCombobox({
   const error = fetchError
     ? fetchError instanceof Error
       ? fetchError.message
-      : "No se pudieron cargar los miembros"
+      : t("loadError")
     : null;
 
   function handleOpenChange(nextOpen: boolean) {
@@ -138,14 +140,14 @@ export function MemberCombobox({
               <span className="truncate text-sm">{selected.name}</span>
             </span>
           ) : (
-            <span className="truncate text-sm">{placeholder}</span>
+            <span className="truncate text-sm">{placeholder ?? t("searchPlaceholder")}</span>
           )}
 
           <span className="ml-2 flex shrink-0 items-center gap-0.5">
             {selected && !disabled && (
               <span
                 role="button"
-                aria-label="Limpiar seleccion"
+                aria-label={t("clearSelection")}
                 onClick={handleClear}
                 className="rounded p-0.5 hover:bg-muted"
               >
@@ -162,12 +164,12 @@ export function MemberCombobox({
         align="start"
       >
         <Command>
-          <CommandInput placeholder="Buscar por nombre..." />
+          <CommandInput placeholder={t("searchPlaceholder")} />
           <CommandList>
             {loading && (
               <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
                 <Loader2 className="size-4 animate-spin" />
-                Cargando miembros...
+                {t("loading")}
               </div>
             )}
 
@@ -178,7 +180,7 @@ export function MemberCombobox({
             )}
 
             {!loading && !error && filteredMembers.length === 0 && (
-              <CommandEmpty>Sin miembros disponibles.</CommandEmpty>
+              <CommandEmpty>{t("empty")}</CommandEmpty>
             )}
 
             {!loading && !error && filteredMembers.length > 0 && (

--- a/src/components/units/unit-form.tsx
+++ b/src/components/units/unit-form.tsx
@@ -3,6 +3,7 @@
 import { useActionState, useState, useCallback } from "react";
 import { useFormStatus } from "react-dom";
 import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -12,28 +13,21 @@ import type { UnitActionState } from "@/lib/units/actions";
 import type { Unit } from "@/lib/api/units";
 import type { ClubSectionMember } from "@/lib/api/clubs";
 
-// ─── Constants ────────────────────────────────────────────────────────────────
-
-const CLUB_TYPES = [
-  { value: 1, label: "Aventureros" },
-  { value: 2, label: "Conquistadores" },
-  { value: 3, label: "Guías Mayores" },
-];
-
 // ─── Submit button ────────────────────────────────────────────────────────────
 
 function SubmitButton({ mode }: { mode: "create" | "edit" }) {
   const { pending } = useFormStatus();
+  const t = useTranslations("units_admin.unitForm");
   return (
     <Button type="submit" disabled={pending}>
       {pending && <Loader2 className="size-4 animate-spin" />}
       {pending
         ? mode === "create"
-          ? "Creando..."
-          : "Guardando..."
+          ? t("submittingCreate")
+          : t("submittingEdit")
         : mode === "create"
-          ? "Crear unidad"
-          : "Guardar cambios"}
+          ? t("submitCreate")
+          : t("submitEdit")}
     </Button>
   );
 }
@@ -55,6 +49,15 @@ interface UnitFormProps {
 const initialState: UnitActionState = {};
 
 export function UnitForm({ mode, clubId, initialData, formAction }: UnitFormProps) {
+  const t = useTranslations("units_admin.unitForm");
+
+  // Club type options must live inside the component so t() is in scope
+  const CLUB_TYPES = [
+    { value: 1, label: t("clubTypeAdventurers") },
+    { value: 2, label: t("clubTypePathfinders") },
+    { value: 3, label: t("clubTypeMasterGuides") },
+  ];
+
   const [state, action] = useActionState(formAction, initialState);
 
   const defaultClubType = initialData?.club_type_id ?? 2;
@@ -84,19 +87,19 @@ export function UnitForm({ mode, clubId, initialData, formAction }: UnitFormProp
       {/* ── Datos generales ── */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Datos de la unidad</CardTitle>
+          <CardTitle className="text-base">{t("generalData")}</CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4 sm:grid-cols-2">
           {/* Nombre */}
           <div className="space-y-2 sm:col-span-2">
             <Label htmlFor="name">
-              Nombre <span className="text-destructive">*</span>
+              {t("name")} <span className="text-destructive">*</span>
             </Label>
             <Input
               id="name"
               name="name"
               defaultValue={initialData?.name ?? ""}
-              placeholder="Ej. Unidad Aguilas"
+              placeholder={t("namePlaceholder")}
               required
             />
           </div>
@@ -104,7 +107,7 @@ export function UnitForm({ mode, clubId, initialData, formAction }: UnitFormProp
           {/* Tipo de club */}
           <div className="space-y-2 sm:col-span-2">
             <Label htmlFor="club_type_id">
-              Tipo de club <span className="text-destructive">*</span>
+              {t("clubType")} <span className="text-destructive">*</span>
             </Label>
             <select
               id="club_type_id"
@@ -125,24 +128,25 @@ export function UnitForm({ mode, clubId, initialData, formAction }: UnitFormProp
       {/* ── Lideres de la unidad ── */}
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Lideres de la unidad</CardTitle>
+          <CardTitle className="text-base">{t("leaders")}</CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4 sm:grid-cols-2">
           <p className="text-xs text-muted-foreground sm:col-span-2">
-            Los campos marcados con{" "}
-            <span className="text-destructive">*</span> son obligatorios.
+            {t("requiredHint")}{" "}
+            <span className="text-destructive">*</span>{" "}
+            {t("requiredHintSuffix")}
           </p>
 
           {/* Capitan */}
           <div className="space-y-2 sm:col-span-2">
             <Label>
-              Capitan <span className="text-destructive">*</span>
+              {t("captain")} <span className="text-destructive">*</span>
             </Label>
             <MemberCombobox
               clubId={clubId}
               value={captainId}
               onChange={setCaptainId}
-              placeholder="Seleccionar capitan..."
+              placeholder={t("captainPlaceholder")}
               excludeUserIds={[secretaryId, advisorId, substituteAdvisorId].filter(Boolean)}
               members={sharedMembers}
               onMembersLoaded={handleMembersLoaded}
@@ -154,13 +158,13 @@ export function UnitForm({ mode, clubId, initialData, formAction }: UnitFormProp
           {/* Secretario */}
           <div className="space-y-2 sm:col-span-2">
             <Label>
-              Secretario <span className="text-destructive">*</span>
+              {t("secretary")} <span className="text-destructive">*</span>
             </Label>
             <MemberCombobox
               clubId={clubId}
               value={secretaryId}
               onChange={setSecretaryId}
-              placeholder="Seleccionar secretario..."
+              placeholder={t("secretaryPlaceholder")}
               excludeUserIds={[captainId, advisorId, substituteAdvisorId].filter(Boolean)}
               members={sharedMembers}
               onMembersLoaded={handleMembersLoaded}
@@ -171,13 +175,13 @@ export function UnitForm({ mode, clubId, initialData, formAction }: UnitFormProp
           {/* Consejero */}
           <div className="space-y-2 sm:col-span-2">
             <Label>
-              Consejero <span className="text-destructive">*</span>
+              {t("advisor")} <span className="text-destructive">*</span>
             </Label>
             <MemberCombobox
               clubId={clubId}
               value={advisorId}
               onChange={setAdvisorId}
-              placeholder="Seleccionar consejero..."
+              placeholder={t("advisorPlaceholder")}
               excludeUserIds={[captainId, secretaryId, substituteAdvisorId].filter(Boolean)}
               members={sharedMembers}
               onMembersLoaded={handleMembersLoaded}
@@ -188,14 +192,14 @@ export function UnitForm({ mode, clubId, initialData, formAction }: UnitFormProp
           {/* Consejero suplente */}
           <div className="space-y-2 sm:col-span-2">
             <Label>
-              Consejero suplente{" "}
-              <span className="text-muted-foreground">(opcional)</span>
+              {t("substituteAdvisor")}{" "}
+              <span className="text-muted-foreground">{t("substituteAdvisorOptional")}</span>
             </Label>
             <MemberCombobox
               clubId={clubId}
               value={substituteAdvisorId}
               onChange={setSubstituteAdvisorId}
-              placeholder="Seleccionar consejero suplente (opcional)..."
+              placeholder={t("substituteAdvisorPlaceholder")}
               excludeUserIds={[captainId, secretaryId, advisorId].filter(Boolean)}
               members={sharedMembers}
               onMembersLoaded={handleMembersLoaded}

--- a/src/components/validation/validation-client-page.tsx
+++ b/src/components/validation/validation-client-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -37,6 +38,7 @@ export function ValidationClientPage({
   initialHonors,
   sections,
 }: ValidationClientPageProps) {
+  const t = useTranslations("validation_admin");
   const [activeTab, setActiveTab] = useState<ValidationEntityType>("class");
   const [sectionId, setSectionId] = useState<string>("all");
   const [classValidations, setClassValidations] =
@@ -83,12 +85,12 @@ export function ValidationClientPage({
       const message =
         error instanceof ApiError
           ? error.message
-          : "No se pudo actualizar la lista";
+          : t("errors.refresh");
       toast.error(message);
     } finally {
       setIsRefreshing(false);
     }
-  }, [sectionId]);
+  }, [sectionId, t]);
 
   // Refresh when section filter changes, skip on initial mount (data comes from server)
   useEffect(() => {
@@ -111,10 +113,10 @@ export function ValidationClientPage({
           {sections.length > 0 && (
             <Select value={sectionId} onValueChange={setSectionId}>
               <SelectTrigger className="w-52">
-                <SelectValue placeholder="Todas las secciones" />
+                <SelectValue placeholder={t("client.filters.allSections")} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">Todas las secciones</SelectItem>
+                <SelectItem value="all">{t("client.filters.allSections")}</SelectItem>
                 {sections.map((s) => (
                   <SelectItem key={s.section_id} value={String(s.section_id)}>
                     {s.name}
@@ -127,8 +129,7 @@ export function ValidationClientPage({
 
         <div className="flex items-center gap-2">
           <p className="text-sm text-muted-foreground">
-            <span className="font-medium text-foreground">{currentCount}</span>{" "}
-            {currentCount === 1 ? "pendiente" : "pendientes"}
+            {t("client.count", { count: currentCount })}
           </p>
           <Button
             variant="outline"
@@ -139,7 +140,7 @@ export function ValidationClientPage({
             <RefreshCw
               className={`size-4 ${isRefreshing ? "animate-spin" : ""}`}
             />
-            Actualizar
+            {t("client.refresh")}
           </Button>
         </div>
       </div>
@@ -149,7 +150,7 @@ export function ValidationClientPage({
         <div className="overflow-x-auto border-b border-border">
           <TabsList variant="line" className="gap-4">
             <TabsTrigger value="class" className="whitespace-nowrap">
-              Clases
+              {t("client.tabs.class")}
               {filteredClasses.length > 0 && (
                 <span className="ml-1.5 inline-flex size-5 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
                   {filteredClasses.length}
@@ -157,7 +158,7 @@ export function ValidationClientPage({
               )}
             </TabsTrigger>
             <TabsTrigger value="honor" className="whitespace-nowrap">
-              Especialidades
+              {t("client.tabs.honor")}
               {filteredHonors.length > 0 && (
                 <span className="ml-1.5 inline-flex size-5 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold text-primary">
                   {filteredHonors.length}

--- a/src/components/validation/validation-history-dialog.tsx
+++ b/src/components/validation/validation-history-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { History, Clock, CheckCircle2, XCircle } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
@@ -34,44 +35,23 @@ function formatDate(iso: string): string {
   }
 }
 
-function getPerformerName(entry: ValidationHistoryEntry): string {
-  if (entry.performer?.first_name || entry.performer?.last_name) {
-    return [entry.performer.first_name, entry.performer.last_name]
-      .filter(Boolean)
-      .join(" ");
-  }
-  if (entry.performed_by) return entry.performed_by;
-  return "Sistema";
-}
+// ─── Action config (visual/structural only — labels resolved via t()) ─────────
 
-const actionConfig: Record<
+const actionVisual: Record<
   string,
-  { label: string; icon: React.ElementType; iconClass: string; dotClass: string }
+  { icon: React.ElementType; iconClass: string; dotClass: string }
 > = {
   APPROVED: {
-    label: "Aprobado",
     icon: CheckCircle2,
     iconClass: "text-success",
     dotClass: "bg-success/20 border-success/40",
   },
   REJECTED: {
-    label: "Rechazado",
     icon: XCircle,
     iconClass: "text-destructive",
     dotClass: "bg-destructive/20 border-destructive/40",
   },
 };
-
-function getActionConfig(action: string) {
-  return (
-    actionConfig[action] ?? {
-      label: action,
-      icon: Clock,
-      iconClass: "text-muted-foreground",
-      dotClass: "bg-muted border-border",
-    }
-  );
-}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -99,6 +79,26 @@ export function ValidationHistoryDialog({
   title,
   onOpenChange,
 }: ValidationHistoryDialogProps) {
+  const t = useTranslations("validation_admin");
+
+  function getPerformerName(entry: ValidationHistoryEntry): string {
+    if (entry.performer?.first_name || entry.performer?.last_name) {
+      return [entry.performer.first_name, entry.performer.last_name]
+        .filter(Boolean)
+        .join(" ");
+    }
+    if (entry.performed_by) return entry.performed_by;
+    return t("history.performer.system");
+  }
+
+  function getActionLabel(action: string): string {
+    const known = ["APPROVED", "REJECTED"] as const;
+    if ((known as readonly string[]).includes(action)) {
+      return t(`history.actions.${action as (typeof known)[number]}`);
+    }
+    return action;
+  }
+
   const { data: entries = [], isLoading: loading } = useQuery({
     queryKey: validationHistoryQueryKey(entityType, entityId),
     queryFn: async () => {
@@ -108,7 +108,7 @@ export function ValidationHistoryDialog({
         const message =
           error instanceof ApiError
             ? error.message
-            : "No se pudo cargar el historial";
+            : t("errors.loadHistory");
         toast.error(message);
         throw error;
       }
@@ -125,7 +125,7 @@ export function ValidationHistoryDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <History className="size-5 text-muted-foreground" />
-            Historial de validación
+            {t("history.title")}
           </DialogTitle>
           <p className="text-sm text-muted-foreground">{title}</p>
         </DialogHeader>
@@ -140,13 +140,17 @@ export function ValidationHistoryDialog({
           ) : entries.length === 0 ? (
             <div className="flex items-center gap-2 rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
               <Clock className="size-4 shrink-0" />
-              <span>No hay historial de validación aún.</span>
+              <span>{t("history.empty")}</span>
             </div>
           ) : (
             <ol className="relative space-y-0">
               {entries.map((entry, idx) => {
-                const config = getActionConfig(entry.action);
-                const Icon = config.icon;
+                const visual = actionVisual[entry.action] ?? {
+                  icon: Clock,
+                  iconClass: "text-muted-foreground",
+                  dotClass: "bg-muted border-border",
+                };
+                const Icon = visual.icon;
                 const isLast = idx === entries.length - 1;
 
                 return (
@@ -155,15 +159,17 @@ export function ValidationHistoryDialog({
                       <div
                         className={cn(
                           "flex size-7 shrink-0 items-center justify-center rounded-full border",
-                          config.dotClass,
+                          visual.dotClass,
                         )}
                       >
-                        <Icon className={cn("size-3.5", config.iconClass)} />
+                        <Icon className={cn("size-3.5", visual.iconClass)} />
                       </div>
                       {!isLast && <div className="mt-1 w-px flex-1 bg-border" />}
                     </div>
                     <div className={cn("pb-4", isLast && "pb-0")}>
-                      <p className="text-sm font-medium leading-tight">{config.label}</p>
+                      <p className="text-sm font-medium leading-tight">
+                        {getActionLabel(entry.action)}
+                      </p>
                       <p className="mt-0.5 text-xs text-muted-foreground">
                         {getPerformerName(entry)} &middot; {formatDate(entry.created_at)}
                       </p>

--- a/src/components/validation/validation-status-badge.tsx
+++ b/src/components/validation/validation-status-badge.tsx
@@ -1,12 +1,8 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { StatusBadge, type StatusIntent } from "@/components/ui/status-badge";
 import type { ValidationStatus } from "@/lib/api/validation";
-
-const statusMap: Record<ValidationStatus, { label: string; intent: StatusIntent }> = {
-  PENDING: { label: "Pendiente", intent: "warning" },
-  APPROVED: { label: "Aprobado", intent: "success" },
-  REJECTED: { label: "Rechazado", intent: "destructive" },
-  NEEDS_REVISION: { label: "Revisión", intent: "neutral" },
-};
 
 interface ValidationStatusBadgeProps {
   status: ValidationStatus;
@@ -14,6 +10,15 @@ interface ValidationStatusBadgeProps {
 }
 
 export function ValidationStatusBadge({ status, className }: ValidationStatusBadgeProps) {
+  const t = useTranslations("validation_admin");
+
+  const statusMap: Record<ValidationStatus, { label: string; intent: StatusIntent }> = {
+    PENDING: { label: t("status.PENDING"), intent: "warning" },
+    APPROVED: { label: t("status.APPROVED"), intent: "success" },
+    REJECTED: { label: t("status.REJECTED"), intent: "destructive" },
+    NEEDS_REVISION: { label: t("status.NEEDS_REVISION"), intent: "neutral" },
+  };
+
   const config = statusMap[status] ?? { label: status, intent: "neutral" as StatusIntent };
   return <StatusBadge intent={config.intent} label={config.label} className={className} />;
 }

--- a/src/components/validation/validation-table.tsx
+++ b/src/components/validation/validation-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { CheckCircle2, XCircle, History, ClipboardList } from "lucide-react";
 import {
@@ -65,6 +66,7 @@ export function ValidationTable({
   entityType,
   onRefresh,
 }: ValidationTableProps) {
+  const t = useTranslations("validation_admin");
   const [dialog, setDialog] = useState<DialogState>(null);
 
   function closeDialog() {
@@ -75,8 +77,8 @@ export function ValidationTable({
     return (
       <EmptyState
         icon={ClipboardList}
-        title="Sin pendientes"
-        description="No hay validaciones pendientes en este momento."
+        title={t("table.empty.title")}
+        description={t("table.empty.description")}
       />
     );
   }
@@ -85,6 +87,11 @@ export function ValidationTable({
   const memberName = activeValidation ? getMemberName(activeValidation) : "";
   const entityName = activeValidation?.entity?.name ?? "—";
 
+  const entityColumnHeader =
+    entityType === "class"
+      ? t("table.columns.class")
+      : t("table.columns.honor");
+
   return (
     <>
       <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
@@ -92,22 +99,22 @@ export function ValidationTable({
           <TableHeader>
             <TableRow>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Miembro
+                {t("table.columns.member")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                {entityType === "class" ? "Clase" : "Especialidad"}
+                {entityColumnHeader}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Sección
+                {t("table.columns.section")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Enviado
+                {t("table.columns.submitted")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Estado
+                {t("table.columns.status")}
               </TableHead>
               <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Acciones
+                {t("table.columns.actions")}
               </TableHead>
             </TableRow>
           </TableHeader>
@@ -142,12 +149,12 @@ export function ValidationTable({
                             variant="ghost"
                             size="icon-sm"
                             onClick={() => setDialog({ type: "history", validation: v })}
-                            aria-label="Ver historial"
+                            aria-label={t("table.actions.viewHistory")}
                           >
                             <History className="size-4" />
                           </Button>
                         </TooltipTrigger>
-                        <TooltipContent>Ver historial</TooltipContent>
+                        <TooltipContent>{t("table.actions.viewHistory")}</TooltipContent>
                       </Tooltip>
 
                       {/* Approve — only for PENDING */}
@@ -161,12 +168,12 @@ export function ValidationTable({
                               onClick={() =>
                                 setDialog({ type: "review", validation: v, action: "APPROVED" })
                               }
-                              aria-label="Aprobar"
+                              aria-label={t("table.actions.approve")}
                             >
                               <CheckCircle2 className="size-4" />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>Aprobar</TooltipContent>
+                          <TooltipContent>{t("table.actions.approve")}</TooltipContent>
                         </Tooltip>
                       )}
 
@@ -181,12 +188,12 @@ export function ValidationTable({
                               onClick={() =>
                                 setDialog({ type: "review", validation: v, action: "REJECTED" })
                               }
-                              aria-label="Rechazar"
+                              aria-label={t("table.actions.reject")}
                             >
                               <XCircle className="size-4" />
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>Rechazar</TooltipContent>
+                          <TooltipContent>{t("table.actions.reject")}</TooltipContent>
                         </Tooltip>
                       )}
                     </div>


### PR DESCRIPTION
## Summary

next-intl batch 7 — single PR combining 3 parallel agent worktrees.

- **shared** (extended +13 keys): sortable-header, data-table-pagination, endpoint-error-banner
- **units_admin** (extended +28 keys): member-combobox, unit-form
- **validation_admin** (extended +28 keys): status-badge, history-dialog, table, client-page
- **requests** (extended +44 keys): request-status-badge, transfers-table/client-page, assignments-table/client-page
- **evidence_review** (extended +35 keys): type-badge, status-badge, table, client-page, history-dialog
- **system_config** (extended +14 keys): table, client-page

21 component files + 4 messages JSONs. ~162 new keys per locale, 4 locales all in sync. Cumulative i18n project: ~1393 keys across 20 namespaces.

## Patterns applied

- **4 status badge components converted to `'use client'`** (`validation-status-badge`, `request-status-badge`, `evidence-status-badge`, `evidence-type-badge`) with module-level intent/icon constants split from `t()`-resolved labels.
- Module-level TABS / actionConfig / statusMap arrays moved inside component body, or split (visual at module, labels via `t()` in body).
- ICU plural for counts (`validation_admin.client.count`, `requests.*.client.count`, `system_config.client.entry_count`).
- ICU interpolation for dialog descriptions (`{name}` in transfers/assignments reject flows).
- **4 shared atoms left untouched** (`data-table-shell`, `app-alert-listener`, `page-header`, `empty-state`) — pure prop-driven, zero hardcoded user-visible strings. **NEW pattern decision worth flagging**: shared atoms with prop-driven labels do NOT receive forced i18n keys.
- `system_config` `groupByPrefix` headings left untouched — backend-derived identifiers (e.g. `honor`, `finance`), not authored UI copy.
- Standard date formatters (`Intl.DateTimeFormat("es-MX")`) deferred to separate locale-routing refactor.

## Test plan

- [x] All 3 sub-agents branched from `origin/development` HEAD `c28b1d7` cleanly (CRITICAL header verification)
- [x] No file overlap between 3 worktrees (0 merge conflicts)
- [x] Python deep-merge produced 4 locale JSONs in sync (`shared=14, units_admin=40, validation_admin=29, requests=45, evidence_review=50, system_config=15` per locale)
- [x] `pnpm typecheck` produces no new errors (6 pre-existing `vitest` module errors on baseline are unchanged)
- [x] All 4 `messages/*.json` parse as valid JSON
- [ ] Manual smoke: locale switcher across the 6 features
- [ ] fr/pt-BR translation review (deferred — accumulated across 15 PRs i18n)