### PR TITLE
feat(i18n): batch 8 — sla, enrollments, notifications, rankings, layout, folders, honors

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -93,6 +93,47 @@
       "catalog_inventory_categories": "Inventory categories",
       "catalog_honors": "Honors (catalog)",
       "catalog_master_honors": "Master honors"
+    },
+    "breadcrumbs": {
+      "dashboard": "Dashboard",
+      "users": "Users",
+      "catalogs": "Catalogs",
+      "geography": "Geography",
+      "countries": "Countries",
+      "unions": "Unions",
+      "local-fields": "Local fields",
+      "districts": "Districts",
+      "churches": "Churches",
+      "allergies": "Allergies",
+      "diseases": "Diseases",
+      "medicines": "Medicines",
+      "relationship-types": "Relationship types",
+      "ecclesiastical-years": "Ecclesiastical years",
+      "club-types": "Club types",
+      "club-ideals": "Club ideals",
+      "honor-categories": "Honor categories",
+      "clubs": "Clubs",
+      "new": "New",
+      "instances": "Instances",
+      "camporees": "Camporees",
+      "classes": "Classes",
+      "honors": "Honors",
+      "activities": "Activities",
+      "finances": "Finances",
+      "inventory": "Inventory",
+      "certifications": "Certifications",
+      "insurance": "Insurance",
+      "notifications": "Notifications",
+      "folders": "Folders",
+      "rbac": "Roles and permissions",
+      "permissions": "Permissions",
+      "roles": "Roles",
+      "matrix": "Matrix"
+    },
+    "themeToggle": {
+      "switchToLight": "Switch to light mode",
+      "switchToDark": "Switch to dark mode",
+      "switchTheme": "Toggle theme"
     }
   },
   "permissions": {
@@ -585,6 +626,50 @@
       "sent": "Notification sent successfully",
       "broadcast_sent": "Broadcast sent successfully",
       "club_sent": "Club notification sent successfully"
+    },
+    "forms": {
+      "direct_title": "Direct send",
+      "direct_description": "Send a push notification to a specific user.",
+      "broadcast_title": "Broadcast",
+      "broadcast_description": "Send a push notification to all registered users.",
+      "broadcast_warning": "This action will send the notification to all users with a registered FCM token.",
+      "club_title": "By club",
+      "club_description": "Send a notification to all members of a club.",
+      "label_user_id": "User ID",
+      "placeholder_user_id": "User UUID",
+      "label_title": "Title",
+      "placeholder_title_notification": "Notification title",
+      "placeholder_title_broadcast": "Broadcast title",
+      "label_body": "Message",
+      "placeholder_body": "Message body",
+      "label_instance_type": "Club type",
+      "placeholder_instance_type": "Select club type...",
+      "option_adventurers": "Adventurers",
+      "option_pathfinders": "Pathfinders",
+      "option_master_guilds": "Master Guides",
+      "label_instance_id": "Instance ID",
+      "placeholder_instance_id": "Numeric club ID",
+      "submit_send": "Send notification",
+      "submit_broadcast": "Send broadcast",
+      "submit_club": "Send to club"
+    },
+    "history": {
+      "col_title": "Title",
+      "col_type": "Type",
+      "col_target": "Target",
+      "col_sent": "Sent",
+      "col_failed": "Failed",
+      "col_sent_by": "Sent by",
+      "col_date": "Date",
+      "empty_title": "No history",
+      "empty_description": "No notifications have been sent yet.",
+      "error_load": "Could not load notification history.",
+      "type_broadcast": "Broadcast",
+      "type_user": "User",
+      "type_club": "Club",
+      "target_all": "All",
+      "target_user": "User",
+      "target_club_section": "Club section"
     }
   },
   "units": {
@@ -624,6 +709,75 @@
       "field_invalid": "The {field} field is invalid",
       "no_changes": "No changes to save",
       "honor_not_identified": "The honor to delete could not be identified."
+    },
+    "crud": {
+      "pageTitle": "Honors",
+      "pageDescription": "Honors catalog.",
+      "createButton": "Create honor",
+      "filtersTitle": "Filters",
+      "filtersSubtitle": "Refine the list by field",
+      "filterNameLabel": "Name",
+      "filterNamePlaceholder": "Search by name...",
+      "filterCategoryLabel": "Category",
+      "filterCategoryPlaceholder": "Category",
+      "filterCategoryAll": "All categories",
+      "filterClubTypeLabel": "Club type",
+      "filterClubTypePlaceholder": "Club type",
+      "filterClubTypeAll": "All types",
+      "filterLevelLabel": "Level",
+      "filterLevelPlaceholder": "Level",
+      "filterLevelAll": "All levels",
+      "filterLevelItem": "Level {level}",
+      "filterStatusLabel": "Status",
+      "filterStatusPlaceholder": "Status",
+      "filterStatusAll": "All statuses",
+      "filterStatusActive": "Active",
+      "filterStatusInactive": "Inactive",
+      "emptyTitle": "No honors",
+      "emptyDescription": "No records found.",
+      "emptyFilterTitle": "No results",
+      "emptyFilterDescription": "No honors match the filters.",
+      "tableHeaderHonor": "Honor",
+      "tableHeaderCategory": "Category",
+      "tableHeaderClubType": "Club type",
+      "tableHeaderLevel": "Level",
+      "tableHeaderStatus": "Status",
+      "tableHeaderActions": "Actions",
+      "badgeActive": "Active",
+      "badgeInactive": "Inactive",
+      "editButton": "Edit",
+      "editAriaLabel": "Edit {name}",
+      "deleteButton": "Delete",
+      "actionsButton": "Actions",
+      "noPermissionBanner": "You do not have permission to modify honors.",
+      "deleteDialogTitle": "Delete honor?",
+      "deleteDialogDescription": "The honor \"{name}\" will be logically deactivated.",
+      "deleteDialogCancel": "Cancel",
+      "deleteDialogConfirm": "Delete"
+    },
+    "form": {
+      "submitCreate": "Create honor",
+      "submitEdit": "Save changes",
+      "cancelButton": "Cancel",
+      "sectionDataTitle": "Honor data",
+      "sectionResourcesTitle": "Resources (optional)",
+      "nameLabel": "Name",
+      "namePlaceholder": "Honor name",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Optional description",
+      "categoryLabel": "Category",
+      "categoryPlaceholder": "Select category",
+      "clubTypeLabel": "Club type",
+      "clubTypePlaceholder": "Select club",
+      "levelLabel": "Level",
+      "masterHonorLabel": "Master honor",
+      "activeLabel": "Honor active",
+      "imageLabel": "Image (relative URL or file)",
+      "imagePlaceholder": "Honors/quilting.png",
+      "materialLabel": "Material (PDF)",
+      "materialPlaceholder": "Honors/Material/quilting.pdf",
+      "yearLabel": "Year",
+      "yearPlaceholder": "2026"
     }
   },
   "honor_categories": {
@@ -1689,6 +1843,59 @@
       "deleted": "Folder deleted successfully",
       "updated": "Folder updated successfully",
       "created": "Folder created successfully"
+    },
+    "statusBadge": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "management": {
+      "searchPlaceholder": "Search folder...",
+      "refreshButton": "Refresh",
+      "folderCount": "{count, plural, one {# folder} other {# folders}}",
+      "noDescription": "No description",
+      "noResultsTitle": "No results",
+      "noResultsDescription": "No folders matching \"{search}\" were found.",
+      "emptyTitle": "No folders",
+      "emptyDescription": "No evidence folders have been configured yet.",
+      "tableHeaderName": "Name",
+      "tableHeaderDescription": "Description",
+      "tableHeaderModules": "Modules",
+      "tableHeaderSections": "Sections",
+      "tableHeaderStatus": "Status",
+      "ariaFolderLink": "View folder {name}",
+      "ariaList": "Folders list",
+      "modulesLabel": "Modules",
+      "sectionsLabel": "Sections"
+    },
+    "detail": {
+      "backButton": "Back to folders",
+      "backLabel": "Back",
+      "refreshButton": "Refresh",
+      "moduleCount": "{count, plural, one {# module} other {# modules}}",
+      "sectionCount": "{count, plural, one {# section} other {# sections}}",
+      "noDescription": "No description",
+      "tabStructure": "Structure",
+      "tabInfo": "Information",
+      "noModulesTitle": "No modules",
+      "noModulesDescription": "This folder has no modules or sections configured yet.",
+      "tableHeaderModule": "Module / Section",
+      "tableHeaderDescription": "Description",
+      "tableHeaderOrder": "Order",
+      "tableHeaderSections": "Sections",
+      "sectionsBadge": "{count, plural, one {# section} other {# sections}}",
+      "noSectionsInModule": "This module has no sections yet.",
+      "infoId": "ID",
+      "infoName": "Name",
+      "infoDescription": "Description",
+      "infoStatus": "Status",
+      "infoModules": "Modules",
+      "infoTotalSections": "Total sections",
+      "infoCreated": "Created",
+      "infoUpdated": "Updated"
+    },
+    "errors": {
+      "refresh_failed": "Folders could not be refreshed",
+      "folder_refresh_failed": "The folder could not be refreshed"
     }
   },
   "validation_admin": {
@@ -2520,6 +2727,17 @@
       "deletingLabel": "Deleting...",
       "overrideDeleted": "Override deleted",
       "overrideDeleteError": "Error deleting the override"
+    },
+    "form": {
+      "saving": "Saving..."
+    },
+    "sum": {
+      "label": "Sum: {sum}"
+    },
+    "override": {
+      "selectPlaceholder": "Select club type",
+      "noTypesAvailable": "No types available",
+      "createLabel": "Create override"
     }
   },
   "classes": {
@@ -2600,6 +2818,122 @@
     "errors": {
       "approve": "An error occurred while approving the request",
       "reject": "An error occurred while rejecting the request"
+    }
+  },
+  "sla": {
+    "client": {
+      "title": "SLA Dashboard",
+      "description": "Operational metrics for investitures, validations, and camporees.",
+      "updated": "Updated {ago}",
+      "cached": " (cached)"
+    },
+    "stats": {
+      "total_pending": "Total pending",
+      "total_pending_subtitle": "{count} under active review",
+      "overdue": "Overdue",
+      "overdue_subtitle": "Submitted more than 30 days ago",
+      "overdue_badge_ok": "Up to date",
+      "overdue_badge_attention": "Needs attention",
+      "avg_approval": "Avg. approval time",
+      "avg_approval_subtitle": "From enrollment to investiture",
+      "avg_approval_days": "{days} day avg.",
+      "avg_approval_no_data": "No data",
+      "approval_rate": "Approval rate",
+      "approval_rate_subtitle": "{count} resolved (90 days)",
+      "approval_rate_badge": "{count} approved"
+    },
+    "pipeline": {
+      "title": "Investiture Pipeline",
+      "description": "Active enrollments by approval stage",
+      "description_distribution": "Distribution by status",
+      "empty": "No active enrollments in the pipeline.",
+      "tooltip_enrollments": "{count, plural, =1 {enrollment} other {enrollments}}"
+    },
+    "throughput": {
+      "title": "Throughput — Last 12 weeks",
+      "description": "Approved and rejected investitures per week",
+      "empty": "No throughput data available.",
+      "legend_approved": "Approved",
+      "legend_rejected": "Rejected"
+    },
+    "validation": {
+      "title": "Validation Queue",
+      "description_pending": "{count, plural, =1 {1 item awaiting validation} other {{count} items awaiting validation}}",
+      "description_empty": "No items pending validation",
+      "class_sections_label": "Class Sections",
+      "class_sections_subtitle": "Progress pending validation",
+      "honors_label": "Honors",
+      "honors_subtitle": "Honors pending validation"
+    },
+    "camporee": {
+      "title": "Camporee Approvals",
+      "description_pending": "{count, plural, =1 {1 record pending approval} other {{count} records pending approval}}",
+      "description_empty": "No records pending approval",
+      "clubs_label": "Registered clubs",
+      "clubs_subtitle": "Pending approval",
+      "members_label": "Registered members",
+      "members_subtitle": "Pending approval",
+      "payments_label": "Registered payments",
+      "payments_subtitle": "Pending approval"
+    },
+    "actions": {
+      "refresh": "Refresh",
+      "refreshing": "Refreshing..."
+    }
+  },
+  "enrollments": {
+    "table": {
+      "col_member": "Member",
+      "col_class": "Class",
+      "col_status": "Status",
+      "col_enrollment_date": "Enrollment date",
+      "col_submitted_at": "Submitted on",
+      "col_actions": "Actions",
+      "empty": "No enrollments to display.",
+      "status": {
+        "IN_PROGRESS": "In progress",
+        "SUBMITTED_FOR_VALIDATION": "Pending validation",
+        "APPROVED": "Approved",
+        "REJECTED": "Rejected",
+        "INVESTIDO": "Invested"
+      }
+    },
+    "actions": {
+      "approve": "Approve",
+      "reject": "Reject",
+      "view_user": "View user",
+      "reject_dialog_title": "Reject enrollment",
+      "reject_dialog_description": "This action will mark the enrollment as rejected. The member will not be able to continue the investiture process with this enrollment.",
+      "reject_dialog_cancel": "Cancel",
+      "reject_dialog_confirm": "Confirm rejection"
+    },
+    "toasts": {
+      "approved": "Enrollment approved successfully.",
+      "rejected": "Enrollment rejected successfully."
+    },
+    "errors": {
+      "generic": "An error occurred. Please try again."
+    }
+  },
+  "rankings": {
+    "breakdown": {
+      "compositeScore": "Institutional composite score",
+      "weightsApplied": "Applied weights",
+      "weightsSource": "Source",
+      "weightsSourceDefault": "Global default",
+      "weightsSourceOverride": "Override by club type",
+      "componentFolder": "Folders",
+      "componentFinance": "Finance",
+      "componentCamporee": "Camporees",
+      "componentEvidence": "Evidence",
+      "pointsOf": "{earned} / {max} points",
+      "sectionsEvaluated": "{count} sections evaluated",
+      "monthsClosedOnTime": "{closed} / {total} months closed on time",
+      "deadlineDay": "Deadline: day {day} of the following month",
+      "missedMonths": "Missed months: {months}",
+      "camporeeEventsOf": "{attended} / {available} events in scope",
+      "evidenceValidatedRejected": "{validated} validated / {rejected} rejected",
+      "evidencePendingExcluded": "{pending} pending (excluded from calculation)"
     }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -93,6 +93,47 @@
       "catalog_inventory_categories": "Categorías de inventario",
       "catalog_honors": "Especialidades (catálogo)",
       "catalog_master_honors": "Honores maestros"
+    },
+    "breadcrumbs": {
+      "dashboard": "Dashboard",
+      "users": "Usuarios",
+      "catalogs": "Catálogos",
+      "geography": "Geografía",
+      "countries": "Países",
+      "unions": "Uniones",
+      "local-fields": "Campos locales",
+      "districts": "Distritos",
+      "churches": "Iglesias",
+      "allergies": "Alergias",
+      "diseases": "Enfermedades",
+      "medicines": "Medicamentos",
+      "relationship-types": "Tipos de relación",
+      "ecclesiastical-years": "Años eclesiásticos",
+      "club-types": "Tipos de club",
+      "club-ideals": "Ideales de club",
+      "honor-categories": "Categorías de especialidades",
+      "clubs": "Clubes",
+      "new": "Nuevo",
+      "instances": "Instancias",
+      "camporees": "Camporees",
+      "classes": "Clases",
+      "honors": "Especialidades",
+      "activities": "Actividades",
+      "finances": "Finanzas",
+      "inventory": "Inventario",
+      "certifications": "Certificaciones",
+      "insurance": "Seguros",
+      "notifications": "Notificaciones",
+      "folders": "Folders",
+      "rbac": "Roles y permisos",
+      "permissions": "Permisos",
+      "roles": "Roles",
+      "matrix": "Matriz"
+    },
+    "themeToggle": {
+      "switchToLight": "Cambiar a modo claro",
+      "switchToDark": "Cambiar a modo oscuro",
+      "switchTheme": "Cambiar tema"
     }
   },
   "permissions": {
@@ -585,6 +626,50 @@
       "sent": "Notificación enviada correctamente",
       "broadcast_sent": "Broadcast enviado correctamente",
       "club_sent": "Notificación de club enviada correctamente"
+    },
+    "forms": {
+      "direct_title": "Envío directo",
+      "direct_description": "Enviar una notificación push a un usuario específico.",
+      "broadcast_title": "Broadcast",
+      "broadcast_description": "Enviar notificación push a todos los usuarios registrados.",
+      "broadcast_warning": "Esta acción enviará la notificación a todos los usuarios con token FCM registrado.",
+      "club_title": "Por club",
+      "club_description": "Enviar notificación a todos los miembros de un club.",
+      "label_user_id": "ID de usuario",
+      "placeholder_user_id": "UUID del usuario",
+      "label_title": "Título",
+      "placeholder_title_notification": "Título de la notificación",
+      "placeholder_title_broadcast": "Título del broadcast",
+      "label_body": "Mensaje",
+      "placeholder_body": "Contenido del mensaje",
+      "label_instance_type": "Tipo de club",
+      "placeholder_instance_type": "Seleccionar tipo de club...",
+      "option_adventurers": "Aventureros",
+      "option_pathfinders": "Conquistadores",
+      "option_master_guilds": "Guías Mayores",
+      "label_instance_id": "ID de instancia",
+      "placeholder_instance_id": "ID numérico del club",
+      "submit_send": "Enviar notificación",
+      "submit_broadcast": "Enviar broadcast",
+      "submit_club": "Enviar a club"
+    },
+    "history": {
+      "col_title": "Título",
+      "col_type": "Tipo",
+      "col_target": "Destino",
+      "col_sent": "Enviados",
+      "col_failed": "Fallidos",
+      "col_sent_by": "Enviado por",
+      "col_date": "Fecha",
+      "empty_title": "Sin historial",
+      "empty_description": "Aún no se han enviado notificaciones.",
+      "error_load": "No se pudo cargar el historial de notificaciones.",
+      "type_broadcast": "Broadcast",
+      "type_user": "Usuario",
+      "type_club": "Club",
+      "target_all": "Todos",
+      "target_user": "Usuario",
+      "target_club_section": "Sección de club"
     }
   },
   "units": {
@@ -624,6 +709,75 @@
       "field_invalid": "El campo {field} no es válido",
       "no_changes": "No hay cambios para guardar",
       "honor_not_identified": "No se pudo identificar la especialidad a eliminar."
+    },
+    "crud": {
+      "pageTitle": "Especialidades",
+      "pageDescription": "Catálogo de especialidades.",
+      "createButton": "Crear especialidad",
+      "filtersTitle": "Filtros",
+      "filtersSubtitle": "Refina el listado por campo",
+      "filterNameLabel": "Nombre",
+      "filterNamePlaceholder": "Buscar por nombre...",
+      "filterCategoryLabel": "Categoría",
+      "filterCategoryPlaceholder": "Categoría",
+      "filterCategoryAll": "Todas las categorías",
+      "filterClubTypeLabel": "Tipo de club",
+      "filterClubTypePlaceholder": "Tipo de club",
+      "filterClubTypeAll": "Todos los tipos",
+      "filterLevelLabel": "Nivel",
+      "filterLevelPlaceholder": "Nivel",
+      "filterLevelAll": "Todos los niveles",
+      "filterLevelItem": "Nivel {level}",
+      "filterStatusLabel": "Estado",
+      "filterStatusPlaceholder": "Estado",
+      "filterStatusAll": "Todos los estados",
+      "filterStatusActive": "Activos",
+      "filterStatusInactive": "Inactivos",
+      "emptyTitle": "No hay especialidades",
+      "emptyDescription": "No se encontraron registros.",
+      "emptyFilterTitle": "Sin resultados",
+      "emptyFilterDescription": "No hay especialidades que coincidan con los filtros.",
+      "tableHeaderHonor": "Especialidad",
+      "tableHeaderCategory": "Categoría",
+      "tableHeaderClubType": "Tipo de club",
+      "tableHeaderLevel": "Nivel",
+      "tableHeaderStatus": "Estado",
+      "tableHeaderActions": "Acciones",
+      "badgeActive": "Activo",
+      "badgeInactive": "Inactivo",
+      "editButton": "Editar",
+      "editAriaLabel": "Editar {name}",
+      "deleteButton": "Eliminar",
+      "actionsButton": "Acciones",
+      "noPermissionBanner": "No cuentas con permisos para modificar especialidades.",
+      "deleteDialogTitle": "¿Eliminar especialidad?",
+      "deleteDialogDescription": "Se desactivará de forma lógica la especialidad \"{name}\".",
+      "deleteDialogCancel": "Cancelar",
+      "deleteDialogConfirm": "Eliminar"
+    },
+    "form": {
+      "submitCreate": "Crear especialidad",
+      "submitEdit": "Guardar cambios",
+      "cancelButton": "Cancelar",
+      "sectionDataTitle": "Datos de la especialidad",
+      "sectionResourcesTitle": "Recursos (opcional)",
+      "nameLabel": "Nombre",
+      "namePlaceholder": "Nombre de la especialidad",
+      "descriptionLabel": "Descripción",
+      "descriptionPlaceholder": "Descripción opcional",
+      "categoryLabel": "Categoría",
+      "categoryPlaceholder": "Seleccionar categoría",
+      "clubTypeLabel": "Tipo de club",
+      "clubTypePlaceholder": "Seleccionar club",
+      "levelLabel": "Nivel",
+      "masterHonorLabel": "Master honor",
+      "activeLabel": "Especialidad activa",
+      "imageLabel": "Imagen (URL relativa o archivo)",
+      "imagePlaceholder": "Especialidades/acolchado.png",
+      "materialLabel": "Material (PDF)",
+      "materialPlaceholder": "Especialidades/Material/acolchado.pdf",
+      "yearLabel": "Año",
+      "yearPlaceholder": "2026"
     }
   },
   "honor_categories": {
@@ -1689,6 +1843,59 @@
       "deleted": "Carpeta eliminada correctamente",
       "updated": "Carpeta actualizada correctamente",
       "created": "Carpeta creada correctamente"
+    },
+    "statusBadge": {
+      "active": "Activa",
+      "inactive": "Inactiva"
+    },
+    "management": {
+      "searchPlaceholder": "Buscar carpeta...",
+      "refreshButton": "Actualizar",
+      "folderCount": "{count, plural, one {# carpeta} other {# carpetas}}",
+      "noDescription": "Sin descripción",
+      "noResultsTitle": "Sin resultados",
+      "noResultsDescription": "No se encontraron carpetas que coincidan con \"{search}\".",
+      "emptyTitle": "Sin carpetas",
+      "emptyDescription": "No hay carpetas de evidencias configuradas todavía.",
+      "tableHeaderName": "Nombre",
+      "tableHeaderDescription": "Descripción",
+      "tableHeaderModules": "Módulos",
+      "tableHeaderSections": "Secciones",
+      "tableHeaderStatus": "Estado",
+      "ariaFolderLink": "Ver carpeta {name}",
+      "ariaList": "Lista de carpetas",
+      "modulesLabel": "Módulos",
+      "sectionsLabel": "Secciones"
+    },
+    "detail": {
+      "backButton": "Volver a carpetas",
+      "backLabel": "Volver",
+      "refreshButton": "Actualizar",
+      "moduleCount": "{count, plural, one {# módulo} other {# módulos}}",
+      "sectionCount": "{count, plural, one {# sección} other {# secciones}}",
+      "noDescription": "Sin descripción",
+      "tabStructure": "Estructura",
+      "tabInfo": "Información",
+      "noModulesTitle": "Sin módulos",
+      "noModulesDescription": "Esta carpeta no tiene módulos ni secciones configurados todavía.",
+      "tableHeaderModule": "Módulo / Sección",
+      "tableHeaderDescription": "Descripción",
+      "tableHeaderOrder": "Orden",
+      "tableHeaderSections": "Secciones",
+      "sectionsBadge": "{count, plural, one {# sección} other {# secciones}}",
+      "noSectionsInModule": "Este módulo no tiene secciones todavía.",
+      "infoId": "ID",
+      "infoName": "Nombre",
+      "infoDescription": "Descripción",
+      "infoStatus": "Estado",
+      "infoModules": "Módulos",
+      "infoTotalSections": "Secciones totales",
+      "infoCreated": "Creada",
+      "infoUpdated": "Actualizada"
+    },
+    "errors": {
+      "refresh_failed": "No se pudieron actualizar las carpetas",
+      "folder_refresh_failed": "No se pudo actualizar la carpeta"
     }
   },
   "validation_admin": {
@@ -2520,6 +2727,17 @@
       "deletingLabel": "Eliminando...",
       "overrideDeleted": "Override eliminado",
       "overrideDeleteError": "Error al eliminar el override"
+    },
+    "form": {
+      "saving": "Guardando..."
+    },
+    "sum": {
+      "label": "Suma: {sum}"
+    },
+    "override": {
+      "selectPlaceholder": "Seleccionar tipo de club",
+      "noTypesAvailable": "Sin tipos disponibles",
+      "createLabel": "Crear override"
     }
   },
   "classes": {
@@ -2600,6 +2818,122 @@
     "errors": {
       "approve": "Ocurrió un error al aprobar la solicitud",
       "reject": "Ocurrió un error al rechazar la solicitud"
+    }
+  },
+  "sla": {
+    "client": {
+      "title": "SLA Dashboard",
+      "description": "Métricas operativas de investiduras, validaciones y camporees.",
+      "updated": "Actualizado {ago}",
+      "cached": " (cache)"
+    },
+    "stats": {
+      "total_pending": "Total pendientes",
+      "total_pending_subtitle": "{count} en revisión activa",
+      "overdue": "Vencidos",
+      "overdue_subtitle": "Enviados hace más de 30 días",
+      "overdue_badge_ok": "Al día",
+      "overdue_badge_attention": "Requieren atención",
+      "avg_approval": "Promedio de aprobación",
+      "avg_approval_subtitle": "De inscripción a investido",
+      "avg_approval_days": "{days} días promedio",
+      "avg_approval_no_data": "Sin datos",
+      "approval_rate": "Tasa de aprobación",
+      "approval_rate_subtitle": "{count} resueltos (90 días)",
+      "approval_rate_badge": "{count} aprobados"
+    },
+    "pipeline": {
+      "title": "Pipeline de Investidura",
+      "description": "Inscripciones activas por estado de aprobación",
+      "description_distribution": "Distribución por estado",
+      "empty": "No hay inscripciones activas en el pipeline.",
+      "tooltip_enrollments": "{count, plural, =1 {inscripción} other {inscripciones}}"
+    },
+    "throughput": {
+      "title": "Throughput — Últimas 12 semanas",
+      "description": "Investiduras aprobadas y rechazadas por semana",
+      "empty": "No hay datos de throughput disponibles.",
+      "legend_approved": "Aprobados",
+      "legend_rejected": "Rechazados"
+    },
+    "validation": {
+      "title": "Cola de Validación",
+      "description_pending": "{count, plural, =1 {1 ítem esperando validación} other {{count} ítems esperando validación}}",
+      "description_empty": "Sin ítems pendientes de validación",
+      "class_sections_label": "Secciones de Clase",
+      "class_sections_subtitle": "Progreso pendiente de validar",
+      "honors_label": "Especialidades",
+      "honors_subtitle": "Honores pendientes de validar"
+    },
+    "camporee": {
+      "title": "Aprobaciones de Camporee",
+      "description_pending": "{count, plural, =1 {1 registro pendiente de aprobación} other {{count} registros pendientes de aprobación}}",
+      "description_empty": "Sin registros pendientes de aprobación",
+      "clubs_label": "Clubes registrados",
+      "clubs_subtitle": "Pendientes de aprobación",
+      "members_label": "Miembros registrados",
+      "members_subtitle": "Pendientes de aprobación",
+      "payments_label": "Pagos registrados",
+      "payments_subtitle": "Pendientes de aprobación"
+    },
+    "actions": {
+      "refresh": "Actualizar",
+      "refreshing": "Actualizando..."
+    }
+  },
+  "enrollments": {
+    "table": {
+      "col_member": "Miembro",
+      "col_class": "Clase",
+      "col_status": "Estado",
+      "col_enrollment_date": "Fecha inscripción",
+      "col_submitted_at": "Enviado el",
+      "col_actions": "Acciones",
+      "empty": "No hay inscripciones para mostrar.",
+      "status": {
+        "IN_PROGRESS": "En progreso",
+        "SUBMITTED_FOR_VALIDATION": "Pendiente validación",
+        "APPROVED": "Aprobado",
+        "REJECTED": "Rechazado",
+        "INVESTIDO": "Investido"
+      }
+    },
+    "actions": {
+      "approve": "Aprobar",
+      "reject": "Rechazar",
+      "view_user": "Ver usuario",
+      "reject_dialog_title": "Rechazar inscripción",
+      "reject_dialog_description": "Esta acción marcará la inscripción como rechazada. El miembro no podrá continuar con el proceso de investidura con esta inscripción.",
+      "reject_dialog_cancel": "Cancelar",
+      "reject_dialog_confirm": "Confirmar rechazo"
+    },
+    "toasts": {
+      "approved": "Inscripción aprobada correctamente.",
+      "rejected": "Inscripción rechazada correctamente."
+    },
+    "errors": {
+      "generic": "Ocurrió un error. Intenta de nuevo."
+    }
+  },
+  "rankings": {
+    "breakdown": {
+      "compositeScore": "Puntaje compuesto institucional",
+      "weightsApplied": "Pesos aplicados",
+      "weightsSource": "Fuente",
+      "weightsSourceDefault": "Default global",
+      "weightsSourceOverride": "Override por tipo de club",
+      "componentFolder": "Carpetas",
+      "componentFinance": "Finanzas",
+      "componentCamporee": "Camporees",
+      "componentEvidence": "Evidencias",
+      "pointsOf": "{earned} / {max} puntos",
+      "sectionsEvaluated": "{count} secciones evaluadas",
+      "monthsClosedOnTime": "{closed} / {total} meses cerrados a tiempo",
+      "deadlineDay": "Deadline: día {day} del mes siguiente",
+      "missedMonths": "Meses faltantes: {months}",
+      "camporeeEventsOf": "{attended} / {available} eventos del scope",
+      "evidenceValidatedRejected": "{validated} validadas / {rejected} rechazadas",
+      "evidencePendingExcluded": "{pending} pendientes (excluidas del cálculo)"
     }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -93,6 +93,47 @@
       "catalog_inventory_categories": "Categories d'inventaire",
       "catalog_honors": "Specialites (catalogue)",
       "catalog_master_honors": "Honneurs maitres"
+    },
+    "breadcrumbs": {
+      "dashboard": "Tableau de bord",
+      "users": "Utilisateurs",
+      "catalogs": "Catalogues",
+      "geography": "Géographie",
+      "countries": "Pays",
+      "unions": "Unions",
+      "local-fields": "Champs locaux",
+      "districts": "Districts",
+      "churches": "Églises",
+      "allergies": "Allergies",
+      "diseases": "Maladies",
+      "medicines": "Médicaments",
+      "relationship-types": "Types de relation",
+      "ecclesiastical-years": "Années ecclésiastiques",
+      "club-types": "Types de club",
+      "club-ideals": "Idéaux de club",
+      "honor-categories": "Catégories de spécialités",
+      "clubs": "Clubs",
+      "new": "Nouveau",
+      "instances": "Instances",
+      "camporees": "Camporées",
+      "classes": "Classes",
+      "honors": "Spécialités",
+      "activities": "Activités",
+      "finances": "Finances",
+      "inventory": "Inventaire",
+      "certifications": "Certifications",
+      "insurance": "Assurances",
+      "notifications": "Notifications",
+      "folders": "Dossiers",
+      "rbac": "Rôles et permissions",
+      "permissions": "Permissions",
+      "roles": "Rôles",
+      "matrix": "Matrice"
+    },
+    "themeToggle": {
+      "switchToLight": "Passer en mode clair",
+      "switchToDark": "Passer en mode sombre",
+      "switchTheme": "Changer le thème"
     }
   },
   "permissions": {
@@ -585,6 +626,50 @@
       "sent": "Notification envoyée avec succès",
       "broadcast_sent": "Diffusion envoyée avec succès",
       "club_sent": "Notification du club envoyée avec succès"
+    },
+    "forms": {
+      "direct_title": "Envoi direct",
+      "direct_description": "Envoyer une notification push à un utilisateur spécifique.",
+      "broadcast_title": "Diffusion",
+      "broadcast_description": "Envoyer une notification push à tous les utilisateurs enregistrés.",
+      "broadcast_warning": "Cette action enverra la notification à tous les utilisateurs avec un token FCM enregistré.",
+      "club_title": "Par club",
+      "club_description": "Envoyer une notification à tous les membres d'un club.",
+      "label_user_id": "ID utilisateur",
+      "placeholder_user_id": "UUID de l'utilisateur",
+      "label_title": "Titre",
+      "placeholder_title_notification": "Titre de la notification",
+      "placeholder_title_broadcast": "Titre de la diffusion",
+      "label_body": "Message",
+      "placeholder_body": "Corps du message",
+      "label_instance_type": "Type de club",
+      "placeholder_instance_type": "Sélectionner le type de club ...",
+      "option_adventurers": "Aventuriers",
+      "option_pathfinders": "Éclaireurs",
+      "option_master_guilds": "Guides principaux",
+      "label_instance_id": "ID instance",
+      "placeholder_instance_id": "ID numérique du club",
+      "submit_send": "Envoyer la notification",
+      "submit_broadcast": "Envoyer la diffusion",
+      "submit_club": "Envoyer au club"
+    },
+    "history": {
+      "col_title": "Titre",
+      "col_type": "Type",
+      "col_target": "Destinataire",
+      "col_sent": "Envoyés",
+      "col_failed": "Échoués",
+      "col_sent_by": "Envoyé par",
+      "col_date": "Date",
+      "empty_title": "Aucun historique",
+      "empty_description": "Aucune notification n'a encore été envoyée.",
+      "error_load": "Impossible de charger l'historique des notifications.",
+      "type_broadcast": "Diffusion",
+      "type_user": "Utilisateur",
+      "type_club": "Club",
+      "target_all": "Tous",
+      "target_user": "Utilisateur",
+      "target_club_section": "Section de club"
     }
   },
   "units": {
@@ -624,6 +709,75 @@
       "field_invalid": "Le champ {field} n'est pas valide",
       "no_changes": "Aucune modification à enregistrer",
       "honor_not_identified": "Impossible d'identifier la spécialité à supprimer."
+    },
+    "crud": {
+      "pageTitle": "Spécialités",
+      "pageDescription": "Catalogue des spécialités.",
+      "createButton": "Créer une spécialité",
+      "filtersTitle": "Filtres",
+      "filtersSubtitle": "Affiner la liste par champ",
+      "filterNameLabel": "Nom",
+      "filterNamePlaceholder": "Rechercher par nom ...",
+      "filterCategoryLabel": "Catégorie",
+      "filterCategoryPlaceholder": "Catégorie",
+      "filterCategoryAll": "Toutes les catégories",
+      "filterClubTypeLabel": "Type de club",
+      "filterClubTypePlaceholder": "Type de club",
+      "filterClubTypeAll": "Tous les types",
+      "filterLevelLabel": "Niveau",
+      "filterLevelPlaceholder": "Niveau",
+      "filterLevelAll": "Tous les niveaux",
+      "filterLevelItem": "Niveau {level}",
+      "filterStatusLabel": "État",
+      "filterStatusPlaceholder": "État",
+      "filterStatusAll": "Tous les états",
+      "filterStatusActive": "Actifs",
+      "filterStatusInactive": "Inactifs",
+      "emptyTitle": "Aucune spécialité",
+      "emptyDescription": "Aucun enregistrement trouvé.",
+      "emptyFilterTitle": "Aucun résultat",
+      "emptyFilterDescription": "Aucune spécialité ne correspond aux filtres.",
+      "tableHeaderHonor": "Spécialité",
+      "tableHeaderCategory": "Catégorie",
+      "tableHeaderClubType": "Type de club",
+      "tableHeaderLevel": "Niveau",
+      "tableHeaderStatus": "État",
+      "tableHeaderActions": "Actions",
+      "badgeActive": "Actif",
+      "badgeInactive": "Inactif",
+      "editButton": "Éditer",
+      "editAriaLabel": "Éditer {name}",
+      "deleteButton": "Supprimer",
+      "actionsButton": "Actions",
+      "noPermissionBanner": "Vous n’avez pas la permission de modifier les spécialités.",
+      "deleteDialogTitle": "Supprimer la spécialité ?",
+      "deleteDialogDescription": "La spécialité « {name} » sera désactivée de façon logique.",
+      "deleteDialogCancel": "Annuler",
+      "deleteDialogConfirm": "Supprimer"
+    },
+    "form": {
+      "submitCreate": "Créer la spécialité",
+      "submitEdit": "Enregistrer les modifications",
+      "cancelButton": "Annuler",
+      "sectionDataTitle": "Données de la spécialité",
+      "sectionResourcesTitle": "Ressources (facultatif)",
+      "nameLabel": "Nom",
+      "namePlaceholder": "Nom de la spécialité",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "Description facultative",
+      "categoryLabel": "Catégorie",
+      "categoryPlaceholder": "Sélectionner une catégorie",
+      "clubTypeLabel": "Type de club",
+      "clubTypePlaceholder": "Sélectionner un club",
+      "levelLabel": "Niveau",
+      "masterHonorLabel": "Spécialité maître",
+      "activeLabel": "Spécialité active",
+      "imageLabel": "Image (URL relative ou fichier)",
+      "imagePlaceholder": "Spécialités/matelassage.png",
+      "materialLabel": "Matériel (PDF)",
+      "materialPlaceholder": "Spécialités/Matériel/matelassage.pdf",
+      "yearLabel": "Année",
+      "yearPlaceholder": "2026"
     }
   },
   "honor_categories": {
@@ -1689,6 +1843,59 @@
       "deleted": "Dossier supprimé avec succès",
       "updated": "Dossier mis à jour avec succès",
       "created": "Dossier créé avec succès"
+    },
+    "statusBadge": {
+      "active": "Active",
+      "inactive": "Inactive"
+    },
+    "management": {
+      "searchPlaceholder": "Rechercher un dossier ...",
+      "refreshButton": "Actualiser",
+      "folderCount": "{count, plural, one {# dossier} other {# dossiers}}",
+      "noDescription": "Sans description",
+      "noResultsTitle": "Aucun résultat",
+      "noResultsDescription": "Aucun dossier correspondant à « {search} » n’a été trouvé.",
+      "emptyTitle": "Aucun dossier",
+      "emptyDescription": "Aucun dossier de preuves n’a encore été configuré.",
+      "tableHeaderName": "Nom",
+      "tableHeaderDescription": "Description",
+      "tableHeaderModules": "Modules",
+      "tableHeaderSections": "Sections",
+      "tableHeaderStatus": "État",
+      "ariaFolderLink": "Voir le dossier {name}",
+      "ariaList": "Liste des dossiers",
+      "modulesLabel": "Modules",
+      "sectionsLabel": "Sections"
+    },
+    "detail": {
+      "backButton": "Retour aux dossiers",
+      "backLabel": "Retour",
+      "refreshButton": "Actualiser",
+      "moduleCount": "{count, plural, one {# module} other {# modules}}",
+      "sectionCount": "{count, plural, one {# section} other {# sections}}",
+      "noDescription": "Sans description",
+      "tabStructure": "Structure",
+      "tabInfo": "Informations",
+      "noModulesTitle": "Aucun module",
+      "noModulesDescription": "Ce dossier n’a pas encore de modules ni de sections configurés.",
+      "tableHeaderModule": "Module / Section",
+      "tableHeaderDescription": "Description",
+      "tableHeaderOrder": "Ordre",
+      "tableHeaderSections": "Sections",
+      "sectionsBadge": "{count, plural, one {# section} other {# sections}}",
+      "noSectionsInModule": "Ce module n’a pas encore de sections.",
+      "infoId": "ID",
+      "infoName": "Nom",
+      "infoDescription": "Description",
+      "infoStatus": "État",
+      "infoModules": "Modules",
+      "infoTotalSections": "Sections totales",
+      "infoCreated": "Créé",
+      "infoUpdated": "Mis à jour"
+    },
+    "errors": {
+      "refresh_failed": "Impossible de rafraîchir les dossiers",
+      "folder_refresh_failed": "Impossible de rafraîchir le dossier"
     }
   },
   "validation_admin": {
@@ -2520,6 +2727,17 @@
       "deletingLabel": "Suppression...",
       "overrideDeleted": "Remplacement supprimé",
       "overrideDeleteError": "Erreur lors de la suppression du remplacement"
+    },
+    "form": {
+      "saving": "Enregistrement..."
+    },
+    "sum": {
+      "label": "Somme : {sum}"
+    },
+    "override": {
+      "selectPlaceholder": "Sélectionner le type de club",
+      "noTypesAvailable": "Aucun type disponible",
+      "createLabel": "Créer un remplacement"
     }
   },
   "classes": {
@@ -2600,6 +2818,122 @@
     "errors": {
       "approve": "Une erreur s’est produite lors de l’approbation de la demande",
       "reject": "Une erreur s’est produite lors du refus de la demande"
+    }
+  },
+  "sla": {
+    "client": {
+      "title": "Tableau de bord SLA",
+      "description": "Métriques opérationnelles des investitures, validations et camporées.",
+      "updated": "Mis à jour {ago}",
+      "cached": " (cache)"
+    },
+    "stats": {
+      "total_pending": "Total en attente",
+      "total_pending_subtitle": "{count} en révision active",
+      "overdue": "En retard",
+      "overdue_subtitle": "Soumis il y a plus de 30 jours",
+      "overdue_badge_ok": "À jour",
+      "overdue_badge_attention": "Nécessite attention",
+      "avg_approval": "Délai moy. d'approbation",
+      "avg_approval_subtitle": "De l'inscription à l'investiture",
+      "avg_approval_days": "{days} jour(s) en moy.",
+      "avg_approval_no_data": "Aucune donnée",
+      "approval_rate": "Taux d'approbation",
+      "approval_rate_subtitle": "{count} résolus (90 jours)",
+      "approval_rate_badge": "{count} approuvés"
+    },
+    "pipeline": {
+      "title": "Pipeline d'investiture",
+      "description": "Inscriptions actives par étape d'approbation",
+      "description_distribution": "Distribution par statut",
+      "empty": "Aucune inscription active dans le pipeline.",
+      "tooltip_enrollments": "{count, plural, =1 {inscription} other {inscriptions}}"
+    },
+    "throughput": {
+      "title": "Débit — 12 dernières semaines",
+      "description": "Investitures approuvées et rejetées par semaine",
+      "empty": "Aucune donnée de débit disponible.",
+      "legend_approved": "Approuvés",
+      "legend_rejected": "Rejetés"
+    },
+    "validation": {
+      "title": "File de validation",
+      "description_pending": "{count, plural, =1 {1 élément en attente de validation} other {{count} éléments en attente de validation}}",
+      "description_empty": "Aucun élément en attente de validation",
+      "class_sections_label": "Sections de classe",
+      "class_sections_subtitle": "Progression en attente de validation",
+      "honors_label": "Spécialités",
+      "honors_subtitle": "Honneurs en attente de validation"
+    },
+    "camporee": {
+      "title": "Approbations de camporée",
+      "description_pending": "{count, plural, =1 {1 enregistrement en attente d'approbation} other {{count} enregistrements en attente d'approbation}}",
+      "description_empty": "Aucun enregistrement en attente d'approbation",
+      "clubs_label": "Clubs enregistrés",
+      "clubs_subtitle": "En attente d'approbation",
+      "members_label": "Membres enregistrés",
+      "members_subtitle": "En attente d'approbation",
+      "payments_label": "Paiements enregistrés",
+      "payments_subtitle": "En attente d'approbation"
+    },
+    "actions": {
+      "refresh": "Actualiser",
+      "refreshing": "Actualisation..."
+    }
+  },
+  "enrollments": {
+    "table": {
+      "col_member": "Membre",
+      "col_class": "Classe",
+      "col_status": "Statut",
+      "col_enrollment_date": "Date d'inscription",
+      "col_submitted_at": "Soumis le",
+      "col_actions": "Actions",
+      "empty": "Aucune inscription à afficher.",
+      "status": {
+        "IN_PROGRESS": "En cours",
+        "SUBMITTED_FOR_VALIDATION": "Validation en attente",
+        "APPROVED": "Approuvé",
+        "REJECTED": "Rejeté",
+        "INVESTIDO": "Investi"
+      }
+    },
+    "actions": {
+      "approve": "Approuver",
+      "reject": "Rejeter",
+      "view_user": "Voir l'utilisateur",
+      "reject_dialog_title": "Rejeter l'inscription",
+      "reject_dialog_description": "Cette action marquera l'inscription comme rejetée. Le membre ne pourra pas continuer le processus d'investiture avec cette inscription.",
+      "reject_dialog_cancel": "Annuler",
+      "reject_dialog_confirm": "Confirmer le rejet"
+    },
+    "toasts": {
+      "approved": "Inscription approuvée avec succès.",
+      "rejected": "Inscription rejetée avec succès."
+    },
+    "errors": {
+      "generic": "Une erreur s'est produite. Veuillez réessayer."
+    }
+  },
+  "rankings": {
+    "breakdown": {
+      "compositeScore": "Score composite institutionnel",
+      "weightsApplied": "Poids appliqués",
+      "weightsSource": "Source",
+      "weightsSourceDefault": "Défaut global",
+      "weightsSourceOverride": "Remplacement par type de club",
+      "componentFolder": "Dossiers",
+      "componentFinance": "Finances",
+      "componentCamporee": "Camporées",
+      "componentEvidence": "Preuves",
+      "pointsOf": "{earned} / {max} points",
+      "sectionsEvaluated": "{count} sections évaluées",
+      "monthsClosedOnTime": "{closed} / {total} mois clôturés à temps",
+      "deadlineDay": "Date limite : jour {day} du mois suivant",
+      "missedMonths": "Mois manquants : {months}",
+      "camporeeEventsOf": "{attended} / {available} événements dans la portée",
+      "evidenceValidatedRejected": "{validated} validées / {rejected} rejetées",
+      "evidencePendingExcluded": "{pending} en attente (exclues du calcul)"
     }
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -93,6 +93,47 @@
       "catalog_inventory_categories": "Categorias de inventário",
       "catalog_honors": "Especialidades (catálogo)",
       "catalog_master_honors": "Honras mestres"
+    },
+    "breadcrumbs": {
+      "dashboard": "Painel",
+      "users": "Usuários",
+      "catalogs": "Catálogos",
+      "geography": "Geografia",
+      "countries": "Países",
+      "unions": "Uniões",
+      "local-fields": "Campos locais",
+      "districts": "Distritos",
+      "churches": "Igrejas",
+      "allergies": "Alergias",
+      "diseases": "Doenças",
+      "medicines": "Medicamentos",
+      "relationship-types": "Tipos de relacionamento",
+      "ecclesiastical-years": "Anos eclesiásticos",
+      "club-types": "Tipos de clube",
+      "club-ideals": "Ideais de clube",
+      "honor-categories": "Categorias de especialidades",
+      "clubs": "Clubes",
+      "new": "Novo",
+      "instances": "Instâncias",
+      "camporees": "Camporees",
+      "classes": "Classes",
+      "honors": "Especialidades",
+      "activities": "Atividades",
+      "finances": "Finanças",
+      "inventory": "Inventário",
+      "certifications": "Certificações",
+      "insurance": "Seguros",
+      "notifications": "Notificações",
+      "folders": "Pastas",
+      "rbac": "Funções e permissões",
+      "permissions": "Permissões",
+      "roles": "Funções",
+      "matrix": "Matriz"
+    },
+    "themeToggle": {
+      "switchToLight": "Mudar para modo claro",
+      "switchToDark": "Mudar para modo escuro",
+      "switchTheme": "Alternar tema"
     }
   },
   "permissions": {
@@ -585,6 +626,50 @@
       "sent": "Notificação enviada com sucesso",
       "broadcast_sent": "Broadcast enviado com sucesso",
       "club_sent": "Notificação do clube enviada com sucesso"
+    },
+    "forms": {
+      "direct_title": "Envio direto",
+      "direct_description": "Enviar uma notificação push para um usuário específico.",
+      "broadcast_title": "Broadcast",
+      "broadcast_description": "Enviar notificação push para todos os usuários registrados.",
+      "broadcast_warning": "Esta ação enviará a notificação para todos os usuários com token FCM registrado.",
+      "club_title": "Por clube",
+      "club_description": "Enviar notificação para todos os membros de um clube.",
+      "label_user_id": "ID do usuário",
+      "placeholder_user_id": "UUID do usuário",
+      "label_title": "Título",
+      "placeholder_title_notification": "Título da notificação",
+      "placeholder_title_broadcast": "Título do broadcast",
+      "label_body": "Mensagem",
+      "placeholder_body": "Conteúdo da mensagem",
+      "label_instance_type": "Tipo de clube",
+      "placeholder_instance_type": "Selecionar tipo de clube...",
+      "option_adventurers": "Aventureiros",
+      "option_pathfinders": "Desbravadores",
+      "option_master_guilds": "Guias Máster",
+      "label_instance_id": "ID da instância",
+      "placeholder_instance_id": "ID numérico do clube",
+      "submit_send": "Enviar notificação",
+      "submit_broadcast": "Enviar broadcast",
+      "submit_club": "Enviar ao clube"
+    },
+    "history": {
+      "col_title": "Título",
+      "col_type": "Tipo",
+      "col_target": "Destino",
+      "col_sent": "Enviados",
+      "col_failed": "Falhas",
+      "col_sent_by": "Enviado por",
+      "col_date": "Data",
+      "empty_title": "Sem histórico",
+      "empty_description": "Nenhuma notificação foi enviada ainda.",
+      "error_load": "Não foi possível carregar o histórico de notificações.",
+      "type_broadcast": "Broadcast",
+      "type_user": "Usuário",
+      "type_club": "Clube",
+      "target_all": "Todos",
+      "target_user": "Usuário",
+      "target_club_section": "Seção de clube"
     }
   },
   "units": {
@@ -624,6 +709,75 @@
       "field_invalid": "O campo {field} não é válido",
       "no_changes": "Não há alterações para salvar",
       "honor_not_identified": "Não foi possível identificar a especialidade a excluir."
+    },
+    "crud": {
+      "pageTitle": "Especialidades",
+      "pageDescription": "Catálogo de especialidades.",
+      "createButton": "Criar especialidade",
+      "filtersTitle": "Filtros",
+      "filtersSubtitle": "Refinar a lista por campo",
+      "filterNameLabel": "Nome",
+      "filterNamePlaceholder": "Buscar por nome...",
+      "filterCategoryLabel": "Categoria",
+      "filterCategoryPlaceholder": "Categoria",
+      "filterCategoryAll": "Todas as categorias",
+      "filterClubTypeLabel": "Tipo de clube",
+      "filterClubTypePlaceholder": "Tipo de clube",
+      "filterClubTypeAll": "Todos os tipos",
+      "filterLevelLabel": "Nível",
+      "filterLevelPlaceholder": "Nível",
+      "filterLevelAll": "Todos os níveis",
+      "filterLevelItem": "Nível {level}",
+      "filterStatusLabel": "Status",
+      "filterStatusPlaceholder": "Status",
+      "filterStatusAll": "Todos os status",
+      "filterStatusActive": "Ativos",
+      "filterStatusInactive": "Inativos",
+      "emptyTitle": "Sem especialidades",
+      "emptyDescription": "Nenhum registro encontrado.",
+      "emptyFilterTitle": "Sem resultados",
+      "emptyFilterDescription": "Nenhuma especialidade corresponde aos filtros.",
+      "tableHeaderHonor": "Especialidade",
+      "tableHeaderCategory": "Categoria",
+      "tableHeaderClubType": "Tipo de clube",
+      "tableHeaderLevel": "Nível",
+      "tableHeaderStatus": "Status",
+      "tableHeaderActions": "Ações",
+      "badgeActive": "Ativo",
+      "badgeInactive": "Inativo",
+      "editButton": "Editar",
+      "editAriaLabel": "Editar {name}",
+      "deleteButton": "Excluir",
+      "actionsButton": "Ações",
+      "noPermissionBanner": "Você não tem permissão para modificar especialidades.",
+      "deleteDialogTitle": "Excluir especialidade?",
+      "deleteDialogDescription": "A especialidade “{name}” será desativada de forma lógica.",
+      "deleteDialogCancel": "Cancelar",
+      "deleteDialogConfirm": "Excluir"
+    },
+    "form": {
+      "submitCreate": "Criar especialidade",
+      "submitEdit": "Salvar alterações",
+      "cancelButton": "Cancelar",
+      "sectionDataTitle": "Dados da especialidade",
+      "sectionResourcesTitle": "Recursos (opcional)",
+      "nameLabel": "Nome",
+      "namePlaceholder": "Nome da especialidade",
+      "descriptionLabel": "Descrição",
+      "descriptionPlaceholder": "Descrição opcional",
+      "categoryLabel": "Categoria",
+      "categoryPlaceholder": "Selecionar categoria",
+      "clubTypeLabel": "Tipo de clube",
+      "clubTypePlaceholder": "Selecionar clube",
+      "levelLabel": "Nível",
+      "masterHonorLabel": "Master honor",
+      "activeLabel": "Especialidade ativa",
+      "imageLabel": "Imagem (URL relativa ou arquivo)",
+      "imagePlaceholder": "Especialidades/acolchoado.png",
+      "materialLabel": "Material (PDF)",
+      "materialPlaceholder": "Especialidades/Material/acolchoado.pdf",
+      "yearLabel": "Ano",
+      "yearPlaceholder": "2026"
     }
   },
   "honor_categories": {
@@ -1689,6 +1843,59 @@
       "deleted": "Pasta excluída com sucesso",
       "updated": "Pasta atualizada com sucesso",
       "created": "Pasta criada com sucesso"
+    },
+    "statusBadge": {
+      "active": "Ativa",
+      "inactive": "Inativa"
+    },
+    "management": {
+      "searchPlaceholder": "Buscar pasta...",
+      "refreshButton": "Atualizar",
+      "folderCount": "{count, plural, one {# pasta} other {# pastas}}",
+      "noDescription": "Sem descrição",
+      "noResultsTitle": "Sem resultados",
+      "noResultsDescription": "Nenhuma pasta correspondendo a “{search}” foi encontrada.",
+      "emptyTitle": "Sem pastas",
+      "emptyDescription": "Nenhuma pasta de evidências foi configurada ainda.",
+      "tableHeaderName": "Nome",
+      "tableHeaderDescription": "Descrição",
+      "tableHeaderModules": "Módulos",
+      "tableHeaderSections": "Seções",
+      "tableHeaderStatus": "Status",
+      "ariaFolderLink": "Ver pasta {name}",
+      "ariaList": "Lista de pastas",
+      "modulesLabel": "Módulos",
+      "sectionsLabel": "Seções"
+    },
+    "detail": {
+      "backButton": "Voltar para pastas",
+      "backLabel": "Voltar",
+      "refreshButton": "Atualizar",
+      "moduleCount": "{count, plural, one {# módulo} other {# módulos}}",
+      "sectionCount": "{count, plural, one {# seção} other {# seções}}",
+      "noDescription": "Sem descrição",
+      "tabStructure": "Estrutura",
+      "tabInfo": "Informações",
+      "noModulesTitle": "Sem módulos",
+      "noModulesDescription": "Esta pasta ainda não tem módulos nem seções configurados.",
+      "tableHeaderModule": "Módulo / Seção",
+      "tableHeaderDescription": "Descrição",
+      "tableHeaderOrder": "Ordem",
+      "tableHeaderSections": "Seções",
+      "sectionsBadge": "{count, plural, one {# seção} other {# seções}}",
+      "noSectionsInModule": "Este módulo ainda não tem seções.",
+      "infoId": "ID",
+      "infoName": "Nome",
+      "infoDescription": "Descrição",
+      "infoStatus": "Status",
+      "infoModules": "Módulos",
+      "infoTotalSections": "Seções totais",
+      "infoCreated": "Criada",
+      "infoUpdated": "Atualizada"
+    },
+    "errors": {
+      "refresh_failed": "Não foi possível atualizar as pastas",
+      "folder_refresh_failed": "Não foi possível atualizar a pasta"
     }
   },
   "validation_admin": {
@@ -2520,6 +2727,17 @@
       "deletingLabel": "Excluindo...",
       "overrideDeleted": "Substituição excluída",
       "overrideDeleteError": "Erro ao excluir a substituição"
+    },
+    "form": {
+      "saving": "Salvando..."
+    },
+    "sum": {
+      "label": "Soma: {sum}"
+    },
+    "override": {
+      "selectPlaceholder": "Selecionar tipo de clube",
+      "noTypesAvailable": "Sem tipos disponíveis",
+      "createLabel": "Criar substituição"
     }
   },
   "classes": {
@@ -2600,6 +2818,122 @@
     "errors": {
       "approve": "Ocorreu um erro ao aprovar a solicitação",
       "reject": "Ocorreu um erro ao rejeitar a solicitação"
+    }
+  },
+  "sla": {
+    "client": {
+      "title": "Painel SLA",
+      "description": "Métricas operacionais de investiduras, validações e camporês.",
+      "updated": "Atualizado {ago}",
+      "cached": " (cache)"
+    },
+    "stats": {
+      "total_pending": "Total pendente",
+      "total_pending_subtitle": "{count} em revisão ativa",
+      "overdue": "Atrasados",
+      "overdue_subtitle": "Enviados há mais de 30 dias",
+      "overdue_badge_ok": "Em dia",
+      "overdue_badge_attention": "Requer atenção",
+      "avg_approval": "Tempo méd. de aprovação",
+      "avg_approval_subtitle": "Da inscrição à investidura",
+      "avg_approval_days": "Méd. de {days} dias",
+      "avg_approval_no_data": "Sem dados",
+      "approval_rate": "Taxa de aprovação",
+      "approval_rate_subtitle": "{count} resolvidos (90 dias)",
+      "approval_rate_badge": "{count} aprovados"
+    },
+    "pipeline": {
+      "title": "Pipeline de Investidura",
+      "description": "Inscrições ativas por etapa de aprovação",
+      "description_distribution": "Distribuição por status",
+      "empty": "Nenhuma inscrição ativa no pipeline.",
+      "tooltip_enrollments": "{count, plural, =1 {inscrição} other {inscrições}}"
+    },
+    "throughput": {
+      "title": "Produtividade — Últimas 12 semanas",
+      "description": "Investiduras aprovadas e rejeitadas por semana",
+      "empty": "Nenhum dado de produtividade disponível.",
+      "legend_approved": "Aprovados",
+      "legend_rejected": "Rejeitados"
+    },
+    "validation": {
+      "title": "Fila de Validação",
+      "description_pending": "{count, plural, =1 {1 item aguardando validação} other {{count} itens aguardando validação}}",
+      "description_empty": "Nenhum item pendente de validação",
+      "class_sections_label": "Seções de Classe",
+      "class_sections_subtitle": "Progresso pendente de validação",
+      "honors_label": "Especialidades",
+      "honors_subtitle": "Honras pendentes de validação"
+    },
+    "camporee": {
+      "title": "Aprovações de Camporê",
+      "description_pending": "{count, plural, =1 {1 registro pendente de aprovação} other {{count} registros pendentes de aprovação}}",
+      "description_empty": "Nenhum registro pendente de aprovação",
+      "clubs_label": "Clubes registrados",
+      "clubs_subtitle": "Pendentes de aprovação",
+      "members_label": "Membros registrados",
+      "members_subtitle": "Pendentes de aprovação",
+      "payments_label": "Pagamentos registrados",
+      "payments_subtitle": "Pendentes de aprovação"
+    },
+    "actions": {
+      "refresh": "Atualizar",
+      "refreshing": "Atualizando..."
+    }
+  },
+  "enrollments": {
+    "table": {
+      "col_member": "Membro",
+      "col_class": "Classe",
+      "col_status": "Status",
+      "col_enrollment_date": "Data de inscrição",
+      "col_submitted_at": "Enviado em",
+      "col_actions": "Ações",
+      "empty": "Nenhuma inscrição para exibir.",
+      "status": {
+        "IN_PROGRESS": "Em andamento",
+        "SUBMITTED_FOR_VALIDATION": "Validação pendente",
+        "APPROVED": "Aprovado",
+        "REJECTED": "Rejeitado",
+        "INVESTIDO": "Investido"
+      }
+    },
+    "actions": {
+      "approve": "Aprovar",
+      "reject": "Rejeitar",
+      "view_user": "Ver usuário",
+      "reject_dialog_title": "Rejeitar inscrição",
+      "reject_dialog_description": "Esta ação marcará a inscrição como rejeitada. O membro não poderá continuar o processo de investidura com esta inscrição.",
+      "reject_dialog_cancel": "Cancelar",
+      "reject_dialog_confirm": "Confirmar rejeição"
+    },
+    "toasts": {
+      "approved": "Inscrição aprovada com sucesso.",
+      "rejected": "Inscrição rejeitada com sucesso."
+    },
+    "errors": {
+      "generic": "Ocorreu um erro. Tente novamente."
+    }
+  },
+  "rankings": {
+    "breakdown": {
+      "compositeScore": "Pontuação composta institucional",
+      "weightsApplied": "Pesos aplicados",
+      "weightsSource": "Fonte",
+      "weightsSourceDefault": "Padrão global",
+      "weightsSourceOverride": "Substituição por tipo de clube",
+      "componentFolder": "Pastas",
+      "componentFinance": "Finanças",
+      "componentCamporee": "Camporees",
+      "componentEvidence": "Evidências",
+      "pointsOf": "{earned} / {max} pontos",
+      "sectionsEvaluated": "{count} seções avaliadas",
+      "monthsClosedOnTime": "{closed} / {total} meses fechados no prazo",
+      "deadlineDay": "Prazo: dia {day} do mês seguinte",
+      "missedMonths": "Meses em falta: {months}",
+      "camporeeEventsOf": "{attended} / {available} eventos no escopo",
+      "evidenceValidatedRejected": "{validated} validadas / {rejected} rejeitadas",
+      "evidencePendingExcluded": "{pending} pendentes (excluídas do cálculo)"
     }
   }
 }

--- a/src/components/enrollments/enrollments-table.tsx
+++ b/src/components/enrollments/enrollments-table.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { toast } from "sonner";
 import { CheckCircle, XCircle, Eye, Loader2 } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableBody,
@@ -30,14 +31,6 @@ import { ApiError } from "@/lib/api/client";
 
 // ─── Status badge ─────────────────────────────────────────────────────────────
 
-const STATUS_LABELS: Record<InvestitureStatus, string> = {
-  IN_PROGRESS: "En progreso",
-  SUBMITTED_FOR_VALIDATION: "Pendiente validación",
-  APPROVED: "Aprobado",
-  REJECTED: "Rechazado",
-  INVESTIDO: "Investido",
-};
-
 type BadgeVariant = "default" | "secondary" | "success" | "destructive" | "warning" | "outline";
 
 const STATUS_VARIANTS: Record<InvestitureStatus, BadgeVariant> = {
@@ -48,10 +41,10 @@ const STATUS_VARIANTS: Record<InvestitureStatus, BadgeVariant> = {
   INVESTIDO: "default",
 };
 
-function StatusBadge({ status }: { status: InvestitureStatus }) {
+function StatusBadge({ status, label }: { status: InvestitureStatus; label: string }) {
   return (
     <Badge variant={STATUS_VARIANTS[status]}>
-      {STATUS_LABELS[status]}
+      {label}
     </Badge>
   );
 }
@@ -102,29 +95,29 @@ interface RejectDialogProps {
 }
 
 function RejectDialog({ enrollmentId, disabled, onConfirm }: RejectDialogProps) {
+  const t = useTranslations("enrollments");
   return (
     <AlertDialog>
       <AlertDialogTrigger asChild>
         <Button variant="outline" size="sm" disabled={disabled}>
           <XCircle className="mr-1.5 size-3.5" />
-          Rechazar
+          {t("actions.reject")}
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent>
         <AlertDialogHeader>
-          <AlertDialogTitle>Rechazar inscripción</AlertDialogTitle>
+          <AlertDialogTitle>{t("actions.reject_dialog_title")}</AlertDialogTitle>
           <AlertDialogDescription>
-            Esta acción marcará la inscripción como rechazada. El miembro no
-            podrá continuar con el proceso de investidura con esta inscripción.
+            {t("actions.reject_dialog_description")}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancelar</AlertDialogCancel>
+          <AlertDialogCancel>{t("actions.reject_dialog_cancel")}</AlertDialogCancel>
           <AlertDialogAction
             onClick={() => onConfirm(enrollmentId)}
             className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
           >
-            Confirmar rechazo
+            {t("actions.reject_dialog_confirm")}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
@@ -140,6 +133,7 @@ interface EnrollmentsTableProps {
 }
 
 export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTableProps) {
+  const t = useTranslations("enrollments");
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [processingId, setProcessingId] = useState<number | null>(null);
@@ -153,8 +147,8 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
       await validateEnrollment(enrollmentId, action);
       toast.success(
         action === "APPROVED"
-          ? "Inscripción aprobada correctamente."
-          : "Inscripción rechazada correctamente.",
+          ? t("toasts.approved")
+          : t("toasts.rejected"),
       );
       startTransition(() => {
         router.refresh();
@@ -164,7 +158,7 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
       const message =
         error instanceof ApiError
           ? error.message
-          : "Ocurrió un error. Intenta de nuevo.";
+          : t("errors.generic");
       toast.error(message);
     } finally {
       setProcessingId(null);
@@ -177,18 +171,18 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Miembro</TableHead>
-              <TableHead>Clase</TableHead>
-              <TableHead>Estado</TableHead>
-              <TableHead>Fecha inscripción</TableHead>
-              <TableHead>Enviado el</TableHead>
-              <TableHead className="text-right">Acciones</TableHead>
+              <TableHead>{t("table.col_member")}</TableHead>
+              <TableHead>{t("table.col_class")}</TableHead>
+              <TableHead>{t("table.col_status")}</TableHead>
+              <TableHead>{t("table.col_enrollment_date")}</TableHead>
+              <TableHead>{t("table.col_submitted_at")}</TableHead>
+              <TableHead className="text-right">{t("table.col_actions")}</TableHead>
             </TableRow>
           </TableHeader>
           <TableBody>
             <TableRow>
               <TableCell colSpan={6} className="h-32 text-center text-muted-foreground">
-                No hay inscripciones para mostrar.
+                {t("table.empty")}
               </TableCell>
             </TableRow>
           </TableBody>
@@ -202,12 +196,12 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
       <Table>
         <TableHeader>
           <TableRow>
-            <TableHead>Miembro</TableHead>
-            <TableHead>Clase</TableHead>
-            <TableHead>Estado</TableHead>
-            <TableHead>Fecha inscripción</TableHead>
-            <TableHead>Enviado el</TableHead>
-            <TableHead className="text-right">Acciones</TableHead>
+            <TableHead>{t("table.col_member")}</TableHead>
+            <TableHead>{t("table.col_class")}</TableHead>
+            <TableHead>{t("table.col_status")}</TableHead>
+            <TableHead>{t("table.col_enrollment_date")}</TableHead>
+            <TableHead>{t("table.col_submitted_at")}</TableHead>
+            <TableHead className="text-right">{t("table.col_actions")}</TableHead>
           </TableRow>
         </TableHeader>
         <TableBody>
@@ -237,7 +231,10 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
 
                 {/* Status */}
                 <TableCell>
-                  <StatusBadge status={enrollment.investiture_status} />
+                  <StatusBadge
+                    status={enrollment.investiture_status}
+                    label={t(`table.status.${enrollment.investiture_status}`)}
+                  />
                 </TableCell>
 
                 {/* Enrollment date */}
@@ -267,7 +264,7 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
                       >
                         <a href={`/dashboard/users/${enrollment.user.user_id}`}>
                           <Eye className="mr-1.5 size-3.5" />
-                          Ver usuario
+                          {t("actions.view_user")}
                         </a>
                       </Button>
                     )}
@@ -284,7 +281,7 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
                           }
                         >
                           <CheckCircle className="mr-1.5 size-3.5" />
-                          Aprobar
+                          {t("actions.approve")}
                         </Button>
 
                         <RejectDialog

--- a/src/components/folders/folder-detail-client.tsx
+++ b/src/components/folders/folder-detail-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, Fragment } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import {
   ArrowLeft,
   ChevronDown,
@@ -38,6 +39,7 @@ interface FolderDetailClientProps {
 // ─── Module rows (expandable) ─────────────────────────────────────────────────
 
 function ModuleRows({ module }: { module: FolderModule }) {
+  const t = useTranslations("folders.detail");
   const [open, setOpen] = useState(false);
   const sortedSections = [...(module.sections ?? [])].sort(
     (a, b) => a.order - b.order,
@@ -61,7 +63,7 @@ function ModuleRows({ module }: { module: FolderModule }) {
         <TableCell className="hidden text-muted-foreground sm:table-cell">
           {module.description ?? (
             <span className="italic text-muted-foreground/60">
-              Sin descripción
+              {t("noDescription")}
             </span>
           )}
         </TableCell>
@@ -72,8 +74,7 @@ function ModuleRows({ module }: { module: FolderModule }) {
         </TableCell>
         <TableCell className="w-24 text-center">
           <Badge variant="outline" className="text-xs">
-            {sortedSections.length}{" "}
-            {sortedSections.length === 1 ? "sección" : "secciones"}
+            {t("sectionsBadge", { count: sortedSections.length })}
           </Badge>
         </TableCell>
       </TableRow>
@@ -94,7 +95,7 @@ function ModuleRows({ module }: { module: FolderModule }) {
             <TableCell className="hidden text-sm text-muted-foreground sm:table-cell">
               {section.description ?? (
                 <span className="italic text-muted-foreground/60">
-                  Sin descripción
+                  {t("noDescription")}
                 </span>
               )}
             </TableCell>
@@ -114,7 +115,7 @@ function ModuleRows({ module }: { module: FolderModule }) {
             colSpan={5}
             className="py-3 pl-8 text-sm text-muted-foreground"
           >
-            Este módulo no tiene secciones todavía.
+            {t("noSectionsInModule")}
           </TableCell>
         </TableRow>
       )}
@@ -125,6 +126,9 @@ function ModuleRows({ module }: { module: FolderModule }) {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
+  const t = useTranslations("folders.detail");
+  const tErrors = useTranslations("folders.errors");
+
   const [folder, setFolder] = useState<FolderTemplate>(initialFolder);
   const [isRefreshing, setIsRefreshing] = useState(false);
 
@@ -148,12 +152,12 @@ export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
       const message =
         err instanceof ApiError
           ? err.message
-          : "No se pudo actualizar la carpeta";
+          : tErrors("folder_refresh_failed");
       toast.error(message);
     } finally {
       setIsRefreshing(false);
     }
-  }, [folder.folder_id]);
+  }, [folder.folder_id, tErrors]);
 
   // ─── Render ────────────────────────────────────────────────────────────────
 
@@ -162,10 +166,10 @@ export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
       {/* Header */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="flex items-start gap-3">
-          <Button variant="ghost" size="icon-sm" asChild title="Volver a carpetas">
+          <Button variant="ghost" size="icon-sm" asChild title={t("backButton")}>
             <Link href="/dashboard/folders">
               <ArrowLeft className="size-4" />
-              <span className="sr-only">Volver</span>
+              <span className="sr-only">{t("backLabel")}</span>
             </Link>
           </Button>
           <div className="space-y-1">
@@ -179,14 +183,12 @@ export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
               <span className="inline-flex items-center gap-1">
                 <Layers className="size-3" />
-                {sortedModules.length}{" "}
-                {sortedModules.length === 1 ? "módulo" : "módulos"}
+                {t("moduleCount", { count: sortedModules.length })}
               </span>
               <span aria-hidden>·</span>
               <span className="inline-flex items-center gap-1">
                 <FolderOpen className="size-3" />
-                {totalSections}{" "}
-                {totalSections === 1 ? "sección" : "secciones"}
+                {t("sectionCount", { count: totalSections })}
               </span>
             </div>
           </div>
@@ -203,12 +205,12 @@ export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
             size="icon-sm"
             onClick={refreshFolder}
             disabled={isRefreshing}
-            title="Actualizar"
+            title={t("refreshButton")}
           >
             <RefreshCw
               className={`size-3.5 ${isRefreshing ? "animate-spin" : ""}`}
             />
-            <span className="sr-only">Actualizar</span>
+            <span className="sr-only">{t("refreshButton")}</span>
           </Button>
         </div>
       </div>
@@ -216,8 +218,8 @@ export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
       {/* Tabs */}
       <Tabs defaultValue="structure">
         <TabsList>
-          <TabsTrigger value="structure">Estructura</TabsTrigger>
-          <TabsTrigger value="info">Información</TabsTrigger>
+          <TabsTrigger value="structure">{t("tabStructure")}</TabsTrigger>
+          <TabsTrigger value="info">{t("tabInfo")}</TabsTrigger>
         </TabsList>
 
         {/* Structure tab */}
@@ -227,9 +229,9 @@ export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
               <div className="flex size-12 items-center justify-center rounded-full bg-muted">
                 <Layers className="size-6 text-muted-foreground" />
               </div>
-              <h3 className="mt-4 text-base font-semibold">Sin módulos</h3>
+              <h3 className="mt-4 text-base font-semibold">{t("noModulesTitle")}</h3>
               <p className="mt-1 max-w-sm text-sm text-muted-foreground">
-                Esta carpeta no tiene módulos ni secciones configurados todavía.
+                {t("noModulesDescription")}
               </p>
             </div>
           ) : (
@@ -238,12 +240,12 @@ export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
                 <TableHeader>
                   <TableRow>
                     <TableHead className="w-8" />
-                    <TableHead>Módulo / Sección</TableHead>
+                    <TableHead>{t("tableHeaderModule")}</TableHead>
                     <TableHead className="hidden sm:table-cell">
-                      Descripción
+                      {t("tableHeaderDescription")}
                     </TableHead>
-                    <TableHead className="w-20 text-center">Orden</TableHead>
-                    <TableHead className="w-24 text-center">Secciones</TableHead>
+                    <TableHead className="w-20 text-center">{t("tableHeaderOrder")}</TableHead>
+                    <TableHead className="w-24 text-center">{t("tableHeaderSections")}</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
@@ -260,38 +262,38 @@ export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
         <TabsContent value="info" className="mt-4">
           <div className="rounded-lg border border-border divide-y divide-border">
             <div className="grid grid-cols-2 gap-2 px-4 py-3 text-sm">
-              <span className="text-muted-foreground">ID</span>
+              <span className="text-muted-foreground">{t("infoId")}</span>
               <span className="font-mono text-xs">{folder.folder_id}</span>
             </div>
             <div className="grid grid-cols-2 gap-2 px-4 py-3 text-sm">
-              <span className="text-muted-foreground">Nombre</span>
+              <span className="text-muted-foreground">{t("infoName")}</span>
               <span>{folder.name}</span>
             </div>
             <div className="grid grid-cols-2 gap-2 px-4 py-3 text-sm">
-              <span className="text-muted-foreground">Descripción</span>
+              <span className="text-muted-foreground">{t("infoDescription")}</span>
               <span>
                 {folder.description ?? (
                   <span className="italic text-muted-foreground/60">
-                    Sin descripción
+                    {t("noDescription")}
                   </span>
                 )}
               </span>
             </div>
             <div className="grid grid-cols-2 gap-2 px-4 py-3 text-sm">
-              <span className="text-muted-foreground">Estado</span>
+              <span className="text-muted-foreground">{t("infoStatus")}</span>
               <FolderStatusBadge active={folder.active} />
             </div>
             <div className="grid grid-cols-2 gap-2 px-4 py-3 text-sm">
-              <span className="text-muted-foreground">Módulos</span>
+              <span className="text-muted-foreground">{t("infoModules")}</span>
               <span>{sortedModules.length}</span>
             </div>
             <div className="grid grid-cols-2 gap-2 px-4 py-3 text-sm">
-              <span className="text-muted-foreground">Secciones totales</span>
+              <span className="text-muted-foreground">{t("infoTotalSections")}</span>
               <span>{totalSections}</span>
             </div>
             {folder.created_at && (
               <div className="grid grid-cols-2 gap-2 px-4 py-3 text-sm">
-                <span className="text-muted-foreground">Creada</span>
+                <span className="text-muted-foreground">{t("infoCreated")}</span>
                 <span>
                   {new Date(folder.created_at).toLocaleDateString("es-AR", {
                     day: "2-digit",
@@ -303,7 +305,7 @@ export function FolderDetailClient({ initialFolder }: FolderDetailClientProps) {
             )}
             {folder.updated_at && (
               <div className="grid grid-cols-2 gap-2 px-4 py-3 text-sm">
-                <span className="text-muted-foreground">Actualizada</span>
+                <span className="text-muted-foreground">{t("infoUpdated")}</span>
                 <span>
                   {new Date(folder.updated_at).toLocaleDateString("es-AR", {
                     day: "2-digit",

--- a/src/components/folders/folder-status-badge.tsx
+++ b/src/components/folders/folder-status-badge.tsx
@@ -1,11 +1,14 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 export type FolderActiveStatus = "active" | "inactive";
 
-const statusConfig: Record<FolderActiveStatus, { label: string; variant: "success" | "secondary" }> = {
-  active: { label: "Activa", variant: "success" },
-  inactive: { label: "Inactiva", variant: "secondary" },
+const statusVariant: Record<FolderActiveStatus, "success" | "secondary"> = {
+  active: "success",
+  inactive: "secondary",
 };
 
 interface FolderStatusBadgeProps {
@@ -14,12 +17,12 @@ interface FolderStatusBadgeProps {
 }
 
 export function FolderStatusBadge({ active, className }: FolderStatusBadgeProps) {
+  const t = useTranslations("folders.statusBadge");
   const key: FolderActiveStatus = active ? "active" : "inactive";
-  const config = statusConfig[key];
 
   return (
-    <Badge variant={config.variant} className={cn("text-xs", className)}>
-      {config.label}
+    <Badge variant={statusVariant[key]} className={cn("text-xs", className)}>
+      {t(key)}
     </Badge>
   );
 }

--- a/src/components/folders/folders-management-client.tsx
+++ b/src/components/folders/folders-management-client.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback } from "react";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import {
   RefreshCw,
   ChevronRight,
@@ -45,6 +46,9 @@ function countTotalSections(folder: FolderTemplate): number {
 export function FoldersManagementClient({
   initialFolders,
 }: FoldersManagementClientProps) {
+  const t = useTranslations("folders.management");
+  const tErrors = useTranslations("folders.errors");
+
   const [folders, setFolders] = useState<FolderTemplate[]>(initialFolders);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [search, setSearch] = useState("");
@@ -60,12 +64,12 @@ export function FoldersManagementClient({
       const message =
         err instanceof ApiError
           ? err.message
-          : "No se pudieron actualizar las carpetas";
+          : tErrors("refresh_failed");
       toast.error(message);
     } finally {
       setIsRefreshing(false);
     }
-  }, []);
+  }, [tErrors]);
 
   // ─── Filtered list ────────────────────────────────────────────────────────
 
@@ -94,7 +98,7 @@ export function FoldersManagementClient({
           <div className="relative">
             <Search className="absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
             <Input
-              placeholder="Buscar carpeta..."
+              placeholder={t("searchPlaceholder")}
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               className="h-8 w-56 pl-8 text-sm"
@@ -105,18 +109,18 @@ export function FoldersManagementClient({
             size="icon-sm"
             onClick={refreshFolders}
             disabled={isRefreshing}
-            title="Actualizar"
+            title={t("refreshButton")}
           >
             <RefreshCw
               className={`size-3.5 ${isRefreshing ? "animate-spin" : ""}`}
             />
-            <span className="sr-only">Actualizar</span>
+            <span className="sr-only">{t("refreshButton")}</span>
           </Button>
           <p className="text-sm text-muted-foreground">
             <span className="font-medium text-foreground">
               {filteredFolders.length}
             </span>{" "}
-            {filteredFolders.length === 1 ? "carpeta" : "carpetas"}
+            {t("folderCount", { count: filteredFolders.length })}
           </p>
         </div>
       </div>
@@ -132,12 +136,12 @@ export function FoldersManagementClient({
             )}
           </div>
           <h3 className="mt-4 text-base font-semibold">
-            {search ? "Sin resultados" : "Sin carpetas"}
+            {search ? t("noResultsTitle") : t("emptyTitle")}
           </h3>
           <p className="mt-1 max-w-sm text-sm text-muted-foreground">
             {search
-              ? `No se encontraron carpetas que coincidan con "${search}".`
-              : "No hay carpetas de evidencias configuradas todavía."}
+              ? t("noResultsDescription", { search })
+              : t("emptyDescription")}
           </p>
         </div>
       )}
@@ -151,17 +155,17 @@ export function FoldersManagementClient({
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Nombre</TableHead>
+                    <TableHead>{t("tableHeaderName")}</TableHead>
                     <TableHead className="hidden sm:table-cell">
-                      Descripción
+                      {t("tableHeaderDescription")}
                     </TableHead>
                     <TableHead className="hidden w-28 text-center md:table-cell">
-                      Módulos
+                      {t("tableHeaderModules")}
                     </TableHead>
                     <TableHead className="hidden w-28 text-center lg:table-cell">
-                      Secciones
+                      {t("tableHeaderSections")}
                     </TableHead>
-                    <TableHead className="w-20 text-center">Estado</TableHead>
+                    <TableHead className="w-20 text-center">{t("tableHeaderStatus")}</TableHead>
                     <TableHead className="w-8" />
                   </TableRow>
                 </TableHeader>
@@ -187,7 +191,7 @@ export function FoldersManagementClient({
                           <span className="line-clamp-1">
                             {folder.description ?? (
                               <span className="italic text-muted-foreground/60">
-                                Sin descripción
+                                {t("noDescription")}
                               </span>
                             )}
                           </span>
@@ -220,7 +224,7 @@ export function FoldersManagementClient({
           </div>
 
           {/* Mobile cards */}
-          <ul className="space-y-3 md:hidden" aria-label="Lista de carpetas">
+          <ul className="space-y-3 md:hidden" aria-label={t("ariaList")}>
             {filteredFolders.map((folder) => {
               const moduleCount = folder.modules?.length ?? 0;
               const sectionCount = countTotalSections(folder);
@@ -230,7 +234,7 @@ export function FoldersManagementClient({
                   <Link
                     href={`/dashboard/folders/${folder.folder_id}`}
                     className="block rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    aria-label={`Ver carpeta ${folder.name}`}
+                    aria-label={t("ariaFolderLink", { name: folder.name })}
                   >
                     <div className="flex items-center gap-3">
                       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
@@ -253,14 +257,14 @@ export function FoldersManagementClient({
 
                     <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
                       <div>
-                        <dt className="text-muted-foreground">Módulos</dt>
+                        <dt className="text-muted-foreground">{t("modulesLabel")}</dt>
                         <dd className="flex items-center gap-1">
                           <Layers className="size-3 text-muted-foreground" aria-hidden="true" />
                           {moduleCount}
                         </dd>
                       </div>
                       <div>
-                        <dt className="text-muted-foreground">Secciones</dt>
+                        <dt className="text-muted-foreground">{t("sectionsLabel")}</dt>
                         <dd>{sectionCount}</dd>
                       </div>
                     </dl>

--- a/src/components/honors/honor-form-fields.tsx
+++ b/src/components/honors/honor-form-fields.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -37,6 +38,8 @@ interface HonorFormFieldsProps {
 }
 
 export function HonorFormFields({ item, categoryOptions, clubTypeOptions }: HonorFormFieldsProps) {
+  const t = useTranslations("honors.form");
+
   const currentCategoryId = toPositiveNumber(item?.honors_category_id ?? item?.category_id);
   const currentClubTypeId = toPositiveNumber(item?.club_type_id);
   const currentSkillLevel = toPositiveNumber(item?.skill_level) ?? 1;
@@ -47,42 +50,42 @@ export function HonorFormFields({ item, categoryOptions, clubTypeOptions }: Hono
     <>
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Datos de la especialidad</CardTitle>
+          <CardTitle className="text-base">{t("sectionDataTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2 sm:col-span-2">
             <Label htmlFor="honor_name">
-              Nombre <span aria-hidden="true" className="text-destructive">*</span>
+              {t("nameLabel")} <span aria-hidden="true" className="text-destructive">*</span>
             </Label>
             <Input
               id="honor_name"
               name="name"
               defaultValue={toText(item?.name) ?? ""}
-              placeholder="Nombre de la especialidad"
+              placeholder={t("namePlaceholder")}
               required
               aria-required="true"
             />
           </div>
 
           <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="honor_description">Descripción</Label>
+            <Label htmlFor="honor_description">{t("descriptionLabel")}</Label>
             <Textarea
               id="honor_description"
               name="description"
               rows={3}
               defaultValue={toText(item?.description) ?? ""}
-              placeholder="Descripción opcional"
+              placeholder={t("descriptionPlaceholder")}
             />
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="honors_category_id">Categoría</Label>
+            <Label htmlFor="honors_category_id">{t("categoryLabel")}</Label>
             <Select
               name="honors_category_id"
               defaultValue={currentCategoryId ? String(currentCategoryId) : undefined}
             >
               <SelectTrigger id="honors_category_id">
-                <SelectValue placeholder="Seleccionar categoría" />
+                <SelectValue placeholder={t("categoryPlaceholder")} />
               </SelectTrigger>
               <SelectContent>
                 {categoryOptions.map((option) => (
@@ -95,13 +98,13 @@ export function HonorFormFields({ item, categoryOptions, clubTypeOptions }: Hono
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="club_type_id">Tipo de club</Label>
+            <Label htmlFor="club_type_id">{t("clubTypeLabel")}</Label>
             <Select
               name="club_type_id"
               defaultValue={currentClubTypeId ? String(currentClubTypeId) : undefined}
             >
               <SelectTrigger id="club_type_id">
-                <SelectValue placeholder="Seleccionar club" />
+                <SelectValue placeholder={t("clubTypePlaceholder")} />
               </SelectTrigger>
               <SelectContent>
                 {clubTypeOptions.map((option) => (
@@ -114,7 +117,7 @@ export function HonorFormFields({ item, categoryOptions, clubTypeOptions }: Hono
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="skill_level">Nivel</Label>
+            <Label htmlFor="skill_level">{t("levelLabel")}</Label>
             <Input
               id="skill_level"
               name="skill_level"
@@ -125,7 +128,7 @@ export function HonorFormFields({ item, categoryOptions, clubTypeOptions }: Hono
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="master_honors">Master honor</Label>
+            <Label htmlFor="master_honors">{t("masterHonorLabel")}</Label>
             <Input
               id="master_honors"
               name="master_honors"
@@ -149,43 +152,43 @@ export function HonorFormFields({ item, categoryOptions, clubTypeOptions }: Hono
                 }
               }}
             />
-            <Label htmlFor="active">Especialidad activa</Label>
+            <Label htmlFor="active">{t("activeLabel")}</Label>
           </div>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Recursos (opcional)</CardTitle>
+          <CardTitle className="text-base">{t("sectionResourcesTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="grid gap-4 sm:grid-cols-2">
           <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="honor_image">Imagen (URL relativa o archivo)</Label>
+            <Label htmlFor="honor_image">{t("imageLabel")}</Label>
             <Input
               id="honor_image"
               name="honor_image"
               defaultValue={toText(item?.honor_image ?? item?.patch_image) ?? ""}
-              placeholder="Especialidades/acolchado.png"
+              placeholder={t("imagePlaceholder")}
             />
           </div>
 
           <div className="space-y-2 sm:col-span-2">
-            <Label htmlFor="material_url">Material (PDF)</Label>
+            <Label htmlFor="material_url">{t("materialLabel")}</Label>
             <Input
               id="material_url"
               name="material_url"
               defaultValue={toText(item?.material_url ?? item?.material_honor) ?? ""}
-              placeholder="Especialidades/Material/acolchado.pdf"
+              placeholder={t("materialPlaceholder")}
             />
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="year">Año</Label>
+            <Label htmlFor="year">{t("yearLabel")}</Label>
             <Input
               id="year"
               name="year"
               defaultValue={toText(item?.year) ?? ""}
-              placeholder="2026"
+              placeholder={t("yearPlaceholder")}
             />
           </div>
         </CardContent>

--- a/src/components/honors/honor-form.tsx
+++ b/src/components/honors/honor-form.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useActionState } from "react";
 import { useFormStatus } from "react-dom";
+import { useTranslations } from "next-intl";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { HonorFormFields } from "@/components/honors/honor-form-fields";
@@ -42,8 +43,9 @@ export function HonorForm({
   clubTypeOptions,
   formAction,
 }: HonorFormProps) {
+  const t = useTranslations("honors.form");
   const [state, action] = useActionState(formAction, initialState);
-  const submitLabel = mode === "create" ? "Crear especialidad" : "Guardar cambios";
+  const submitLabel = mode === "create" ? t("submitCreate") : t("submitEdit");
 
   return (
     <form action={action} className="space-y-6" noValidate>
@@ -65,7 +67,7 @@ export function HonorForm({
 
       <div className="flex justify-end gap-2">
         <Button variant="outline" asChild>
-          <Link href="/dashboard/honors">Cancelar</Link>
+          <Link href="/dashboard/honors">{t("cancelButton")}</Link>
         </Button>
         <SubmitButton label={submitLabel} />
       </div>

--- a/src/components/honors/honors-crud-page.tsx
+++ b/src/components/honors/honors-crud-page.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useActionState, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useFormStatus } from "react-dom";
+import { useTranslations } from "next-intl";
 import {
   Award,
   Loader2,
@@ -170,12 +171,12 @@ function resolveClubTypeName(item: HonorRecord, clubTypeById: Map<number, string
   return clubTypeById.get(id) ?? `#${id}`;
 }
 
-function DeleteButton() {
+function DeleteButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
   return (
     <Button type="submit" disabled={pending} className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
       {pending && <Loader2 className="size-4 animate-spin" />}
-      Eliminar
+      {label}
     </Button>
   );
 }
@@ -190,6 +191,8 @@ export function HonorsCrudPage({
   canDelete,
   deactivateAction,
 }: HonorsCrudPageProps) {
+  const t = useTranslations("honors.crud");
+
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -339,12 +342,12 @@ export function HonorsCrudPage({
 
   return (
     <div className="space-y-6">
-      <PageHeader title="Especialidades" description="Catálogo de especialidades.">
+      <PageHeader title={t("pageTitle")} description={t("pageDescription")}>
         {canCreate && (
           <Button asChild>
             <Link href="/dashboard/honors/new">
               <Plus className="size-4" />
-              Crear especialidad
+              {t("createButton")}
             </Link>
           </Button>
         )}
@@ -353,17 +356,17 @@ export function HonorsCrudPage({
       <div className="space-y-4">
         <div className="rounded-xl border bg-muted/20 p-4">
           <div className="mb-3 flex items-center justify-between gap-2">
-            <h3 className="text-sm font-semibold tracking-wide text-foreground">Filtros</h3>
-            <span className="text-xs text-muted-foreground">Refina el listado por campo</span>
+            <h3 className="text-sm font-semibold tracking-wide text-foreground">{t("filtersTitle")}</h3>
+            <span className="text-xs text-muted-foreground">{t("filtersSubtitle")}</span>
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5">
               <div className="space-y-1">
-                <Label htmlFor="honors-filter-name">Nombre</Label>
+                <Label htmlFor="honors-filter-name">{t("filterNameLabel")}</Label>
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
                     id="honors-filter-name"
-                    placeholder="Buscar por nombre..."
+                    placeholder={t("filterNamePlaceholder")}
                     value={searchInput}
                     onChange={(event) => handleSearchInputChange(event.target.value)}
                     className="bg-background pl-9"
@@ -372,13 +375,13 @@ export function HonorsCrudPage({
               </div>
 
               <div className="space-y-1">
-                <Label htmlFor="honors-filter-category">Categoría</Label>
+                <Label htmlFor="honors-filter-category">{t("filterCategoryLabel")}</Label>
                 <Select value={currentCategoryFilter} onValueChange={(value) => updateParam("categoryId", value)}>
                   <SelectTrigger id="honors-filter-category" className="bg-background">
-                    <SelectValue placeholder="Categoría" />
+                    <SelectValue placeholder={t("filterCategoryPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Todas las categorías</SelectItem>
+                    <SelectItem value="all">{t("filterCategoryAll")}</SelectItem>
                     {categoryOptions.map((option) => (
                       <SelectItem key={option.value} value={String(option.value)}>
                         {option.label}
@@ -389,13 +392,13 @@ export function HonorsCrudPage({
               </div>
 
               <div className="space-y-1">
-                <Label htmlFor="honors-filter-club-type">Tipo de club</Label>
+                <Label htmlFor="honors-filter-club-type">{t("filterClubTypeLabel")}</Label>
                 <Select value={currentClubTypeFilter} onValueChange={(value) => updateParam("clubTypeId", value)}>
                   <SelectTrigger id="honors-filter-club-type" className="bg-background">
-                    <SelectValue placeholder="Tipo de club" />
+                    <SelectValue placeholder={t("filterClubTypePlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Todos los tipos</SelectItem>
+                    <SelectItem value="all">{t("filterClubTypeAll")}</SelectItem>
                     {clubTypeOptions.map((option) => (
                       <SelectItem key={option.value} value={String(option.value)}>
                         {option.label}
@@ -406,16 +409,16 @@ export function HonorsCrudPage({
               </div>
 
               <div className="space-y-1">
-                <Label htmlFor="honors-filter-level">Nivel</Label>
+                <Label htmlFor="honors-filter-level">{t("filterLevelLabel")}</Label>
                 <Select value={currentLevelFilter} onValueChange={(value) => updateParam("skillLevel", value)}>
                   <SelectTrigger id="honors-filter-level" className="bg-background">
-                    <SelectValue placeholder="Nivel" />
+                    <SelectValue placeholder={t("filterLevelPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Todos los niveles</SelectItem>
+                    <SelectItem value="all">{t("filterLevelAll")}</SelectItem>
                     {levelFilterOptions.map((option) => (
                       <SelectItem key={option} value={String(option)}>
-                        Nivel {option}
+                        {t("filterLevelItem", { level: option })}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -423,15 +426,15 @@ export function HonorsCrudPage({
               </div>
 
               <div className="space-y-1">
-                <Label htmlFor="honors-filter-status">Estado</Label>
+                <Label htmlFor="honors-filter-status">{t("filterStatusLabel")}</Label>
                 <Select value={currentStatusFilter} onValueChange={(value) => updateParam("active", value)}>
                   <SelectTrigger id="honors-filter-status" className="bg-background">
-                    <SelectValue placeholder="Estado" />
+                    <SelectValue placeholder={t("filterStatusPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Todos los estados</SelectItem>
-                    <SelectItem value="true">Activos</SelectItem>
-                    <SelectItem value="false">Inactivos</SelectItem>
+                    <SelectItem value="all">{t("filterStatusAll")}</SelectItem>
+                    <SelectItem value="true">{t("filterStatusActive")}</SelectItem>
+                    <SelectItem value="false">{t("filterStatusInactive")}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -441,14 +444,14 @@ export function HonorsCrudPage({
         {items.length === 0 ? (
           <EmptyState
             icon={Award}
-            title={hasActiveFilters ? "Sin resultados" : "No hay especialidades"}
-            description={hasActiveFilters ? "No hay especialidades que coincidan con los filtros." : "No se encontraron registros."}
+            title={hasActiveFilters ? t("emptyFilterTitle") : t("emptyTitle")}
+            description={hasActiveFilters ? t("emptyFilterDescription") : t("emptyDescription")}
           >
             {canCreate && !hasActiveFilters && (
               <Button asChild>
                 <Link href="/dashboard/honors/new">
                   <Plus className="size-4" />
-                  Crear especialidad
+                  {t("createButton")}
                 </Link>
               </Button>
             )}
@@ -459,14 +462,14 @@ export function HonorsCrudPage({
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Especialidad</TableHead>
-                    <TableHead>Categoría</TableHead>
-                    <TableHead>Tipo de club</TableHead>
-                    <TableHead>Nivel</TableHead>
-                    <TableHead>Estado</TableHead>
+                    <TableHead>{t("tableHeaderHonor")}</TableHead>
+                    <TableHead>{t("tableHeaderCategory")}</TableHead>
+                    <TableHead>{t("tableHeaderClubType")}</TableHead>
+                    <TableHead>{t("tableHeaderLevel")}</TableHead>
+                    <TableHead>{t("tableHeaderStatus")}</TableHead>
                     {(canEdit || canDelete) && (
                       <TableHead className="sticky right-0 z-20 w-[100px] border-l bg-background">
-                        Acciones
+                        {t("tableHeaderActions")}
                       </TableHead>
                     )}
                   </TableRow>
@@ -496,7 +499,7 @@ export function HonorsCrudPage({
                         <TableCell className="text-sm">{skillLevel ?? "—"}</TableCell>
                         <TableCell>
                           <Badge variant={item.active !== false ? "soft-success" : "outline"} className="text-xs">
-                            {item.active !== false ? "Activo" : "Inactivo"}
+                            {item.active !== false ? t("badgeActive") : t("badgeInactive")}
                           </Badge>
                         </TableCell>
                         {(canEdit || canDelete) && (
@@ -508,9 +511,9 @@ export function HonorsCrudPage({
                                   size="icon"
                                   className="size-8"
                                   asChild
-                                  title="Editar"
+                                  title={t("editButton")}
                                 >
-                                  <Link href={editHref} aria-label={`Editar ${honorName}`}>
+                                  <Link href={editHref} aria-label={t("editAriaLabel", { name: honorName })}>
                                     <Pencil className="size-3.5" />
                                   </Link>
                                 </Button>
@@ -522,7 +525,7 @@ export function HonorsCrudPage({
                                   className="size-8 text-destructive hover:text-destructive"
                                   disabled={!honorId}
                                   onClick={() => setDeleteItem(item)}
-                                  title="Eliminar"
+                                  title={t("deleteButton")}
                                 >
                                   <Trash2 className="size-3.5" />
                                 </Button>
@@ -531,7 +534,7 @@ export function HonorsCrudPage({
                             <div className="md:hidden">
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
-                                  <Button variant="ghost" size="icon" className="size-8" title="Acciones">
+                                  <Button variant="ghost" size="icon" className="size-8" title={t("actionsButton")}>
                                     <MoreHorizontal className="size-4" />
                                   </Button>
                                 </DropdownMenuTrigger>
@@ -540,7 +543,7 @@ export function HonorsCrudPage({
                                     <DropdownMenuItem asChild>
                                       <Link href={editHref}>
                                         <Pencil className="size-4" />
-                                        Editar
+                                        {t("editButton")}
                                       </Link>
                                     </DropdownMenuItem>
                                   )}
@@ -551,7 +554,7 @@ export function HonorsCrudPage({
                                       onSelect={() => setDeleteItem(item)}
                                     >
                                       <Trash2 className="size-4" />
-                                      Eliminar
+                                      {t("deleteButton")}
                                     </DropdownMenuItem>
                                   )}
                                 </DropdownMenuContent>
@@ -581,20 +584,19 @@ export function HonorsCrudPage({
         <AlertDialog open={!!deleteItem} onOpenChange={(open) => { if (!open) setDeleteItem(null); }}>
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>¿Eliminar especialidad?</AlertDialogTitle>
+              <AlertDialogTitle>{t("deleteDialogTitle")}</AlertDialogTitle>
               <AlertDialogDescription>
-                Se desactivará de forma lógica la especialidad{" "}
-                <span className="font-medium">&quot;{pickHonorName(deleteItem)}&quot;</span>.
+                {t("deleteDialogDescription", { name: pickHonorName(deleteItem) })}
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancelar</AlertDialogCancel>
+              <AlertDialogCancel>{t("deleteDialogCancel")}</AlertDialogCancel>
               <form action={deleteFormAction} className="space-y-2">
                 <input type="hidden" name="id" value={String(pickHonorId(deleteItem) ?? "")} />
                 {deleteState.error && (
                   <p className="text-xs text-destructive">{deleteState.error}</p>
                 )}
-                <DeleteButton />
+                <DeleteButton label={t("deleteDialogConfirm")} />
               </form>
             </AlertDialogFooter>
           </AlertDialogContent>
@@ -603,7 +605,7 @@ export function HonorsCrudPage({
 
       {!canMutate && (
         <div className="rounded-md border border-dashed px-4 py-3 text-sm text-muted-foreground">
-          No cuentas con permisos para modificar especialidades.
+          {t("noPermissionBanner")}
         </div>
       )}
     </div>

--- a/src/components/layout/app-breadcrumbs.tsx
+++ b/src/components/layout/app-breadcrumbs.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
 import Link from "next/link";
 import {
@@ -12,48 +13,19 @@ import {
 } from "@/components/ui/breadcrumb";
 import { Fragment } from "react";
 
-const labelMap: Record<string, string> = {
-  dashboard: "Dashboard",
-  users: "Usuarios",
-  catalogs: "Catálogos",
-  geography: "Geografía",
-  countries: "Países",
-  unions: "Uniones",
-  "local-fields": "Campos locales",
-  districts: "Distritos",
-  churches: "Iglesias",
-  allergies: "Alergias",
-  diseases: "Enfermedades",
-  medicines: "Medicamentos",
-  "relationship-types": "Tipos de relación",
-  "ecclesiastical-years": "Años eclesiásticos",
-  "club-types": "Tipos de club",
-  "club-ideals": "Ideales de club",
-  "honor-categories": "Categorías de especialidades",
-  clubs: "Clubes",
-  new: "Nuevo",
-  instances: "Instancias",
-  camporees: "Camporees",
-  classes: "Clases",
-  honors: "Especialidades",
-  activities: "Actividades",
-  finances: "Finanzas",
-  inventory: "Inventario",
-  certifications: "Certificaciones",
-  insurance: "Seguros",
-  notifications: "Notificaciones",
-  folders: "Folders",
-  rbac: "Roles y permisos",
-  permissions: "Permisos",
-  roles: "Roles",
-  matrix: "Matriz",
-};
-
-function getLabel(segment: string): string {
-  return labelMap[segment] ?? segment;
-}
+// Segments that have a known translation key in nav.breadcrumbs
+const TRANSLATED_SEGMENTS = new Set([
+  "dashboard", "users", "catalogs", "geography", "countries", "unions",
+  "local-fields", "districts", "churches", "allergies", "diseases",
+  "medicines", "relationship-types", "ecclesiastical-years", "club-types",
+  "club-ideals", "honor-categories", "clubs", "new", "instances",
+  "camporees", "classes", "honors", "activities", "finances", "inventory",
+  "certifications", "insurance", "notifications", "folders", "rbac",
+  "permissions", "roles", "matrix",
+]);
 
 export function AppBreadcrumbs() {
+  const t = useTranslations("nav.breadcrumbs");
   const pathname = usePathname();
   const segments = pathname.split("/").filter(Boolean);
 
@@ -62,7 +34,11 @@ export function AppBreadcrumbs() {
   const crumbs = segments.map((segment, index) => {
     const href = "/" + segments.slice(0, index + 1).join("/");
     const isLast = index === segments.length - 1;
-    return { label: getLabel(segment), href, isLast };
+    // Translate known segments; fall back to raw segment for dynamic IDs / unknown routes
+    const label = TRANSLATED_SEGMENTS.has(segment)
+      ? t(segment as Parameters<typeof t>[0])
+      : segment;
+    return { label, href, isLast };
   });
 
   return (

--- a/src/components/layout/theme-toggle.tsx
+++ b/src/components/layout/theme-toggle.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { Moon, Sun } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 export function ThemeToggle() {
+  const t = useTranslations("nav.themeToggle");
   const { theme, setTheme, resolvedTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
 
@@ -16,9 +18,9 @@ export function ThemeToggle() {
   const nextTheme = isDark ? "light" : "dark";
   const label = mounted
     ? isDark
-      ? "Cambiar a modo claro"
-      : "Cambiar a modo oscuro"
-    : "Cambiar tema";
+      ? t("switchToLight")
+      : t("switchToDark")
+    : t("switchTheme");
 
   return (
     <Button

--- a/src/components/notifications/notification-forms.tsx
+++ b/src/components/notifications/notification-forms.tsx
@@ -3,6 +3,7 @@
 import { useActionState } from "react";
 import { useFormStatus } from "react-dom";
 import { Loader2, Send, Radio, Users } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -53,6 +54,7 @@ function StatusBanner({ state }: { state: NotificationActionState }) {
 const initial: NotificationActionState = {};
 
 export function DirectNotificationForm() {
+  const t = useTranslations("notifications.forms");
   const [state, action] = useActionState(sendDirectNotificationAction, initial);
 
   return (
@@ -60,32 +62,32 @@ export function DirectNotificationForm() {
       <CardHeader>
         <div className="flex items-center gap-2">
           <Send className="size-5 text-primary" />
-          <CardTitle className="text-base">Envío directo</CardTitle>
+          <CardTitle className="text-base">{t("direct_title")}</CardTitle>
         </div>
-        <CardDescription>Enviar una notificación push a un usuario específico.</CardDescription>
+        <CardDescription>{t("direct_description")}</CardDescription>
       </CardHeader>
       <CardContent>
         <form action={action} className="space-y-4">
           <StatusBanner state={state} />
           <div className="space-y-2">
             <Label htmlFor="direct_user_id">
-              ID de usuario <span className="text-destructive">*</span>
+              {t("label_user_id")} <span className="text-destructive">*</span>
             </Label>
-            <Input id="direct_user_id" name="user_id" placeholder="UUID del usuario" required />
+            <Input id="direct_user_id" name="user_id" placeholder={t("placeholder_user_id")} required />
           </div>
           <div className="space-y-2">
             <Label htmlFor="direct_title">
-              Título <span className="text-destructive">*</span>
+              {t("label_title")} <span className="text-destructive">*</span>
             </Label>
-            <Input id="direct_title" name="title" placeholder="Título de la notificación" required />
+            <Input id="direct_title" name="title" placeholder={t("placeholder_title_notification")} required />
           </div>
           <div className="space-y-2">
             <Label htmlFor="direct_body">
-              Mensaje <span className="text-destructive">*</span>
+              {t("label_body")} <span className="text-destructive">*</span>
             </Label>
-            <Textarea id="direct_body" name="body" placeholder="Contenido del mensaje" rows={3} required />
+            <Textarea id="direct_body" name="body" placeholder={t("placeholder_body")} rows={3} required />
           </div>
-          <SubmitButton label="Enviar notificación" />
+          <SubmitButton label={t("submit_send")} />
         </form>
       </CardContent>
     </Card>
@@ -93,6 +95,7 @@ export function DirectNotificationForm() {
 }
 
 export function BroadcastNotificationForm() {
+  const t = useTranslations("notifications.forms");
   const [state, action] = useActionState(broadcastNotificationAction, initial);
 
   return (
@@ -100,29 +103,29 @@ export function BroadcastNotificationForm() {
       <CardHeader>
         <div className="flex items-center gap-2">
           <Radio className="size-5 text-primary" />
-          <CardTitle className="text-base">Broadcast</CardTitle>
+          <CardTitle className="text-base">{t("broadcast_title")}</CardTitle>
         </div>
-        <CardDescription>Enviar notificación push a todos los usuarios registrados.</CardDescription>
+        <CardDescription>{t("broadcast_description")}</CardDescription>
       </CardHeader>
       <CardContent>
         <form action={action} className="space-y-4">
           <StatusBanner state={state} />
           <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-sm text-warning-foreground dark:text-warning">
-            Esta acción enviará la notificación a <strong>todos</strong> los usuarios con token FCM registrado.
+            {t("broadcast_warning")}
           </div>
           <div className="space-y-2">
             <Label htmlFor="broadcast_title">
-              Título <span className="text-destructive">*</span>
+              {t("label_title")} <span className="text-destructive">*</span>
             </Label>
-            <Input id="broadcast_title" name="title" placeholder="Título del broadcast" required />
+            <Input id="broadcast_title" name="title" placeholder={t("placeholder_title_broadcast")} required />
           </div>
           <div className="space-y-2">
             <Label htmlFor="broadcast_body">
-              Mensaje <span className="text-destructive">*</span>
+              {t("label_body")} <span className="text-destructive">*</span>
             </Label>
-            <Textarea id="broadcast_body" name="body" placeholder="Contenido del mensaje" rows={3} required />
+            <Textarea id="broadcast_body" name="body" placeholder={t("placeholder_body")} rows={3} required />
           </div>
-          <SubmitButton label="Enviar broadcast" />
+          <SubmitButton label={t("submit_broadcast")} />
         </form>
       </CardContent>
     </Card>
@@ -130,6 +133,7 @@ export function BroadcastNotificationForm() {
 }
 
 export function ClubNotificationForm() {
+  const t = useTranslations("notifications.forms");
   const [state, action] = useActionState(clubNotificationAction, initial);
 
   return (
@@ -137,47 +141,47 @@ export function ClubNotificationForm() {
       <CardHeader>
         <div className="flex items-center gap-2">
           <Users className="size-5 text-primary" />
-          <CardTitle className="text-base">Por club</CardTitle>
+          <CardTitle className="text-base">{t("club_title")}</CardTitle>
         </div>
-        <CardDescription>Enviar notificación a todos los miembros de un club.</CardDescription>
+        <CardDescription>{t("club_description")}</CardDescription>
       </CardHeader>
       <CardContent>
         <form action={action} className="space-y-4">
           <StatusBanner state={state} />
           <div className="space-y-2">
             <Label htmlFor="club_instance_type">
-              Tipo de club <span className="text-destructive">*</span>
+              {t("label_instance_type")} <span className="text-destructive">*</span>
             </Label>
             <Select name="instance_type" required>
               <SelectTrigger id="club_instance_type">
-                <SelectValue placeholder="Seleccionar tipo de club..." />
+                <SelectValue placeholder={t("placeholder_instance_type")} />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="adventurers">Aventureros</SelectItem>
-                <SelectItem value="pathfinders">Conquistadores</SelectItem>
-                <SelectItem value="master_guilds">Guías Mayores</SelectItem>
+                <SelectItem value="adventurers">{t("option_adventurers")}</SelectItem>
+                <SelectItem value="pathfinders">{t("option_pathfinders")}</SelectItem>
+                <SelectItem value="master_guilds">{t("option_master_guilds")}</SelectItem>
               </SelectContent>
             </Select>
           </div>
           <div className="space-y-2">
             <Label htmlFor="club_instance_id">
-              ID de instancia <span className="text-destructive">*</span>
+              {t("label_instance_id")} <span className="text-destructive">*</span>
             </Label>
-            <Input id="club_instance_id" name="instance_id" type="number" placeholder="ID numérico del club" required />
+            <Input id="club_instance_id" name="instance_id" type="number" placeholder={t("placeholder_instance_id")} required />
           </div>
           <div className="space-y-2">
             <Label htmlFor="club_title">
-              Título <span className="text-destructive">*</span>
+              {t("label_title")} <span className="text-destructive">*</span>
             </Label>
-            <Input id="club_title" name="title" placeholder="Título de la notificación" required />
+            <Input id="club_title" name="title" placeholder={t("placeholder_title_notification")} required />
           </div>
           <div className="space-y-2">
             <Label htmlFor="club_body">
-              Mensaje <span className="text-destructive">*</span>
+              {t("label_body")} <span className="text-destructive">*</span>
             </Label>
-            <Textarea id="club_body" name="body" placeholder="Contenido del mensaje" rows={3} required />
+            <Textarea id="club_body" name="body" placeholder={t("placeholder_body")} rows={3} required />
           </div>
-          <SubmitButton label="Enviar a club" />
+          <SubmitButton label={t("submit_club")} />
         </form>
       </CardContent>
     </Card>

--- a/src/components/notifications/notification-history-table.tsx
+++ b/src/components/notifications/notification-history-table.tsx
@@ -9,6 +9,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { getTranslations } from "next-intl/server";
 import { DataTablePagination } from "@/components/shared/data-table-pagination";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
@@ -19,18 +20,6 @@ interface NotificationHistoryTableProps {
   page: number;
   limit: number;
 }
-
-const TYPE_LABELS: Record<string, string> = {
-  BROADCAST: "Broadcast",
-  USER: "Usuario",
-  CLUB: "Club",
-};
-
-const TARGET_TYPE_LABELS: Record<string, string> = {
-  all: "Todos",
-  user: "Usuario",
-  club_section: "Sección de club",
-};
 
 function typeVariant(type: string): "default" | "secondary" | "outline" {
   if (type === "BROADCAST") return "default";
@@ -58,10 +47,24 @@ function senderName(log: NotificationLog): string {
   return log.users?.email ?? log.sent_by;
 }
 
+const TYPE_LABEL_KEYS: Record<string, string> = {
+  BROADCAST: "type_broadcast",
+  USER: "type_user",
+  CLUB: "type_club",
+};
+
+const TARGET_TYPE_LABEL_KEYS: Record<string, string> = {
+  all: "target_all",
+  user: "target_user",
+  club_section: "target_club_section",
+};
+
 export async function NotificationHistoryTable({
   page,
   limit,
 }: NotificationHistoryTableProps) {
+  const t = await getTranslations("notifications.history");
+
   let result: Awaited<ReturnType<typeof getNotificationHistory>> | null = null;
   let errorMessage: string | null = null;
 
@@ -71,7 +74,7 @@ export async function NotificationHistoryTable({
     errorMessage =
       error instanceof ApiError
         ? error.message
-        : "No se pudo cargar el historial de notificaciones.";
+        : t("error_load");
   }
 
   if (errorMessage) {
@@ -82,8 +85,8 @@ export async function NotificationHistoryTable({
     return (
       <EmptyState
         icon={Bell}
-        title="Sin historial"
-        description="Aún no se han enviado notificaciones."
+        title={t("empty_title")}
+        description={t("empty_description")}
       />
     );
   }
@@ -95,59 +98,63 @@ export async function NotificationHistoryTable({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Título</TableHead>
-                <TableHead>Tipo</TableHead>
-                <TableHead>Destino</TableHead>
-                <TableHead className="text-center">Enviados</TableHead>
-                <TableHead className="text-center">Fallidos</TableHead>
-                <TableHead>Enviado por</TableHead>
-                <TableHead>Fecha</TableHead>
+                <TableHead>{t("col_title")}</TableHead>
+                <TableHead>{t("col_type")}</TableHead>
+                <TableHead>{t("col_target")}</TableHead>
+                <TableHead className="text-center">{t("col_sent")}</TableHead>
+                <TableHead className="text-center">{t("col_failed")}</TableHead>
+                <TableHead>{t("col_sent_by")}</TableHead>
+                <TableHead>{t("col_date")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {result.data.map((log) => (
-                <TableRow key={log.log_id}>
-                  <TableCell>
-                    <div className="max-w-[200px]">
-                      <p className="truncate font-medium text-sm">{log.title}</p>
-                      <p className="truncate text-xs text-muted-foreground">{log.body}</p>
-                    </div>
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant={typeVariant(log.type)}>
-                      {TYPE_LABELS[log.type] ?? log.type}
-                    </Badge>
-                  </TableCell>
-                  <TableCell>
-                    <span className="text-sm text-muted-foreground">
-                      {TARGET_TYPE_LABELS[log.target_type] ?? log.target_type}
-                      {log.target_id && (
-                        <span className="ml-1 font-mono text-xs">({log.target_id})</span>
-                      )}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-center">
-                    <span className="inline-flex items-center gap-1 text-sm text-success">
-                      <CheckCircle2 className="size-3.5" />
-                      {log.tokens_sent}
-                    </span>
-                  </TableCell>
-                  <TableCell className="text-center">
-                    <span className="inline-flex items-center gap-1 text-sm text-destructive">
-                      <XCircle className="size-3.5" />
-                      {log.tokens_failed}
-                    </span>
-                  </TableCell>
-                  <TableCell>
-                    <span className="text-sm">{senderName(log)}</span>
-                  </TableCell>
-                  <TableCell>
-                    <span className="whitespace-nowrap text-sm text-muted-foreground">
-                      {formatDate(log.created_at)}
-                    </span>
-                  </TableCell>
-                </TableRow>
-              ))}
+              {result.data.map((log) => {
+                const typeLabelKey = TYPE_LABEL_KEYS[log.type];
+                const targetLabelKey = TARGET_TYPE_LABEL_KEYS[log.target_type];
+                return (
+                  <TableRow key={log.log_id}>
+                    <TableCell>
+                      <div className="max-w-[200px]">
+                        <p className="truncate font-medium text-sm">{log.title}</p>
+                        <p className="truncate text-xs text-muted-foreground">{log.body}</p>
+                      </div>
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant={typeVariant(log.type)}>
+                        {typeLabelKey ? t(typeLabelKey as Parameters<typeof t>[0]) : log.type}
+                      </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-sm text-muted-foreground">
+                        {targetLabelKey ? t(targetLabelKey as Parameters<typeof t>[0]) : log.target_type}
+                        {log.target_id && (
+                          <span className="ml-1 font-mono text-xs">({log.target_id})</span>
+                        )}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <span className="inline-flex items-center gap-1 text-sm text-success">
+                        <CheckCircle2 className="size-3.5" />
+                        {log.tokens_sent}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <span className="inline-flex items-center gap-1 text-sm text-destructive">
+                        <XCircle className="size-3.5" />
+                        {log.tokens_failed}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-sm">{senderName(log)}</span>
+                    </TableCell>
+                    <TableCell>
+                      <span className="whitespace-nowrap text-sm text-muted-foreground">
+                        {formatDate(log.created_at)}
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </CardContent>

--- a/src/components/ranking-weights/new-override-form.tsx
+++ b/src/components/ranking-weights/new-override-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Select,
   SelectContent,
@@ -26,6 +27,7 @@ export function NewOverrideForm({
   existingClubTypeIds,
   onCreated,
 }: NewOverrideFormProps) {
+  const t = useTranslations("rankingWeights.override");
   const [types, setTypes] = useState<ClubType[]>([]);
   const [selected, setSelected] = useState<number | null>(null);
 
@@ -47,12 +49,12 @@ export function NewOverrideForm({
         onValueChange={(v) => setSelected(parseInt(v, 10))}
       >
         <SelectTrigger>
-          <SelectValue placeholder="Seleccionar tipo de club" />
+          <SelectValue placeholder={t("selectPlaceholder")} />
         </SelectTrigger>
         <SelectContent>
           {available.length === 0 ? (
             <SelectItem value="__none" disabled>
-              Sin tipos disponibles
+              {t("noTypesAvailable")}
             </SelectItem>
           ) : (
             available.map((t) => (
@@ -75,7 +77,7 @@ export function NewOverrideForm({
             camporee_weight: 15,
             evidence_weight: 10,
           }}
-          submitLabel="Crear override"
+          submitLabel={t("createLabel")}
           onSubmit={async (values) => {
             await createRankingWeights({
               club_type_id: selected,

--- a/src/components/ranking-weights/weight-sum-indicator.tsx
+++ b/src/components/ranking-weights/weight-sum-indicator.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -9,13 +12,14 @@ interface WeightSumIndicatorProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function WeightSumIndicator({ sum }: WeightSumIndicatorProps) {
+  const t = useTranslations("rankingWeights.sum");
   const ok = sum === 100;
   return (
     <Badge
       variant={ok ? "soft-success" : "destructive"}
       className="font-mono tabular-nums"
     >
-      Suma: {sum} {ok ? "✓" : "✗"}
+      {t("label", { sum })} {ok ? "✓" : "✗"}
     </Badge>
   );
 }

--- a/src/components/ranking-weights/weights-form.tsx
+++ b/src/components/ranking-weights/weights-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useTranslations } from "next-intl";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { WeightInput } from "./weight-input";
@@ -30,6 +31,7 @@ export function WeightsForm({
   submitLabel = "Guardar",
   onSubmit,
 }: WeightsFormProps) {
+  const t = useTranslations("rankingWeights.form");
   const [v, setV] = useState<WeightsValues>(initial);
   const [busy, setBusy] = useState(false);
 
@@ -84,7 +86,7 @@ export function WeightsForm({
           {busy ? (
             <>
               <Loader2 className="animate-spin" />
-              Guardando...
+              {t("saving")}
             </>
           ) : (
             submitLabel

--- a/src/components/rankings/breakdown-view.tsx
+++ b/src/components/rankings/breakdown-view.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RankingScoreBadge } from "@/components/rankings/ranking-score-badge";
 import type {
@@ -12,25 +15,27 @@ function WeightsCard({
 }: {
   weights: RankingBreakdown["weights_applied"];
 }) {
+  const t = useTranslations("rankings.breakdown");
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Pesos aplicados</CardTitle>
+        <CardTitle>{t("weightsApplied")}</CardTitle>
       </CardHeader>
       <CardContent className="space-y-1 text-sm">
         <div className="text-muted-foreground">
-          Fuente:{" "}
+          {t("weightsSource")}:{" "}
           <span className="text-foreground font-medium">
             {weights.source === "default"
-              ? "Default global"
-              : "Override por tipo de club"}
+              ? t("weightsSourceDefault")
+              : t("weightsSourceOverride")}
           </span>
         </div>
         <div className="flex flex-wrap gap-x-4 gap-y-1">
-          <span>Carpetas: {weights.folder}%</span>
-          <span>Finanzas: {weights.finance}%</span>
-          <span>Camporees: {weights.camporee}%</span>
-          <span>Evidencias: {weights.evidence}%</span>
+          <span>{t("componentFolder")}: {weights.folder}%</span>
+          <span>{t("componentFinance")}: {weights.finance}%</span>
+          <span>{t("componentCamporee")}: {weights.camporee}%</span>
+          <span>{t("componentEvidence")}: {weights.evidence}%</span>
         </div>
       </CardContent>
     </Card>
@@ -68,6 +73,7 @@ interface Props {
 }
 
 export function BreakdownView({ data }: Props) {
+  const t = useTranslations("rankings.breakdown");
   const { components: c, weights_applied } = data;
 
   return (
@@ -76,7 +82,7 @@ export function BreakdownView({ data }: Props) {
       <div className="flex items-center gap-3">
         <RankingScoreBadge value={data.composite_score_pct} className="text-lg px-3 py-1" />
         <span className="text-sm text-muted-foreground">
-          Puntaje compuesto institucional
+          {t("compositeScore")}
         </span>
       </div>
 
@@ -86,16 +92,16 @@ export function BreakdownView({ data }: Props) {
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center justify-between text-base">
-              Carpetas
+              {t("componentFolder")}
               <RankingScoreBadge value={c.folder.score_pct} />
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-1 text-sm">
             <div>
-              {c.folder.earned_points} / {c.folder.max_points} puntos
+              {t("pointsOf", { earned: c.folder.earned_points, max: c.folder.max_points })}
             </div>
             <div className="text-muted-foreground">
-              {c.folder.sections_evaluated} secciones evaluadas
+              {t("sectionsEvaluated", { count: c.folder.sections_evaluated })}
             </div>
           </CardContent>
         </Card>
@@ -104,21 +110,20 @@ export function BreakdownView({ data }: Props) {
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center justify-between text-base">
-              Finanzas
+              {t("componentFinance")}
               <RankingScoreBadge value={c.finance.score_pct} />
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-1 text-sm">
             <div>
-              {c.finance.months_closed_on_time} / {c.finance.months_total}{" "}
-              meses cerrados a tiempo
+              {t("monthsClosedOnTime", { closed: c.finance.months_closed_on_time, total: c.finance.months_total })}
             </div>
             <div className="text-muted-foreground">
-              Deadline: día {c.finance.deadline_day} del mes siguiente
+              {t("deadlineDay", { day: c.finance.deadline_day })}
             </div>
             {c.finance.missed_months.length > 0 && (
               <div className="text-destructive text-xs">
-                Meses faltantes: {c.finance.missed_months.join(", ")}
+                {t("missedMonths", { months: c.finance.missed_months.join(", ") })}
               </div>
             )}
           </CardContent>
@@ -128,14 +133,13 @@ export function BreakdownView({ data }: Props) {
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center justify-between text-base">
-              Camporees
+              {t("componentCamporee")}
               <RankingScoreBadge value={c.camporee.score_pct} />
             </CardTitle>
           </CardHeader>
           <CardContent className="text-sm">
             <div>
-              {c.camporee.attended} / {c.camporee.available_in_scope} eventos
-              del scope
+              {t("camporeeEventsOf", { attended: c.camporee.attended, available: c.camporee.available_in_scope })}
             </div>
             <CamporeeEventList events={c.camporee.events} />
           </CardContent>
@@ -145,17 +149,16 @@ export function BreakdownView({ data }: Props) {
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center justify-between text-base">
-              Evidencias
+              {t("componentEvidence")}
               <RankingScoreBadge value={c.evidence.score_pct} />
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-1 text-sm">
             <div>
-              {c.evidence.validated} validadas / {c.evidence.rejected}{" "}
-              rechazadas
+              {t("evidenceValidatedRejected", { validated: c.evidence.validated, rejected: c.evidence.rejected })}
             </div>
             <div className="text-xs text-muted-foreground">
-              {c.evidence.pending_excluded} pendientes (excluidas del cálculo)
+              {t("evidencePendingExcluded", { pending: c.evidence.pending_excluded })}
             </div>
           </CardContent>
         </Card>

--- a/src/components/sla/sla-camporee-card.tsx
+++ b/src/components/sla/sla-camporee-card.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Tent, Users, CreditCard } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { CamporeeSummary } from "@/lib/api/analytics";
 
 interface SlaCamporeeCardProps {
@@ -10,6 +11,7 @@ interface SlaCamporeeCardProps {
 }
 
 export function SlaCamporeeCard({ camporee }: SlaCamporeeCardProps) {
+  const t = useTranslations("sla.camporee");
   const { clubs_pending, members_pending, payments_pending } = camporee;
   const total = clubs_pending + members_pending + payments_pending;
 
@@ -22,11 +24,11 @@ export function SlaCamporeeCard({ camporee }: SlaCamporeeCardProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Aprobaciones de Camporee</CardTitle>
+        <CardTitle className="text-base">{t("title")}</CardTitle>
         <CardDescription>
           {total > 0
-            ? `${total.toLocaleString("es-MX")} registro${total !== 1 ? "s" : ""} pendiente${total !== 1 ? "s" : ""} de aprobación`
-            : "Sin registros pendientes de aprobación"}
+            ? t("description_pending", { count: total })
+            : t("description_empty")}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -36,8 +38,8 @@ export function SlaCamporeeCard({ camporee }: SlaCamporeeCardProps) {
               <Tent className="size-4 text-primary" />
             </div>
             <div>
-              <p className="text-sm font-medium">Clubes registrados</p>
-              <p className="text-xs text-muted-foreground">Pendientes de aprobación</p>
+              <p className="text-sm font-medium">{t("clubs_label")}</p>
+              <p className="text-xs text-muted-foreground">{t("clubs_subtitle")}</p>
             </div>
           </div>
           <Badge variant={badgeVariant(clubs_pending)}>
@@ -51,8 +53,8 @@ export function SlaCamporeeCard({ camporee }: SlaCamporeeCardProps) {
               <Users className="size-4 text-primary" />
             </div>
             <div>
-              <p className="text-sm font-medium">Miembros registrados</p>
-              <p className="text-xs text-muted-foreground">Pendientes de aprobación</p>
+              <p className="text-sm font-medium">{t("members_label")}</p>
+              <p className="text-xs text-muted-foreground">{t("members_subtitle")}</p>
             </div>
           </div>
           <Badge variant={badgeVariant(members_pending)}>
@@ -66,8 +68,8 @@ export function SlaCamporeeCard({ camporee }: SlaCamporeeCardProps) {
               <CreditCard className="size-4 text-primary" />
             </div>
             <div>
-              <p className="text-sm font-medium">Pagos registrados</p>
-              <p className="text-xs text-muted-foreground">Pendientes de aprobación</p>
+              <p className="text-sm font-medium">{t("payments_label")}</p>
+              <p className="text-xs text-muted-foreground">{t("payments_subtitle")}</p>
             </div>
           </div>
           <Badge variant={badgeVariant(payments_pending)}>

--- a/src/components/sla/sla-dashboard-client.tsx
+++ b/src/components/sla/sla-dashboard-client.tsx
@@ -3,6 +3,7 @@
 import { formatDistanceToNow } from "date-fns";
 import { es } from "date-fns/locale";
 import { RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { SlaDashboard } from "@/lib/api/analytics";
 import { SlaStatCards } from "./sla-stat-cards";
 import { SlaPipelineChart } from "./sla-pipeline-chart";
@@ -15,6 +16,8 @@ interface SlaDashboardClientProps {
 }
 
 export function SlaDashboardClient({ data }: SlaDashboardClientProps) {
+  const t = useTranslations("sla.client");
+
   const computedAgo = formatDistanceToNow(new Date(data.computed_at), {
     addSuffix: true,
     locale: es,
@@ -25,14 +28,14 @@ export function SlaDashboardClient({ data }: SlaDashboardClientProps) {
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">SLA Dashboard</h1>
+          <h1 className="text-2xl font-bold tracking-tight">{t("title")}</h1>
           <p className="text-muted-foreground">
-            Metricas operativas de investiduras, validaciones y camporees.
+            {t("description")}
           </p>
         </div>
         <div className="flex items-center gap-1.5 text-xs text-muted-foreground pt-1">
           <RefreshCw className="size-3" />
-          <span>Actualizado {computedAgo}{data.cached ? " (cache)" : ""}</span>
+          <span>{t("updated", { ago: computedAgo })}{data.cached ? t("cached") : ""}</span>
         </div>
       </div>
 

--- a/src/components/sla/sla-pipeline-chart.tsx
+++ b/src/components/sla/sla-pipeline-chart.tsx
@@ -10,6 +10,7 @@ import {
   Cell,
 } from "recharts";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
 import type { InvestiturePipelineItem } from "@/lib/api/analytics";
 
 interface SlaPipelineChartProps {
@@ -37,30 +38,32 @@ interface TooltipProps {
 }
 
 function CustomTooltip({ active, payload }: TooltipProps) {
+  const t = useTranslations("sla.pipeline");
   if (!active || !payload?.length) return null;
   const entry = payload[0].payload;
   return (
     <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
       <p className="font-medium">{entry.label}</p>
       <p className="text-muted-foreground">
-        {entry.count.toLocaleString("es-MX")} inscripción{entry.count !== 1 ? "es" : ""}
+        {entry.count.toLocaleString("es-MX")} {t("tooltip_enrollments", { count: entry.count })}
       </p>
     </div>
   );
 }
 
 export function SlaPipelineChart({ pipeline }: SlaPipelineChartProps) {
+  const t = useTranslations("sla.pipeline");
   const visiblePipeline = pipeline.filter((p) => p.count > 0 || p.status !== "FIELD_APPROVED");
 
   if (visiblePipeline.every((p) => p.count === 0)) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Pipeline de Investidura</CardTitle>
-          <CardDescription>Distribución por estado</CardDescription>
+          <CardTitle className="text-base">{t("title")}</CardTitle>
+          <CardDescription>{t("description_distribution")}</CardDescription>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">No hay inscripciones activas en el pipeline.</p>
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
         </CardContent>
       </Card>
     );
@@ -69,8 +72,8 @@ export function SlaPipelineChart({ pipeline }: SlaPipelineChartProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Pipeline de Investidura</CardTitle>
-        <CardDescription>Inscripciones activas por estado de aprobación</CardDescription>
+        <CardTitle className="text-base">{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
       <CardContent>
         <ResponsiveContainer width="100%" height={220}>

--- a/src/components/sla/sla-refresh-button.tsx
+++ b/src/components/sla/sla-refresh-button.tsx
@@ -2,10 +2,12 @@
 
 import { useRouter } from "next/navigation";
 import { useTransition } from "react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { RefreshCw } from "lucide-react";
 
 export function SlaRefreshButton() {
+  const t = useTranslations("sla.actions");
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -23,7 +25,7 @@ export function SlaRefreshButton() {
       disabled={isPending}
     >
       <RefreshCw className={`mr-2 h-4 w-4 ${isPending ? "animate-spin" : ""}`} />
-      {isPending ? "Actualizando..." : "Actualizar"}
+      {isPending ? t("refreshing") : t("refresh")}
     </Button>
   );
 }

--- a/src/components/sla/sla-stat-cards.tsx
+++ b/src/components/sla/sla-stat-cards.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Clock, AlertTriangle, TrendingUp, CheckCircle2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { SlaDashboard } from "@/lib/api/analytics";
 
 interface SlaStatCardsProps {
@@ -41,10 +42,11 @@ function StatCard({ title, value, subtitle, icon: Icon, badgeLabel, badgeVariant
 }
 
 export function SlaStatCards({ data }: SlaStatCardsProps) {
+  const t = useTranslations("sla.stats");
   const { investiture, timing, approval_rate } = data;
 
   const avgDays = timing.avg_days_total;
-  const avgDaysLabel = avgDays !== null ? `${avgDays} días promedio` : "Sin datos";
+  const avgDaysLabel = avgDays !== null ? t("avg_approval_days", { days: avgDays }) : t("avg_approval_no_data");
 
   const overdueVariant: StatCardProps["badgeVariant"] =
     investiture.overdue === 0 ? "success" : investiture.overdue < 5 ? "warning" : "destructive";
@@ -55,31 +57,31 @@ export function SlaStatCards({ data }: SlaStatCardsProps) {
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       <StatCard
-        title="Total pendientes"
+        title={t("total_pending")}
         value={investiture.total_pending}
-        subtitle={`${investiture.in_review} en revisión activa`}
+        subtitle={t("total_pending_subtitle", { count: investiture.in_review })}
         icon={Clock}
       />
       <StatCard
-        title="Vencidos"
+        title={t("overdue")}
         value={investiture.overdue}
-        subtitle="Enviados hace más de 30 días"
+        subtitle={t("overdue_subtitle")}
         icon={AlertTriangle}
-        badgeLabel={investiture.overdue === 0 ? "Al día" : "Requieren atención"}
+        badgeLabel={investiture.overdue === 0 ? t("overdue_badge_ok") : t("overdue_badge_attention")}
         badgeVariant={overdueVariant}
       />
       <StatCard
-        title="Promedio de aprobación"
+        title={t("avg_approval")}
         value={avgDaysLabel}
-        subtitle="De inscripción a investido"
+        subtitle={t("avg_approval_subtitle")}
         icon={TrendingUp}
       />
       <StatCard
-        title="Tasa de aprobación"
+        title={t("approval_rate")}
         value={`${approval_rate.rate}%`}
-        subtitle={`${approval_rate.resolved} resueltos (90 días)`}
+        subtitle={t("approval_rate_subtitle", { count: approval_rate.resolved })}
         icon={CheckCircle2}
-        badgeLabel={`${approval_rate.approved} aprobados`}
+        badgeLabel={t("approval_rate_badge", { count: approval_rate.approved })}
         badgeVariant={approvalVariant}
       />
     </div>

--- a/src/components/sla/sla-throughput-chart.tsx
+++ b/src/components/sla/sla-throughput-chart.tsx
@@ -11,6 +11,7 @@ import {
   CartesianGrid,
 } from "recharts";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
 import type { ThroughputWeek } from "@/lib/api/analytics";
 
 interface SlaThroughputChartProps {
@@ -24,13 +25,14 @@ interface TooltipProps {
 }
 
 function CustomTooltip({ active, payload, label }: TooltipProps) {
+  const t = useTranslations("sla.throughput");
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
       <p className="mb-1 font-medium text-xs text-muted-foreground">{label}</p>
       {payload.map((entry) => (
         <p key={entry.name} style={{ color: entry.color }} className="text-sm">
-          {entry.name === "approved" ? "Aprobados" : "Rechazados"}: {entry.value}
+          {entry.name === "approved" ? t("legend_approved") : t("legend_rejected")}: {entry.value}
         </p>
       ))}
     </div>
@@ -38,15 +40,17 @@ function CustomTooltip({ active, payload, label }: TooltipProps) {
 }
 
 export function SlaThroughputChart({ throughput }: SlaThroughputChartProps) {
+  const t = useTranslations("sla.throughput");
+
   if (throughput.length === 0) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Throughput — Ultimas 12 semanas</CardTitle>
-          <CardDescription>Investiduras aprobadas y rechazadas por semana</CardDescription>
+          <CardTitle className="text-base">{t("title")}</CardTitle>
+          <CardDescription>{t("description")}</CardDescription>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground">No hay datos de throughput disponibles.</p>
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
         </CardContent>
       </Card>
     );
@@ -55,8 +59,8 @@ export function SlaThroughputChart({ throughput }: SlaThroughputChartProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Throughput — Ultimas 12 semanas</CardTitle>
-        <CardDescription>Investiduras aprobadas y rechazadas por semana</CardDescription>
+        <CardTitle className="text-base">{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
       </CardHeader>
       <CardContent>
         <ResponsiveContainer width="100%" height={220}>
@@ -83,7 +87,7 @@ export function SlaThroughputChart({ throughput }: SlaThroughputChartProps) {
               iconSize={10}
               formatter={(value) => (
                 <span className="text-xs text-muted-foreground">
-                  {value === "approved" ? "Aprobados" : "Rechazados"}
+                  {value === "approved" ? t("legend_approved") : t("legend_rejected")}
                 </span>
               )}
             />

--- a/src/components/sla/sla-validation-card.tsx
+++ b/src/components/sla/sla-validation-card.tsx
@@ -3,6 +3,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { GraduationCap, Award } from "lucide-react";
+import { useTranslations } from "next-intl";
 import type { ValidationSummary } from "@/lib/api/analytics";
 
 interface SlaValidationCardProps {
@@ -10,16 +11,17 @@ interface SlaValidationCardProps {
 }
 
 export function SlaValidationCard({ validation }: SlaValidationCardProps) {
+  const t = useTranslations("sla.validation");
   const { class_sections_pending, honors_pending, total_pending } = validation;
 
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Cola de Validación</CardTitle>
+        <CardTitle className="text-base">{t("title")}</CardTitle>
         <CardDescription>
           {total_pending > 0
-            ? `${total_pending.toLocaleString("es-MX")} item${total_pending !== 1 ? "s" : ""} esperando validación`
-            : "Sin items pendientes de validación"}
+            ? t("description_pending", { count: total_pending })
+            : t("description_empty")}
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -29,8 +31,8 @@ export function SlaValidationCard({ validation }: SlaValidationCardProps) {
               <GraduationCap className="size-4 text-primary" />
             </div>
             <div>
-              <p className="text-sm font-medium">Secciones de Clase</p>
-              <p className="text-xs text-muted-foreground">Progreso pendiente de validar</p>
+              <p className="text-sm font-medium">{t("class_sections_label")}</p>
+              <p className="text-xs text-muted-foreground">{t("class_sections_subtitle")}</p>
             </div>
           </div>
           <Badge
@@ -46,8 +48,8 @@ export function SlaValidationCard({ validation }: SlaValidationCardProps) {
               <Award className="size-4 text-primary" />
             </div>
             <div>
-              <p className="text-sm font-medium">Especialidades</p>
-              <p className="text-xs text-muted-foreground">Honores pendientes de validar</p>
+              <p className="text-sm font-medium">{t("honors_label")}</p>
+              <p className="text-xs text-muted-foreground">{t("honors_subtitle")}</p>
             </div>
           </div>
           <Badge


### PR DESCRIPTION
## Summary

next-intl batch 8 — single PR combining 3 parallel agent worktrees.

- **sla** (NEW, +45 keys): dashboard-client, stat-cards, refresh-button, pipeline-chart, validation-card, throughput-chart, camporee-card
- **enrollments** (NEW, +22 keys): enrollments-table
- **notifications** (extended +40 keys): notification-forms, notification-history-table
- **rankings** (NEW, +17 keys): breakdown-view
- **rankingWeights** (extended +5 keys): weights-form, weight-sum-indicator, new-override-form
- **nav** (extended +37 keys): app-breadcrumbs, theme-toggle
- **folders** (extended +45 keys): folder-status-badge, folders-management-client, folder-detail-client
- **honors** (extended +65 keys): honors-crud-page, honor-form-fields, honor-form

22 component files + 4 messages JSONs. ~276 new keys per locale, 4 locales all in sync. Cumulative i18n project: ~1669 keys across 22 namespaces.

## Patterns applied

- **3 components newly `'use client'`**: folder-status-badge, weight-sum-indicator, breakdown-view (added the directive when adopting `useTranslations`).
- **recharts charts**: tooltip/legend/axis labels translated. `dataKey` / `STATUS_COLORS` constants kept raw (technical identifiers, not UI copy).
- **ICU plural**: SLA pipeline tooltip enrollment count, validation pending count, folder count, sections count.
- **ICU interpolation**: delete-dialog descriptions ({name}), points-of expressions ({earned} / {max}), sum indicator ({sum}).
- **DeleteButton refactor**: accepts `label` prop (consistent with `SubmitButton` pattern in `honor-form`). Avoids hooks-in-callback pitfalls when sub-component uses `useFormStatus`.
- **Locale switcher native names**: `"Español"`, `"English"`, `"Français"`, `"Português (Brasil)"` intentionally kept raw in the component — rendered native in every locale, not translated.
- **Theme toggle aria-labels** translated as `nav.themeToggle.{switchToLight,switchToDark,switchTheme}`.
- **TYPE_LABELS / STATUS_LABELS** module-level maps removed in favor of `t(key)` inside render (split visual constants from UI strings, validated batches 4-7).
- **5 components left untouched** (no-migration-needed):
  - `ranking-score-badge` — only renders `{value.toFixed(1)}%`
  - `weight-input` — `label` is caller-provided prop
  - `app-header` — purely structural, delegates to children
  - `locale-switcher` — native names rule (above)
  - `honor-image-cell` — `alt` is prop, `"—"` is sentinel
- **Zod schema strings explicitly deferred** to separate cross-PR refactor.

## Test plan

- [x] All 3 sub-agents branched from `origin/development` HEAD `1f21d3f` cleanly (CRITICAL header verification)
- [x] No file overlap between 3 worktrees (0 merge conflicts)
- [x] Python deep-merge produced 4 locale JSONs in sync (`sla=45, enrollments=22, notifications=53, rankings=17, rankingWeights=33, nav=127, folders=48, honors=80` per locale)
- [x] `pnpm typecheck` produces no new errors (6 pre-existing `vitest` module errors on baseline are unchanged)
- [x] All 4 `messages/*.json` parse as valid JSON
- [ ] Manual smoke: locale switcher across the 8 features (especially recharts tooltips/legends in SLA dashboard)
- [ ] fr/pt-BR translation review (deferred — accumulated across 16 PRs i18n)