### PR TITLE
feat(i18n): batch 11 — all remaining pages + _components + app root

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -385,19 +385,23 @@
     "pages": {
       "countries": {
         "title": "Countries",
-        "description": "System country catalog."
+        "description": "System country catalog.",
+        "metadataTitle": "Countries"
       },
       "churches": {
         "title": "Churches",
-        "description": "System church catalog."
+        "description": "System church catalog.",
+        "metadataTitle": "Churches"
       },
       "districts": {
         "title": "Districts",
-        "description": "System district catalog."
+        "description": "System district catalog.",
+        "metadataTitle": "Districts"
       },
       "unions": {
         "title": "Unions",
-        "description": "System union catalog."
+        "description": "System union catalog.",
+        "metadataTitle": "Unions"
       },
       "unionsDetail": {
         "back": "Back",
@@ -413,7 +417,8 @@
       },
       "localFields": {
         "title": "Local Fields",
-        "description": "System local field catalog."
+        "description": "System local field catalog.",
+        "metadataTitle": "Local fields"
       },
       "localFieldsDetail": {
         "back": "Back",
@@ -429,7 +434,8 @@
       },
       "activityTypes": {
         "title": "Activity types",
-        "description": "System activity type catalog."
+        "description": "System activity type catalog.",
+        "metadataTitle": "Activity types"
       },
       "folderSections": {
         "title": "Folder sections",
@@ -548,6 +554,41 @@
         "tableName": "Name",
         "tableLevel": "Level",
         "tableStatus": "Status"
+      },
+      "diseases": {
+        "title": "Diseases",
+        "description": "Chronic diseases or relevant medical conditions.",
+        "metadataTitle": "Diseases"
+      },
+      "clubTypes": {
+        "title": "Club types",
+        "description": "Club types available in the system.",
+        "metadataTitle": "Club types"
+      },
+      "medicines": {
+        "title": "Medicines",
+        "description": "Commonly used medications for members.",
+        "metadataTitle": "Medicines"
+      },
+      "clubIdeals": {
+        "title": "Club ideals",
+        "description": "Ideals associated with each club type.",
+        "metadataTitle": "Club ideals"
+      },
+      "allergies": {
+        "title": "Allergies",
+        "description": "List of allergies for the members' health profile.",
+        "metadataTitle": "Allergies"
+      },
+      "relationshipTypes": {
+        "title": "Relationship types",
+        "description": "Family or emergency contact relationships.",
+        "metadataTitle": "Relationship types"
+      },
+      "ecclesiasticalYears": {
+        "title": "Ecclesiastical years",
+        "description": "Annual periods for organizing activities.",
+        "metadataTitle": "Ecclesiastical years"
       }
     }
   },
@@ -1340,6 +1381,265 @@
         "defaultName": "No name",
         "defaultCategoryName": "Category {id}",
         "defaultAchievementName": "Achievement {id}"
+      }
+    },
+    "imageUpload": {
+      "dropzoneAriaLabel": "Upload area for achievement image",
+      "uploading": "Uploading image...",
+      "dropzonePrompt": "Drag an image or click to select",
+      "dropzoneHint": "PNG, SVG or WebP — maximum 2 MB",
+      "previewAlt": "Achievement preview",
+      "previewTitle": "Preview",
+      "tierLabel": "Tier:",
+      "noImageLabel": "No image",
+      "removeAriaLabel": "Remove image",
+      "toastSuccess": "Achievement image updated successfully.",
+      "toastError": "Could not upload the image. Try again.",
+      "toastSaveFirst": "Save the achievement first to upload an image.",
+      "validateTypeError": "Only PNG, SVG or WebP images are allowed.",
+      "validateSizeError": "File cannot exceed 2 MB."
+    },
+    "cards": {
+      "preview": {
+        "tierLabels": {
+          "BRONZE": "Bronze",
+          "SILVER": "Silver",
+          "GOLD": "Gold",
+          "PLATINUM": "Platinum",
+          "DIAMOND": "Diamond"
+        },
+        "typeLabels": {
+          "THRESHOLD": "Threshold",
+          "STREAK": "Streak",
+          "MILESTONE": "Milestone",
+          "COLLECTION": "Collection",
+          "COMPOUND": "Compound"
+        },
+        "repeatableBadge": "Repeatable",
+        "secretBadge": "Secret",
+        "pointsSuffix": "pts",
+        "defaultName": "Achievement name"
+      }
+    },
+    "forms": {
+      "category": {
+        "titleCreate": "New category",
+        "titleEdit": "Edit category",
+        "descriptionCreate": "Fill in the fields to create a new achievement category.",
+        "descriptionEdit": "Modify the achievement category data.",
+        "labelName": "Name",
+        "placeholderName": "E.g. Participation",
+        "labelDescription": "Description",
+        "placeholderDescription": "Describe this category...",
+        "labelIcon": "Icon",
+        "placeholderIcon": "trophy",
+        "labelIconHint": "(lucide-react icon name, e.g. trophy)",
+        "labelOrder": "Display order",
+        "placeholderOrder": "0",
+        "labelActive": "Active category",
+        "cancelButton": "Cancel",
+        "submitCreate": "Create category",
+        "submitEdit": "Save changes"
+      },
+      "achievement": {
+        "tabBasic": "Basic information",
+        "tabCriteria": "Criteria",
+        "tabMedia": "Image",
+        "labelName": "Name",
+        "placeholderName": "E.g. Dedicated Attendee",
+        "labelDescription": "Description",
+        "placeholderDescription": "Describe this achievement...",
+        "labelPoints": "Points",
+        "labelTier": "Tier",
+        "placeholderTier": "Tier...",
+        "labelType": "Type",
+        "placeholderType": "Achievement type...",
+        "labelScope": "Scope",
+        "placeholderScope": "Scope...",
+        "labelCategory": "Category",
+        "placeholderCategory": "Select a category...",
+        "labelPrerequisite": "Prerequisite",
+        "placeholderPrerequisite": "No prerequisite...",
+        "labelRepeatable": "Repeatable achievement",
+        "labelMaxRepeats": "Maximum repeats",
+        "labelSecret": "Secret achievement",
+        "labelActive": "Active",
+        "labelPreview": "Preview",
+        "cancelButton": "Cancel",
+        "submitCreate": "Create achievement",
+        "submitEdit": "Save changes",
+        "scopeLabels": {
+          "CLUB": "Club",
+          "SECTION": "Section",
+          "INDIVIDUAL": "Individual",
+          "GLOBAL": "Global",
+          "CLUB_TYPE": "Club type",
+          "ECCLESIASTICAL_YEAR": "Ecclesiastical year"
+        },
+        "defaultName": "Achievement name",
+        "tierLabels": {
+          "BRONZE": "Bronze",
+          "SILVER": "Silver",
+          "GOLD": "Gold",
+          "PLATINUM": "Platinum",
+          "DIAMOND": "Diamond"
+        },
+        "typeLabels": {
+          "THRESHOLD": "Threshold",
+          "STREAK": "Streak",
+          "COMPOUND": "Compound",
+          "MILESTONE": "Milestone",
+          "COLLECTION": "Collection"
+        }
+      },
+      "criteria": {
+        "typeDescriptions": {
+          "THRESHOLD": "Awarded when the user reaches a set number of events.",
+          "STREAK": "Awarded when the user maintains a consecutive streak of events.",
+          "MILESTONE": "Awarded when a specific field of an event reaches a certain value.",
+          "COLLECTION": "Awarded when the user completes N distinct items in a collection.",
+          "COMPOUND": "Awarded when multiple conditions are met at the same time."
+        },
+        "labelEvent": "Event",
+        "placeholderEvent": "Select an event...",
+        "labelField": "Field",
+        "placeholderField": "E.g. level",
+        "labelTarget": "Target",
+        "labelTargetValue": "Target value",
+        "placeholderTargetValue": "E.g. gold",
+        "labelOperator": "Operator",
+        "placeholderOperator": "Operator...",
+        "labelStreakTarget": "Streak target",
+        "labelUnit": "Unit",
+        "placeholderUnit": "Unit...",
+        "labelGrace": "Grace period",
+        "labelGraceHint": "(optional)",
+        "labelDistinctField": "Distinct field",
+        "placeholderDistinctField": "E.g. honor_id",
+        "labelQuantityTarget": "Target quantity",
+        "labelLogic": "Combination logic",
+        "logicAnd": "All conditions (AND)",
+        "logicOr": "Any condition (OR)",
+        "conditionLabel": "Condition {index}",
+        "addConditionButton": "Add condition",
+        "eventLabels": {
+          "CLASS_COMPLETED": "Class completed",
+          "HONOR_EARNED": "Honor earned",
+          "INVESTITURE_ACHIEVED": "Investiture achieved",
+          "CAMPOREE_ATTENDED": "Camporee attended",
+          "MEETING_ATTENDED": "Meeting attended",
+          "ACTIVITY_COMPLETED": "Activity completed",
+          "REPORT_SUBMITTED": "Report submitted",
+          "POINTS_EARNED": "Points earned",
+          "activity_attendance": "Activity attendance",
+          "honor_completed": "Honor completed",
+          "class_completed": "Class completed",
+          "investiture_completed": "Investiture completed",
+          "camporee_attended": "Camporee attended",
+          "evidence_submitted": "Evidence submitted",
+          "evidence_approved": "Evidence approved",
+          "consecutive_attendance": "Consecutive attendance",
+          "profile_completed": "Profile completed",
+          "club_role_assigned": "Club role assigned"
+        },
+        "operatorLabels": {
+          "gt": "Greater than",
+          "gte": ">= (greater or equal)",
+          "lt": "Less than",
+          "lte": "<= (less or equal)",
+          "eq": "= (equal to)",
+          "ne": "Not equal to"
+        },
+        "streakUnitLabels": {
+          "day": "Days",
+          "week": "Weeks",
+          "month": "Months"
+        }
+      }
+    },
+    "crud": {
+      "list": {
+        "page": "Achievements",
+        "pageDescription": "Achievements in this category.",
+        "breadcrumbRoot": "Achievements",
+        "newButton": "New achievement",
+        "filtersTitle": "Filters",
+        "filterName": "Name",
+        "filterNamePlaceholder": "Search achievement...",
+        "search": "Search",
+        "filterTier": "Tier",
+        "filterTierPlaceholder": "Tier",
+        "filterTierAll": "All tiers",
+        "filterType": "Type",
+        "filterTypePlaceholder": "Type",
+        "filterTypeAll": "All types",
+        "filterStatus": "Status",
+        "filterStatusPlaceholder": "Status",
+        "filterStatusAll": "All",
+        "filterStatusActive": "Active",
+        "filterStatusInactive": "Inactive",
+        "tableColName": "Name",
+        "tableColTier": "Tier",
+        "tableColType": "Type",
+        "tableColPoints": "Points",
+        "tableColScope": "Scope",
+        "tableColSecret": "Secret",
+        "tableColStatus": "Status",
+        "tableColActions": "Actions",
+        "ariaRepeatable": "Repeatable",
+        "ariaSecret": "Secret",
+        "ariaVisible": "Visible",
+        "statusActive": "Active",
+        "statusInactive": "Inactive",
+        "active": "Active",
+        "tier": "Tier",
+        "type": "Type",
+        "emptyNoFiltersTitle": "No achievements in this category",
+        "emptyNoFiltersDescription": "Create the first achievement for this category.",
+        "emptyFiltersTitle": "No results",
+        "emptyFiltersDescription": "No achievements match the filters.",
+        "deleteTitle": "Delete achievement?",
+        "deleteDescription": "The achievement \"{name}\" will be deleted. This action cannot be undone.",
+        "deleteCancelButton": "Cancel",
+        "deleteConfirmButton": "Delete",
+        "actionEdit": "Edit",
+        "actionDelete": "Delete"
+      },
+      "categories": {
+        "pageTitle": "Achievements",
+        "page": "Categories",
+        "pageDescription": "Categories and achievements of the rewards system.",
+        "newButton": "New category",
+        "filtersTitle": "Filters",
+        "filtersSubtitle": "Refine the list",
+        "filterName": "Name",
+        "filterNamePlaceholder": "Search by name...",
+        "search": "Search",
+        "q": "Search",
+        "filterStatus": "Status",
+        "filterStatusPlaceholder": "Status",
+        "filterStatusAll": "All statuses",
+        "filterStatusActive": "Active",
+        "filterStatusInactive": "Inactive",
+        "tableColName": "Name",
+        "tableColDescription": "Description",
+        "tableColIcon": "Icon",
+        "tableColOrder": "Order",
+        "tableColStatus": "Status",
+        "tableColActions": "Actions",
+        "statusActive": "Active",
+        "statusInactive": "Inactive",
+        "active": "Active",
+        "emptyNoFiltersTitle": "No achievement categories",
+        "emptyNoFiltersDescription": "Create the first category to organize achievements.",
+        "emptyFiltersTitle": "No results",
+        "emptyFiltersDescription": "No categories match the filters.",
+        "deleteTitle": "Delete category?",
+        "deleteDescription": "The category \"{name}\" will be deleted. This action cannot be undone.",
+        "deleteCancelButton": "Cancel",
+        "deleteConfirmButton": "Delete",
+        "actionEdit": "Edit",
+        "actionDelete": "Delete"
       }
     }
   },
@@ -2559,6 +2859,37 @@
       "errorFallback": "Could not load winners. Check your server connection.",
       "emptyNoTypesTitle": "No catalogs available",
       "emptyNoTypesDescription": "Could not load club types for the filters."
+    },
+    "supervision": {
+      "filterClubTypePlaceholder": "Club type",
+      "filterClubTypeAll": "All types",
+      "filterLocalFieldPlaceholder": "Local field",
+      "filterLocalFieldAll": "All fields",
+      "filterYearPlaceholder": "Year",
+      "filterMonthPlaceholder": "Month",
+      "filterMonthAll": "All months",
+      "filterNotifiedPlaceholder": "Notified",
+      "filterNotifiedAll": "Any",
+      "filterNotifiedTrue": "Notified",
+      "filterNotifiedFalse": "Pending",
+      "tableColMember": "Member",
+      "tableColSection": "Section",
+      "tableColClubType": "Club type",
+      "tableColClub": "Club",
+      "tableColLocalField": "Local field",
+      "tableColPeriod": "Period",
+      "tableColPoints": "Points",
+      "tableColNotified": "Notified",
+      "tableColActions": "Actions",
+      "badgeNotified": "Notified",
+      "badgePending": "Pending",
+      "emptyTitle": "No winners for the selected filters.",
+      "emptyHint": "Adjust the filters to see results.",
+      "paginationTotal": "{total, plural, =0 {No results} one {# winner total} other {# winners total}}",
+      "paginationPage": "Page {page} of {totalPages}",
+      "paginationPrev": "Previous",
+      "paginationNext": "Next",
+      "reevaluateButton": "Re-evaluate"
     }
   },
   "reports": {
@@ -2695,6 +3026,53 @@
       "empty_no_catalogs_title": "No catalogs available",
       "empty_no_catalogs_description": "Club type catalogs could not be loaded for the filters.",
       "error_load_reports": "Could not load reports. Please check the server connection."
+    },
+    "supervisionClient": {
+      "filterClubTypePlaceholder": "Club type",
+      "filterClubTypeAll": "All types",
+      "filterLocalFieldPlaceholder": "Local field",
+      "filterLocalFieldAll": "All fields",
+      "filterYearPlaceholder": "Year",
+      "filterMonthPlaceholder": "Month",
+      "filterMonthAll": "All months",
+      "filterStatusPlaceholder": "Status",
+      "filterStatusAll": "All statuses",
+      "months": {
+        "1": "January",
+        "2": "February",
+        "3": "March",
+        "4": "April",
+        "5": "May",
+        "6": "June",
+        "7": "July",
+        "8": "August",
+        "9": "September",
+        "10": "October",
+        "11": "November",
+        "12": "December"
+      },
+      "statusOptions": {
+        "draft": "Draft",
+        "generated": "Generated",
+        "submitted": "Submitted"
+      },
+      "tableColClub": "Club",
+      "tableColType": "Type",
+      "tableColLocalField": "Local field",
+      "tableColPeriod": "Period",
+      "tableColStatus": "Status",
+      "tableColGenerated": "Generated",
+      "tableColSubmitted": "Submitted",
+      "tableColActions": "Actions",
+      "memberCount": "({count} members)",
+      "emptyTitle": "No reports found",
+      "emptyHint": "Adjust the filters to see results.",
+      "paginationTotal": "{total, plural, =0 {No results} one {# report total} other {# reports total}}",
+      "paginationPage": "Page {page} of {totalPages}",
+      "paginationPrev": "Previous",
+      "paginationNext": "Next",
+      "actionView": "View",
+      "actionPdf": "PDF"
     }
   },
   "requests": {
@@ -3300,7 +3678,16 @@
   },
   "shared": {
     "errors": {
-      "unexpected": "Unexpected error"
+      "unexpected": "Unexpected error",
+      "dashboardTitle": "Something went wrong",
+      "dashboardDescription": "An error occurred while loading this section.",
+      "dashboardHeading": "Could not load the page",
+      "dashboardBody": "The error has been reported automatically. You can retry or go back to the dashboard.",
+      "dashboardRetry": "Retry",
+      "dashboardGoHome": "Go to dashboard",
+      "notFoundTitle": "Page not found",
+      "notFoundBody": "The route you are looking for does not exist or has been moved.",
+      "notFoundGoHome": "Go to Dashboard"
     },
     "pagination": {
       "showing": "Showing {from}–{to} of {total} records",
@@ -3322,6 +3709,10 @@
       "missing": "Not available",
       "rateLimited": "Rate limit reached",
       "goToLogin": "Go to login"
+    },
+    "appMetadata": {
+      "title": "SACDIA Admin Panel",
+      "description": "SACDIA administration panel"
     }
   },
   "translations": {
@@ -3385,6 +3776,19 @@
         "back": "Back",
         "cannotLoad": "Could not load the configuration"
       }
+    },
+    "weightsPage": {
+      "deleteTitle": "Delete weight override",
+      "deleteDescription": "Rankings that used this configuration will revert to the global default. This action cannot be undone.",
+      "deleteCancel": "Cancel",
+      "deleteConfirm": "Delete",
+      "deleteConfirmLoading": "Deleting...",
+      "deleteSuccess": "Override deleted"
+    },
+    "sumIndicator": {
+      "label": "Sum: {sum}%",
+      "valid": "✓",
+      "invalid": "— must be 100"
     }
   },
   "rankingWeights": {
@@ -3732,6 +4136,75 @@
       "back": "Back to sections",
       "breadcrumbParent": "Section Rankings",
       "breadcrumbCurrent": "Section #{sectionId}"
+    },
+    "filters": {
+      "labelYear": "Ecclesiastical year",
+      "labelClub": "Club ID",
+      "labelSection": "Section ID",
+      "placeholderYear": "2026",
+      "placeholderClub": "All",
+      "placeholderSection": "All",
+      "apply": "Filter",
+      "clear": "Clear"
+    },
+    "table": {
+      "colRank": "#",
+      "colMember": "Member",
+      "colSection": "Section",
+      "colComposite": "Composite",
+      "colClass": "Class",
+      "colInvestiture": "Investiture",
+      "colCamporee": "Camporees",
+      "colCategory": "Category",
+      "colAction": "Action",
+      "emptyTitle": "No rankings available",
+      "emptyDescription": "No rankings for the selected filters.",
+      "countSingular": "{total} ranked member",
+      "countPlural": "{total} ranked members",
+      "investedLabel": "Invested",
+      "inProgressLabel": "In progress",
+      "viewDetail": "View detail"
+    },
+    "breakdownCard": {
+      "weightLabel": "Weight: {weight}%",
+      "scoreLabel": "Score"
+    },
+    "sectionFilters": {
+      "labelYear": "Ecclesiastical year",
+      "labelClub": "Club ID",
+      "placeholderYear": "2026",
+      "placeholderClub": "All",
+      "apply": "Filter",
+      "clear": "Clear"
+    },
+    "sectionTable": {
+      "colRank": "#",
+      "colSection": "Section",
+      "colComposite": "Composite",
+      "colActiveMembers": "Active members",
+      "colCategory": "Category",
+      "colCalculated": "Calculated",
+      "colAction": "Action",
+      "emptyTitle": "No rankings available",
+      "emptyDescription": "No rankings for the selected filters.",
+      "countSingular": "{total} ranked section",
+      "countPlural": "{total} ranked sections",
+      "viewMembers": "View members"
+    },
+    "sectionMembersTable": {
+      "colRank": "#",
+      "colMember": "Member",
+      "colComposite": "Composite",
+      "colClass": "Class",
+      "colInvestiture": "Investiture",
+      "colCamporee": "Camporees",
+      "colCategory": "Category",
+      "colAction": "Action",
+      "emptyTitle": "No members with ranking",
+      "emptyDescription": "This section has no members with a calculated ranking.",
+      "investedLabel": "Invested",
+      "inProgressLabel": "In progress",
+      "viewDetail": "View detail"
     }
   },
   "system_jobs": {
@@ -3753,6 +4226,116 @@
       "description": "Paginated record of all scheduled job executions.",
       "back": "Back",
       "errorLoad": "Could not load cron run history. Make sure the backend is available and try again."
+    },
+    "cronRuns": {
+      "cardTitle": "Cron Jobs",
+      "colJob": "Job",
+      "colLastRun": "Last run",
+      "colStatus": "Status",
+      "colDuration": "Duration",
+      "colItems": "Items",
+      "colLastSuccess": "Last success",
+      "colLastFailure": "Last failure",
+      "colFailureRate": "Failure rate 7d",
+      "colRuns7d": "Runs 7d",
+      "noRuns": "No runs",
+      "statusCompleted": "Completed",
+      "statusFailed": "Failed",
+      "statusRunning": "Running",
+      "statusSkipped": "Skipped",
+      "jobMonthlyReports": "Monthly reports (auto-generate)",
+      "jobRankingsRecalculate": "Annual rankings (recalculate)",
+      "jobDataExportCleanup": "Cleanup expired exports",
+      "jobMemberOfMonth": "Member of the month (auto-evaluate)",
+      "jobFinancePeriod": "Finance period closing",
+      "jobActivitiesReminder": "Activities reminders",
+      "jobMembershipExpiry": "Expire membership requests",
+      "jobCleanupExpired": "Cleanup expired sessions/tokens",
+      "jobFcmCleanup": "Cleanup orphaned FCM tokens"
+    },
+    "overview": {
+      "queuesTitle": "Queues",
+      "queuesCountSingular": "{count} registered queue",
+      "queuesCountPlural": "{count} registered queues",
+      "refreshButton": "Refresh",
+      "refreshLoading": "Refreshing...",
+      "noQueues": "No active queues found.",
+      "activeLabel": "active",
+      "statWaiting": "Waiting",
+      "statActive": "Active",
+      "statCompleted": "Completed",
+      "statFailed": "Failed",
+      "statDelayed": "Delayed",
+      "statPaused": "Paused",
+      "failedJobsTitle": "Recent failures",
+      "failedJobsEmpty": "No recent failures",
+      "colQueue": "Queue",
+      "colJob": "Job",
+      "colReason": "Reason",
+      "colAttempts": "Attempts",
+      "colDate": "Date",
+      "colAction": "Action",
+      "retryButton": "Retry",
+      "retryLoading": "Retrying...",
+      "retryDialogTitle": "Retry this job?",
+      "retryDialogDescription": "The job {jobName} will be re-queued in the {queue} queue.",
+      "retryDialogCancel": "Cancel",
+      "retryDialogConfirm": "Retry",
+      "retrySuccess": "Job retried",
+      "retrySuccessDescription": "The job \"{name}\" was successfully re-queued.",
+      "retryErrorTitle": "Retry error",
+      "retryErrorFallback": "Unknown error when retrying the job.",
+      "queueNotifications": "Notifications",
+      "queueNotificationsDesc": "Push notifications and realtime cache",
+      "queueEmail": "Emails",
+      "queueEmailDesc": "Transactional (rate-limited 90/day)",
+      "queueAchievements": "Achievements",
+      "queueAchievementsDesc": "Achievement evaluation and matching",
+      "queueBackgroundJobs": "Background Jobs",
+      "queueBackgroundJobsDesc": "Reports, finances, rankings, exports"
+    },
+    "history": {
+      "filterLabelJob": "Job",
+      "filterLabelStatus": "Status",
+      "filterLabelSince": "From",
+      "filterLabelUntil": "To",
+      "filterAllJobs": "All jobs",
+      "filterAllStatuses": "All statuses",
+      "statusCompleted": "Completed",
+      "statusFailed": "Failed",
+      "statusSkipped": "Skipped",
+      "statusRunning": "Running",
+      "recordCount": "{total} records",
+      "noResults": "No executions found with the applied filters.",
+      "colJob": "Job",
+      "colStart": "Start",
+      "colStatus": "Status",
+      "colDuration": "Duration",
+      "colItems": "Items",
+      "colError": "Error",
+      "colDetails": "Details",
+      "viewButton": "View",
+      "pagination": "Page {page} of {totalPages}",
+      "paginationPrev": "Previous",
+      "paginationNext": "Next",
+      "detailTitle": "Run #{runId} details",
+      "detailLabelJob": "Job",
+      "detailLabelStatus": "Status",
+      "detailLabelStart": "Start",
+      "detailLabelEnd": "End",
+      "detailLabelDuration": "Duration",
+      "detailLabelItems": "Items processed",
+      "detailLabelError": "Error message",
+      "detailLabelMetadata": "Metadata",
+      "jobMonthlyReports": "Monthly reports (auto-generate)",
+      "jobRankingsRecalculate": "Annual rankings (recalculate)",
+      "jobDataExportCleanup": "Cleanup expired exports",
+      "jobMemberOfMonth": "Member of the month (auto-evaluate)",
+      "jobFinancePeriod": "Finance period closing",
+      "jobActivitiesReminder": "Activities reminders",
+      "jobMembershipExpiry": "Expire membership requests",
+      "jobCleanupExpired": "Cleanup expired sessions/tokens",
+      "jobFcmCleanup": "Cleanup orphaned FCM tokens"
     }
   },
   "settings": {
@@ -3766,7 +4349,8 @@
       },
       "scoringCategories": {
         "title": "Scoring categories",
-        "description": "Management of scoring categories by division."
+        "description": "Management of scoring categories by division.",
+        "metadataTitle": "Scoring categories"
       }
     }
   }

--- a/messages/es.json
+++ b/messages/es.json
@@ -385,19 +385,23 @@
     "pages": {
       "countries": {
         "title": "Países",
-        "description": "Catálogo de países del sistema."
+        "description": "Catálogo de países del sistema.",
+        "metadataTitle": "Países"
       },
       "churches": {
         "title": "Iglesias",
-        "description": "Catálogo de iglesias del sistema."
+        "description": "Catálogo de iglesias del sistema.",
+        "metadataTitle": "Iglesias"
       },
       "districts": {
         "title": "Distritos",
-        "description": "Catálogo de distritos del sistema."
+        "description": "Catálogo de distritos del sistema.",
+        "metadataTitle": "Distritos"
       },
       "unions": {
         "title": "Uniones",
-        "description": "Catálogo de uniones del sistema."
+        "description": "Catálogo de uniones del sistema.",
+        "metadataTitle": "Uniones"
       },
       "unionsDetail": {
         "back": "Volver",
@@ -413,7 +417,8 @@
       },
       "localFields": {
         "title": "Campos Locales",
-        "description": "Catálogo de campos locales del sistema."
+        "description": "Catálogo de campos locales del sistema.",
+        "metadataTitle": "Campos locales"
       },
       "localFieldsDetail": {
         "back": "Volver",
@@ -429,7 +434,8 @@
       },
       "activityTypes": {
         "title": "Tipos de actividad",
-        "description": "Catálogo de tipos de actividad del sistema."
+        "description": "Catálogo de tipos de actividad del sistema.",
+        "metadataTitle": "Tipos de actividad"
       },
       "folderSections": {
         "title": "Secciones de carpeta",
@@ -548,6 +554,41 @@
         "tableName": "Nombre",
         "tableLevel": "Nivel",
         "tableStatus": "Estado"
+      },
+      "diseases": {
+        "title": "Enfermedades",
+        "description": "Enfermedades crónicas o condiciones médicas relevantes.",
+        "metadataTitle": "Enfermedades"
+      },
+      "clubTypes": {
+        "title": "Tipos de club",
+        "description": "Tipos de club disponibles en el sistema.",
+        "metadataTitle": "Tipos de club"
+      },
+      "medicines": {
+        "title": "Medicamentos",
+        "description": "Medicamentos de uso habitual para los miembros.",
+        "metadataTitle": "Medicamentos"
+      },
+      "clubIdeals": {
+        "title": "Ideales de club",
+        "description": "Ideales asociados a cada tipo de club.",
+        "metadataTitle": "Ideales de club"
+      },
+      "allergies": {
+        "title": "Alergias",
+        "description": "Listado de alergias para el perfil de salud de los miembros.",
+        "metadataTitle": "Alergias"
+      },
+      "relationshipTypes": {
+        "title": "Tipos de relación",
+        "description": "Vínculos familiares o de contacto de emergencia.",
+        "metadataTitle": "Tipos de relación"
+      },
+      "ecclesiasticalYears": {
+        "title": "Años eclesiásticos",
+        "description": "Períodos anuales para la organización de actividades.",
+        "metadataTitle": "Años eclesiásticos"
       }
     }
   },
@@ -1340,6 +1381,265 @@
         "defaultName": "Sin nombre",
         "defaultCategoryName": "Categoría {id}",
         "defaultAchievementName": "Logro {id}"
+      }
+    },
+    "imageUpload": {
+      "dropzoneAriaLabel": "Zona para subir imagen del logro",
+      "uploading": "Subiendo imagen...",
+      "dropzonePrompt": "Arrastra una imagen o haz clic para seleccionar",
+      "dropzoneHint": "PNG, SVG o WebP — máximo 2 MB",
+      "previewAlt": "Vista previa del logro",
+      "previewTitle": "Vista previa",
+      "tierLabel": "Nivel:",
+      "noImageLabel": "Sin imagen",
+      "removeAriaLabel": "Eliminar imagen",
+      "toastSuccess": "Imagen del logro actualizada correctamente.",
+      "toastError": "No se pudo subir la imagen. Intenta de nuevo.",
+      "toastSaveFirst": "Guarda el logro primero para poder subir la imagen.",
+      "validateTypeError": "Solo se permiten imágenes PNG, SVG o WebP.",
+      "validateSizeError": "El archivo no puede superar los 2 MB."
+    },
+    "cards": {
+      "preview": {
+        "tierLabels": {
+          "BRONZE": "Bronce",
+          "SILVER": "Plata",
+          "GOLD": "Oro",
+          "PLATINUM": "Platino",
+          "DIAMOND": "Diamante"
+        },
+        "typeLabels": {
+          "THRESHOLD": "Umbral",
+          "STREAK": "Racha",
+          "MILESTONE": "Hito",
+          "COLLECTION": "Colección",
+          "COMPOUND": "Compuesto"
+        },
+        "repeatableBadge": "Repetible",
+        "secretBadge": "Secreto",
+        "pointsSuffix": "pts",
+        "defaultName": "Nombre del logro"
+      }
+    },
+    "forms": {
+      "category": {
+        "titleCreate": "Nueva categoría",
+        "titleEdit": "Editar categoría",
+        "descriptionCreate": "Completa los campos para crear una nueva categoría de logros.",
+        "descriptionEdit": "Modifica los datos de la categoría de logros.",
+        "labelName": "Nombre",
+        "placeholderName": "Ej. Participación",
+        "labelDescription": "Descripción",
+        "placeholderDescription": "Describe esta categoría...",
+        "labelIcon": "Icono",
+        "placeholderIcon": "trophy",
+        "labelIconHint": "(nombre de ícono lucide-react, ej: trophy)",
+        "labelOrder": "Orden de visualización",
+        "placeholderOrder": "0",
+        "labelActive": "Categoría activa",
+        "cancelButton": "Cancelar",
+        "submitCreate": "Crear categoría",
+        "submitEdit": "Guardar cambios"
+      },
+      "achievement": {
+        "tabBasic": "Información básica",
+        "tabCriteria": "Criterios",
+        "tabMedia": "Imagen",
+        "labelName": "Nombre",
+        "placeholderName": "Ej. Asistente Dedicado",
+        "labelDescription": "Descripción",
+        "placeholderDescription": "Describe este logro...",
+        "labelPoints": "Puntos",
+        "labelTier": "Nivel",
+        "placeholderTier": "Nivel...",
+        "labelType": "Tipo",
+        "placeholderType": "Tipo de logro...",
+        "labelScope": "Alcance",
+        "placeholderScope": "Alcance...",
+        "labelCategory": "Categoría",
+        "placeholderCategory": "Selecciona una categoría...",
+        "labelPrerequisite": "Prerequisito",
+        "placeholderPrerequisite": "Sin prerequisito...",
+        "labelRepeatable": "Logro repetible",
+        "labelMaxRepeats": "Máximo de repeticiones",
+        "labelSecret": "Logro secreto",
+        "labelActive": "Activo",
+        "labelPreview": "Vista previa",
+        "cancelButton": "Cancelar",
+        "submitCreate": "Crear logro",
+        "submitEdit": "Guardar cambios",
+        "scopeLabels": {
+          "CLUB": "Club",
+          "SECTION": "Sección",
+          "INDIVIDUAL": "Individual",
+          "GLOBAL": "Global",
+          "CLUB_TYPE": "Tipo de club",
+          "ECCLESIASTICAL_YEAR": "Año eclesiástico"
+        },
+        "defaultName": "Nombre del logro",
+        "tierLabels": {
+          "BRONZE": "Bronce",
+          "SILVER": "Plata",
+          "GOLD": "Oro",
+          "PLATINUM": "Platino",
+          "DIAMOND": "Diamante"
+        },
+        "typeLabels": {
+          "THRESHOLD": "Umbral",
+          "STREAK": "Racha",
+          "COMPOUND": "Compuesto",
+          "MILESTONE": "Hito",
+          "COLLECTION": "Colección"
+        }
+      },
+      "criteria": {
+        "typeDescriptions": {
+          "THRESHOLD": "Se otorga cuando el usuario alcanza un número determinado de eventos.",
+          "STREAK": "Se otorga cuando el usuario mantiene una racha consecutiva de eventos.",
+          "MILESTONE": "Se otorga cuando un campo específico de un evento alcanza cierto valor.",
+          "COLLECTION": "Se otorga cuando el usuario completa N elementos distintos de una colección.",
+          "COMPOUND": "Se otorga cuando se cumplen múltiples condiciones al mismo tiempo."
+        },
+        "labelEvent": "Evento",
+        "placeholderEvent": "Selecciona un evento...",
+        "labelField": "Campo",
+        "placeholderField": "Ej. level",
+        "labelTarget": "Objetivo",
+        "labelTargetValue": "Valor objetivo",
+        "placeholderTargetValue": "Ej. gold",
+        "labelOperator": "Operador",
+        "placeholderOperator": "Operador...",
+        "labelStreakTarget": "Racha objetivo",
+        "labelUnit": "Unidad",
+        "placeholderUnit": "Unidad...",
+        "labelGrace": "Gracia",
+        "labelGraceHint": "(opcional)",
+        "labelDistinctField": "Campo único",
+        "placeholderDistinctField": "Ej. honor_id",
+        "labelQuantityTarget": "Cantidad objetivo",
+        "labelLogic": "Lógica de combinación",
+        "logicAnd": "Todas las condiciones (AND)",
+        "logicOr": "Cualquier condición (OR)",
+        "conditionLabel": "Condición {index}",
+        "addConditionButton": "Agregar condición",
+        "eventLabels": {
+          "CLASS_COMPLETED": "Clase completada",
+          "HONOR_EARNED": "Honor ganado",
+          "INVESTITURE_ACHIEVED": "Investidura lograda",
+          "CAMPOREE_ATTENDED": "Camporee asistido",
+          "MEETING_ATTENDED": "Reunión asistida",
+          "ACTIVITY_COMPLETED": "Actividad completada",
+          "REPORT_SUBMITTED": "Reporte enviado",
+          "POINTS_EARNED": "Puntos ganados",
+          "activity_attendance": "Asistencia a actividad",
+          "honor_completed": "Especialidad completada",
+          "class_completed": "Clase completada",
+          "investiture_completed": "Investidura completada",
+          "camporee_attended": "Camporee asistido",
+          "evidence_submitted": "Evidencia enviada",
+          "evidence_approved": "Evidencia aprobada",
+          "consecutive_attendance": "Asistencia consecutiva",
+          "profile_completed": "Perfil completado",
+          "club_role_assigned": "Rol de club asignado"
+        },
+        "operatorLabels": {
+          "gt": "Mayor que",
+          "gte": ">= (mayor o igual)",
+          "lt": "Menor que",
+          "lte": "<= (menor o igual)",
+          "eq": "= (igual a)",
+          "ne": "Distinto de"
+        },
+        "streakUnitLabels": {
+          "day": "Días",
+          "week": "Semanas",
+          "month": "Meses"
+        }
+      }
+    },
+    "crud": {
+      "list": {
+        "page": "Logros",
+        "pageDescription": "Logros en esta categoría.",
+        "breadcrumbRoot": "Logros",
+        "newButton": "Nuevo logro",
+        "filtersTitle": "Filtros",
+        "filterName": "Nombre",
+        "filterNamePlaceholder": "Buscar logro...",
+        "search": "Buscar",
+        "filterTier": "Nivel",
+        "filterTierPlaceholder": "Nivel",
+        "filterTierAll": "Todos los niveles",
+        "filterType": "Tipo",
+        "filterTypePlaceholder": "Tipo",
+        "filterTypeAll": "Todos los tipos",
+        "filterStatus": "Estado",
+        "filterStatusPlaceholder": "Estado",
+        "filterStatusAll": "Todos",
+        "filterStatusActive": "Activos",
+        "filterStatusInactive": "Inactivos",
+        "tableColName": "Nombre",
+        "tableColTier": "Nivel",
+        "tableColType": "Tipo",
+        "tableColPoints": "Puntos",
+        "tableColScope": "Alcance",
+        "tableColSecret": "Secreto",
+        "tableColStatus": "Estado",
+        "tableColActions": "Acciones",
+        "ariaRepeatable": "Repetible",
+        "ariaSecret": "Secreto",
+        "ariaVisible": "Visible",
+        "statusActive": "Activo",
+        "statusInactive": "Inactivo",
+        "active": "Activo",
+        "tier": "Nivel",
+        "type": "Tipo",
+        "emptyNoFiltersTitle": "No hay logros en esta categoría",
+        "emptyNoFiltersDescription": "Crea el primer logro para esta categoría.",
+        "emptyFiltersTitle": "Sin resultados",
+        "emptyFiltersDescription": "No hay logros que coincidan con los filtros.",
+        "deleteTitle": "¿Eliminar logro?",
+        "deleteDescription": "Se eliminará el logro \"{name}\". Esta acción no puede deshacerse.",
+        "deleteCancelButton": "Cancelar",
+        "deleteConfirmButton": "Eliminar",
+        "actionEdit": "Editar",
+        "actionDelete": "Eliminar"
+      },
+      "categories": {
+        "pageTitle": "Logros",
+        "page": "Categorías",
+        "pageDescription": "Categorías y logros del sistema de recompensas.",
+        "newButton": "Nueva categoría",
+        "filtersTitle": "Filtros",
+        "filtersSubtitle": "Refina el listado",
+        "filterName": "Nombre",
+        "filterNamePlaceholder": "Buscar por nombre...",
+        "search": "Buscar",
+        "q": "Buscar",
+        "filterStatus": "Estado",
+        "filterStatusPlaceholder": "Estado",
+        "filterStatusAll": "Todos los estados",
+        "filterStatusActive": "Activas",
+        "filterStatusInactive": "Inactivas",
+        "tableColName": "Nombre",
+        "tableColDescription": "Descripción",
+        "tableColIcon": "Icono",
+        "tableColOrder": "Orden",
+        "tableColStatus": "Estado",
+        "tableColActions": "Acciones",
+        "statusActive": "Activa",
+        "statusInactive": "Inactiva",
+        "active": "Activa",
+        "emptyNoFiltersTitle": "No hay categorías de logros",
+        "emptyNoFiltersDescription": "Crea la primera categoría para organizar los logros.",
+        "emptyFiltersTitle": "Sin resultados",
+        "emptyFiltersDescription": "No hay categorías que coincidan con los filtros.",
+        "deleteTitle": "¿Eliminar categoría?",
+        "deleteDescription": "Se eliminará la categoría \"{name}\". Esta acción no puede deshacerse.",
+        "deleteCancelButton": "Cancelar",
+        "deleteConfirmButton": "Eliminar",
+        "actionEdit": "Editar",
+        "actionDelete": "Eliminar"
       }
     }
   },
@@ -2559,6 +2859,37 @@
       "errorFallback": "No se pudieron cargar los ganadores. Verifica la conexión con el servidor.",
       "emptyNoTypesTitle": "Sin catálogos disponibles",
       "emptyNoTypesDescription": "No se pudieron cargar los tipos de club para los filtros."
+    },
+    "supervision": {
+      "filterClubTypePlaceholder": "Tipo de club",
+      "filterClubTypeAll": "Todos los tipos",
+      "filterLocalFieldPlaceholder": "Campo local",
+      "filterLocalFieldAll": "Todos los campos",
+      "filterYearPlaceholder": "Año",
+      "filterMonthPlaceholder": "Mes",
+      "filterMonthAll": "Todos los meses",
+      "filterNotifiedPlaceholder": "Notificado",
+      "filterNotifiedAll": "Cualquiera",
+      "filterNotifiedTrue": "Notificado",
+      "filterNotifiedFalse": "Pendiente",
+      "tableColMember": "Miembro",
+      "tableColSection": "Sección",
+      "tableColClubType": "Tipo de club",
+      "tableColClub": "Club",
+      "tableColLocalField": "Campo Local",
+      "tableColPeriod": "Período",
+      "tableColPoints": "Puntos",
+      "tableColNotified": "Notificado",
+      "tableColActions": "Acciones",
+      "badgeNotified": "Notificado",
+      "badgePending": "Pendiente",
+      "emptyTitle": "Sin ganadores para los filtros seleccionados.",
+      "emptyHint": "Ajusta los filtros para ver resultados.",
+      "paginationTotal": "{total, plural, =0 {Sin resultados} one {# ganador en total} other {# ganadores en total}}",
+      "paginationPage": "Página {page} de {totalPages}",
+      "paginationPrev": "Anterior",
+      "paginationNext": "Siguiente",
+      "reevaluateButton": "Re-evaluar"
     }
   },
   "reports": {
@@ -2695,6 +3026,53 @@
       "empty_no_catalogs_title": "Sin catálogos disponibles",
       "empty_no_catalogs_description": "No se pudieron cargar los tipos de club para los filtros.",
       "error_load_reports": "No se pudieron cargar los reportes. Verifica la conexión con el servidor."
+    },
+    "supervisionClient": {
+      "filterClubTypePlaceholder": "Tipo de club",
+      "filterClubTypeAll": "Todos los tipos",
+      "filterLocalFieldPlaceholder": "Campo local",
+      "filterLocalFieldAll": "Todos los campos",
+      "filterYearPlaceholder": "Año",
+      "filterMonthPlaceholder": "Mes",
+      "filterMonthAll": "Todos los meses",
+      "filterStatusPlaceholder": "Estado",
+      "filterStatusAll": "Todos los estados",
+      "months": {
+        "1": "Enero",
+        "2": "Febrero",
+        "3": "Marzo",
+        "4": "Abril",
+        "5": "Mayo",
+        "6": "Junio",
+        "7": "Julio",
+        "8": "Agosto",
+        "9": "Septiembre",
+        "10": "Octubre",
+        "11": "Noviembre",
+        "12": "Diciembre"
+      },
+      "statusOptions": {
+        "draft": "Borrador",
+        "generated": "Generado",
+        "submitted": "Enviado"
+      },
+      "tableColClub": "Club",
+      "tableColType": "Tipo",
+      "tableColLocalField": "Campo Local",
+      "tableColPeriod": "Periodo",
+      "tableColStatus": "Estado",
+      "tableColGenerated": "Generado",
+      "tableColSubmitted": "Enviado",
+      "tableColActions": "Acciones",
+      "memberCount": "({count} miembros)",
+      "emptyTitle": "No se encontraron reportes",
+      "emptyHint": "Ajusta los filtros para ver resultados.",
+      "paginationTotal": "{total, plural, =0 {Sin resultados} one {# reporte en total} other {# reportes en total}}",
+      "paginationPage": "Página {page} de {totalPages}",
+      "paginationPrev": "Anterior",
+      "paginationNext": "Siguiente",
+      "actionView": "Ver",
+      "actionPdf": "PDF"
     }
   },
   "requests": {
@@ -3300,7 +3678,16 @@
   },
   "shared": {
     "errors": {
-      "unexpected": "Error inesperado"
+      "unexpected": "Error inesperado",
+      "dashboardTitle": "Algo salió mal",
+      "dashboardDescription": "Ocurrió un error al cargar esta sección.",
+      "dashboardHeading": "No se pudo cargar la página",
+      "dashboardBody": "El error fue reportado automáticamente. Puedes reintentar o volver al dashboard.",
+      "dashboardRetry": "Reintentar",
+      "dashboardGoHome": "Ir al dashboard",
+      "notFoundTitle": "Página no encontrada",
+      "notFoundBody": "La ruta que buscas no existe o fue movida.",
+      "notFoundGoHome": "Ir al Dashboard"
     },
     "pagination": {
       "showing": "Mostrando {from}–{to} de {total} registros",
@@ -3322,6 +3709,10 @@
       "missing": "No disponible",
       "rateLimited": "Límite de solicitudes",
       "goToLogin": "Ir a login"
+    },
+    "appMetadata": {
+      "title": "SACDIA Panel Administrativo",
+      "description": "Panel de administración de SACDIA"
     }
   },
   "translations": {
@@ -3385,6 +3776,19 @@
         "back": "Volver",
         "cannotLoad": "No se pudo cargar la configuración"
       }
+    },
+    "weightsPage": {
+      "deleteTitle": "Eliminar sobreescritura de pesos",
+      "deleteDescription": "Los cálculos de ranking que usaban esta configuración volverán a usar la configuración por defecto global. Esta acción no se puede deshacer.",
+      "deleteCancel": "Cancelar",
+      "deleteConfirm": "Eliminar",
+      "deleteConfirmLoading": "Eliminando...",
+      "deleteSuccess": "Sobreescritura eliminada"
+    },
+    "sumIndicator": {
+      "label": "Suma: {sum}%",
+      "valid": "✓",
+      "invalid": "— debe ser 100"
     }
   },
   "rankingWeights": {
@@ -3732,6 +4136,75 @@
       "back": "Volver a secciones",
       "breadcrumbParent": "Ranking de secciones",
       "breadcrumbCurrent": "Sección #{sectionId}"
+    },
+    "filters": {
+      "labelYear": "Año eclesiástico",
+      "labelClub": "ID de club",
+      "labelSection": "ID de sección",
+      "placeholderYear": "2026",
+      "placeholderClub": "Todos",
+      "placeholderSection": "Todas",
+      "apply": "Filtrar",
+      "clear": "Limpiar"
+    },
+    "table": {
+      "colRank": "#",
+      "colMember": "Miembro",
+      "colSection": "Sección",
+      "colComposite": "Composite",
+      "colClass": "Clase",
+      "colInvestiture": "Investidura",
+      "colCamporee": "Camporees",
+      "colCategory": "Categoría",
+      "colAction": "Acción",
+      "emptyTitle": "Sin rankings disponibles",
+      "emptyDescription": "Sin rankings para los filtros seleccionados.",
+      "countSingular": "{total} miembro rankeado",
+      "countPlural": "{total} miembros rankeados",
+      "investedLabel": "Investido",
+      "inProgressLabel": "En progreso",
+      "viewDetail": "Ver detalle"
+    },
+    "breakdownCard": {
+      "weightLabel": "Peso: {weight}%",
+      "scoreLabel": "Puntuación"
+    },
+    "sectionFilters": {
+      "labelYear": "Año eclesiástico",
+      "labelClub": "ID de club",
+      "placeholderYear": "2026",
+      "placeholderClub": "Todos",
+      "apply": "Filtrar",
+      "clear": "Limpiar"
+    },
+    "sectionTable": {
+      "colRank": "#",
+      "colSection": "Sección",
+      "colComposite": "Composite",
+      "colActiveMembers": "Miembros activos",
+      "colCategory": "Categoría",
+      "colCalculated": "Calculado",
+      "colAction": "Acción",
+      "emptyTitle": "Sin rankings disponibles",
+      "emptyDescription": "Sin rankings para los filtros seleccionados.",
+      "countSingular": "{total} sección rankeada",
+      "countPlural": "{total} secciones rankeadas",
+      "viewMembers": "Ver miembros"
+    },
+    "sectionMembersTable": {
+      "colRank": "#",
+      "colMember": "Miembro",
+      "colComposite": "Composite",
+      "colClass": "Clase",
+      "colInvestiture": "Investidura",
+      "colCamporee": "Camporees",
+      "colCategory": "Categoría",
+      "colAction": "Acción",
+      "emptyTitle": "Sin miembros con ranking",
+      "emptyDescription": "Esta sección no tiene miembros con ranking calculado.",
+      "investedLabel": "Investido",
+      "inProgressLabel": "En progreso",
+      "viewDetail": "Ver detalle"
     }
   },
   "system_jobs": {
@@ -3753,6 +4226,116 @@
       "description": "Registro paginado de todas las ejecuciones de los jobs programados.",
       "back": "Volver",
       "errorLoad": "No se pudo cargar el historial de cron runs. Verifica que el backend esté disponible e intentalo de nuevo."
+    },
+    "cronRuns": {
+      "cardTitle": "Cron Jobs",
+      "colJob": "Job",
+      "colLastRun": "Última ejecución",
+      "colStatus": "Status",
+      "colDuration": "Duración",
+      "colItems": "Items",
+      "colLastSuccess": "Último éxito",
+      "colLastFailure": "Último fallo",
+      "colFailureRate": "Tasa fallo 7d",
+      "colRuns7d": "Runs 7d",
+      "noRuns": "Sin ejecuciones",
+      "statusCompleted": "Completado",
+      "statusFailed": "Fallido",
+      "statusRunning": "Ejecutando",
+      "statusSkipped": "Omitido",
+      "jobMonthlyReports": "Reportes mensuales (auto-generar)",
+      "jobRankingsRecalculate": "Rankings anuales (recalcular)",
+      "jobDataExportCleanup": "Cleanup exportes vencidos",
+      "jobMemberOfMonth": "Miembro del mes (auto-evaluar)",
+      "jobFinancePeriod": "Cierre de periodo financiero",
+      "jobActivitiesReminder": "Recordatorios de actividades",
+      "jobMembershipExpiry": "Expirar solicitudes de membresía",
+      "jobCleanupExpired": "Cleanup sesiones/tokens vencidos",
+      "jobFcmCleanup": "Cleanup FCM tokens huérfanos"
+    },
+    "overview": {
+      "queuesTitle": "Colas",
+      "queuesCountSingular": "{count} cola registrada",
+      "queuesCountPlural": "{count} colas registradas",
+      "refreshButton": "Actualizar",
+      "refreshLoading": "Actualizando...",
+      "noQueues": "No se encontraron colas activas.",
+      "activeLabel": "activo",
+      "statWaiting": "Pendientes",
+      "statActive": "Activos",
+      "statCompleted": "Completados",
+      "statFailed": "Fallidos",
+      "statDelayed": "Diferidos",
+      "statPaused": "Pausados",
+      "failedJobsTitle": "Últimos fallos",
+      "failedJobsEmpty": "Sin fallos recientes",
+      "colQueue": "Cola",
+      "colJob": "Job",
+      "colReason": "Razón",
+      "colAttempts": "Intentos",
+      "colDate": "Fecha",
+      "colAction": "Acción",
+      "retryButton": "Retry",
+      "retryLoading": "Reintentando...",
+      "retryDialogTitle": "¿Reintentar este job?",
+      "retryDialogDescription": "Se volverá a encolar el job {jobName} de la cola {queue}.",
+      "retryDialogCancel": "Cancelar",
+      "retryDialogConfirm": "Reintentar",
+      "retrySuccess": "Job reintentado",
+      "retrySuccessDescription": "El job \"{name}\" fue reencolado correctamente.",
+      "retryErrorTitle": "Error al reintentar",
+      "retryErrorFallback": "Error desconocido al reintentar el job.",
+      "queueNotifications": "Notificaciones",
+      "queueNotificationsDesc": "Push notifications y realtime cache",
+      "queueEmail": "Emails",
+      "queueEmailDesc": "Transaccionales (rate-limited 90/día)",
+      "queueAchievements": "Logros",
+      "queueAchievementsDesc": "Evaluación y matching de logros",
+      "queueBackgroundJobs": "Background Jobs",
+      "queueBackgroundJobsDesc": "Reportes, finanzas, rankings, exports"
+    },
+    "history": {
+      "filterLabelJob": "Job",
+      "filterLabelStatus": "Estado",
+      "filterLabelSince": "Desde",
+      "filterLabelUntil": "Hasta",
+      "filterAllJobs": "Todos los jobs",
+      "filterAllStatuses": "Todos los estados",
+      "statusCompleted": "Completado",
+      "statusFailed": "Fallido",
+      "statusSkipped": "Omitido",
+      "statusRunning": "Ejecutando",
+      "recordCount": "{total} registros",
+      "noResults": "No se encontraron ejecuciones con los filtros aplicados.",
+      "colJob": "Job",
+      "colStart": "Inicio",
+      "colStatus": "Estado",
+      "colDuration": "Duración",
+      "colItems": "Items",
+      "colError": "Error",
+      "colDetails": "Detalles",
+      "viewButton": "Ver",
+      "pagination": "Página {page} de {totalPages}",
+      "paginationPrev": "Anterior",
+      "paginationNext": "Siguiente",
+      "detailTitle": "Detalles del run #{runId}",
+      "detailLabelJob": "Job",
+      "detailLabelStatus": "Status",
+      "detailLabelStart": "Inicio",
+      "detailLabelEnd": "Fin",
+      "detailLabelDuration": "Duración",
+      "detailLabelItems": "Items procesados",
+      "detailLabelError": "Mensaje de error",
+      "detailLabelMetadata": "Metadata",
+      "jobMonthlyReports": "Reportes mensuales (auto-generar)",
+      "jobRankingsRecalculate": "Rankings anuales (recalcular)",
+      "jobDataExportCleanup": "Cleanup exportes vencidos",
+      "jobMemberOfMonth": "Miembro del mes (auto-evaluar)",
+      "jobFinancePeriod": "Cierre de periodo financiero",
+      "jobActivitiesReminder": "Recordatorios de actividades",
+      "jobMembershipExpiry": "Expirar solicitudes de membresía",
+      "jobCleanupExpired": "Cleanup sesiones/tokens vencidos",
+      "jobFcmCleanup": "Cleanup FCM tokens huérfanos"
     }
   },
   "settings": {
@@ -3766,7 +4349,8 @@
       },
       "scoringCategories": {
         "title": "Categorías de puntuación",
-        "description": "Gestión de categorías de puntuación por división."
+        "description": "Gestión de categorías de puntuación por división.",
+        "metadataTitle": "Categorías de puntuación"
       }
     }
   }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -385,19 +385,23 @@
     "pages": {
       "countries": {
         "title": "Pays",
-        "description": "Catalogue des pays du système."
+        "description": "Catalogue des pays du système.",
+        "metadataTitle": "Pays"
       },
       "churches": {
         "title": "Églises",
-        "description": "Catalogue des églises du système."
+        "description": "Catalogue des églises du système.",
+        "metadataTitle": "Églises"
       },
       "districts": {
         "title": "Districts",
-        "description": "Catalogue des districts du système."
+        "description": "Catalogue des districts du système.",
+        "metadataTitle": "Districts"
       },
       "unions": {
         "title": "Unions",
-        "description": "Catalogue des unions du système."
+        "description": "Catalogue des unions du système.",
+        "metadataTitle": "Unions"
       },
       "unionsDetail": {
         "back": "Retour",
@@ -413,7 +417,8 @@
       },
       "localFields": {
         "title": "Champs locaux",
-        "description": "Catalogue des champs locaux du système."
+        "description": "Catalogue des champs locaux du système.",
+        "metadataTitle": "Champs locaux"
       },
       "localFieldsDetail": {
         "back": "Retour",
@@ -429,7 +434,8 @@
       },
       "activityTypes": {
         "title": "Types d'activité",
-        "description": "Catalogue des types d'activité du système."
+        "description": "Catalogue des types d'activité du système.",
+        "metadataTitle": "Types d'activité"
       },
       "folderSections": {
         "title": "Sections de dossier",
@@ -548,6 +554,41 @@
         "tableName": "Nom",
         "tableLevel": "Niveau",
         "tableStatus": "Statut"
+      },
+      "diseases": {
+        "title": "Maladies",
+        "description": "Maladies chroniques ou conditions médicales pertinentes.",
+        "metadataTitle": "Maladies"
+      },
+      "clubTypes": {
+        "title": "Types de club",
+        "description": "Types de club disponibles dans le système.",
+        "metadataTitle": "Types de club"
+      },
+      "medicines": {
+        "title": "Médicaments",
+        "description": "Médicaments couramment utilisés par les membres.",
+        "metadataTitle": "Médicaments"
+      },
+      "clubIdeals": {
+        "title": "Idéaux de club",
+        "description": "Idéaux associés à chaque type de club.",
+        "metadataTitle": "Idéaux de club"
+      },
+      "allergies": {
+        "title": "Allergies",
+        "description": "Liste des allergies pour le profil de santé des membres.",
+        "metadataTitle": "Allergies"
+      },
+      "relationshipTypes": {
+        "title": "Types de relation",
+        "description": "Liens familiaux ou de contact d'urgence.",
+        "metadataTitle": "Types de relation"
+      },
+      "ecclesiasticalYears": {
+        "title": "Années ecclésiastiques",
+        "description": "Périodes annuelles pour l'organisation des activités.",
+        "metadataTitle": "Années ecclésiastiques"
       }
     }
   },
@@ -1340,6 +1381,265 @@
         "defaultName": "Sans nom",
         "defaultCategoryName": "Catégorie {id}",
         "defaultAchievementName": "Réalisation {id}"
+      }
+    },
+    "imageUpload": {
+      "dropzoneAriaLabel": "Zone de téléchargement de l’image du succès",
+      "uploading": "Téléchargement en cours ...",
+      "dropzonePrompt": "Faites glisser une image ou cliquez pour sélectionner",
+      "dropzoneHint": "PNG, SVG ou WebP — maximum 2 Mo",
+      "previewAlt": "Aperçu du succès",
+      "previewTitle": "Aperçu",
+      "tierLabel": "Niveau :",
+      "noImageLabel": "Aucune image",
+      "removeAriaLabel": "Supprimer l’image",
+      "toastSuccess": "Image du succès mise à jour avec succès.",
+      "toastError": "Impossible de télécharger l’image. Réessayez.",
+      "toastSaveFirst": "Enregistrez le succès d’abord pour pouvoir télécharger l’image.",
+      "validateTypeError": "Seules les images PNG, SVG ou WebP sont autorisées.",
+      "validateSizeError": "Le fichier ne peut pas dépasser 2 Mo."
+    },
+    "cards": {
+      "preview": {
+        "tierLabels": {
+          "BRONZE": "Bronze",
+          "SILVER": "Argent",
+          "GOLD": "Or",
+          "PLATINUM": "Platine",
+          "DIAMOND": "Diamant"
+        },
+        "typeLabels": {
+          "THRESHOLD": "Seuil",
+          "STREAK": "Série",
+          "MILESTONE": "Jalon",
+          "COLLECTION": "Collection",
+          "COMPOUND": "Composé"
+        },
+        "repeatableBadge": "Répétable",
+        "secretBadge": "Secret",
+        "pointsSuffix": "pts",
+        "defaultName": "Nom du succès"
+      }
+    },
+    "forms": {
+      "category": {
+        "titleCreate": "Nouvelle catégorie",
+        "titleEdit": "Modifier la catégorie",
+        "descriptionCreate": "Remplissez les champs pour créer une nouvelle catégorie de succès.",
+        "descriptionEdit": "Modifiez les données de la catégorie de succès.",
+        "labelName": "Nom",
+        "placeholderName": "Ex. Participation",
+        "labelDescription": "Description",
+        "placeholderDescription": "Décrivez cette catégorie ...",
+        "labelIcon": "Icône",
+        "placeholderIcon": "trophy",
+        "labelIconHint": "(nom d’icône lucide-react, ex : trophy)",
+        "labelOrder": "Ordre d’affichage",
+        "placeholderOrder": "0",
+        "labelActive": "Catégorie active",
+        "cancelButton": "Annuler",
+        "submitCreate": "Créer la catégorie",
+        "submitEdit": "Enregistrer les modifications"
+      },
+      "achievement": {
+        "tabBasic": "Informations de base",
+        "tabCriteria": "Critères",
+        "tabMedia": "Image",
+        "labelName": "Nom",
+        "placeholderName": "Ex. Participant assidu",
+        "labelDescription": "Description",
+        "placeholderDescription": "Décrivez ce succès ...",
+        "labelPoints": "Points",
+        "labelTier": "Niveau",
+        "placeholderTier": "Niveau ...",
+        "labelType": "Type",
+        "placeholderType": "Type de succès ...",
+        "labelScope": "Portée",
+        "placeholderScope": "Portée ...",
+        "labelCategory": "Catégorie",
+        "placeholderCategory": "Sélectionnez une catégorie ...",
+        "labelPrerequisite": "Prérequis",
+        "placeholderPrerequisite": "Sans prérequis ...",
+        "labelRepeatable": "Succès répétable",
+        "labelMaxRepeats": "Répétitions maximales",
+        "labelSecret": "Succès secret",
+        "labelActive": "Actif",
+        "labelPreview": "Aperçu",
+        "cancelButton": "Annuler",
+        "submitCreate": "Créer le succès",
+        "submitEdit": "Enregistrer les modifications",
+        "scopeLabels": {
+          "CLUB": "Club",
+          "SECTION": "Section",
+          "INDIVIDUAL": "Individuel",
+          "GLOBAL": "Global",
+          "CLUB_TYPE": "Type de club",
+          "ECCLESIASTICAL_YEAR": "Année ecclésiastique"
+        },
+        "defaultName": "Nom du succès",
+        "tierLabels": {
+          "BRONZE": "Bronze",
+          "SILVER": "Argent",
+          "GOLD": "Or",
+          "PLATINUM": "Platine",
+          "DIAMOND": "Diamant"
+        },
+        "typeLabels": {
+          "THRESHOLD": "Seuil",
+          "STREAK": "Série",
+          "COMPOUND": "Composé",
+          "MILESTONE": "Jalon",
+          "COLLECTION": "Collection"
+        }
+      },
+      "criteria": {
+        "typeDescriptions": {
+          "THRESHOLD": "Accordé lorsque l’utilisateur atteint un nombre déterminé d’événements.",
+          "STREAK": "Accordé lorsque l’utilisateur maintient une série consécutive d’événements.",
+          "MILESTONE": "Accordé lorsqu’un champ spécifique d’un événement atteint une certaine valeur.",
+          "COLLECTION": "Accordé lorsque l’utilisateur complète N éléments distincts d’une collection.",
+          "COMPOUND": "Accordé lorsque plusieurs conditions sont remplies simultanément."
+        },
+        "labelEvent": "Événement",
+        "placeholderEvent": "Sélectionnez un événement ...",
+        "labelField": "Champ",
+        "placeholderField": "Ex. level",
+        "labelTarget": "Objectif",
+        "labelTargetValue": "Valeur cible",
+        "placeholderTargetValue": "Ex. gold",
+        "labelOperator": "Opérateur",
+        "placeholderOperator": "Opérateur ...",
+        "labelStreakTarget": "Objectif de série",
+        "labelUnit": "Unité",
+        "placeholderUnit": "Unité ...",
+        "labelGrace": "Période de grâce",
+        "labelGraceHint": "(optionnel)",
+        "labelDistinctField": "Champ distinct",
+        "placeholderDistinctField": "Ex. honor_id",
+        "labelQuantityTarget": "Quantité cible",
+        "labelLogic": "Logique de combinaison",
+        "logicAnd": "Toutes les conditions (AND)",
+        "logicOr": "N’importe quelle condition (OR)",
+        "conditionLabel": "Condition {index}",
+        "addConditionButton": "Ajouter une condition",
+        "eventLabels": {
+          "CLASS_COMPLETED": "Classe terminée",
+          "HONOR_EARNED": "Honneur obtenu",
+          "INVESTITURE_ACHIEVED": "Investiture réalisée",
+          "CAMPOREE_ATTENDED": "Camporee assisté",
+          "MEETING_ATTENDED": "Réunion assistée",
+          "ACTIVITY_COMPLETED": "Activité complétée",
+          "REPORT_SUBMITTED": "Rapport soumis",
+          "POINTS_EARNED": "Points obtenus",
+          "activity_attendance": "Présence à une activité",
+          "honor_completed": "Spécialité complétée",
+          "class_completed": "Classe complétée",
+          "investiture_completed": "Investiture complétée",
+          "camporee_attended": "Camporee assisté",
+          "evidence_submitted": "Preuve soumise",
+          "evidence_approved": "Preuve approuvée",
+          "consecutive_attendance": "Présence consécutive",
+          "profile_completed": "Profil complété",
+          "club_role_assigned": "Rôle de club attribué"
+        },
+        "operatorLabels": {
+          "gt": "Supérieur à",
+          "gte": ">= (supérieur ou égal)",
+          "lt": "Inférieur à",
+          "lte": "<= (inférieur ou égal)",
+          "eq": "= (égal à)",
+          "ne": "Différent de"
+        },
+        "streakUnitLabels": {
+          "day": "Jours",
+          "week": "Semaines",
+          "month": "Mois"
+        }
+      }
+    },
+    "crud": {
+      "list": {
+        "page": "Succès",
+        "pageDescription": "Succès dans cette catégorie.",
+        "breadcrumbRoot": "Succès",
+        "newButton": "Nouveau succès",
+        "filtersTitle": "Filtres",
+        "filterName": "Nom",
+        "filterNamePlaceholder": "Rechercher un succès ...",
+        "search": "Rechercher",
+        "filterTier": "Niveau",
+        "filterTierPlaceholder": "Niveau",
+        "filterTierAll": "Tous les niveaux",
+        "filterType": "Type",
+        "filterTypePlaceholder": "Type",
+        "filterTypeAll": "Tous les types",
+        "filterStatus": "État",
+        "filterStatusPlaceholder": "État",
+        "filterStatusAll": "Tous",
+        "filterStatusActive": "Actifs",
+        "filterStatusInactive": "Inactifs",
+        "tableColName": "Nom",
+        "tableColTier": "Niveau",
+        "tableColType": "Type",
+        "tableColPoints": "Points",
+        "tableColScope": "Portée",
+        "tableColSecret": "Secret",
+        "tableColStatus": "État",
+        "tableColActions": "Actions",
+        "ariaRepeatable": "Répétable",
+        "ariaSecret": "Secret",
+        "ariaVisible": "Visible",
+        "statusActive": "Actif",
+        "statusInactive": "Inactif",
+        "active": "Actif",
+        "tier": "Niveau",
+        "type": "Type",
+        "emptyNoFiltersTitle": "Aucun succès dans cette catégorie",
+        "emptyNoFiltersDescription": "Créez le premier succès pour cette catégorie.",
+        "emptyFiltersTitle": "Aucun résultat",
+        "emptyFiltersDescription": "Aucun succès ne correspond aux filtres.",
+        "deleteTitle": "Supprimer le succès ?",
+        "deleteDescription": "Le succès \"{name}\" sera supprimé. Cette action est irréversible.",
+        "deleteCancelButton": "Annuler",
+        "deleteConfirmButton": "Supprimer",
+        "actionEdit": "Modifier",
+        "actionDelete": "Supprimer"
+      },
+      "categories": {
+        "pageTitle": "Succès",
+        "page": "Catégories",
+        "pageDescription": "Catégories et succès du système de récompenses.",
+        "newButton": "Nouvelle catégorie",
+        "filtersTitle": "Filtres",
+        "filtersSubtitle": "Affiner la liste",
+        "filterName": "Nom",
+        "filterNamePlaceholder": "Rechercher par nom ...",
+        "search": "Rechercher",
+        "q": "Rechercher",
+        "filterStatus": "État",
+        "filterStatusPlaceholder": "État",
+        "filterStatusAll": "Tous les états",
+        "filterStatusActive": "Actives",
+        "filterStatusInactive": "Inactives",
+        "tableColName": "Nom",
+        "tableColDescription": "Description",
+        "tableColIcon": "Icône",
+        "tableColOrder": "Ordre",
+        "tableColStatus": "État",
+        "tableColActions": "Actions",
+        "statusActive": "Active",
+        "statusInactive": "Inactive",
+        "active": "Active",
+        "emptyNoFiltersTitle": "Aucune catégorie de succès",
+        "emptyNoFiltersDescription": "Créez la première catégorie pour organiser les succès.",
+        "emptyFiltersTitle": "Aucun résultat",
+        "emptyFiltersDescription": "Aucune catégorie ne correspond aux filtres.",
+        "deleteTitle": "Supprimer la catégorie ?",
+        "deleteDescription": "La catégorie \"{name}\" sera supprimée. Cette action est irréversible.",
+        "deleteCancelButton": "Annuler",
+        "deleteConfirmButton": "Supprimer",
+        "actionEdit": "Modifier",
+        "actionDelete": "Supprimer"
       }
     }
   },
@@ -2559,6 +2859,37 @@
       "errorFallback": "Impossible de charger les gagnants. Vérifiez la connexion au serveur.",
       "emptyNoTypesTitle": "Aucun catalogue disponible",
       "emptyNoTypesDescription": "Impossible de charger les types de club pour les filtres."
+    },
+    "supervision": {
+      "filterClubTypePlaceholder": "Type de club",
+      "filterClubTypeAll": "Tous les types",
+      "filterLocalFieldPlaceholder": "Champ local",
+      "filterLocalFieldAll": "Tous les champs",
+      "filterYearPlaceholder": "Année",
+      "filterMonthPlaceholder": "Mois",
+      "filterMonthAll": "Tous les mois",
+      "filterNotifiedPlaceholder": "Notifié",
+      "filterNotifiedAll": "N'importe lequel",
+      "filterNotifiedTrue": "Notifié",
+      "filterNotifiedFalse": "En attente",
+      "tableColMember": "Membre",
+      "tableColSection": "Section",
+      "tableColClubType": "Type de club",
+      "tableColClub": "Club",
+      "tableColLocalField": "Champ local",
+      "tableColPeriod": "Période",
+      "tableColPoints": "Points",
+      "tableColNotified": "Notifié",
+      "tableColActions": "Actions",
+      "badgeNotified": "Notifié",
+      "badgePending": "En attente",
+      "emptyTitle": "Aucun gagnant pour les filtres sélectionnés.",
+      "emptyHint": "Ajustez les filtres pour voir les résultats.",
+      "paginationTotal": "{total, plural, =0 {Aucun résultat} one {# gagnant au total} other {# gagnants au total}}",
+      "paginationPage": "Page {page} sur {totalPages}",
+      "paginationPrev": "Précédent",
+      "paginationNext": "Suivant",
+      "reevaluateButton": "Réévaluer"
     }
   },
   "reports": {
@@ -2695,6 +3026,53 @@
       "empty_no_catalogs_title": "Aucun catalogue disponible",
       "empty_no_catalogs_description": "Impossible de charger les types de club pour les filtres.",
       "error_load_reports": "Impossible de charger les rapports. Vérifiez la connexion avec le serveur."
+    },
+    "supervisionClient": {
+      "filterClubTypePlaceholder": "Type de club",
+      "filterClubTypeAll": "Tous les types",
+      "filterLocalFieldPlaceholder": "Champ local",
+      "filterLocalFieldAll": "Tous les champs",
+      "filterYearPlaceholder": "Année",
+      "filterMonthPlaceholder": "Mois",
+      "filterMonthAll": "Tous les mois",
+      "filterStatusPlaceholder": "État",
+      "filterStatusAll": "Tous les états",
+      "months": {
+        "1": "Janvier",
+        "2": "Février",
+        "3": "Mars",
+        "4": "Avril",
+        "5": "Mai",
+        "6": "Juin",
+        "7": "Juillet",
+        "8": "Août",
+        "9": "Septembre",
+        "10": "Octobre",
+        "11": "Novembre",
+        "12": "Décembre"
+      },
+      "statusOptions": {
+        "draft": "Brouillon",
+        "generated": "Généré",
+        "submitted": "Soumis"
+      },
+      "tableColClub": "Club",
+      "tableColType": "Type",
+      "tableColLocalField": "Champ local",
+      "tableColPeriod": "Période",
+      "tableColStatus": "État",
+      "tableColGenerated": "Généré",
+      "tableColSubmitted": "Soumis",
+      "tableColActions": "Actions",
+      "memberCount": "({count} membres)",
+      "emptyTitle": "Aucun rapport trouvé",
+      "emptyHint": "Ajustez les filtres pour voir les résultats.",
+      "paginationTotal": "{total, plural, =0 {Aucun résultat} one {# rapport au total} other {# rapports au total}}",
+      "paginationPage": "Page {page} sur {totalPages}",
+      "paginationPrev": "Précédent",
+      "paginationNext": "Suivant",
+      "actionView": "Voir",
+      "actionPdf": "PDF"
     }
   },
   "requests": {
@@ -3300,7 +3678,16 @@
   },
   "shared": {
     "errors": {
-      "unexpected": "Erreur inattendue"
+      "unexpected": "Erreur inattendue",
+      "dashboardTitle": "Une erreur s'est produite",
+      "dashboardDescription": "Une erreur s'est produite lors du chargement de cette section.",
+      "dashboardHeading": "Impossible de charger la page",
+      "dashboardBody": "L'erreur a été signalée automatiquement. Vous pouvez réessayer ou revenir au tableau de bord.",
+      "dashboardRetry": "Réessayer",
+      "dashboardGoHome": "Aller au tableau de bord",
+      "notFoundTitle": "Page introuvable",
+      "notFoundBody": "La route que vous recherchez n'existe pas ou a été déplacée.",
+      "notFoundGoHome": "Aller au tableau de bord"
     },
     "pagination": {
       "showing": "Affichage {from}–{to} sur {total} enregistrements",
@@ -3322,6 +3709,10 @@
       "missing": "Non disponible",
       "rateLimited": "Limite de requêtes atteinte",
       "goToLogin": "Aller à la connexion"
+    },
+    "appMetadata": {
+      "title": "SACDIA Panneau d'administration",
+      "description": "Panneau d'administration SACDIA"
     }
   },
   "translations": {
@@ -3385,6 +3776,19 @@
         "back": "Retour",
         "cannotLoad": "Impossible de charger la configuration"
       }
+    },
+    "weightsPage": {
+      "deleteTitle": "Supprimer la substitution de pondération",
+      "deleteDescription": "Les calculs de classement utilisant cette configuration reviendront à la configuration par défaut globale. Cette action est irréversible.",
+      "deleteCancel": "Annuler",
+      "deleteConfirm": "Supprimer",
+      "deleteConfirmLoading": "Suppression...",
+      "deleteSuccess": "Substitution supprimée"
+    },
+    "sumIndicator": {
+      "label": "Somme : {sum} %",
+      "valid": "✓",
+      "invalid": "— doit être 100"
     }
   },
   "rankingWeights": {
@@ -3732,6 +4136,75 @@
       "back": "Retour aux sections",
       "breadcrumbParent": "Classement des sections",
       "breadcrumbCurrent": "Section n°{sectionId}"
+    },
+    "filters": {
+      "labelYear": "Année ecclésiastique",
+      "labelClub": "ID du club",
+      "labelSection": "ID de la section",
+      "placeholderYear": "2026",
+      "placeholderClub": "Tous",
+      "placeholderSection": "Toutes",
+      "apply": "Filtrer",
+      "clear": "Effacer"
+    },
+    "table": {
+      "colRank": "#",
+      "colMember": "Membre",
+      "colSection": "Section",
+      "colComposite": "Composite",
+      "colClass": "Classe",
+      "colInvestiture": "Investiture",
+      "colCamporee": "Camporées",
+      "colCategory": "Catégorie",
+      "colAction": "Action",
+      "emptyTitle": "Aucun classement disponible",
+      "emptyDescription": "Aucun classement pour les filtres sélectionnés.",
+      "countSingular": "{total} membre classé",
+      "countPlural": "{total} membres classés",
+      "investedLabel": "Investi",
+      "inProgressLabel": "En cours",
+      "viewDetail": "Voir le détail"
+    },
+    "breakdownCard": {
+      "weightLabel": "Poids : {weight} %",
+      "scoreLabel": "Score"
+    },
+    "sectionFilters": {
+      "labelYear": "Année ecclésiastique",
+      "labelClub": "ID du club",
+      "placeholderYear": "2026",
+      "placeholderClub": "Tous",
+      "apply": "Filtrer",
+      "clear": "Effacer"
+    },
+    "sectionTable": {
+      "colRank": "#",
+      "colSection": "Section",
+      "colComposite": "Composite",
+      "colActiveMembers": "Membres actifs",
+      "colCategory": "Catégorie",
+      "colCalculated": "Calculé",
+      "colAction": "Action",
+      "emptyTitle": "Aucun classement disponible",
+      "emptyDescription": "Aucun classement pour les filtres sélectionnés.",
+      "countSingular": "{total} section classée",
+      "countPlural": "{total} sections classées",
+      "viewMembers": "Voir les membres"
+    },
+    "sectionMembersTable": {
+      "colRank": "#",
+      "colMember": "Membre",
+      "colComposite": "Composite",
+      "colClass": "Classe",
+      "colInvestiture": "Investiture",
+      "colCamporee": "Camporées",
+      "colCategory": "Catégorie",
+      "colAction": "Action",
+      "emptyTitle": "Aucun membre avec classement",
+      "emptyDescription": "Cette section n'a aucun membre avec un classement calculé.",
+      "investedLabel": "Investi",
+      "inProgressLabel": "En cours",
+      "viewDetail": "Voir le détail"
     }
   },
   "system_jobs": {
@@ -3753,6 +4226,116 @@
       "description": "Registre paginé de toutes les exécutions des jobs programmés.",
       "back": "Retour",
       "errorLoad": "Impossible de charger l'historique des cron runs. Vérifiez que le backend est disponible et réessayez."
+    },
+    "cronRuns": {
+      "cardTitle": "Cron Jobs",
+      "colJob": "Job",
+      "colLastRun": "Dernière exécution",
+      "colStatus": "Statut",
+      "colDuration": "Durée",
+      "colItems": "Éléments",
+      "colLastSuccess": "Dernier succès",
+      "colLastFailure": "Dernier échec",
+      "colFailureRate": "Taux d'échec 7j",
+      "colRuns7d": "Runs 7j",
+      "noRuns": "Aucune exécution",
+      "statusCompleted": "Terminé",
+      "statusFailed": "Échoué",
+      "statusRunning": "En cours",
+      "statusSkipped": "Ignoré",
+      "jobMonthlyReports": "Rapports mensuels (auto-générer)",
+      "jobRankingsRecalculate": "Classements annuels (recalculer)",
+      "jobDataExportCleanup": "Nettoyage des exports expirés",
+      "jobMemberOfMonth": "Membre du mois (auto-évaluer)",
+      "jobFinancePeriod": "Clôture de période financière",
+      "jobActivitiesReminder": "Rappels d'activités",
+      "jobMembershipExpiry": "Expiration des demandes d'adhésion",
+      "jobCleanupExpired": "Nettoyage des sessions/tokens expirés",
+      "jobFcmCleanup": "Nettoyage des tokens FCM orphelins"
+    },
+    "overview": {
+      "queuesTitle": "Files d'attente",
+      "queuesCountSingular": "{count} file enregistrée",
+      "queuesCountPlural": "{count} files enregistrées",
+      "refreshButton": "Actualiser",
+      "refreshLoading": "Actualisation...",
+      "noQueues": "Aucune file active trouvée.",
+      "activeLabel": "actif",
+      "statWaiting": "En attente",
+      "statActive": "Actifs",
+      "statCompleted": "Terminés",
+      "statFailed": "Échoués",
+      "statDelayed": "Différés",
+      "statPaused": "Suspendus",
+      "failedJobsTitle": "Derniers échecs",
+      "failedJobsEmpty": "Aucun échec récent",
+      "colQueue": "File",
+      "colJob": "Job",
+      "colReason": "Raison",
+      "colAttempts": "Tentatives",
+      "colDate": "Date",
+      "colAction": "Action",
+      "retryButton": "Réessayer",
+      "retryLoading": "Nouvelle tentative...",
+      "retryDialogTitle": "Réessayer ce job ?",
+      "retryDialogDescription": "Le job {jobName} sera remis en file dans la file {queue}.",
+      "retryDialogCancel": "Annuler",
+      "retryDialogConfirm": "Réessayer",
+      "retrySuccess": "Job remis en file",
+      "retrySuccessDescription": "Le job « {name} » a été remis en file avec succès.",
+      "retryErrorTitle": "Erreur lors de la nouvelle tentative",
+      "retryErrorFallback": "Erreur inconnue lors de la nouvelle tentative du job.",
+      "queueNotifications": "Notifications",
+      "queueNotificationsDesc": "Notifications push et cache temps réel",
+      "queueEmail": "E-mails",
+      "queueEmailDesc": "Transactionnels (limité 90/jour)",
+      "queueAchievements": "Réalisations",
+      "queueAchievementsDesc": "Évaluation et correspondance des réalisations",
+      "queueBackgroundJobs": "Jobs en arrière-plan",
+      "queueBackgroundJobsDesc": "Rapports, finances, classements, exports"
+    },
+    "history": {
+      "filterLabelJob": "Job",
+      "filterLabelStatus": "Statut",
+      "filterLabelSince": "Depuis",
+      "filterLabelUntil": "Jusqu'au",
+      "filterAllJobs": "Tous les jobs",
+      "filterAllStatuses": "Tous les statuts",
+      "statusCompleted": "Terminé",
+      "statusFailed": "Échoué",
+      "statusSkipped": "Ignoré",
+      "statusRunning": "En cours",
+      "recordCount": "{total} enregistrements",
+      "noResults": "Aucune exécution trouvée avec les filtres appliqués.",
+      "colJob": "Job",
+      "colStart": "Début",
+      "colStatus": "Statut",
+      "colDuration": "Durée",
+      "colItems": "Éléments",
+      "colError": "Erreur",
+      "colDetails": "Détails",
+      "viewButton": "Voir",
+      "pagination": "Page {page} sur {totalPages}",
+      "paginationPrev": "Précédent",
+      "paginationNext": "Suivant",
+      "detailTitle": "Détails du run #{runId}",
+      "detailLabelJob": "Job",
+      "detailLabelStatus": "Statut",
+      "detailLabelStart": "Début",
+      "detailLabelEnd": "Fin",
+      "detailLabelDuration": "Durée",
+      "detailLabelItems": "Éléments traités",
+      "detailLabelError": "Message d'erreur",
+      "detailLabelMetadata": "Métadonnées",
+      "jobMonthlyReports": "Rapports mensuels (auto-générer)",
+      "jobRankingsRecalculate": "Classements annuels (recalculer)",
+      "jobDataExportCleanup": "Nettoyage des exports expirés",
+      "jobMemberOfMonth": "Membre du mois (auto-évaluer)",
+      "jobFinancePeriod": "Clôture de période financière",
+      "jobActivitiesReminder": "Rappels d'activités",
+      "jobMembershipExpiry": "Expiration des demandes d'adhésion",
+      "jobCleanupExpired": "Nettoyage des sessions/tokens expirés",
+      "jobFcmCleanup": "Nettoyage des tokens FCM orphelins"
     }
   },
   "settings": {
@@ -3766,7 +4349,8 @@
       },
       "scoringCategories": {
         "title": "Catégories de notation",
-        "description": "Gestion des catégories de notation par division."
+        "description": "Gestion des catégories de notation par division.",
+        "metadataTitle": "Catégories de notation"
       }
     }
   }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -385,19 +385,23 @@
     "pages": {
       "countries": {
         "title": "Países",
-        "description": "Catálogo de países do sistema."
+        "description": "Catálogo de países do sistema.",
+        "metadataTitle": "Países"
       },
       "churches": {
         "title": "Igrejas",
-        "description": "Catálogo de igrejas do sistema."
+        "description": "Catálogo de igrejas do sistema.",
+        "metadataTitle": "Igrejas"
       },
       "districts": {
         "title": "Distritos",
-        "description": "Catálogo de distritos do sistema."
+        "description": "Catálogo de distritos do sistema.",
+        "metadataTitle": "Distritos"
       },
       "unions": {
         "title": "Uniões",
-        "description": "Catálogo de uniões do sistema."
+        "description": "Catálogo de uniões do sistema.",
+        "metadataTitle": "Uniões"
       },
       "unionsDetail": {
         "back": "Voltar",
@@ -413,7 +417,8 @@
       },
       "localFields": {
         "title": "Campos Locais",
-        "description": "Catálogo de campos locais do sistema."
+        "description": "Catálogo de campos locais do sistema.",
+        "metadataTitle": "Campos locais"
       },
       "localFieldsDetail": {
         "back": "Voltar",
@@ -429,7 +434,8 @@
       },
       "activityTypes": {
         "title": "Tipos de atividade",
-        "description": "Catálogo de tipos de atividade do sistema."
+        "description": "Catálogo de tipos de atividade do sistema.",
+        "metadataTitle": "Tipos de atividade"
       },
       "folderSections": {
         "title": "Seções de pasta",
@@ -548,6 +554,41 @@
         "tableName": "Nome",
         "tableLevel": "Nível",
         "tableStatus": "Status"
+      },
+      "diseases": {
+        "title": "Doenças",
+        "description": "Doenças crônicas ou condições médicas relevantes.",
+        "metadataTitle": "Doenças"
+      },
+      "clubTypes": {
+        "title": "Tipos de clube",
+        "description": "Tipos de clube disponíveis no sistema.",
+        "metadataTitle": "Tipos de clube"
+      },
+      "medicines": {
+        "title": "Medicamentos",
+        "description": "Medicamentos de uso habitual dos membros.",
+        "metadataTitle": "Medicamentos"
+      },
+      "clubIdeals": {
+        "title": "Ideais de clube",
+        "description": "Ideais associados a cada tipo de clube.",
+        "metadataTitle": "Ideais de clube"
+      },
+      "allergies": {
+        "title": "Alergias",
+        "description": "Lista de alergias para o perfil de saúde dos membros.",
+        "metadataTitle": "Alergias"
+      },
+      "relationshipTypes": {
+        "title": "Tipos de relacionamento",
+        "description": "Vínculos familiares ou de contato de emergência.",
+        "metadataTitle": "Tipos de relacionamento"
+      },
+      "ecclesiasticalYears": {
+        "title": "Anos eclesiásticos",
+        "description": "Períodos anuais para a organização de atividades.",
+        "metadataTitle": "Anos eclesiásticos"
       }
     }
   },
@@ -1340,6 +1381,265 @@
         "defaultName": "Sem nome",
         "defaultCategoryName": "Categoria {id}",
         "defaultAchievementName": "Conquista {id}"
+      }
+    },
+    "imageUpload": {
+      "dropzoneAriaLabel": "Área de upload da imagem da conquista",
+      "uploading": "Enviando imagem...",
+      "dropzonePrompt": "Arraste uma imagem ou clique para selecionar",
+      "dropzoneHint": "PNG, SVG ou WebP — máximo 2 MB",
+      "previewAlt": "Pré-visualização da conquista",
+      "previewTitle": "Pré-visualização",
+      "tierLabel": "Nível:",
+      "noImageLabel": "Sem imagem",
+      "removeAriaLabel": "Remover imagem",
+      "toastSuccess": "Imagem da conquista atualizada com sucesso.",
+      "toastError": "Não foi possível enviar a imagem. Tente novamente.",
+      "toastSaveFirst": "Salve a conquista primeiro para poder enviar a imagem.",
+      "validateTypeError": "Apenas imagens PNG, SVG ou WebP são permitidas.",
+      "validateSizeError": "O arquivo não pode exceder 2 MB."
+    },
+    "cards": {
+      "preview": {
+        "tierLabels": {
+          "BRONZE": "Bronze",
+          "SILVER": "Prata",
+          "GOLD": "Ouro",
+          "PLATINUM": "Platina",
+          "DIAMOND": "Diamante"
+        },
+        "typeLabels": {
+          "THRESHOLD": "Limiar",
+          "STREAK": "Sequência",
+          "MILESTONE": "Marco",
+          "COLLECTION": "Coleção",
+          "COMPOUND": "Composto"
+        },
+        "repeatableBadge": "Repetível",
+        "secretBadge": "Secreto",
+        "pointsSuffix": "pts",
+        "defaultName": "Nome da conquista"
+      }
+    },
+    "forms": {
+      "category": {
+        "titleCreate": "Nova categoria",
+        "titleEdit": "Editar categoria",
+        "descriptionCreate": "Preencha os campos para criar uma nova categoria de conquistas.",
+        "descriptionEdit": "Modifique os dados da categoria de conquistas.",
+        "labelName": "Nome",
+        "placeholderName": "Ex. Participação",
+        "labelDescription": "Descrição",
+        "placeholderDescription": "Descreva esta categoria...",
+        "labelIcon": "Ícone",
+        "placeholderIcon": "trophy",
+        "labelIconHint": "(nome de ícone lucide-react, ex: trophy)",
+        "labelOrder": "Ordem de exibição",
+        "placeholderOrder": "0",
+        "labelActive": "Categoria ativa",
+        "cancelButton": "Cancelar",
+        "submitCreate": "Criar categoria",
+        "submitEdit": "Salvar alterações"
+      },
+      "achievement": {
+        "tabBasic": "Informações básicas",
+        "tabCriteria": "Critérios",
+        "tabMedia": "Imagem",
+        "labelName": "Nome",
+        "placeholderName": "Ex. Participante Dedicado",
+        "labelDescription": "Descrição",
+        "placeholderDescription": "Descreva esta conquista...",
+        "labelPoints": "Pontos",
+        "labelTier": "Nível",
+        "placeholderTier": "Nível...",
+        "labelType": "Tipo",
+        "placeholderType": "Tipo de conquista...",
+        "labelScope": "Escopo",
+        "placeholderScope": "Escopo...",
+        "labelCategory": "Categoria",
+        "placeholderCategory": "Selecione uma categoria...",
+        "labelPrerequisite": "Pré-requisito",
+        "placeholderPrerequisite": "Sem pré-requisito...",
+        "labelRepeatable": "Conquista repetível",
+        "labelMaxRepeats": "Máximo de repetições",
+        "labelSecret": "Conquista secreta",
+        "labelActive": "Ativo",
+        "labelPreview": "Pré-visualização",
+        "cancelButton": "Cancelar",
+        "submitCreate": "Criar conquista",
+        "submitEdit": "Salvar alterações",
+        "scopeLabels": {
+          "CLUB": "Clube",
+          "SECTION": "Seção",
+          "INDIVIDUAL": "Individual",
+          "GLOBAL": "Global",
+          "CLUB_TYPE": "Tipo de clube",
+          "ECCLESIASTICAL_YEAR": "Ano eclesiástico"
+        },
+        "defaultName": "Nome da conquista",
+        "tierLabels": {
+          "BRONZE": "Bronze",
+          "SILVER": "Prata",
+          "GOLD": "Ouro",
+          "PLATINUM": "Platina",
+          "DIAMOND": "Diamante"
+        },
+        "typeLabels": {
+          "THRESHOLD": "Limiar",
+          "STREAK": "Sequência",
+          "COMPOUND": "Composto",
+          "MILESTONE": "Marco",
+          "COLLECTION": "Coleção"
+        }
+      },
+      "criteria": {
+        "typeDescriptions": {
+          "THRESHOLD": "Concedida quando o usuário atinge um número determinado de eventos.",
+          "STREAK": "Concedida quando o usuário mantém uma sequência consecutiva de eventos.",
+          "MILESTONE": "Concedida quando um campo específico de um evento atinge certo valor.",
+          "COLLECTION": "Concedida quando o usuário completa N itens distintos de uma coleção.",
+          "COMPOUND": "Concedida quando várias condições são atendidas simultaneamente."
+        },
+        "labelEvent": "Evento",
+        "placeholderEvent": "Selecione um evento...",
+        "labelField": "Campo",
+        "placeholderField": "Ex. level",
+        "labelTarget": "Objetivo",
+        "labelTargetValue": "Valor alvo",
+        "placeholderTargetValue": "Ex. gold",
+        "labelOperator": "Operador",
+        "placeholderOperator": "Operador...",
+        "labelStreakTarget": "Objetivo de sequência",
+        "labelUnit": "Unidade",
+        "placeholderUnit": "Unidade...",
+        "labelGrace": "Período de tolerância",
+        "labelGraceHint": "(opcional)",
+        "labelDistinctField": "Campo distinto",
+        "placeholderDistinctField": "Ex. honor_id",
+        "labelQuantityTarget": "Quantidade alvo",
+        "labelLogic": "Lógica de combinação",
+        "logicAnd": "Todas as condições (AND)",
+        "logicOr": "Qualquer condição (OR)",
+        "conditionLabel": "Condição {index}",
+        "addConditionButton": "Adicionar condição",
+        "eventLabels": {
+          "CLASS_COMPLETED": "Classe concluída",
+          "HONOR_EARNED": "Honra conquistada",
+          "INVESTITURE_ACHIEVED": "Investidura realizada",
+          "CAMPOREE_ATTENDED": "Acampamento assistido",
+          "MEETING_ATTENDED": "Reunião assistida",
+          "ACTIVITY_COMPLETED": "Atividade concluída",
+          "REPORT_SUBMITTED": "Relatório enviado",
+          "POINTS_EARNED": "Pontos obtidos",
+          "activity_attendance": "Presença em atividade",
+          "honor_completed": "Especialidade concluída",
+          "class_completed": "Aula concluída",
+          "investiture_completed": "Investidura concluída",
+          "camporee_attended": "Campori assistido",
+          "evidence_submitted": "Evidência enviada",
+          "evidence_approved": "Evidência aprovada",
+          "consecutive_attendance": "Presença consecutiva",
+          "profile_completed": "Perfil concluído",
+          "club_role_assigned": "Função de clube atribuída"
+        },
+        "operatorLabels": {
+          "gt": "Maior que",
+          "gte": ">= (maior ou igual)",
+          "lt": "Menor que",
+          "lte": "<= (menor ou igual)",
+          "eq": "= (igual a)",
+          "ne": "Diferente de"
+        },
+        "streakUnitLabels": {
+          "day": "Dias",
+          "week": "Semanas",
+          "month": "Meses"
+        }
+      }
+    },
+    "crud": {
+      "list": {
+        "page": "Conquistas",
+        "pageDescription": "Conquistas nesta categoria.",
+        "breadcrumbRoot": "Conquistas",
+        "newButton": "Nova conquista",
+        "filtersTitle": "Filtros",
+        "filterName": "Nome",
+        "filterNamePlaceholder": "Buscar conquista...",
+        "search": "Pesquisar",
+        "filterTier": "Nível",
+        "filterTierPlaceholder": "Nível",
+        "filterTierAll": "Todos os níveis",
+        "filterType": "Tipo",
+        "filterTypePlaceholder": "Tipo",
+        "filterTypeAll": "Todos os tipos",
+        "filterStatus": "Estado",
+        "filterStatusPlaceholder": "Estado",
+        "filterStatusAll": "Todos",
+        "filterStatusActive": "Ativos",
+        "filterStatusInactive": "Inativos",
+        "tableColName": "Nome",
+        "tableColTier": "Nível",
+        "tableColType": "Tipo",
+        "tableColPoints": "Pontos",
+        "tableColScope": "Escopo",
+        "tableColSecret": "Secreto",
+        "tableColStatus": "Estado",
+        "tableColActions": "Ações",
+        "ariaRepeatable": "Repetível",
+        "ariaSecret": "Secreto",
+        "ariaVisible": "Visível",
+        "statusActive": "Ativo",
+        "statusInactive": "Inativo",
+        "active": "Ativo",
+        "tier": "Nível",
+        "type": "Tipo",
+        "emptyNoFiltersTitle": "Nenhuma conquista nesta categoria",
+        "emptyNoFiltersDescription": "Crie a primeira conquista para esta categoria.",
+        "emptyFiltersTitle": "Sem resultados",
+        "emptyFiltersDescription": "Nenhuma conquista corresponde aos filtros.",
+        "deleteTitle": "Excluir conquista?",
+        "deleteDescription": "A conquista \"{name}\" será excluída. Esta ação não pode ser desfeita.",
+        "deleteCancelButton": "Cancelar",
+        "deleteConfirmButton": "Excluir",
+        "actionEdit": "Editar",
+        "actionDelete": "Excluir"
+      },
+      "categories": {
+        "pageTitle": "Conquistas",
+        "page": "Categorias",
+        "pageDescription": "Categorias e conquistas do sistema de recompensas.",
+        "newButton": "Nova categoria",
+        "filtersTitle": "Filtros",
+        "filtersSubtitle": "Refinar a lista",
+        "filterName": "Nome",
+        "filterNamePlaceholder": "Buscar por nome...",
+        "search": "Pesquisar",
+        "q": "Pesquisar",
+        "filterStatus": "Estado",
+        "filterStatusPlaceholder": "Estado",
+        "filterStatusAll": "Todos os estados",
+        "filterStatusActive": "Ativas",
+        "filterStatusInactive": "Inativas",
+        "tableColName": "Nome",
+        "tableColDescription": "Descrição",
+        "tableColIcon": "Ícone",
+        "tableColOrder": "Ordem",
+        "tableColStatus": "Estado",
+        "tableColActions": "Ações",
+        "statusActive": "Ativa",
+        "statusInactive": "Inativa",
+        "active": "Ativa",
+        "emptyNoFiltersTitle": "Nenhuma categoria de conquistas",
+        "emptyNoFiltersDescription": "Crie a primeira categoria para organizar as conquistas.",
+        "emptyFiltersTitle": "Sem resultados",
+        "emptyFiltersDescription": "Nenhuma categoria corresponde aos filtros.",
+        "deleteTitle": "Excluir categoria?",
+        "deleteDescription": "A categoria \"{name}\" será excluída. Esta ação não pode ser desfeita.",
+        "deleteCancelButton": "Cancelar",
+        "deleteConfirmButton": "Excluir",
+        "actionEdit": "Editar",
+        "actionDelete": "Excluir"
       }
     }
   },
@@ -2559,6 +2859,37 @@
       "errorFallback": "Não foi possível carregar os vencedores. Verifique a conexão com o servidor.",
       "emptyNoTypesTitle": "Sem catálogos disponíveis",
       "emptyNoTypesDescription": "Não foi possível carregar os tipos de clube para os filtros."
+    },
+    "supervision": {
+      "filterClubTypePlaceholder": "Tipo de clube",
+      "filterClubTypeAll": "Todos os tipos",
+      "filterLocalFieldPlaceholder": "Campo local",
+      "filterLocalFieldAll": "Todos os campos",
+      "filterYearPlaceholder": "Ano",
+      "filterMonthPlaceholder": "Mês",
+      "filterMonthAll": "Todos os meses",
+      "filterNotifiedPlaceholder": "Notificado",
+      "filterNotifiedAll": "Qualquer",
+      "filterNotifiedTrue": "Notificado",
+      "filterNotifiedFalse": "Pendente",
+      "tableColMember": "Membro",
+      "tableColSection": "Seção",
+      "tableColClubType": "Tipo de clube",
+      "tableColClub": "Clube",
+      "tableColLocalField": "Campo local",
+      "tableColPeriod": "Período",
+      "tableColPoints": "Pontos",
+      "tableColNotified": "Notificado",
+      "tableColActions": "Ações",
+      "badgeNotified": "Notificado",
+      "badgePending": "Pendente",
+      "emptyTitle": "Sem ganhadores para os filtros selecionados.",
+      "emptyHint": "Ajuste os filtros para ver resultados.",
+      "paginationTotal": "{total, plural, =0 {Sem resultados} one {# ganhador no total} other {# ganhadores no total}}",
+      "paginationPage": "Página {page} de {totalPages}",
+      "paginationPrev": "Anterior",
+      "paginationNext": "Próximo",
+      "reevaluateButton": "Reavaliar"
     }
   },
   "reports": {
@@ -2695,6 +3026,53 @@
       "empty_no_catalogs_title": "Sem catálogos disponíveis",
       "empty_no_catalogs_description": "Não foi possível carregar os tipos de clube para os filtros.",
       "error_load_reports": "Não foi possível carregar os relatórios. Verifique a conexão com o servidor."
+    },
+    "supervisionClient": {
+      "filterClubTypePlaceholder": "Tipo de clube",
+      "filterClubTypeAll": "Todos os tipos",
+      "filterLocalFieldPlaceholder": "Campo local",
+      "filterLocalFieldAll": "Todos os campos",
+      "filterYearPlaceholder": "Ano",
+      "filterMonthPlaceholder": "Mês",
+      "filterMonthAll": "Todos os meses",
+      "filterStatusPlaceholder": "Estado",
+      "filterStatusAll": "Todos os estados",
+      "months": {
+        "1": "Janeiro",
+        "2": "Fevereiro",
+        "3": "Março",
+        "4": "Abril",
+        "5": "Maio",
+        "6": "Junho",
+        "7": "Julho",
+        "8": "Agosto",
+        "9": "Setembro",
+        "10": "Outubro",
+        "11": "Novembro",
+        "12": "Dezembro"
+      },
+      "statusOptions": {
+        "draft": "Rascunho",
+        "generated": "Gerado",
+        "submitted": "Enviado"
+      },
+      "tableColClub": "Clube",
+      "tableColType": "Tipo",
+      "tableColLocalField": "Campo local",
+      "tableColPeriod": "Período",
+      "tableColStatus": "Estado",
+      "tableColGenerated": "Gerado",
+      "tableColSubmitted": "Enviado",
+      "tableColActions": "Ações",
+      "memberCount": "({count} membros)",
+      "emptyTitle": "Nenhum relatório encontrado",
+      "emptyHint": "Ajuste os filtros para ver resultados.",
+      "paginationTotal": "{total, plural, =0 {Sem resultados} one {# relatório no total} other {# relatórios no total}}",
+      "paginationPage": "Página {page} de {totalPages}",
+      "paginationPrev": "Anterior",
+      "paginationNext": "Próximo",
+      "actionView": "Ver",
+      "actionPdf": "PDF"
     }
   },
   "requests": {
@@ -3300,7 +3678,16 @@
   },
   "shared": {
     "errors": {
-      "unexpected": "Erro inesperado"
+      "unexpected": "Erro inesperado",
+      "dashboardTitle": "Algo deu errado",
+      "dashboardDescription": "Ocorreu um erro ao carregar esta seção.",
+      "dashboardHeading": "Não foi possível carregar a página",
+      "dashboardBody": "O erro foi reportado automaticamente. Você pode tentar novamente ou voltar ao painel.",
+      "dashboardRetry": "Tentar novamente",
+      "dashboardGoHome": "Ir ao painel",
+      "notFoundTitle": "Página não encontrada",
+      "notFoundBody": "A rota que você procura não existe ou foi movida.",
+      "notFoundGoHome": "Ir ao painel"
     },
     "pagination": {
       "showing": "Mostrando {from}–{to} de {total} registros",
@@ -3322,6 +3709,10 @@
       "missing": "Não disponível",
       "rateLimited": "Limite de requisições atingido",
       "goToLogin": "Ir para login"
+    },
+    "appMetadata": {
+      "title": "SACDIA Painel Administrativo",
+      "description": "Painel de administração do SACDIA"
     }
   },
   "translations": {
@@ -3385,6 +3776,19 @@
         "back": "Voltar",
         "cannotLoad": "Não foi possível carregar a configuração"
       }
+    },
+    "weightsPage": {
+      "deleteTitle": "Excluir substituição de pesos",
+      "deleteDescription": "Os cálculos de ranking que usavam esta configuração voltarão a usar a configuração padrão global. Esta ação não pode ser desfeita.",
+      "deleteCancel": "Cancelar",
+      "deleteConfirm": "Excluir",
+      "deleteConfirmLoading": "Excluindo...",
+      "deleteSuccess": "Substituição excluída"
+    },
+    "sumIndicator": {
+      "label": "Soma: {sum}%",
+      "valid": "✓",
+      "invalid": "— deve ser 100"
     }
   },
   "rankingWeights": {
@@ -3732,6 +4136,75 @@
       "back": "Voltar para seções",
       "breadcrumbParent": "Ranking de seções",
       "breadcrumbCurrent": "Seção #{sectionId}"
+    },
+    "filters": {
+      "labelYear": "Ano eclesiástico",
+      "labelClub": "ID do clube",
+      "labelSection": "ID da seção",
+      "placeholderYear": "2026",
+      "placeholderClub": "Todos",
+      "placeholderSection": "Todas",
+      "apply": "Filtrar",
+      "clear": "Limpar"
+    },
+    "table": {
+      "colRank": "#",
+      "colMember": "Membro",
+      "colSection": "Seção",
+      "colComposite": "Composite",
+      "colClass": "Classe",
+      "colInvestiture": "Investidura",
+      "colCamporee": "Camporees",
+      "colCategory": "Categoria",
+      "colAction": "Ação",
+      "emptyTitle": "Sem rankings disponíveis",
+      "emptyDescription": "Sem rankings para os filtros selecionados.",
+      "countSingular": "{total} membro classificado",
+      "countPlural": "{total} membros classificados",
+      "investedLabel": "Investido",
+      "inProgressLabel": "Em andamento",
+      "viewDetail": "Ver detalhe"
+    },
+    "breakdownCard": {
+      "weightLabel": "Peso: {weight}%",
+      "scoreLabel": "Pontuação"
+    },
+    "sectionFilters": {
+      "labelYear": "Ano eclesiástico",
+      "labelClub": "ID do clube",
+      "placeholderYear": "2026",
+      "placeholderClub": "Todos",
+      "apply": "Filtrar",
+      "clear": "Limpar"
+    },
+    "sectionTable": {
+      "colRank": "#",
+      "colSection": "Seção",
+      "colComposite": "Composite",
+      "colActiveMembers": "Membros ativos",
+      "colCategory": "Categoria",
+      "colCalculated": "Calculado",
+      "colAction": "Ação",
+      "emptyTitle": "Sem rankings disponíveis",
+      "emptyDescription": "Sem rankings para os filtros selecionados.",
+      "countSingular": "{total} seção classificada",
+      "countPlural": "{total} seções classificadas",
+      "viewMembers": "Ver membros"
+    },
+    "sectionMembersTable": {
+      "colRank": "#",
+      "colMember": "Membro",
+      "colComposite": "Composite",
+      "colClass": "Classe",
+      "colInvestiture": "Investidura",
+      "colCamporee": "Camporees",
+      "colCategory": "Categoria",
+      "colAction": "Ação",
+      "emptyTitle": "Sem membros com ranking",
+      "emptyDescription": "Esta seção não tem membros com ranking calculado.",
+      "investedLabel": "Investido",
+      "inProgressLabel": "Em andamento",
+      "viewDetail": "Ver detalhe"
     }
   },
   "system_jobs": {
@@ -3753,6 +4226,116 @@
       "description": "Registro paginado de todas as execuções dos jobs programados.",
       "back": "Voltar",
       "errorLoad": "Não foi possível carregar o histórico de cron runs. Verifique se o backend está disponível e tente novamente."
+    },
+    "cronRuns": {
+      "cardTitle": "Cron Jobs",
+      "colJob": "Job",
+      "colLastRun": "Última execução",
+      "colStatus": "Status",
+      "colDuration": "Duração",
+      "colItems": "Itens",
+      "colLastSuccess": "Último sucesso",
+      "colLastFailure": "Última falha",
+      "colFailureRate": "Taxa de falha 7d",
+      "colRuns7d": "Runs 7d",
+      "noRuns": "Sem execuções",
+      "statusCompleted": "Concluído",
+      "statusFailed": "Falhou",
+      "statusRunning": "Executando",
+      "statusSkipped": "Ignorado",
+      "jobMonthlyReports": "Relatórios mensais (auto-gerar)",
+      "jobRankingsRecalculate": "Rankings anuais (recalcular)",
+      "jobDataExportCleanup": "Limpeza de exports vencidos",
+      "jobMemberOfMonth": "Membro do mês (auto-avaliar)",
+      "jobFinancePeriod": "Fechamento de período financeiro",
+      "jobActivitiesReminder": "Lembretes de atividades",
+      "jobMembershipExpiry": "Expirar solicitações de adesão",
+      "jobCleanupExpired": "Limpeza de sessões/tokens vencidos",
+      "jobFcmCleanup": "Limpeza de tokens FCM órfãos"
+    },
+    "overview": {
+      "queuesTitle": "Filas",
+      "queuesCountSingular": "{count} fila registrada",
+      "queuesCountPlural": "{count} filas registradas",
+      "refreshButton": "Atualizar",
+      "refreshLoading": "Atualizando...",
+      "noQueues": "Nenhuma fila ativa encontrada.",
+      "activeLabel": "ativo",
+      "statWaiting": "Aguardando",
+      "statActive": "Ativos",
+      "statCompleted": "Concluídos",
+      "statFailed": "Com falha",
+      "statDelayed": "Adiados",
+      "statPaused": "Pausados",
+      "failedJobsTitle": "Últimas falhas",
+      "failedJobsEmpty": "Sem falhas recentes",
+      "colQueue": "Fila",
+      "colJob": "Job",
+      "colReason": "Motivo",
+      "colAttempts": "Tentativas",
+      "colDate": "Data",
+      "colAction": "Ação",
+      "retryButton": "Tentar novamente",
+      "retryLoading": "Tentando novamente...",
+      "retryDialogTitle": "Tentar novamente este job?",
+      "retryDialogDescription": "O job {jobName} será reenfileirado na fila {queue}.",
+      "retryDialogCancel": "Cancelar",
+      "retryDialogConfirm": "Tentar novamente",
+      "retrySuccess": "Job reenfileirado",
+      "retrySuccessDescription": "O job \"{name}\" foi reenfileirado com sucesso.",
+      "retryErrorTitle": "Erro ao tentar novamente",
+      "retryErrorFallback": "Erro desconhecido ao tentar novamente o job.",
+      "queueNotifications": "Notificações",
+      "queueNotificationsDesc": "Push notifications e cache em tempo real",
+      "queueEmail": "E-mails",
+      "queueEmailDesc": "Transacionais (rate-limited 90/dia)",
+      "queueAchievements": "Conquistas",
+      "queueAchievementsDesc": "Avaliação e correspondência de conquistas",
+      "queueBackgroundJobs": "Jobs em segundo plano",
+      "queueBackgroundJobsDesc": "Relatórios, finanças, rankings, exports"
+    },
+    "history": {
+      "filterLabelJob": "Job",
+      "filterLabelStatus": "Status",
+      "filterLabelSince": "De",
+      "filterLabelUntil": "Até",
+      "filterAllJobs": "Todos os jobs",
+      "filterAllStatuses": "Todos os status",
+      "statusCompleted": "Concluído",
+      "statusFailed": "Falhou",
+      "statusSkipped": "Ignorado",
+      "statusRunning": "Executando",
+      "recordCount": "{total} registros",
+      "noResults": "Nenhuma execução encontrada com os filtros aplicados.",
+      "colJob": "Job",
+      "colStart": "Início",
+      "colStatus": "Status",
+      "colDuration": "Duração",
+      "colItems": "Itens",
+      "colError": "Erro",
+      "colDetails": "Detalhes",
+      "viewButton": "Ver",
+      "pagination": "Página {page} de {totalPages}",
+      "paginationPrev": "Anterior",
+      "paginationNext": "Próximo",
+      "detailTitle": "Detalhes do run #{runId}",
+      "detailLabelJob": "Job",
+      "detailLabelStatus": "Status",
+      "detailLabelStart": "Início",
+      "detailLabelEnd": "Fim",
+      "detailLabelDuration": "Duração",
+      "detailLabelItems": "Itens processados",
+      "detailLabelError": "Mensagem de erro",
+      "detailLabelMetadata": "Metadados",
+      "jobMonthlyReports": "Relatórios mensais (auto-gerar)",
+      "jobRankingsRecalculate": "Rankings anuais (recalcular)",
+      "jobDataExportCleanup": "Limpeza de exports vencidos",
+      "jobMemberOfMonth": "Membro do mês (auto-avaliar)",
+      "jobFinancePeriod": "Fechamento de período financeiro",
+      "jobActivitiesReminder": "Lembretes de atividades",
+      "jobMembershipExpiry": "Expirar solicitações de adesão",
+      "jobCleanupExpired": "Limpeza de sessões/tokens vencidos",
+      "jobFcmCleanup": "Limpeza de tokens FCM órfãos"
     }
   },
   "settings": {
@@ -3766,7 +4349,8 @@
       },
       "scoringCategories": {
         "title": "Categorias de pontuação",
-        "description": "Gestão de categorias de pontuação por divisão."
+        "description": "Gestão de categorias de pontuação por divisão.",
+        "metadataTitle": "Categorias de pontuação"
       }
     }
   }

--- a/src/app/(dashboard)/dashboard/achievements/_components/achievement-categories-crud-page.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/achievement-categories-crud-page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useActionState, useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   Loader2,
   MoreHorizontal,
@@ -89,7 +90,7 @@ function pickName(item: CategoryRecord): string {
   return toText(item.name) ?? toText(item.title) ?? "—";
 }
 
-function DeleteButton() {
+function DeleteButton({ label }: { label: string }) {
   const [pending, setPending] = useState(false);
   return (
     <Button
@@ -99,7 +100,7 @@ function DeleteButton() {
       disabled={pending}
     >
       {pending && <Loader2 className="size-4 animate-spin" />}
-      Eliminar
+      {label}
     </Button>
   );
 }
@@ -111,6 +112,7 @@ export function AchievementCategoriesCrudPage({
   updateAction,
   deleteAction,
 }: Props) {
+  const t = useTranslations("achievements.crud.categories");
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -198,12 +200,12 @@ export function AchievementCategoriesCrudPage({
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Logros"
-        description="Categorías y logros del sistema de recompensas."
+        title={t("pageTitle")}
+        description={t("pageDescription")}
       >
         <Button onClick={() => setCreateOpen(true)}>
           <Plus className="size-4" />
-          Nueva categoría
+          {t("newButton")}
         </Button>
       </PageHeader>
 
@@ -211,18 +213,18 @@ export function AchievementCategoriesCrudPage({
         {/* Filters */}
         <div className="rounded-xl border bg-muted/20 p-4">
           <div className="mb-3 flex items-center justify-between gap-2">
-            <h3 className="text-sm font-semibold tracking-wide text-foreground">Filtros</h3>
-            <span className="text-xs text-muted-foreground">Refina el listado</span>
+            <h3 className="text-sm font-semibold tracking-wide text-foreground">{t("filtersTitle")}</h3>
+            <span className="text-xs text-muted-foreground">{t("filtersSubtitle")}</span>
           </div>
           <div className="overflow-x-auto pb-1">
             <div className="flex min-w-max items-end gap-4">
               <div className="w-[300px] space-y-1">
-                <Label htmlFor="cat-filter-name">Nombre</Label>
+                <Label htmlFor="cat-filter-name">{t("filterName")}</Label>
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
                     id="cat-filter-name"
-                    placeholder="Buscar por nombre..."
+                    placeholder={t("filterNamePlaceholder")}
                     value={searchInput}
                     onChange={(e) => handleSearchInputChange(e.target.value)}
                     className="bg-background pl-9"
@@ -230,18 +232,18 @@ export function AchievementCategoriesCrudPage({
                 </div>
               </div>
               <div className="w-[200px] space-y-1">
-                <Label htmlFor="cat-filter-status">Estado</Label>
+                <Label htmlFor="cat-filter-status">{t("filterStatus")}</Label>
                 <Select
                   value={currentStatusFilter}
                   onValueChange={(value) => updateParam("active", value)}
                 >
                   <SelectTrigger id="cat-filter-status" className="bg-background">
-                    <SelectValue placeholder="Estado" />
+                    <SelectValue placeholder={t("filterStatusPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Todos los estados</SelectItem>
-                    <SelectItem value="true">Activas</SelectItem>
-                    <SelectItem value="false">Inactivas</SelectItem>
+                    <SelectItem value="all">{t("filterStatusAll")}</SelectItem>
+                    <SelectItem value="true">{t("filterStatusActive")}</SelectItem>
+                    <SelectItem value="false">{t("filterStatusInactive")}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -253,17 +255,17 @@ export function AchievementCategoriesCrudPage({
         {items.length === 0 ? (
           <EmptyState
             icon={Trophy}
-            title={hasActiveFilters ? "Sin resultados" : "No hay categorías de logros"}
+            title={hasActiveFilters ? t("emptyFiltersTitle") : t("emptyNoFiltersTitle")}
             description={
               hasActiveFilters
-                ? "No hay categorías que coincidan con los filtros."
-                : "Crea la primera categoría para organizar los logros."
+                ? t("emptyFiltersDescription")
+                : t("emptyNoFiltersDescription")
             }
           >
             {!hasActiveFilters && (
               <Button onClick={() => setCreateOpen(true)}>
                 <Plus className="size-4" />
-                Nueva categoría
+                {t("newButton")}
               </Button>
             )}
           </EmptyState>
@@ -273,13 +275,13 @@ export function AchievementCategoriesCrudPage({
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Nombre</TableHead>
-                    <TableHead>Descripción</TableHead>
-                    <TableHead>Icono</TableHead>
-                    <TableHead>Orden</TableHead>
-                    <TableHead>Estado</TableHead>
+                    <TableHead>{t("tableColName")}</TableHead>
+                    <TableHead>{t("tableColDescription")}</TableHead>
+                    <TableHead>{t("tableColIcon")}</TableHead>
+                    <TableHead>{t("tableColOrder")}</TableHead>
+                    <TableHead>{t("tableColStatus")}</TableHead>
                     <TableHead className="sticky right-0 z-20 w-[120px] border-l bg-background text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Acciones
+                      {t("tableColActions")}
                     </TableHead>
                   </TableRow>
                 </TableHeader>
@@ -317,7 +319,7 @@ export function AchievementCategoriesCrudPage({
                         </TableCell>
                         <TableCell>
                           <Badge variant={item.active !== false ? "success" : "secondary"} className="text-xs">
-                            {item.active !== false ? "Activa" : "Inactiva"}
+                            {item.active !== false ? t("statusActive") : t("statusInactive")}
                           </Badge>
                         </TableCell>
                         <TableCell className="sticky right-0 z-10 border-l bg-background">
@@ -328,7 +330,7 @@ export function AchievementCategoriesCrudPage({
                               className="size-8"
                               disabled={!categoryId}
                               onClick={() => setEditItem(item)}
-                              title="Editar"
+                              title={t("actionEdit")}
                             >
                               <Pencil className="size-3.5" />
                             </Button>
@@ -338,7 +340,7 @@ export function AchievementCategoriesCrudPage({
                               className="size-8 text-destructive hover:text-destructive"
                               disabled={!categoryId}
                               onClick={() => setDeleteItem(item)}
-                              title="Eliminar"
+                              title={t("actionDelete")}
                             >
                               <Trash2 className="size-3.5" />
                             </Button>
@@ -356,7 +358,7 @@ export function AchievementCategoriesCrudPage({
                                   onSelect={() => setEditItem(item)}
                                 >
                                   <Pencil className="size-4" />
-                                  Editar
+                                  {t("actionEdit")}
                                 </DropdownMenuItem>
                                 <DropdownMenuItem
                                   disabled={!categoryId}
@@ -364,7 +366,7 @@ export function AchievementCategoriesCrudPage({
                                   onSelect={() => setDeleteItem(item)}
                                 >
                                   <Trash2 className="size-4" />
-                                  Eliminar
+                                  {t("actionDelete")}
                                 </DropdownMenuItem>
                               </DropdownMenuContent>
                             </DropdownMenu>
@@ -417,21 +419,19 @@ export function AchievementCategoriesCrudPage({
         >
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>¿Eliminar categoría?</AlertDialogTitle>
+              <AlertDialogTitle>{t("deleteTitle")}</AlertDialogTitle>
               <AlertDialogDescription>
-                Se eliminará la categoría{" "}
-                <strong className="text-foreground">&quot;{pickName(deleteItem)}&quot;</strong>.
-                Esta acción no puede deshacerse.
+                {t("deleteDescription", { name: pickName(deleteItem) })}
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancelar</AlertDialogCancel>
+              <AlertDialogCancel>{t("deleteCancelButton")}</AlertDialogCancel>
               <form action={deleteFormAction}>
                 <input type="hidden" name="id" value={String(pickId(deleteItem) ?? "")} />
                 {deleteState.error && (
                   <p className="mb-2 text-xs text-destructive">{deleteState.error}</p>
                 )}
-                <DeleteButton />
+                <DeleteButton label={t("deleteConfirmButton")} />
               </form>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/src/app/(dashboard)/dashboard/achievements/_components/achievement-form.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/achievement-form.tsx
@@ -4,6 +4,7 @@ import { useActionState, useState } from "react";
 import { useFormStatus } from "react-dom";
 import Link from "next/link";
 import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -46,26 +47,26 @@ interface AchievementFormProps {
   cancelHref?: string;
 }
 
-const ACHIEVEMENT_TYPES: { value: AchievementType; label: string }[] = [
-  { value: "THRESHOLD", label: "Umbral" },
-  { value: "STREAK", label: "Racha" },
-  { value: "COMPOUND", label: "Compuesto" },
-  { value: "MILESTONE", label: "Hito" },
-  { value: "COLLECTION", label: "Colección" },
+const ACHIEVEMENT_TYPE_VALUES: AchievementType[] = [
+  "THRESHOLD",
+  "STREAK",
+  "COMPOUND",
+  "MILESTONE",
+  "COLLECTION",
 ];
 
-const ACHIEVEMENT_TIERS: { value: AchievementTier; label: string; color: string }[] = [
-  { value: "BRONZE", label: "Bronce", color: "#CD7F32" },
-  { value: "SILVER", label: "Plata", color: "#C0C0C0" },
-  { value: "GOLD", label: "Oro", color: "#FFD700" },
-  { value: "PLATINUM", label: "Platino", color: "#E5E4E2" },
-  { value: "DIAMOND", label: "Diamante", color: "#B9F2FF" },
+const ACHIEVEMENT_TIER_VALUES: { value: AchievementTier; color: string }[] = [
+  { value: "BRONZE", color: "#CD7F32" },
+  { value: "SILVER", color: "#C0C0C0" },
+  { value: "GOLD", color: "#FFD700" },
+  { value: "PLATINUM", color: "#E5E4E2" },
+  { value: "DIAMOND", color: "#B9F2FF" },
 ];
 
-const ACHIEVEMENT_SCOPES: { value: AchievementScope; label: string }[] = [
-  { value: "GLOBAL", label: "Global" },
-  { value: "CLUB_TYPE", label: "Tipo de club" },
-  { value: "ECCLESIASTICAL_YEAR", label: "Año eclesiástico" },
+const ACHIEVEMENT_SCOPE_VALUES: AchievementScope[] = [
+  "GLOBAL",
+  "CLUB_TYPE",
+  "ECCLESIASTICAL_YEAR",
 ];
 
 function toText(value: unknown): string {
@@ -114,6 +115,8 @@ export function AchievementForm({
   actionState,
   cancelHref = "/dashboard/achievements",
 }: AchievementFormProps) {
+  const t = useTranslations("achievements.forms.achievement");
+  const tPreview = useTranslations("achievements.cards.preview");
   const [state, action] = useActionState(formAction, actionState);
   const isEdit = mode === "edit";
 
@@ -172,13 +175,13 @@ export function AchievementForm({
       <Tabs defaultValue="basic" className="w-full">
         <TabsList className="w-full">
           <TabsTrigger value="basic" className="flex-1">
-            Información básica
+            {t("tabBasic")}
           </TabsTrigger>
           <TabsTrigger value="criteria" className="flex-1">
-            Criterios
+            {t("tabCriteria")}
           </TabsTrigger>
           <TabsTrigger value="media" className="flex-1">
-            Imagen
+            {t("tabMedia")}
           </TabsTrigger>
         </TabsList>
 
@@ -187,12 +190,12 @@ export function AchievementForm({
           {/* Name */}
           <div className="space-y-2">
             <Label htmlFor="ach-name">
-              Nombre <span className="ml-0.5 text-destructive">*</span>
+              {t("labelName")} <span className="ml-0.5 text-destructive">*</span>
             </Label>
             <Input
               id="ach-name"
               name="name"
-              placeholder="Ej. Asistente Dedicado"
+              placeholder={t("placeholderName")}
               value={name}
               onChange={(e) => setName(e.target.value)}
               required
@@ -201,12 +204,12 @@ export function AchievementForm({
 
           {/* Description */}
           <div className="space-y-2">
-            <Label htmlFor="ach-description">Descripción</Label>
+            <Label htmlFor="ach-description">{t("labelDescription")}</Label>
             <Textarea
               id="ach-description"
               name="description"
               rows={2}
-              placeholder="Describe este logro..."
+              placeholder={t("placeholderDescription")}
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               className="min-h-[70px] resize-none"
@@ -216,13 +219,13 @@ export function AchievementForm({
           {/* Category */}
           {categories.length > 0 && (
             <div className="space-y-2">
-              <Label htmlFor="ach-category">Categoría</Label>
+              <Label htmlFor="ach-category">{t("labelCategory")}</Label>
               <Select
                 name="category_id"
                 defaultValue={selectedCategoryId ? String(selectedCategoryId) : undefined}
               >
                 <SelectTrigger id="ach-category">
-                  <SelectValue placeholder="Selecciona una categoría..." />
+                  <SelectValue placeholder={t("placeholderCategory")} />
                 </SelectTrigger>
                 <SelectContent>
                   {categories.map((cat) => (
@@ -238,7 +241,7 @@ export function AchievementForm({
           {/* Type */}
           <div className="space-y-2">
             <Label htmlFor="ach-type">
-              Tipo <span className="ml-0.5 text-destructive">*</span>
+              {t("labelType")} <span className="ml-0.5 text-destructive">*</span>
             </Label>
             <Select
               name="type"
@@ -247,12 +250,12 @@ export function AchievementForm({
               required
             >
               <SelectTrigger id="ach-type">
-                <SelectValue placeholder="Tipo de logro..." />
+                <SelectValue placeholder={t("placeholderType")} />
               </SelectTrigger>
               <SelectContent>
-                {ACHIEVEMENT_TYPES.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
+                {ACHIEVEMENT_TYPE_VALUES.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {tPreview(`typeLabels.${v}`)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -263,7 +266,7 @@ export function AchievementForm({
           <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <Label htmlFor="ach-tier">
-                Nivel <span className="ml-0.5 text-destructive">*</span>
+                {t("labelTier")} <span className="ml-0.5 text-destructive">*</span>
               </Label>
               <Select
                 name="tier"
@@ -272,10 +275,10 @@ export function AchievementForm({
                 required
               >
                 <SelectTrigger id="ach-tier">
-                  <SelectValue placeholder="Nivel..." />
+                  <SelectValue placeholder={t("placeholderTier")} />
                 </SelectTrigger>
                 <SelectContent>
-                  {ACHIEVEMENT_TIERS.map((opt) => (
+                  {ACHIEVEMENT_TIER_VALUES.map((opt) => (
                     <SelectItem key={opt.value} value={opt.value}>
                       <span className="flex items-center gap-2">
                         <span
@@ -283,7 +286,7 @@ export function AchievementForm({
                           style={{ backgroundColor: opt.color }}
                           aria-hidden
                         />
-                        {opt.label}
+                        {tPreview(`tierLabels.${opt.value}`)}
                       </span>
                     </SelectItem>
                   ))}
@@ -293,7 +296,7 @@ export function AchievementForm({
 
             <div className="space-y-2">
               <Label htmlFor="ach-points">
-                Puntos <span className="ml-0.5 text-destructive">*</span>
+                {t("labelPoints")} <span className="ml-0.5 text-destructive">*</span>
               </Label>
               <Input
                 id="ach-points"
@@ -310,7 +313,7 @@ export function AchievementForm({
           {/* Scope */}
           <div className="space-y-2">
             <Label htmlFor="ach-scope">
-              Alcance <span className="ml-0.5 text-destructive">*</span>
+              {t("labelScope")} <span className="ml-0.5 text-destructive">*</span>
             </Label>
             <Select
               name="scope"
@@ -319,12 +322,12 @@ export function AchievementForm({
               required
             >
               <SelectTrigger id="ach-scope">
-                <SelectValue placeholder="Alcance..." />
+                <SelectValue placeholder={t("placeholderScope")} />
               </SelectTrigger>
               <SelectContent>
-                {ACHIEVEMENT_SCOPES.map((opt) => (
-                  <SelectItem key={opt.value} value={opt.value}>
-                    {opt.label}
+                {ACHIEVEMENT_SCOPE_VALUES.map((v) => (
+                  <SelectItem key={v} value={v}>
+                    {t(`scopeLabels.${v}`)}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -334,7 +337,7 @@ export function AchievementForm({
           {/* Prerequisite */}
           {allAchievements.length > 0 && (
             <div className="space-y-2">
-              <Label htmlFor="ach-prerequisite">Prerequisito</Label>
+              <Label htmlFor="ach-prerequisite">{t("labelPrerequisite")}</Label>
               <Select
                 name="prerequisite_id"
                 defaultValue={
@@ -344,7 +347,7 @@ export function AchievementForm({
                 }
               >
                 <SelectTrigger id="ach-prerequisite">
-                  <SelectValue placeholder="Sin prerequisito..." />
+                  <SelectValue placeholder={t("placeholderPrerequisite")} />
                 </SelectTrigger>
                 <SelectContent>
                   {allAchievements
@@ -364,14 +367,14 @@ export function AchievementForm({
             <div className="flex items-center gap-3">
               <Switch id="ach-secret" checked={secret} onCheckedChange={setSecret} />
               <Label htmlFor="ach-secret" className="cursor-pointer">
-                Logro secreto
+                {t("labelSecret")}
               </Label>
             </div>
 
             <div className="flex items-center gap-3">
               <Switch id="ach-active" checked={active} onCheckedChange={setActive} />
               <Label htmlFor="ach-active" className="cursor-pointer">
-                Activo
+                {t("labelActive")}
               </Label>
             </div>
           </div>
@@ -385,12 +388,12 @@ export function AchievementForm({
                 onCheckedChange={setRepeatable}
               />
               <Label htmlFor="ach-repeatable" className="cursor-pointer">
-                Logro repetible
+                {t("labelRepeatable")}
               </Label>
             </div>
             {repeatable && (
               <div className="space-y-2 pl-9">
-                <Label htmlFor="ach-max-repeats">Máximo de repeticiones</Label>
+                <Label htmlFor="ach-max-repeats">{t("labelMaxRepeats")}</Label>
                 <Input
                   id="ach-max-repeats"
                   name="max_repeats"
@@ -407,10 +410,10 @@ export function AchievementForm({
           {/* Live preview */}
           <div className="pt-2">
             <p className="mb-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Vista previa
+              {t("labelPreview")}
             </p>
             <AchievementPreviewCard
-              name={name || "Nombre del logro"}
+              name={name || tPreview("defaultName")}
               description={description}
               tier={tier}
               type={type}
@@ -452,9 +455,9 @@ export function AchievementForm({
       {/* Form actions */}
       <div className="flex items-center justify-end gap-3 border-t pt-4">
         <Button type="button" variant="outline" asChild>
-          <Link href={cancelHref}>Cancelar</Link>
+          <Link href={cancelHref}>{t("cancelButton")}</Link>
         </Button>
-        <SubmitButton label={isEdit ? "Guardar cambios" : "Crear logro"} />
+        <SubmitButton label={isEdit ? t("submitEdit") : t("submitCreate")} />
       </div>
     </form>
   );

--- a/src/app/(dashboard)/dashboard/achievements/_components/achievement-preview-card.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/achievement-preview-card.tsx
@@ -2,23 +2,16 @@
 
 import Image from "next/image";
 import { EyeOff, Lock, RefreshCw } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 import type { AchievementTier, AchievementType } from "@/lib/api/achievements";
 
-const TIER_COLORS: Record<AchievementTier, { ring: string; label: string; bg: string }> = {
-  BRONZE: { ring: "#CD7F32", label: "Bronce", bg: "#CD7F3220" },
-  SILVER: { ring: "#C0C0C0", label: "Plata", bg: "#C0C0C020" },
-  GOLD: { ring: "#FFD700", label: "Oro", bg: "#FFD70020" },
-  PLATINUM: { ring: "#E5E4E2", label: "Platino", bg: "#E5E4E220" },
-  DIAMOND: { ring: "#B9F2FF", label: "Diamante", bg: "#B9F2FF20" },
-};
-
-const TYPE_LABELS: Record<AchievementType, string> = {
-  THRESHOLD: "Umbral",
-  STREAK: "Racha",
-  COMPOUND: "Compuesto",
-  MILESTONE: "Hito",
-  COLLECTION: "Colección",
+const TIER_COLORS: Record<AchievementTier, { ring: string; bg: string }> = {
+  BRONZE: { ring: "#CD7F32", bg: "#CD7F3220" },
+  SILVER: { ring: "#C0C0C0", bg: "#C0C0C020" },
+  GOLD: { ring: "#FFD700", bg: "#FFD70020" },
+  PLATINUM: { ring: "#E5E4E2", bg: "#E5E4E220" },
+  DIAMOND: { ring: "#B9F2FF", bg: "#B9F2FF20" },
 };
 
 interface Props {
@@ -42,6 +35,7 @@ export function AchievementPreviewCard({
   repeatable = false,
   badgeImageUrl,
 }: Props) {
+  const t = useTranslations("achievements.cards.preview");
   const tierConfig = TIER_COLORS[tier];
 
   return (
@@ -78,7 +72,7 @@ export function AchievementPreviewCard({
 
       {/* Name */}
       <div className="space-y-1">
-        <h3 className="text-base font-semibold leading-tight">{name || "Nombre del logro"}</h3>
+        <h3 className="text-base font-semibold leading-tight">{name || t("defaultName")}</h3>
         {description && (
           <p className="text-xs text-muted-foreground line-clamp-2">{description}</p>
         )}
@@ -95,27 +89,27 @@ export function AchievementPreviewCard({
             border: `1px solid ${tierConfig.ring}40`,
           }}
         >
-          {tierConfig.label}
+          {t(`tierLabels.${tier}`)}
         </span>
 
         <Badge variant="secondary" className="text-xs">
-          {TYPE_LABELS[type]}
+          {t(`typeLabels.${type}`)}
         </Badge>
 
         <Badge variant="default" className="text-xs">
-          {points} pts
+          {points} {t("pointsSuffix")}
         </Badge>
 
         {repeatable && (
           <Badge variant="outline" className="gap-1 text-xs">
             <RefreshCw className="size-3" />
-            Repetible
+            {t("repeatableBadge")}
           </Badge>
         )}
         {secret && (
           <Badge variant="outline" className="gap-1 text-xs">
             <Lock className="size-3" />
-            Secreto
+            {t("secretBadge")}
           </Badge>
         )}
       </div>

--- a/src/app/(dashboard)/dashboard/achievements/_components/achievements-crud-page.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/achievements-crud-page.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useActionState, useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   Eye,
   EyeOff,
@@ -88,22 +89,6 @@ const TIER_COLORS: Record<AchievementTier, string> = {
   DIAMOND: "#B9F2FF",
 };
 
-const TIER_LABELS: Record<AchievementTier, string> = {
-  BRONZE: "Bronce",
-  SILVER: "Plata",
-  GOLD: "Oro",
-  PLATINUM: "Platino",
-  DIAMOND: "Diamante",
-};
-
-const TYPE_LABELS: Record<AchievementType, string> = {
-  THRESHOLD: "Umbral",
-  STREAK: "Racha",
-  COMPOUND: "Compuesto",
-  MILESTONE: "Hito",
-  COLLECTION: "Colección",
-};
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function toText(value: unknown): string | null {
@@ -138,7 +123,7 @@ function pickType(item: AchievementRecord): AchievementType | null {
   return type as AchievementType;
 }
 
-function DeleteButton() {
+function DeleteButton({ label }: { label: string }) {
   const [pending, setPending] = useState(false);
   return (
     <Button
@@ -148,7 +133,7 @@ function DeleteButton() {
       disabled={pending}
     >
       {pending && <Loader2 className="size-4 animate-spin" />}
-      Eliminar
+      {label}
     </Button>
   );
 }
@@ -162,6 +147,8 @@ export function AchievementsCrudPage({
   categoryName,
   deleteAction,
 }: Props) {
+  const t = useTranslations("achievements.crud.list");
+  const tPreview = useTranslations("achievements.cards.preview");
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -257,7 +244,7 @@ export function AchievementsCrudPage({
         <BreadcrumbList>
           <BreadcrumbItem>
             <BreadcrumbLink asChild>
-              <Link href="/dashboard/achievements">Logros</Link>
+              <Link href="/dashboard/achievements">{t("breadcrumbRoot")}</Link>
             </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />
@@ -271,12 +258,12 @@ export function AchievementsCrudPage({
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">{categoryName}</h1>
-          <p className="text-muted-foreground">Logros en esta categoría.</p>
+          <p className="text-muted-foreground">{t("pageDescription")}</p>
         </div>
         <Button asChild>
           <Link href={`/dashboard/achievements/${categoryId}/new`}>
             <Plus className="size-4" />
-            Nuevo logro
+            {t("newButton")}
           </Link>
         </Button>
       </div>
@@ -285,17 +272,17 @@ export function AchievementsCrudPage({
         {/* Filters */}
         <div className="rounded-xl border bg-muted/20 p-4">
           <div className="mb-3 flex items-center justify-between gap-2">
-            <h3 className="text-sm font-semibold tracking-wide text-foreground">Filtros</h3>
+            <h3 className="text-sm font-semibold tracking-wide text-foreground">{t("filtersTitle")}</h3>
           </div>
           <div className="overflow-x-auto pb-1">
             <div className="flex min-w-max flex-wrap items-end gap-4">
               <div className="w-[260px] space-y-1">
-                <Label htmlFor="ach-filter-name">Nombre</Label>
+                <Label htmlFor="ach-filter-name">{t("filterName")}</Label>
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
                   <Input
                     id="ach-filter-name"
-                    placeholder="Buscar logro..."
+                    placeholder={t("filterNamePlaceholder")}
                     value={searchInput}
                     onChange={(e) => handleSearchInputChange(e.target.value)}
                     className="bg-background pl-9"
@@ -304,58 +291,58 @@ export function AchievementsCrudPage({
               </div>
 
               <div className="w-[160px] space-y-1">
-                <Label htmlFor="ach-filter-type">Tipo</Label>
+                <Label htmlFor="ach-filter-type">{t("filterType")}</Label>
                 <Select
                   value={currentTypeFilter}
                   onValueChange={(v) => updateParam("type", v)}
                 >
                   <SelectTrigger id="ach-filter-type" className="bg-background">
-                    <SelectValue placeholder="Tipo" />
+                    <SelectValue placeholder={t("filterTypePlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Todos los tipos</SelectItem>
-                    <SelectItem value="THRESHOLD">Umbral</SelectItem>
-                    <SelectItem value="STREAK">Racha</SelectItem>
-                    <SelectItem value="COMPOUND">Compuesto</SelectItem>
-                    <SelectItem value="MILESTONE">Hito</SelectItem>
-                    <SelectItem value="COLLECTION">Colección</SelectItem>
+                    <SelectItem value="all">{t("filterTypeAll")}</SelectItem>
+                    <SelectItem value="THRESHOLD">{tPreview("typeLabels.THRESHOLD")}</SelectItem>
+                    <SelectItem value="STREAK">{tPreview("typeLabels.STREAK")}</SelectItem>
+                    <SelectItem value="COMPOUND">{tPreview("typeLabels.COMPOUND")}</SelectItem>
+                    <SelectItem value="MILESTONE">{tPreview("typeLabels.MILESTONE")}</SelectItem>
+                    <SelectItem value="COLLECTION">{tPreview("typeLabels.COLLECTION")}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
 
               <div className="w-[160px] space-y-1">
-                <Label htmlFor="ach-filter-tier">Nivel</Label>
+                <Label htmlFor="ach-filter-tier">{t("filterTier")}</Label>
                 <Select
                   value={currentTierFilter}
                   onValueChange={(v) => updateParam("tier", v)}
                 >
                   <SelectTrigger id="ach-filter-tier" className="bg-background">
-                    <SelectValue placeholder="Nivel" />
+                    <SelectValue placeholder={t("filterTierPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Todos los niveles</SelectItem>
-                    <SelectItem value="BRONZE">Bronce</SelectItem>
-                    <SelectItem value="SILVER">Plata</SelectItem>
-                    <SelectItem value="GOLD">Oro</SelectItem>
-                    <SelectItem value="PLATINUM">Platino</SelectItem>
-                    <SelectItem value="DIAMOND">Diamante</SelectItem>
+                    <SelectItem value="all">{t("filterTierAll")}</SelectItem>
+                    <SelectItem value="BRONZE">{tPreview("tierLabels.BRONZE")}</SelectItem>
+                    <SelectItem value="SILVER">{tPreview("tierLabels.SILVER")}</SelectItem>
+                    <SelectItem value="GOLD">{tPreview("tierLabels.GOLD")}</SelectItem>
+                    <SelectItem value="PLATINUM">{tPreview("tierLabels.PLATINUM")}</SelectItem>
+                    <SelectItem value="DIAMOND">{tPreview("tierLabels.DIAMOND")}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
 
               <div className="w-[160px] space-y-1">
-                <Label htmlFor="ach-filter-status">Estado</Label>
+                <Label htmlFor="ach-filter-status">{t("filterStatus")}</Label>
                 <Select
                   value={currentStatusFilter}
                   onValueChange={(v) => updateParam("active", v)}
                 >
                   <SelectTrigger id="ach-filter-status" className="bg-background">
-                    <SelectValue placeholder="Estado" />
+                    <SelectValue placeholder={t("filterStatusPlaceholder")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Todos</SelectItem>
-                    <SelectItem value="true">Activos</SelectItem>
-                    <SelectItem value="false">Inactivos</SelectItem>
+                    <SelectItem value="all">{t("filterStatusAll")}</SelectItem>
+                    <SelectItem value="true">{t("filterStatusActive")}</SelectItem>
+                    <SelectItem value="false">{t("filterStatusInactive")}</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -367,18 +354,18 @@ export function AchievementsCrudPage({
         {achievements.length === 0 ? (
           <EmptyState
             icon={Trophy}
-            title={hasActiveFilters ? "Sin resultados" : "No hay logros en esta categoría"}
+            title={hasActiveFilters ? t("emptyFiltersTitle") : t("emptyNoFiltersTitle")}
             description={
               hasActiveFilters
-                ? "No hay logros que coincidan con los filtros."
-                : "Crea el primer logro para esta categoría."
+                ? t("emptyFiltersDescription")
+                : t("emptyNoFiltersDescription")
             }
           >
             {!hasActiveFilters && (
               <Button asChild>
                 <Link href={`/dashboard/achievements/${categoryId}/new`}>
                   <Plus className="size-4" />
-                  Nuevo logro
+                  {t("newButton")}
                 </Link>
               </Button>
             )}
@@ -389,15 +376,15 @@ export function AchievementsCrudPage({
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Nombre</TableHead>
-                    <TableHead>Tipo</TableHead>
-                    <TableHead>Nivel</TableHead>
-                    <TableHead>Puntos</TableHead>
-                    <TableHead>Alcance</TableHead>
-                    <TableHead>Secreto</TableHead>
-                    <TableHead>Estado</TableHead>
+                    <TableHead>{t("tableColName")}</TableHead>
+                    <TableHead>{t("tableColType")}</TableHead>
+                    <TableHead>{t("tableColTier")}</TableHead>
+                    <TableHead>{t("tableColPoints")}</TableHead>
+                    <TableHead>{t("tableColScope")}</TableHead>
+                    <TableHead>{t("tableColSecret")}</TableHead>
+                    <TableHead>{t("tableColStatus")}</TableHead>
                     <TableHead className="sticky right-0 z-20 w-[120px] border-l bg-background text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                      Acciones
+                      {t("tableColActions")}
                     </TableHead>
                   </TableRow>
                 </TableHeader>
@@ -422,7 +409,7 @@ export function AchievementsCrudPage({
                         <TableCell>
                           {type ? (
                             <Badge variant="secondary" className="text-xs">
-                              {TYPE_LABELS[type]}
+                              {tPreview(`typeLabels.${type}`)}
                             </Badge>
                           ) : (
                             "—"
@@ -444,7 +431,7 @@ export function AchievementsCrudPage({
                                 style={{ backgroundColor: TIER_COLORS[tier] }}
                                 aria-hidden
                               />
-                              {TIER_LABELS[tier]}
+                              {tPreview(`tierLabels.${tier}`)}
                             </Badge>
                           ) : (
                             "—"
@@ -461,12 +448,12 @@ export function AchievementsCrudPage({
 
                         <TableCell>
                           {item.secret ? (
-                            <EyeOff className="size-4 text-muted-foreground" aria-label="Secreto" />
+                            <EyeOff className="size-4 text-muted-foreground" aria-label={t("ariaSecret")} />
                           ) : (
-                            <Eye className="size-4 text-muted-foreground/40" aria-label="Visible" />
+                            <Eye className="size-4 text-muted-foreground/40" aria-label={t("ariaVisible")} />
                           )}
                           {Boolean(item.repeatable) && (
-                            <RefreshCw className="ml-1 inline size-3.5 text-muted-foreground" aria-label="Repetible" />
+                            <RefreshCw className="ml-1 inline size-3.5 text-muted-foreground" aria-label={t("ariaRepeatable")} />
                           )}
                         </TableCell>
 
@@ -475,7 +462,7 @@ export function AchievementsCrudPage({
                             variant={item.active !== false ? "success" : "secondary"}
                             className="text-xs"
                           >
-                            {item.active !== false ? "Activo" : "Inactivo"}
+                            {item.active !== false ? t("statusActive") : t("statusInactive")}
                           </Badge>
                         </TableCell>
 
@@ -487,7 +474,7 @@ export function AchievementsCrudPage({
                                 size="icon"
                                 className="size-8"
                                 asChild
-                                title="Editar"
+                                title={t("actionEdit")}
                               >
                                 <Link
                                   href={`/dashboard/achievements/${categoryId}/${achId}/edit`}
@@ -501,7 +488,7 @@ export function AchievementsCrudPage({
                                 size="icon"
                                 className="size-8"
                                 disabled
-                                title="Editar"
+                                title={t("actionEdit")}
                               >
                                 <Pencil className="size-3.5" />
                               </Button>
@@ -512,7 +499,7 @@ export function AchievementsCrudPage({
                               className="size-8 text-destructive hover:text-destructive"
                               disabled={!achId}
                               onClick={() => setDeleteItem(item)}
-                              title="Eliminar"
+                              title={t("actionDelete")}
                             >
                               <Trash2 className="size-3.5" />
                             </Button>
@@ -532,13 +519,13 @@ export function AchievementsCrudPage({
                                       href={`/dashboard/achievements/${categoryId}/${achId}/edit`}
                                     >
                                       <Pencil className="size-4" />
-                                      Editar
+                                      {t("actionEdit")}
                                     </Link>
                                   </DropdownMenuItem>
                                 ) : (
                                   <DropdownMenuItem disabled>
                                     <Pencil className="size-4" />
-                                    Editar
+                                    {t("actionEdit")}
                                   </DropdownMenuItem>
                                 )}
                                 <DropdownMenuItem
@@ -547,7 +534,7 @@ export function AchievementsCrudPage({
                                   onSelect={() => setDeleteItem(item)}
                                 >
                                   <Trash2 className="size-4" />
-                                  Eliminar
+                                  {t("actionDelete")}
                                 </DropdownMenuItem>
                               </DropdownMenuContent>
                             </DropdownMenu>
@@ -579,24 +566,20 @@ export function AchievementsCrudPage({
         >
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>¿Eliminar logro?</AlertDialogTitle>
+              <AlertDialogTitle>{t("deleteTitle")}</AlertDialogTitle>
               <AlertDialogDescription>
-                Se eliminará el logro{" "}
-                <strong className="text-foreground">
-                  &quot;{pickName(deleteItem)}&quot;
-                </strong>
-                . Esta acción no puede deshacerse.
+                {t("deleteDescription", { name: pickName(deleteItem) })}
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel>Cancelar</AlertDialogCancel>
+              <AlertDialogCancel>{t("deleteCancelButton")}</AlertDialogCancel>
               <form action={deleteFormAction}>
                 <input type="hidden" name="id" value={String(pickId(deleteItem) ?? "")} />
                 <input type="hidden" name="category_id" value={String(categoryId)} />
                 {deleteState.error && (
                   <p className="mb-2 text-xs text-destructive">{deleteState.error}</p>
                 )}
-                <DeleteButton />
+                <DeleteButton label={t("deleteConfirmButton")} />
               </form>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/src/app/(dashboard)/dashboard/achievements/_components/badge-image-upload.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/badge-image-upload.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState } from "react";
 import { ImageIcon, Loader2, UploadCloud, X } from "lucide-react";
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { uploadAchievementImage } from "@/lib/api/achievements";
 import type { AchievementTier } from "@/lib/api/achievements";
@@ -26,12 +27,16 @@ interface Props {
   onUploaded?: (url: string) => void;
 }
 
-function validateFile(file: File): string | null {
+function validateFile(
+  file: File,
+  typeError: string,
+  sizeError: string,
+): string | null {
   if (!ACCEPTED_TYPES.includes(file.type)) {
-    return "Solo se permiten imágenes PNG, SVG o WebP.";
+    return typeError;
   }
   if (file.size > MAX_SIZE_BYTES) {
-    return "El archivo no puede superar los 2 MB.";
+    return sizeError;
   }
   return null;
 }
@@ -42,6 +47,7 @@ export function BadgeImageUpload({
   tier,
   onUploaded,
 }: Props) {
+  const t = useTranslations("achievements.imageUpload");
   const inputRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<string | null>(currentImageUrl ?? null);
   const [uploading, setUploading] = useState(false);
@@ -50,7 +56,7 @@ export function BadgeImageUpload({
   const ringColor = TIER_RING_COLORS[tier];
 
   async function processFile(file: File) {
-    const error = validateFile(file);
+    const error = validateFile(file, t("validateTypeError"), t("validateSizeError"));
     if (error) {
       toast.error(error);
       return;
@@ -62,7 +68,7 @@ export function BadgeImageUpload({
 
     if (!achievementId) {
       // Can't upload without an ID — just preview
-      toast.warning("Guarda el logro primero para poder subir la imagen.");
+      toast.warning(t("toastSaveFirst"));
       return;
     }
 
@@ -70,9 +76,9 @@ export function BadgeImageUpload({
       setUploading(true);
       const result = await uploadAchievementImage(achievementId, file);
       onUploaded?.(result.badge_image_url);
-      toast.success("Imagen del logro actualizada correctamente.");
+      toast.success(t("toastSuccess"));
     } catch {
-      toast.error("No se pudo subir la imagen. Intenta de nuevo.");
+      toast.error(t("toastError"));
       setPreview(currentImageUrl ?? null);
     } finally {
       setUploading(false);
@@ -111,7 +117,7 @@ export function BadgeImageUpload({
       <div
         role="button"
         tabIndex={0}
-        aria-label="Zona para subir imagen del logro"
+        aria-label={t("dropzoneAriaLabel")}
         className={[
           "relative flex cursor-pointer flex-col items-center justify-center rounded-xl border-2 border-dashed p-8 text-center transition-colors",
           dragOver
@@ -130,9 +136,9 @@ export function BadgeImageUpload({
           <UploadCloud className="mb-3 size-8 text-muted-foreground" />
         )}
         <p className="text-sm font-medium">
-          {uploading ? "Subiendo imagen..." : "Arrastra una imagen o haz clic para seleccionar"}
+          {uploading ? t("uploading") : t("dropzonePrompt")}
         </p>
-        <p className="mt-1 text-xs text-muted-foreground">PNG, SVG o WebP — máximo 2 MB</p>
+        <p className="mt-1 text-xs text-muted-foreground">{t("dropzoneHint")}</p>
 
         <input
           ref={inputRef}
@@ -155,7 +161,7 @@ export function BadgeImageUpload({
           >
             <Image
               src={preview}
-              alt="Vista previa del logro"
+              alt={t("previewAlt")}
               fill
               className="object-cover"
               unoptimized
@@ -163,9 +169,9 @@ export function BadgeImageUpload({
           </div>
 
           <div className="flex-1 space-y-1">
-            <p className="text-sm font-medium">Vista previa</p>
+            <p className="text-sm font-medium">{t("previewTitle")}</p>
             <p className="text-xs text-muted-foreground">
-              Nivel:{" "}
+              {t("tierLabel")}{" "}
               <span className="font-medium" style={{ color: ringColor }}>
                 {tier}
               </span>
@@ -178,7 +184,7 @@ export function BadgeImageUpload({
             size="icon"
             className="size-8 shrink-0 text-muted-foreground hover:text-destructive"
             onClick={handleClear}
-            aria-label="Eliminar imagen"
+            aria-label={t("removeAriaLabel")}
           >
             <X className="size-4" />
           </Button>
@@ -196,9 +202,9 @@ export function BadgeImageUpload({
             <ImageIcon className="size-8 text-muted-foreground" />
           </div>
           <div>
-            <p className="text-sm text-muted-foreground">Sin imagen</p>
+            <p className="text-sm text-muted-foreground">{t("noImageLabel")}</p>
             <p className="text-xs text-muted-foreground">
-              Nivel:{" "}
+              {t("tierLabel")}{" "}
               <span style={{ color: ringColor }} className="font-medium">
                 {tier}
               </span>

--- a/src/app/(dashboard)/dashboard/achievements/_components/category-form-dialog.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/category-form-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useFormStatus } from "react-dom";
 import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -59,6 +60,7 @@ export function CategoryFormDialog({
   formAction,
   actionState,
 }: Props) {
+  const t = useTranslations("achievements.forms.category");
   const isEdit = mode === "edit";
 
   const [active, setActive] = useState<boolean>(
@@ -84,12 +86,10 @@ export function CategoryFormDialog({
       <DialogContent className="max-w-lg">
         <DialogHeader>
           <DialogTitle>
-            {isEdit ? "Editar categoría" : "Nueva categoría"}
+            {isEdit ? t("titleEdit") : t("titleCreate")}
           </DialogTitle>
           <DialogDescription>
-            {isEdit
-              ? "Modifica los datos de la categoría de logros."
-              : "Completa los campos para crear una nueva categoría de logros."}
+            {isEdit ? t("descriptionEdit") : t("descriptionCreate")}
           </DialogDescription>
         </DialogHeader>
 
@@ -108,12 +108,12 @@ export function CategoryFormDialog({
           {/* Name */}
           <div className="space-y-2">
             <Label htmlFor="cat-name">
-              Nombre <span className="ml-0.5 text-destructive">*</span>
+              {t("labelName")} <span className="ml-0.5 text-destructive">*</span>
             </Label>
             <Input
               id="cat-name"
               name="name"
-              placeholder="Ej. Participación"
+              placeholder={t("placeholderName")}
               defaultValue={toText(item?.name)}
               required
             />
@@ -121,12 +121,12 @@ export function CategoryFormDialog({
 
           {/* Description */}
           <div className="space-y-2">
-            <Label htmlFor="cat-description">Descripción</Label>
+            <Label htmlFor="cat-description">{t("labelDescription")}</Label>
             <Textarea
               id="cat-description"
               name="description"
               rows={3}
-              placeholder="Describe esta categoría..."
+              placeholder={t("placeholderDescription")}
               defaultValue={toText(item?.description)}
               className="min-h-[80px] resize-none"
             />
@@ -135,28 +135,28 @@ export function CategoryFormDialog({
           {/* Icon */}
           <div className="space-y-2">
             <Label htmlFor="cat-icon">
-              Icono{" "}
+              {t("labelIcon")}{" "}
               <span className="text-xs font-normal text-muted-foreground">
-                (nombre de ícono lucide-react, ej: trophy)
+                {t("labelIconHint")}
               </span>
             </Label>
             <Input
               id="cat-icon"
               name="icon"
-              placeholder="trophy"
+              placeholder={t("placeholderIcon")}
               defaultValue={toText(item?.icon)}
             />
           </div>
 
           {/* Display order */}
           <div className="space-y-2">
-            <Label htmlFor="cat-order">Orden de visualización</Label>
+            <Label htmlFor="cat-order">{t("labelOrder")}</Label>
             <Input
               id="cat-order"
               name="display_order"
               type="number"
               min={0}
-              placeholder="0"
+              placeholder={t("placeholderOrder")}
               defaultValue={displayOrder !== null ? String(displayOrder) : ""}
             />
           </div>
@@ -169,7 +169,7 @@ export function CategoryFormDialog({
               onCheckedChange={setActive}
             />
             <Label htmlFor="cat-active" className="cursor-pointer">
-              Categoría activa
+              {t("labelActive")}
             </Label>
           </div>
 
@@ -179,9 +179,9 @@ export function CategoryFormDialog({
               variant="outline"
               onClick={() => onOpenChange(false)}
             >
-              Cancelar
+              {t("cancelButton")}
             </Button>
-            <SubmitButton label={isEdit ? "Guardar cambios" : "Crear categoría"} />
+            <SubmitButton label={isEdit ? t("submitEdit") : t("submitCreate")} />
           </DialogFooter>
         </form>
       </DialogContent>

--- a/src/app/(dashboard)/dashboard/achievements/_components/criteria-editor.tsx
+++ b/src/app/(dashboard)/dashboard/achievements/_components/criteria-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { Plus, Trash2 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -26,30 +27,24 @@ import type {
   CompoundLogic,
 } from "@/lib/api/achievements";
 
-const EVENT_OPTIONS = [
-  { value: "activity_attendance", label: "Asistencia a actividad" },
-  { value: "honor_completed", label: "Especialidad completada" },
-  { value: "class_completed", label: "Clase completada" },
-  { value: "investiture_completed", label: "Investidura completada" },
-  { value: "camporee_attended", label: "Camporee asistido" },
-  { value: "evidence_submitted", label: "Evidencia enviada" },
-  { value: "evidence_approved", label: "Evidencia aprobada" },
-  { value: "consecutive_attendance", label: "Asistencia consecutiva" },
-  { value: "profile_completed", label: "Perfil completado" },
-  { value: "club_role_assigned", label: "Rol de club asignado" },
-];
+// Event, operator and streak-unit option value lists (values stay in code,
+// labels resolved via t() inside components — pattern rule #2).
+const EVENT_VALUES = [
+  "activity_attendance",
+  "honor_completed",
+  "class_completed",
+  "investiture_completed",
+  "camporee_attended",
+  "evidence_submitted",
+  "evidence_approved",
+  "consecutive_attendance",
+  "profile_completed",
+  "club_role_assigned",
+] as const;
 
-const OPERATOR_OPTIONS: { value: CriteriaOperator; label: string }[] = [
-  { value: "gte", label: ">= (mayor o igual)" },
-  { value: "lte", label: "<= (menor o igual)" },
-  { value: "eq", label: "= (igual a)" },
-];
+const OPERATOR_VALUES: CriteriaOperator[] = ["gte", "lte", "eq"];
 
-const STREAK_UNIT_OPTIONS: { value: StreakUnit; label: string }[] = [
-  { value: "day", label: "Días" },
-  { value: "week", label: "Semanas" },
-  { value: "month", label: "Meses" },
-];
+const STREAK_UNIT_VALUES: StreakUnit[] = ["day", "week", "month"];
 
 // ─── Sub-editors ──────────────────────────────────────────────────────────────
 
@@ -60,21 +55,22 @@ function ThresholdEditor({
   value: ThresholdCriteria;
   onChange: (val: ThresholdCriteria) => void;
 }) {
+  const t = useTranslations("achievements.forms.criteria");
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label>Evento</Label>
+        <Label>{t("labelEvent")}</Label>
         <Select
           value={value.event}
           onValueChange={(event) => onChange({ ...value, event })}
         >
           <SelectTrigger>
-            <SelectValue placeholder="Selecciona un evento..." />
+            <SelectValue placeholder={t("placeholderEvent")} />
           </SelectTrigger>
           <SelectContent>
-            {EVENT_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
+            {EVENT_VALUES.map((v) => (
+              <SelectItem key={v} value={v}>
+                {t(`eventLabels.${v}`)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -83,7 +79,7 @@ function ThresholdEditor({
 
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
-          <Label>Operador</Label>
+          <Label>{t("labelOperator")}</Label>
           <Select
             value={value.operator}
             onValueChange={(operator) =>
@@ -91,12 +87,12 @@ function ThresholdEditor({
             }
           >
             <SelectTrigger>
-              <SelectValue placeholder="Operador..." />
+              <SelectValue placeholder={t("placeholderOperator")} />
             </SelectTrigger>
             <SelectContent>
-              {OPERATOR_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
+              {OPERATOR_VALUES.map((v) => (
+                <SelectItem key={v} value={v}>
+                  {t(`operatorLabels.${v}`)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -104,7 +100,7 @@ function ThresholdEditor({
         </div>
 
         <div className="space-y-2">
-          <Label>Objetivo</Label>
+          <Label>{t("labelTarget")}</Label>
           <Input
             type="number"
             min={1}
@@ -127,21 +123,22 @@ function StreakEditor({
   value: StreakCriteria;
   onChange: (val: StreakCriteria) => void;
 }) {
+  const t = useTranslations("achievements.forms.criteria");
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label>Evento</Label>
+        <Label>{t("labelEvent")}</Label>
         <Select
           value={value.event}
           onValueChange={(event) => onChange({ ...value, event })}
         >
           <SelectTrigger>
-            <SelectValue placeholder="Selecciona un evento..." />
+            <SelectValue placeholder={t("placeholderEvent")} />
           </SelectTrigger>
           <SelectContent>
-            {EVENT_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
+            {EVENT_VALUES.map((v) => (
+              <SelectItem key={v} value={v}>
+                {t(`eventLabels.${v}`)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -150,7 +147,7 @@ function StreakEditor({
 
       <div className="grid grid-cols-3 gap-4">
         <div className="space-y-2">
-          <Label>Racha objetivo</Label>
+          <Label>{t("labelStreakTarget")}</Label>
           <Input
             type="number"
             min={1}
@@ -163,7 +160,7 @@ function StreakEditor({
         </div>
 
         <div className="space-y-2">
-          <Label>Unidad</Label>
+          <Label>{t("labelUnit")}</Label>
           <Select
             value={value.streak_unit}
             onValueChange={(streak_unit) =>
@@ -171,12 +168,12 @@ function StreakEditor({
             }
           >
             <SelectTrigger>
-              <SelectValue placeholder="Unidad..." />
+              <SelectValue placeholder={t("placeholderUnit")} />
             </SelectTrigger>
             <SelectContent>
-              {STREAK_UNIT_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
+              {STREAK_UNIT_VALUES.map((v) => (
+                <SelectItem key={v} value={v}>
+                  {t(`streakUnitLabels.${v}`)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -185,8 +182,8 @@ function StreakEditor({
 
         <div className="space-y-2">
           <Label>
-            Gracia{" "}
-            <span className="text-xs text-muted-foreground">(opcional)</span>
+            {t("labelGrace")}{" "}
+            <span className="text-xs text-muted-foreground">{t("labelGraceHint")}</span>
           </Label>
           <Input
             type="number"
@@ -217,11 +214,12 @@ function CompoundConditionRow({
   onChange: (val: CompoundCondition) => void;
   onRemove: () => void;
 }) {
+  const t = useTranslations("achievements.forms.criteria");
   return (
     <div className="rounded-lg border bg-muted/20 p-3 space-y-3">
       <div className="flex items-center justify-between">
         <span className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
-          Condición {index + 1}
+          {t("conditionLabel", { index: index + 1 })}
         </span>
         <Button
           type="button"
@@ -235,18 +233,18 @@ function CompoundConditionRow({
       </div>
 
       <div className="space-y-2">
-        <Label className="text-xs">Evento</Label>
+        <Label className="text-xs">{t("labelEvent")}</Label>
         <Select
           value={condition.event}
           onValueChange={(event) => onChange({ ...condition, event })}
         >
           <SelectTrigger className="h-8 text-sm">
-            <SelectValue placeholder="Evento..." />
+            <SelectValue placeholder={t("placeholderEvent")} />
           </SelectTrigger>
           <SelectContent>
-            {EVENT_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
+            {EVENT_VALUES.map((v) => (
+              <SelectItem key={v} value={v}>
+                {t(`eventLabels.${v}`)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -255,7 +253,7 @@ function CompoundConditionRow({
 
       <div className="grid grid-cols-2 gap-3">
         <div className="space-y-1">
-          <Label className="text-xs">Operador</Label>
+          <Label className="text-xs">{t("labelOperator")}</Label>
           <Select
             value={condition.operator}
             onValueChange={(operator) =>
@@ -263,12 +261,12 @@ function CompoundConditionRow({
             }
           >
             <SelectTrigger className="h-8 text-sm">
-              <SelectValue placeholder="Op..." />
+              <SelectValue placeholder={t("placeholderOperator")} />
             </SelectTrigger>
             <SelectContent>
-              {OPERATOR_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
+              {OPERATOR_VALUES.map((v) => (
+                <SelectItem key={v} value={v}>
+                  {t(`operatorLabels.${v}`)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -276,7 +274,7 @@ function CompoundConditionRow({
         </div>
 
         <div className="space-y-1">
-          <Label className="text-xs">Objetivo</Label>
+          <Label className="text-xs">{t("labelTarget")}</Label>
           <Input
             type="number"
             min={1}
@@ -300,6 +298,8 @@ function CompoundEditor({
   value: CompoundCriteria;
   onChange: (val: CompoundCriteria) => void;
 }) {
+  const t = useTranslations("achievements.forms.criteria");
+
   const addCondition = () => {
     onChange({
       ...value,
@@ -327,7 +327,7 @@ function CompoundEditor({
     <div className="space-y-4">
       {/* Logic selector */}
       <div className="space-y-2">
-        <Label>Lógica de combinación</Label>
+        <Label>{t("labelLogic")}</Label>
         <div className="flex gap-3">
           {(["AND", "OR"] as CompoundLogic[]).map((logic) => (
             <label
@@ -343,7 +343,7 @@ function CompoundEditor({
                 className="accent-primary"
               />
               <span className="text-sm font-medium">
-                {logic === "AND" ? "Todas las condiciones (AND)" : "Cualquier condición (OR)"}
+                {logic === "AND" ? t("logicAnd") : t("logicOr")}
               </span>
             </label>
           ))}
@@ -370,7 +370,7 @@ function CompoundEditor({
         onClick={addCondition}
       >
         <Plus className="mr-2 size-3.5" />
-        Agregar condición
+        {t("addConditionButton")}
       </Button>
     </div>
   );
@@ -383,21 +383,22 @@ function MilestoneEditor({
   value: MilestoneCriteria;
   onChange: (val: MilestoneCriteria) => void;
 }) {
+  const t = useTranslations("achievements.forms.criteria");
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label>Evento</Label>
+        <Label>{t("labelEvent")}</Label>
         <Select
           value={value.event}
           onValueChange={(event) => onChange({ ...value, event })}
         >
           <SelectTrigger>
-            <SelectValue placeholder="Selecciona un evento..." />
+            <SelectValue placeholder={t("placeholderEvent")} />
           </SelectTrigger>
           <SelectContent>
-            {EVENT_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
+            {EVENT_VALUES.map((v) => (
+              <SelectItem key={v} value={v}>
+                {t(`eventLabels.${v}`)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -406,16 +407,16 @@ function MilestoneEditor({
 
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
-          <Label>Campo</Label>
+          <Label>{t("labelField")}</Label>
           <Input
             value={value.field}
             onChange={(e) => onChange({ ...value, field: e.target.value })}
-            placeholder="Ej. level"
+            placeholder={t("placeholderField")}
           />
         </div>
 
         <div className="space-y-2">
-          <Label>Operador</Label>
+          <Label>{t("labelOperator")}</Label>
           <Select
             value={value.operator}
             onValueChange={(operator) =>
@@ -423,12 +424,12 @@ function MilestoneEditor({
             }
           >
             <SelectTrigger>
-              <SelectValue placeholder="Operador..." />
+              <SelectValue placeholder={t("placeholderOperator")} />
             </SelectTrigger>
             <SelectContent>
-              {OPERATOR_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
+              {OPERATOR_VALUES.map((v) => (
+                <SelectItem key={v} value={v}>
+                  {t(`operatorLabels.${v}`)}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -437,11 +438,11 @@ function MilestoneEditor({
       </div>
 
       <div className="space-y-2">
-        <Label>Valor objetivo</Label>
+        <Label>{t("labelTargetValue")}</Label>
         <Input
           value={value.target}
           onChange={(e) => onChange({ ...value, target: e.target.value })}
-          placeholder="Ej. gold"
+          placeholder={t("placeholderTargetValue")}
         />
       </div>
     </div>
@@ -455,21 +456,22 @@ function CollectionEditor({
   value: CollectionCriteria;
   onChange: (val: CollectionCriteria) => void;
 }) {
+  const t = useTranslations("achievements.forms.criteria");
   return (
     <div className="space-y-4">
       <div className="space-y-2">
-        <Label>Evento</Label>
+        <Label>{t("labelEvent")}</Label>
         <Select
           value={value.event}
           onValueChange={(event) => onChange({ ...value, event })}
         >
           <SelectTrigger>
-            <SelectValue placeholder="Selecciona un evento..." />
+            <SelectValue placeholder={t("placeholderEvent")} />
           </SelectTrigger>
           <SelectContent>
-            {EVENT_OPTIONS.map((opt) => (
-              <SelectItem key={opt.value} value={opt.value}>
-                {opt.label}
+            {EVENT_VALUES.map((v) => (
+              <SelectItem key={v} value={v}>
+                {t(`eventLabels.${v}`)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -478,16 +480,16 @@ function CollectionEditor({
 
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">
-          <Label>Campo único</Label>
+          <Label>{t("labelDistinctField")}</Label>
           <Input
             value={value.distinct_field}
             onChange={(e) => onChange({ ...value, distinct_field: e.target.value })}
-            placeholder="Ej. honor_id"
+            placeholder={t("placeholderDistinctField")}
           />
         </div>
 
         <div className="space-y-2">
-          <Label>Cantidad objetivo</Label>
+          <Label>{t("labelQuantityTarget")}</Label>
           <Input
             type="number"
             min={1}
@@ -534,6 +536,7 @@ interface CriteriaEditorProps {
 }
 
 export function CriteriaEditor({ type, initialValue, onChange }: CriteriaEditorProps) {
+  const t = useTranslations("achievements.forms.criteria");
   const [criteria, setCriteria] = useState<AchievementCriteria>(
     () => initialValue ?? getDefaultCriteria(type),
   );
@@ -543,17 +546,9 @@ export function CriteriaEditor({ type, initialValue, onChange }: CriteriaEditorP
     onChange?.(newCriteria);
   };
 
-  const typeDescriptions: Record<AchievementType, string> = {
-    THRESHOLD: "Se otorga cuando el usuario alcanza un número determinado de eventos.",
-    STREAK: "Se otorga cuando el usuario mantiene una racha consecutiva de eventos.",
-    COMPOUND: "Se otorga cuando se cumplen múltiples condiciones al mismo tiempo.",
-    MILESTONE: "Se otorga cuando un campo específico de un evento alcanza cierto valor.",
-    COLLECTION: "Se otorga cuando el usuario completa N elementos distintos de una colección.",
-  };
-
   return (
     <div className="space-y-4">
-      <p className="text-sm text-muted-foreground">{typeDescriptions[type]}</p>
+      <p className="text-sm text-muted-foreground">{t(`typeDescriptions.${type}`)}</p>
 
       {type === "THRESHOLD" && (
         <ThresholdEditor

--- a/src/app/(dashboard)/dashboard/catalogs/activity-types/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/activity-types/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.activityTypes");
+  return { title: t("metadataTitle") };
+}
 
 export default function ActivityTypesPage() {
   return <CatalogEntityPage entityKey="activity-types" />;

--- a/src/app/(dashboard)/dashboard/catalogs/allergies/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/allergies/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.allergies");
+  return { title: t("metadataTitle") };
+}
 
 export default function AllergiesPage() {
   return <CatalogEntityPage entityKey="allergies" />;

--- a/src/app/(dashboard)/dashboard/catalogs/club-ideals/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/club-ideals/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.clubIdeals");
+  return { title: t("metadataTitle") };
+}
 
 export default function ClubIdealsPage() {
   return <CatalogEntityPage entityKey="club-ideals" />;

--- a/src/app/(dashboard)/dashboard/catalogs/club-types/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/club-types/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.clubTypes");
+  return { title: t("metadataTitle") };
+}
 
 export default function ClubTypesPage() {
   return <CatalogEntityPage entityKey="club-types" />;

--- a/src/app/(dashboard)/dashboard/catalogs/diseases/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/diseases/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.diseases");
+  return { title: t("metadataTitle") };
+}
 
 export default function DiseasesPage() {
   return <CatalogEntityPage entityKey="diseases" />;

--- a/src/app/(dashboard)/dashboard/catalogs/ecclesiastical-years/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/ecclesiastical-years/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.ecclesiasticalYears");
+  return { title: t("metadataTitle") };
+}
 
 export default function EcclesiasticalYearsPage() {
   return <CatalogEntityPage entityKey="ecclesiastical-years" />;

--- a/src/app/(dashboard)/dashboard/catalogs/geography/churches/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/churches/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.churches");
+  return { title: t("metadataTitle") };
+}
 
 export default function ChurchesPage() {
   return <CatalogEntityPage entityKey="churches" />;

--- a/src/app/(dashboard)/dashboard/catalogs/geography/countries/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/countries/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.countries");
+  return { title: t("metadataTitle") };
+}
 
 export default function CountriesPage() {
   return <CatalogEntityPage entityKey="countries" />;

--- a/src/app/(dashboard)/dashboard/catalogs/geography/districts/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/districts/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.districts");
+  return { title: t("metadataTitle") };
+}
 
 export default function DistrictsPage() {
   return <CatalogEntityPage entityKey="districts" />;

--- a/src/app/(dashboard)/dashboard/catalogs/geography/local-fields/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/local-fields/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.localFields");
+  return { title: t("metadataTitle") };
+}
 
 export default function LocalFieldsPage() {
   return <CatalogEntityPage entityKey="local-fields" />;

--- a/src/app/(dashboard)/dashboard/catalogs/geography/unions/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/unions/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.unions");
+  return { title: t("metadataTitle") };
+}
 
 export default function UnionsPage() {
   return <CatalogEntityPage entityKey="unions" />;

--- a/src/app/(dashboard)/dashboard/catalogs/medicines/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/medicines/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.medicines");
+  return { title: t("metadataTitle") };
+}
 
 export default function MedicinesPage() {
   return <CatalogEntityPage entityKey="medicines" />;

--- a/src/app/(dashboard)/dashboard/catalogs/relationship-types/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/relationship-types/page.tsx
@@ -1,4 +1,11 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("catalogs.pages.relationshipTypes");
+  return { title: t("metadataTitle") };
+}
 
 export default function RelationshipTypesPage() {
   return <CatalogEntityPage entityKey="relationship-types" />;

--- a/src/app/(dashboard)/dashboard/member-of-month/_components/member-of-month-supervision-client.tsx
+++ b/src/app/(dashboard)/dashboard/member-of-month/_components/member-of-month-supervision-client.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronLeft, ChevronRight, Trophy } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
@@ -45,10 +46,11 @@ function getInitials(name: string | null): string {
 }
 
 function NotifiedBadge({ notified }: { notified: boolean }) {
+  const t = useTranslations("member_of_month.supervision");
   if (notified) {
-    return <Badge variant="success">Notificado</Badge>;
+    return <Badge variant="success">{t("badgeNotified")}</Badge>;
   }
-  return <Badge variant="secondary">Pendiente</Badge>;
+  return <Badge variant="secondary">{t("badgePending")}</Badge>;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -85,6 +87,7 @@ export function MemberOfMonthSupervisionClient({
   localFields,
   searchParams,
 }: MemberOfMonthSupervisionClientProps) {
+  const t = useTranslations("member_of_month.supervision");
   const router = useRouter();
 
   const currentPage = Number(searchParams.page ?? "1");
@@ -132,10 +135,10 @@ export function MemberOfMonthSupervisionClient({
           onValueChange={(v) => handleFilter("club_type_id", v)}
         >
           <SelectTrigger className="w-44">
-            <SelectValue placeholder="Tipo de club" />
+            <SelectValue placeholder={t("filterClubTypePlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos los tipos</SelectItem>
+            <SelectItem value="all">{t("filterClubTypeAll")}</SelectItem>
             {clubTypes.map((ct) => (
               <SelectItem key={ct.club_type_id} value={String(ct.club_type_id)}>
                 {ct.name}
@@ -150,10 +153,10 @@ export function MemberOfMonthSupervisionClient({
           onValueChange={(v) => handleFilter("local_field_id", v)}
         >
           <SelectTrigger className="w-48">
-            <SelectValue placeholder="Campo local" />
+            <SelectValue placeholder={t("filterLocalFieldPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos los campos</SelectItem>
+            <SelectItem value="all">{t("filterLocalFieldAll")}</SelectItem>
             {localFields.map((lf) => (
               <SelectItem key={lf.local_field_id} value={String(lf.local_field_id)}>
                 {lf.name}
@@ -168,7 +171,7 @@ export function MemberOfMonthSupervisionClient({
           onValueChange={(v) => handleFilter("year", v)}
         >
           <SelectTrigger className="w-28">
-            <SelectValue placeholder="Año" />
+            <SelectValue placeholder={t("filterYearPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
             {Array.from({ length: 5 }, (_, i) => new Date().getFullYear() - i).map(
@@ -187,10 +190,10 @@ export function MemberOfMonthSupervisionClient({
           onValueChange={(v) => handleFilter("month", v)}
         >
           <SelectTrigger className="w-36">
-            <SelectValue placeholder="Mes" />
+            <SelectValue placeholder={t("filterMonthPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos los meses</SelectItem>
+            <SelectItem value="all">{t("filterMonthAll")}</SelectItem>
             {monthOptions.map((m) => (
               <SelectItem key={m.value} value={m.value}>
                 {m.label}
@@ -205,12 +208,12 @@ export function MemberOfMonthSupervisionClient({
           onValueChange={(v) => handleFilter("notified", v)}
         >
           <SelectTrigger className="w-40">
-            <SelectValue placeholder="Notificado" />
+            <SelectValue placeholder={t("filterNotifiedPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Cualquiera</SelectItem>
-            <SelectItem value="true">Notificado</SelectItem>
-            <SelectItem value="false">Pendiente</SelectItem>
+            <SelectItem value="all">{t("filterNotifiedAll")}</SelectItem>
+            <SelectItem value="true">{t("filterNotifiedTrue")}</SelectItem>
+            <SelectItem value="false">{t("filterNotifiedFalse")}</SelectItem>
           </SelectContent>
         </Select>
       </div>
@@ -220,10 +223,10 @@ export function MemberOfMonthSupervisionClient({
         <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
           <Trophy className="mb-3 size-10 text-muted-foreground/50" />
           <p className="text-sm font-medium text-muted-foreground">
-            Sin ganadores para los filtros seleccionados.
+            {t("emptyTitle")}
           </p>
           <p className="mt-1 text-xs text-muted-foreground/70">
-            Ajusta los filtros para ver resultados.
+            {t("emptyHint")}
           </p>
         </div>
       ) : (
@@ -231,15 +234,15 @@ export function MemberOfMonthSupervisionClient({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Miembro</TableHead>
-                <TableHead>Sección</TableHead>
-                <TableHead>Tipo de club</TableHead>
-                <TableHead>Club</TableHead>
-                <TableHead>Campo Local</TableHead>
-                <TableHead>Período</TableHead>
-                <TableHead className="text-right">Puntos</TableHead>
-                <TableHead>Notificado</TableHead>
-                <TableHead className="text-right">Acciones</TableHead>
+                <TableHead>{t("tableColMember")}</TableHead>
+                <TableHead>{t("tableColSection")}</TableHead>
+                <TableHead>{t("tableColClubType")}</TableHead>
+                <TableHead>{t("tableColClub")}</TableHead>
+                <TableHead>{t("tableColLocalField")}</TableHead>
+                <TableHead>{t("tableColPeriod")}</TableHead>
+                <TableHead className="text-right">{t("tableColPoints")}</TableHead>
+                <TableHead>{t("tableColNotified")}</TableHead>
+                <TableHead className="text-right">{t("tableColActions")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -291,7 +294,7 @@ export function MemberOfMonthSupervisionClient({
                           });
                         }}
                       >
-                        Re-evaluar
+                        {t("reevaluateButton")}
                       </Button>
                     </div>
                   </TableCell>
@@ -306,9 +309,7 @@ export function MemberOfMonthSupervisionClient({
       {items.length > 0 && (
         <div className="flex items-center justify-between text-sm text-muted-foreground">
           <span>
-            {total === 0
-              ? "Sin resultados"
-              : `${total} ${total === 1 ? "ganador" : "ganadores"} en total`}
+            {t("paginationTotal", { total })}
           </span>
           <div className="flex items-center gap-2">
             <Button
@@ -318,10 +319,10 @@ export function MemberOfMonthSupervisionClient({
               onClick={() => handlePage(currentPage - 1)}
             >
               <ChevronLeft className="size-4" />
-              Anterior
+              {t("paginationPrev")}
             </Button>
             <span className="tabular-nums">
-              Página {currentPage} de {totalPages}
+              {t("paginationPage", { page: currentPage, totalPages })}
             </span>
             <Button
               variant="outline"
@@ -329,7 +330,7 @@ export function MemberOfMonthSupervisionClient({
               disabled={currentPage * limit >= total}
               onClick={() => handlePage(currentPage + 1)}
             >
-              Siguiente
+              {t("paginationNext")}
               <ChevronRight className="size-4" />
             </Button>
           </div>

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weight-sum-indicator.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weight-sum-indicator.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Badge } from "@/components/ui/badge";
 
 interface WeightSumIndicatorProps {
@@ -13,6 +14,8 @@ interface WeightSumIndicatorProps {
  *   Math.abs(sum - 100) <= 0.01
  */
 export function WeightSumIndicator({ values }: WeightSumIndicatorProps) {
+  const t = useTranslations("memberRankingWeights.sumIndicator");
+
   const sum = values.reduce(
     (acc, v) => acc + (Number.isFinite(v) ? v : 0),
     0,
@@ -21,7 +24,7 @@ export function WeightSumIndicator({ values }: WeightSumIndicatorProps) {
 
   return (
     <Badge variant={isValid ? "success" : "destructive"}>
-      Suma: {sum.toFixed(2)}% {isValid ? "✓" : "— debe ser 100"}
+      {t("label", { sum: sum.toFixed(2) })} {isValid ? t("valid") : t("invalid")}
     </Badge>
   );
 }

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-client-page.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-client-page.tsx
@@ -3,6 +3,7 @@
 import { useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -36,6 +37,7 @@ export function WeightsClientPage({
   clubTypes,
   ecclesiasticalYears,
 }: WeightsClientPageProps) {
+  const t = useTranslations("memberRankingWeights.weightsPage");
   const router = useRouter();
 
   // ── Delete dialog state ───────────────────────────────────────────────────
@@ -59,7 +61,7 @@ export function WeightsClientPage({
     setIsDeleting(true);
     try {
       await deleteMemberRankingWeights(deletingRow.id);
-      toast.success("Sobreescritura eliminada");
+      toast.success(t("deleteSuccess"));
       setDeleteOpen(false);
       setDeletingRow(null);
       refresh();
@@ -84,20 +86,21 @@ export function WeightsClientPage({
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Eliminar sobreescritura de pesos</AlertDialogTitle>
+            <AlertDialogTitle>{t("deleteTitle")}</AlertDialogTitle>
             <AlertDialogDescription>
-              Los cálculos de ranking que usaban esta configuración volverán a usar
-              la configuración por defecto global. Esta acción no se puede deshacer.
+              {t("deleteDescription")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={isDeleting}>Cancelar</AlertDialogCancel>
+            <AlertDialogCancel disabled={isDeleting}>
+              {t("deleteCancel")}
+            </AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
               disabled={isDeleting}
               className="bg-destructive text-white hover:bg-destructive/90"
             >
-              {isDeleting ? "Eliminando..." : "Eliminar"}
+              {isDeleting ? t("deleteConfirmLoading") : t("deleteConfirm")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/app/(dashboard)/dashboard/member-rankings/[enrollmentId]/breakdown/_components/member-breakdown-card.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/[enrollmentId]/breakdown/_components/member-breakdown-card.tsx
@@ -1,4 +1,7 @@
+"use client";
+
 import type { ReactNode } from "react";
+import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Progress } from "@/components/ui/progress";
 import { MemberRankingScoreBadge } from "@/app/(dashboard)/dashboard/member-rankings/_components/member-ranking-score-badge";
@@ -15,9 +18,8 @@ interface MemberBreakdownCardProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 /**
- * Pure server component. Renders a single signal card (class / investiture /
- * camporee) with a progress bar, score badge, weight pill, and slot for
- * the signal-specific breakdown detail.
+ * Renders a single signal card (class / investiture / camporee) with a progress
+ * bar, score badge, weight pill, and slot for the signal-specific breakdown detail.
  */
 export function MemberBreakdownCard({
   title,
@@ -25,6 +27,8 @@ export function MemberBreakdownCard({
   weight,
   breakdown,
 }: MemberBreakdownCardProps) {
+  const t = useTranslations("rankings.breakdownCard");
+
   const progressValue = score !== null ? Math.min(100, Math.max(0, score)) : 0;
 
   return (
@@ -33,7 +37,7 @@ export function MemberBreakdownCard({
         <div className="flex items-start justify-between gap-2">
           <CardTitle className="text-base">{title}</CardTitle>
           <span className="shrink-0 rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-            Peso: {weight}%
+            {t("weightLabel", { weight })}
           </span>
         </div>
       </CardHeader>
@@ -42,7 +46,7 @@ export function MemberBreakdownCard({
         {/* Score badge + progress bar */}
         <div className="space-y-2">
           <div className="flex items-center justify-between text-sm">
-            <span className="text-muted-foreground">Puntuación</span>
+            <span className="text-muted-foreground">{t("scoreLabel")}</span>
             <MemberRankingScoreBadge score={score} />
           </div>
           <Progress value={progressValue} />

--- a/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-filters.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-filters.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -28,12 +31,14 @@ export function MemberRankingsFilters({
   defaultClubId,
   defaultSectionId,
 }: MemberRankingsFiltersProps) {
+  const t = useTranslations("rankings.filters");
+
   return (
     <form className="flex flex-wrap items-end gap-3" method="GET">
       {/* Year filter */}
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="filter-year" className="text-xs text-muted-foreground">
-          Año eclesiástico
+          {t("labelYear")}
         </Label>
         <Input
           id="filter-year"
@@ -41,7 +46,7 @@ export function MemberRankingsFilters({
           type="number"
           min={2000}
           max={2100}
-          placeholder="2026"
+          placeholder={t("placeholderYear")}
           defaultValue={defaultYear}
           className="h-9 w-32"
         />
@@ -53,14 +58,14 @@ export function MemberRankingsFilters({
           htmlFor="filter-club"
           className="text-xs text-muted-foreground"
         >
-          ID de club
+          {t("labelClub")}
         </Label>
         <Input
           id="filter-club"
           name="club_id"
           type="number"
           min={1}
-          placeholder="Todos"
+          placeholder={t("placeholderClub")}
           defaultValue={defaultClubId}
           className="h-9 w-32"
         />
@@ -72,14 +77,14 @@ export function MemberRankingsFilters({
           htmlFor="filter-section"
           className="text-xs text-muted-foreground"
         >
-          ID de sección
+          {t("labelSection")}
         </Label>
         <Input
           id="filter-section"
           name="section_id"
           type="number"
           min={1}
-          placeholder="Todas"
+          placeholder={t("placeholderSection")}
           defaultValue={defaultSectionId}
           className="h-9 w-32"
         />
@@ -88,10 +93,10 @@ export function MemberRankingsFilters({
       {/* Actions */}
       <div className="flex items-center gap-2">
         <Button type="submit" size="sm">
-          Filtrar
+          {t("apply")}
         </Button>
         <Button variant="ghost" size="sm" asChild>
-          <Link href="/dashboard/member-rankings">Limpiar</Link>
+          <Link href="/dashboard/member-rankings">{t("clear")}</Link>
         </Button>
       </div>
     </form>

--- a/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-table.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-table.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
 import { Trophy } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableBody,
@@ -43,18 +46,10 @@ function formatScorePct(value: number | null | undefined): string {
   return `${value.toFixed(1)}%`;
 }
 
-function formatInvestitureScore(value: number | null | undefined): string {
-  if (value === null) return "—";
-  if (value === 100) return "Investido";
-  if (value === 0) return "En progreso";
-  // Partial scores theoretically possible if backend evolves — fallback semantically
-  return "En progreso";
-}
-
 // ─── Component ────────────────────────────────────────────────────────────────
 
 /**
- * Pure server component — renders paginated member rankings in a shadcn Table.
+ * Client component — renders paginated member rankings in a shadcn Table.
  * Pagination is handled by the shared DataTablePagination (client component).
  */
 export function MemberRankingsTable({
@@ -65,12 +60,20 @@ export function MemberRankingsTable({
   totalPages,
   selectedYearId,
 }: MemberRankingsTableProps) {
+  const t = useTranslations("rankings.table");
+
+  function formatInvestitureScore(value: number | null | undefined): string {
+    if (value === null || value === undefined) return "—";
+    if (value === 100) return t("investedLabel");
+    return t("inProgressLabel");
+  }
+
   if (data.length === 0) {
     return (
       <EmptyState
         icon={Trophy}
-        title="Sin rankings disponibles"
-        description="Sin rankings para los filtros seleccionados."
+        title={t("emptyTitle")}
+        description={t("emptyDescription")}
       />
     );
   }
@@ -79,7 +82,7 @@ export function MemberRankingsTable({
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">
         <span className="font-medium text-foreground">{total}</span>{" "}
-        {total === 1 ? "miembro rankeado" : "miembros rankeados"}
+        {total === 1 ? t("countSingular", { total }) : t("countPlural", { total })}
       </p>
 
       <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
@@ -87,31 +90,31 @@ export function MemberRankingsTable({
           <TableHeader>
             <TableRow>
               <TableHead className="h-9 w-14 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                #
+                {t("colRank")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Miembro
+                {t("colMember")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Sección
+                {t("colSection")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Composite
+                {t("colComposite")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Clase
+                {t("colClass")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Investidura
+                {t("colInvestiture")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Camporees
+                {t("colCamporee")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Categoría
+                {t("colCategory")}
               </TableHead>
               <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Acción
+                {t("colAction")}
               </TableHead>
             </TableRow>
           </TableHeader>
@@ -176,7 +179,7 @@ export function MemberRankingsTable({
                     <Link
                       href={`/dashboard/member-rankings/${item.enrollment_id}/breakdown?year_id=${selectedYearId}`}
                     >
-                      Ver detalle
+                      {t("viewDetail")}
                     </Link>
                   </Button>
                 </TableCell>

--- a/src/app/(dashboard)/dashboard/reports/supervision/_components/reports-supervision-client.tsx
+++ b/src/app/(dashboard)/dashboard/reports/supervision/_components/reports-supervision-client.tsx
@@ -8,6 +8,7 @@ import {
   FileText,
   Download,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { StatusBadge } from "@/components/ui/status-badge";
 import {
@@ -30,29 +31,6 @@ import type { AdminReportsPage, AdminReportItem } from "@/lib/api/monthly-report
 import type { ClubType } from "@/lib/api/catalogs";
 import type { LocalField } from "@/lib/api/geography";
 
-// ─── Constants ────────────────────────────────────────────────────────────────
-
-const MONTHS: { value: string; label: string }[] = [
-  { value: "1", label: "Enero" },
-  { value: "2", label: "Febrero" },
-  { value: "3", label: "Marzo" },
-  { value: "4", label: "Abril" },
-  { value: "5", label: "Mayo" },
-  { value: "6", label: "Junio" },
-  { value: "7", label: "Julio" },
-  { value: "8", label: "Agosto" },
-  { value: "9", label: "Septiembre" },
-  { value: "10", label: "Octubre" },
-  { value: "11", label: "Noviembre" },
-  { value: "12", label: "Diciembre" },
-];
-
-const STATUS_OPTIONS: { value: string; label: string }[] = [
-  { value: "draft", label: "Borrador" },
-  { value: "generated", label: "Generado" },
-  { value: "submitted", label: "Enviado" },
-];
-
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatPeriod(month: number, year: number): string {
@@ -71,13 +49,14 @@ function formatShortDate(iso: string | null): string {
 }
 
 function ReportStatusBadge({ status }: { status: AdminReportItem["status"] }) {
+  const t = useTranslations("reports.supervisionClient");
   if (status === "submitted") {
-    return <StatusBadge intent="success" label="Enviado" />;
+    return <StatusBadge intent="success" label={t("statusOptions.submitted")} />;
   }
   if (status === "generated") {
-    return <StatusBadge intent="neutral" label="Generado" />;
+    return <StatusBadge intent="neutral" label={t("statusOptions.generated")} />;
   }
-  return <StatusBadge intent="neutral" label="Borrador" />;
+  return <StatusBadge intent="neutral" label={t("statusOptions.draft")} />;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -104,11 +83,16 @@ export function ReportsSupervisionClient({
   localFields,
   searchParams,
 }: ReportsSupervisionClientProps) {
+  const t = useTranslations("reports.supervisionClient");
   const router = useRouter();
 
   const currentPage = Number(searchParams.page ?? "1");
   const { total, limit, items } = initialData;
   const totalPages = Math.ceil(total / limit);
+
+  // Month options built from translation keys (values stay stable, labels from t())
+  const MONTH_VALUES = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"] as const;
+  const STATUS_VALUES = ["draft", "generated", "submitted"] as const;
 
   // ─── URL builder ────────────────────────────────────────────────────────────
 
@@ -147,10 +131,10 @@ export function ReportsSupervisionClient({
           onValueChange={(v) => handleFilter("club_type_id", v)}
         >
           <SelectTrigger className="w-44">
-            <SelectValue placeholder="Tipo de club" />
+            <SelectValue placeholder={t("filterClubTypePlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos los tipos</SelectItem>
+            <SelectItem value="all">{t("filterClubTypeAll")}</SelectItem>
             {clubTypes.map((ct) => (
               <SelectItem key={ct.club_type_id} value={String(ct.club_type_id)}>
                 {ct.name}
@@ -165,10 +149,10 @@ export function ReportsSupervisionClient({
           onValueChange={(v) => handleFilter("local_field_id", v)}
         >
           <SelectTrigger className="w-48">
-            <SelectValue placeholder="Campo local" />
+            <SelectValue placeholder={t("filterLocalFieldPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos los campos</SelectItem>
+            <SelectItem value="all">{t("filterLocalFieldAll")}</SelectItem>
             {localFields.map((lf) => (
               <SelectItem key={lf.local_field_id} value={String(lf.local_field_id)}>
                 {lf.name}
@@ -183,13 +167,13 @@ export function ReportsSupervisionClient({
           onValueChange={(v) => handleFilter("month", v)}
         >
           <SelectTrigger className="w-36">
-            <SelectValue placeholder="Mes" />
+            <SelectValue placeholder={t("filterMonthPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos los meses</SelectItem>
-            {MONTHS.map((m) => (
-              <SelectItem key={m.value} value={m.value}>
-                {m.label}
+            <SelectItem value="all">{t("filterMonthAll")}</SelectItem>
+            {MONTH_VALUES.map((v) => (
+              <SelectItem key={v} value={v}>
+                {t(`months.${v}`)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -201,7 +185,7 @@ export function ReportsSupervisionClient({
           onValueChange={(v) => handleFilter("year", v)}
         >
           <SelectTrigger className="w-28">
-            <SelectValue placeholder="Año" />
+            <SelectValue placeholder={t("filterYearPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
             {Array.from({ length: 5 }, (_, i) => new Date().getFullYear() - i).map(
@@ -220,13 +204,13 @@ export function ReportsSupervisionClient({
           onValueChange={(v) => handleFilter("status", v)}
         >
           <SelectTrigger className="w-36">
-            <SelectValue placeholder="Estado" />
+            <SelectValue placeholder={t("filterStatusPlaceholder")} />
           </SelectTrigger>
           <SelectContent>
-            <SelectItem value="all">Todos los estados</SelectItem>
-            {STATUS_OPTIONS.map((s) => (
-              <SelectItem key={s.value} value={s.value}>
-                {s.label}
+            <SelectItem value="all">{t("filterStatusAll")}</SelectItem>
+            {STATUS_VALUES.map((v) => (
+              <SelectItem key={v} value={v}>
+                {t(`statusOptions.${v}`)}
               </SelectItem>
             ))}
           </SelectContent>
@@ -238,10 +222,10 @@ export function ReportsSupervisionClient({
         <div className="flex flex-col items-center justify-center rounded-lg border border-dashed py-16 text-center">
           <FileText className="mb-3 size-10 text-muted-foreground/50" />
           <p className="text-sm font-medium text-muted-foreground">
-            No se encontraron reportes
+            {t("emptyTitle")}
           </p>
           <p className="mt-1 text-xs text-muted-foreground/70">
-            Ajusta los filtros para ver resultados.
+            {t("emptyHint")}
           </p>
         </div>
       ) : (
@@ -249,14 +233,14 @@ export function ReportsSupervisionClient({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>Club</TableHead>
-                <TableHead>Tipo</TableHead>
-                <TableHead>Campo Local</TableHead>
-                <TableHead>Periodo</TableHead>
-                <TableHead>Estado</TableHead>
-                <TableHead>Generado</TableHead>
-                <TableHead>Enviado</TableHead>
-                <TableHead className="text-right">Acciones</TableHead>
+                <TableHead>{t("tableColClub")}</TableHead>
+                <TableHead>{t("tableColType")}</TableHead>
+                <TableHead>{t("tableColLocalField")}</TableHead>
+                <TableHead>{t("tableColPeriod")}</TableHead>
+                <TableHead>{t("tableColStatus")}</TableHead>
+                <TableHead>{t("tableColGenerated")}</TableHead>
+                <TableHead>{t("tableColSubmitted")}</TableHead>
+                <TableHead className="text-right">{t("tableColActions")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -266,7 +250,7 @@ export function ReportsSupervisionClient({
                     {item.club_name ?? "—"}
                     {item.member_count !== null && (
                       <span className="ml-1.5 text-xs text-muted-foreground">
-                        ({item.member_count} miembros)
+                        {t("memberCount", { count: item.member_count })}
                       </span>
                     )}
                   </TableCell>
@@ -284,7 +268,7 @@ export function ReportsSupervisionClient({
                     <div className="flex items-center justify-end gap-2">
                       <Button asChild variant="outline" size="sm">
                         <Link href={`/dashboard/reports/${item.monthly_report_id}`}>
-                          Ver
+                          {t("actionView")}
                         </Link>
                       </Button>
                       {item.status !== "draft" && (
@@ -295,7 +279,7 @@ export function ReportsSupervisionClient({
                             rel="noopener noreferrer"
                           >
                             <Download className="mr-1 size-3.5" />
-                            PDF
+                            {t("actionPdf")}
                           </a>
                         </Button>
                       )}
@@ -312,9 +296,7 @@ export function ReportsSupervisionClient({
       {items.length > 0 && (
         <div className="flex items-center justify-between text-sm text-muted-foreground">
           <span>
-            {total === 0
-              ? "Sin resultados"
-              : `${total} ${total === 1 ? "reporte" : "reportes"} en total`}
+            {t("paginationTotal", { total })}
           </span>
           <div className="flex items-center gap-2">
             <Button
@@ -324,10 +306,10 @@ export function ReportsSupervisionClient({
               onClick={() => handlePage(currentPage - 1)}
             >
               <ChevronLeft className="size-4" />
-              Anterior
+              {t("paginationPrev")}
             </Button>
             <span className="tabular-nums">
-              Página {currentPage} de {totalPages}
+              {t("paginationPage", { page: currentPage, totalPages })}
             </span>
             <Button
               variant="outline"
@@ -335,7 +317,7 @@ export function ReportsSupervisionClient({
               disabled={currentPage * limit >= total}
               onClick={() => handlePage(currentPage + 1)}
             >
-              Siguiente
+              {t("paginationNext")}
               <ChevronRight className="size-4" />
             </Button>
           </div>

--- a/src/app/(dashboard)/dashboard/section-rankings/[sectionId]/members/_components/section-members-table.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/[sectionId]/members/_components/section-members-table.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
 import { Users } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableBody,
@@ -39,12 +42,6 @@ function formatScorePct(value: number | null | undefined): string {
   return `${value.toFixed(1)}%`;
 }
 
-function formatInvestitureScore(value: number | null | undefined): string {
-  if (value === null || value === undefined) return "—";
-  if (value === 100) return "Investido";
-  return "En progreso";
-}
-
 // ─── Component ────────────────────────────────────────────────────────────────
 
 /**
@@ -62,12 +59,20 @@ export function SectionMembersTable({
   data,
   yearId,
 }: SectionMembersTableProps) {
+  const t = useTranslations("rankings.sectionMembersTable");
+
+  function formatInvestitureScore(value: number | null | undefined): string {
+    if (value === null || value === undefined) return "—";
+    if (value === 100) return t("investedLabel");
+    return t("inProgressLabel");
+  }
+
   if (data.length === 0) {
     return (
       <EmptyState
         icon={Users}
-        title="Sin miembros con ranking"
-        description="Esta sección no tiene miembros con ranking calculado."
+        title={t("emptyTitle")}
+        description={t("emptyDescription")}
       />
     );
   }
@@ -78,28 +83,28 @@ export function SectionMembersTable({
         <TableHeader>
           <TableRow>
             <TableHead className="h-9 w-14 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              #
+              {t("colRank")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Miembro
+              {t("colMember")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Composite
+              {t("colComposite")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Clase
+              {t("colClass")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Investidura
+              {t("colInvestiture")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Camporees
+              {t("colCamporee")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Categoría
+              {t("colCategory")}
             </TableHead>
             <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-              Acción
+              {t("colAction")}
             </TableHead>
           </TableRow>
         </TableHeader>
@@ -162,7 +167,7 @@ export function SectionMembersTable({
                   <Link
                     href={`/dashboard/member-rankings/${item.enrollment_id}/breakdown?year_id=${yearId}`}
                   >
-                    Ver detalle
+                    {t("viewDetail")}
                   </Link>
                 </Button>
               </TableCell>

--- a/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-filters.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-filters.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
@@ -28,12 +31,14 @@ export function SectionRankingsFilters({
   defaultYear,
   defaultClubId,
 }: SectionRankingsFiltersProps) {
+  const t = useTranslations("rankings.sectionFilters");
+
   return (
     <form className="flex flex-wrap items-end gap-3" method="GET">
       {/* Year filter */}
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="filter-year" className="text-xs text-muted-foreground">
-          Año eclesiástico
+          {t("labelYear")}
         </Label>
         <Input
           id="filter-year"
@@ -41,7 +46,7 @@ export function SectionRankingsFilters({
           type="number"
           min={2000}
           max={2100}
-          placeholder="2026"
+          placeholder={t("placeholderYear")}
           defaultValue={defaultYear}
           className="h-9 w-32"
         />
@@ -50,14 +55,14 @@ export function SectionRankingsFilters({
       {/* Club filter */}
       <div className="flex flex-col gap-1.5">
         <Label htmlFor="filter-club" className="text-xs text-muted-foreground">
-          ID de club
+          {t("labelClub")}
         </Label>
         <Input
           id="filter-club"
           name="club_id"
           type="number"
           min={1}
-          placeholder="Todos"
+          placeholder={t("placeholderClub")}
           defaultValue={defaultClubId}
           className="h-9 w-32"
         />
@@ -66,10 +71,10 @@ export function SectionRankingsFilters({
       {/* Actions */}
       <div className="flex items-center gap-2">
         <Button type="submit" size="sm">
-          Filtrar
+          {t("apply")}
         </Button>
         <Button variant="ghost" size="sm" asChild>
-          <Link href="/dashboard/section-rankings">Limpiar</Link>
+          <Link href="/dashboard/section-rankings">{t("clear")}</Link>
         </Button>
       </div>
     </form>

--- a/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-table.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-table.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
 import { BarChart3 } from "lucide-react";
+import { useTranslations } from "next-intl";
 import {
   Table,
   TableBody,
@@ -29,7 +32,7 @@ interface SectionRankingsTableProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 /**
- * Pure server component — renders paginated section rankings in a shadcn Table.
+ * Client component — renders paginated section rankings in a shadcn Table.
  *
  * Columns (6 data + 1 action = 7):
  *   # | Sección | Composite | Miembros activos | Categoría | Calculado | Acción
@@ -49,12 +52,14 @@ export function SectionRankingsTable({
   totalPages,
   yearId,
 }: SectionRankingsTableProps) {
+  const t = useTranslations("rankings.sectionTable");
+
   if (data.length === 0) {
     return (
       <EmptyState
         icon={BarChart3}
-        title="Sin rankings disponibles"
-        description="Sin rankings para los filtros seleccionados."
+        title={t("emptyTitle")}
+        description={t("emptyDescription")}
       />
     );
   }
@@ -63,7 +68,7 @@ export function SectionRankingsTable({
     <div className="space-y-4">
       <p className="text-sm text-muted-foreground">
         <span className="font-medium text-foreground">{total}</span>{" "}
-        {total === 1 ? "sección rankeada" : "secciones rankeadas"}
+        {total === 1 ? t("countSingular", { total }) : t("countPlural", { total })}
       </p>
 
       <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
@@ -71,25 +76,25 @@ export function SectionRankingsTable({
           <TableHeader>
             <TableRow>
               <TableHead className="h-9 w-14 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                #
+                {t("colRank")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Sección
+                {t("colSection")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Composite
+                {t("colComposite")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Miembros activos
+                {t("colActiveMembers")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Categoría
+                {t("colCategory")}
               </TableHead>
               <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Calculado
+                {t("colCalculated")}
               </TableHead>
               <TableHead className="h-9 px-3 text-right text-xs font-medium uppercase tracking-wider text-muted-foreground">
-                Acción
+                {t("colAction")}
               </TableHead>
             </TableRow>
           </TableHeader>
@@ -148,7 +153,7 @@ export function SectionRankingsTable({
                       <Link
                         href={`/dashboard/section-rankings/${item.club_section_id}/members?year_id=${yearId}`}
                       >
-                        Ver miembros
+                        {t("viewMembers")}
                       </Link>
                     </Button>
                   </TableCell>

--- a/src/app/(dashboard)/dashboard/settings/scoring-categories/page.tsx
+++ b/src/app/(dashboard)/dashboard/settings/scoring-categories/page.tsx
@@ -1,5 +1,12 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
 import { requireAdminUser } from "@/lib/auth/session";
 import { DivisionScoringCategoriesPage } from "@/components/scoring-categories/division-scoring-categories-page";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("settings.pages.scoringCategories");
+  return { title: t("metadataTitle") };
+}
 
 export default async function ScoringCategoriesSettingsPage() {
   await requireAdminUser();

--- a/src/app/(dashboard)/dashboard/system/jobs/_components/cron-runs-section.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/_components/cron-runs-section.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
@@ -18,26 +19,42 @@ import {
 } from "@/components/ui/tooltip";
 import type { CronRunsSummary, CronRecentRun, CronJobStats } from "@/lib/api/analytics";
 
-// ─── Constants ────────────────────────────────────────────────────────────────
+// ─── Types ────────────────────────────────────────────────────────────────────
 
-type JobDefinition = {
-  canonical_name: string;
-  display_name: string;
-};
+type CronJobKey =
+  | "monthly-reports-auto-generate"
+  | "rankings-recalculate"
+  | "data-export-cleanup"
+  | "member-of-month-auto-evaluate"
+  | "finance-period-closing"
+  | "activities-reminder"
+  | "membership-requests-expiry"
+  | "cleanup-expired-records"
+  | "fcm-tokens-cleanup";
 
-const JOB_DEFINITIONS: JobDefinition[] = [
-  { canonical_name: "monthly-reports-auto-generate",  display_name: "Reportes mensuales (auto-generar)" },
-  { canonical_name: "rankings-recalculate",           display_name: "Rankings anuales (recalcular)" },
-  { canonical_name: "data-export-cleanup",            display_name: "Cleanup exportes vencidos" },
-  { canonical_name: "member-of-month-auto-evaluate",  display_name: "Miembro del mes (auto-evaluar)" },
-  { canonical_name: "finance-period-closing",         display_name: "Cierre de periodo financiero" },
-  { canonical_name: "activities-reminder",            display_name: "Recordatorios de actividades" },
-  { canonical_name: "membership-requests-expiry",     display_name: "Expirar solicitudes de membresía" },
-  { canonical_name: "cleanup-expired-records",        display_name: "Cleanup sesiones/tokens vencidos" },
-  { canonical_name: "fcm-tokens-cleanup",             display_name: "Cleanup FCM tokens huérfanos" },
+const JOB_CANONICAL_NAMES: CronJobKey[] = [
+  "monthly-reports-auto-generate",
+  "rankings-recalculate",
+  "data-export-cleanup",
+  "member-of-month-auto-evaluate",
+  "finance-period-closing",
+  "activities-reminder",
+  "membership-requests-expiry",
+  "cleanup-expired-records",
+  "fcm-tokens-cleanup",
 ];
 
-// ─── Types ────────────────────────────────────────────────────────────────────
+const JOB_I18N_KEYS: Record<CronJobKey, string> = {
+  "monthly-reports-auto-generate":  "jobMonthlyReports",
+  "rankings-recalculate":           "jobRankingsRecalculate",
+  "data-export-cleanup":            "jobDataExportCleanup",
+  "member-of-month-auto-evaluate":  "jobMemberOfMonth",
+  "finance-period-closing":         "jobFinancePeriod",
+  "activities-reminder":            "jobActivitiesReminder",
+  "membership-requests-expiry":     "jobMembershipExpiry",
+  "cleanup-expired-records":        "jobCleanupExpired",
+  "fcm-tokens-cleanup":             "jobFcmCleanup",
+};
 
 interface CronRunsSectionProps {
   data: CronRunsSummary;
@@ -84,17 +101,8 @@ function statusVariant(
   }
 }
 
-function statusLabel(status: string): string {
-  switch (status as CronStatus) {
-    case "completed": return "Completado";
-    case "failed":    return "Fallido";
-    case "running":   return "Ejecutando";
-    case "skipped":   return "Omitido";
-    default:          return status;
-  }
-}
+// ─── Status Badge ─────────────────────────────────────────────────────────────
 
-// Running gets a blue-ish look via className override
 function StatusBadge({
   status,
   errorMessage,
@@ -102,20 +110,29 @@ function StatusBadge({
   status: string | null;
   errorMessage?: string | null;
 }) {
+  const t = useTranslations("system_jobs.cronRuns");
+
   if (!status) {
     return (
       <Badge variant="outline" className="text-xs text-muted-foreground">
-        Sin ejecuciones
+        {t("noRuns")}
       </Badge>
     );
   }
 
+  function getStatusLabel(s: string): string {
+    switch (s as CronStatus) {
+      case "completed": return t("statusCompleted");
+      case "failed":    return t("statusFailed");
+      case "running":   return t("statusRunning");
+      case "skipped":   return t("statusSkipped");
+      default:          return s;
+    }
+  }
+
   const badge = (
-    <Badge
-      variant={statusVariant(status)}
-      className="text-xs"
-    >
-      {statusLabel(status)}
+    <Badge variant={statusVariant(status)} className="text-xs">
+      {getStatusLabel(status)}
     </Badge>
   );
 
@@ -138,6 +155,8 @@ function StatusBadge({
 // ─── Main Component ───────────────────────────────────────────────────────────
 
 export function CronRunsSection({ data }: CronRunsSectionProps) {
+  const t = useTranslations("system_jobs.cronRuns");
+
   // Index server data by job_name for O(1) lookups
   const recentByName = new Map<string, CronRecentRun>(
     data.recent.map((r) => [r.job_name, r]),
@@ -149,40 +168,41 @@ export function CronRunsSection({ data }: CronRunsSectionProps) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Cron Jobs</CardTitle>
+        <CardTitle className="text-base">{t("cardTitle")}</CardTitle>
       </CardHeader>
       <CardContent className="p-0">
         <TooltipProvider>
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="pl-6 min-w-[200px]">Job</TableHead>
-                <TableHead>Última ejecución</TableHead>
-                <TableHead>Status</TableHead>
-                <TableHead>Duración</TableHead>
-                <TableHead className="text-right">Items</TableHead>
-                <TableHead>Último éxito</TableHead>
-                <TableHead>Último fallo</TableHead>
-                <TableHead className="text-right">Tasa fallo 7d</TableHead>
-                <TableHead className="text-right pr-6">Runs 7d</TableHead>
+                <TableHead className="pl-6 min-w-[200px]">{t("colJob")}</TableHead>
+                <TableHead>{t("colLastRun")}</TableHead>
+                <TableHead>{t("colStatus")}</TableHead>
+                <TableHead>{t("colDuration")}</TableHead>
+                <TableHead className="text-right">{t("colItems")}</TableHead>
+                <TableHead>{t("colLastSuccess")}</TableHead>
+                <TableHead>{t("colLastFailure")}</TableHead>
+                <TableHead className="text-right">{t("colFailureRate")}</TableHead>
+                <TableHead className="text-right pr-6">{t("colRuns7d")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
-              {JOB_DEFINITIONS.map((def) => {
-                const run   = recentByName.get(def.canonical_name) ?? null;
-                const stats = statsByName.get(def.canonical_name) ?? null;
+              {JOB_CANONICAL_NAMES.map((canonicalName) => {
+                const i18nKey = JOB_I18N_KEYS[canonicalName];
+                const run   = recentByName.get(canonicalName) ?? null;
+                const stats = statsByName.get(canonicalName) ?? null;
 
                 return (
-                  <TableRow key={def.canonical_name}>
+                  <TableRow key={canonicalName}>
                     {/* Job name */}
                     <TableCell className="pl-6">
-                      <span className="text-sm font-medium">{def.display_name}</span>
+                      <span className="text-sm font-medium">{t(i18nKey)}</span>
                       <span className="block text-[11px] text-muted-foreground font-mono">
-                        {def.canonical_name}
+                        {canonicalName}
                       </span>
                     </TableCell>
 
-                    {/* Última ejecución */}
+                    {/* Last run */}
                     <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
                       {formatDate(run?.started_at ?? null)}
                     </TableCell>
@@ -195,29 +215,29 @@ export function CronRunsSection({ data }: CronRunsSectionProps) {
                       />
                     </TableCell>
 
-                    {/* Duración */}
+                    {/* Duration */}
                     <TableCell className="tabular-nums text-sm">
                       {formatDuration(run?.duration_ms ?? null)}
                     </TableCell>
 
-                    {/* Items procesados */}
+                    {/* Items processed */}
                     <TableCell className="text-right tabular-nums text-sm">
                       {run?.items_processed !== undefined && run.items_processed !== null
                         ? run.items_processed.toLocaleString("es-MX")
                         : "—"}
                     </TableCell>
 
-                    {/* Último éxito */}
+                    {/* Last success */}
                     <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
                       {formatDate(stats?.last_success ?? null)}
                     </TableCell>
 
-                    {/* Último fallo */}
+                    {/* Last failure */}
                     <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
                       {formatDate(stats?.last_failure ?? null)}
                     </TableCell>
 
-                    {/* Tasa fallo 7d */}
+                    {/* Failure rate 7d */}
                     <TableCell className="text-right tabular-nums text-sm">
                       {formatFailureRate(stats?.failure_rate_7d ?? null)}
                     </TableCell>

--- a/src/app/(dashboard)/dashboard/system/jobs/_components/jobs-overview-client.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/_components/jobs-overview-client.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { useTransition, useState } from "react";
 import { RefreshCw, RotateCcw, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -43,16 +44,12 @@ interface JobsOverviewClientProps {
 
 // ─── Queue Metadata ───────────────────────────────────────────────────────────
 
-const QUEUE_META: Record<KnownQueueName, { label: string; description: string }> = {
-  'notifications': { label: 'Notificaciones', description: 'Push notifications y realtime cache' },
-  'email': { label: 'Emails', description: 'Transaccionales (rate-limited 90/día)' },
-  'achievements': { label: 'Logros', description: 'Evaluación y matching de logros' },
-  'background-jobs': { label: 'Background Jobs', description: 'Reportes, finanzas, rankings, exports' },
+const QUEUE_I18N_KEYS: Record<KnownQueueName, { labelKey: string; descKey: string }> = {
+  'notifications':   { labelKey: 'queueNotifications',    descKey: 'queueNotificationsDesc' },
+  'email':           { labelKey: 'queueEmail',            descKey: 'queueEmailDesc' },
+  'achievements':    { labelKey: 'queueAchievements',     descKey: 'queueAchievementsDesc' },
+  'background-jobs': { labelKey: 'queueBackgroundJobs',   descKey: 'queueBackgroundJobsDesc' },
 };
-
-function getQueueMeta(name: string): { label: string; description: string } {
-  return QUEUE_META[name as KnownQueueName] ?? { label: name, description: '' };
-}
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -93,32 +90,35 @@ function QueueStatRow({ label, value, destructive }: QueueStatRowProps) {
 }
 
 function QueueCard({ queue }: { queue: JobCounts }) {
+  const t = useTranslations("system_jobs.overview");
   const hasActive = queue.active > 0;
-  const meta = getQueueMeta(queue.name);
+  const queueKeys = QUEUE_I18N_KEYS[queue.name as KnownQueueName];
+  const label = queueKeys ? t(queueKeys.labelKey) : queue.name;
+  const description = queueKeys ? t(queueKeys.descKey) : "";
 
   return (
     <Card>
       <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
         <div className="min-w-0 flex-1">
-          <CardTitle className="text-sm font-semibold truncate">{meta.label}</CardTitle>
-          {meta.description && (
-            <p className="text-xs text-muted-foreground">{meta.description}</p>
+          <CardTitle className="text-sm font-semibold truncate">{label}</CardTitle>
+          {description && (
+            <p className="text-xs text-muted-foreground">{description}</p>
           )}
         </div>
         {hasActive && (
           <Badge variant="default" className="text-[10px] px-1.5 py-0 shrink-0 ml-2">
-            activo
+            {t("activeLabel")}
           </Badge>
         )}
       </CardHeader>
       <CardContent className="space-y-0.5">
-        <QueueStatRow label="Pendientes" value={queue.waiting} />
-        <QueueStatRow label="Activos" value={queue.active} />
-        <QueueStatRow label="Completados" value={queue.completed} />
-        <QueueStatRow label="Fallidos" value={queue.failed} destructive />
-        <QueueStatRow label="Diferidos" value={queue.delayed} />
+        <QueueStatRow label={t("statWaiting")} value={queue.waiting} />
+        <QueueStatRow label={t("statActive")} value={queue.active} />
+        <QueueStatRow label={t("statCompleted")} value={queue.completed} />
+        <QueueStatRow label={t("statFailed")} value={queue.failed} destructive />
+        <QueueStatRow label={t("statDelayed")} value={queue.delayed} />
         {queue.paused !== undefined && (
-          <QueueStatRow label="Pausados" value={queue.paused} />
+          <QueueStatRow label={t("statPaused")} value={queue.paused} />
         )}
       </CardContent>
     </Card>
@@ -134,6 +134,7 @@ interface RetryButtonProps {
 }
 
 function RetryActionButton({ job, isPendingRow, onConfirm }: RetryButtonProps) {
+  const t = useTranslations("system_jobs.overview");
   const isDisabled = job.job_id === null || isPendingRow;
 
   return (
@@ -150,22 +151,19 @@ function RetryActionButton({ job, isPendingRow, onConfirm }: RetryButtonProps) {
           ) : (
             <RotateCcw className="size-3" />
           )}
-          {isPendingRow ? "Reintentando..." : "Retry"}
+          {isPendingRow ? t("retryLoading") : t("retryButton")}
         </Button>
       </AlertDialogTrigger>
       <AlertDialogContent className="sm:max-w-sm">
         <AlertDialogHeader>
-          <AlertDialogTitle>¿Reintentar este job?</AlertDialogTitle>
+          <AlertDialogTitle>{t("retryDialogTitle")}</AlertDialogTitle>
           <AlertDialogDescription>
-            Se volverá a encolar el job{" "}
-            <span className="font-semibold text-foreground">{job.name}</span> de
-            la cola{" "}
-            <span className="font-mono text-foreground">{job.queue}</span>.
+            {t("retryDialogDescription", { jobName: job.name, queue: job.queue })}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel>Cancelar</AlertDialogCancel>
-          <AlertDialogAction onClick={onConfirm}>Reintentar</AlertDialogAction>
+          <AlertDialogCancel>{t("retryDialogCancel")}</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>{t("retryDialogConfirm")}</AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
@@ -175,6 +173,7 @@ function RetryActionButton({ job, isPendingRow, onConfirm }: RetryButtonProps) {
 // ─── Failed Jobs Table ────────────────────────────────────────────────────────
 
 function FailedJobsTable({ jobs }: { jobs: FailedJob[] }) {
+  const t = useTranslations("system_jobs.overview");
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [pendingRowId, setPendingRowId] = useState<string | number | null>(null);
@@ -185,14 +184,14 @@ function FailedJobsTable({ jobs }: { jobs: FailedJob[] }) {
     startTransition(async () => {
       try {
         await retryJob(job.queue, job.job_id as string | number);
-        toast.success("Job reintentado", {
-          description: `El job "${job.name}" fue reencolado correctamente.`,
+        toast.success(t("retrySuccess"), {
+          description: t("retrySuccessDescription", { name: job.name }),
         });
         router.refresh();
       } catch (err) {
         const message =
-          err instanceof Error ? err.message : "Error desconocido al reintentar el job.";
-        toast.error("Error al reintentar", { description: message });
+          err instanceof Error ? err.message : t("retryErrorFallback");
+        toast.error(t("retryErrorTitle"), { description: message });
       } finally {
         setPendingRowId(null);
       }
@@ -203,10 +202,10 @@ function FailedJobsTable({ jobs }: { jobs: FailedJob[] }) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">Últimos fallos</CardTitle>
+          <CardTitle className="text-base">{t("failedJobsTitle")}</CardTitle>
         </CardHeader>
         <CardContent className="py-8 text-center">
-          <p className="text-sm text-muted-foreground">Sin fallos recientes</p>
+          <p className="text-sm text-muted-foreground">{t("failedJobsEmpty")}</p>
         </CardContent>
       </Card>
     );
@@ -215,19 +214,19 @@ function FailedJobsTable({ jobs }: { jobs: FailedJob[] }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">Últimos fallos</CardTitle>
+        <CardTitle className="text-base">{t("failedJobsTitle")}</CardTitle>
       </CardHeader>
       <CardContent className="p-0">
         <TooltipProvider>
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="pl-6">Cola</TableHead>
-                <TableHead>Job</TableHead>
-                <TableHead>Razón</TableHead>
-                <TableHead className="text-center">Intentos</TableHead>
-                <TableHead>Fecha</TableHead>
-                <TableHead className="pr-6 text-right">Acción</TableHead>
+                <TableHead className="pl-6">{t("colQueue")}</TableHead>
+                <TableHead>{t("colJob")}</TableHead>
+                <TableHead>{t("colReason")}</TableHead>
+                <TableHead className="text-center">{t("colAttempts")}</TableHead>
+                <TableHead>{t("colDate")}</TableHead>
+                <TableHead className="pr-6 text-right">{t("colAction")}</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -297,6 +296,7 @@ function FailedJobsTable({ jobs }: { jobs: FailedJob[] }) {
 // ─── Refresh Button ───────────────────────────────────────────────────────────
 
 function RefreshButton() {
+  const t = useTranslations("system_jobs.overview");
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -314,7 +314,7 @@ function RefreshButton() {
       disabled={isPending}
     >
       <RefreshCw className={`mr-2 h-4 w-4 ${isPending ? "animate-spin" : ""}`} />
-      {isPending ? "Actualizando..." : "Actualizar"}
+      {isPending ? t("refreshLoading") : t("refreshButton")}
     </Button>
   );
 }
@@ -322,6 +322,7 @@ function RefreshButton() {
 // ─── Main Client Component ────────────────────────────────────────────────────
 
 export function JobsOverviewClient({ data }: JobsOverviewClientProps) {
+  const t = useTranslations("system_jobs.overview");
   const { queues, recent_failed } = data;
 
   return (
@@ -329,9 +330,11 @@ export function JobsOverviewClient({ data }: JobsOverviewClientProps) {
       {/* Header row with refresh */}
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-base font-semibold">Colas</h2>
+          <h2 className="text-base font-semibold">{t("queuesTitle")}</h2>
           <p className="text-xs text-muted-foreground">
-            {queues.length} {queues.length === 1 ? "cola registrada" : "colas registradas"}
+            {queues.length === 1
+              ? t("queuesCountSingular", { count: queues.length })
+              : t("queuesCountPlural", { count: queues.length })}
           </p>
         </div>
         <RefreshButton />
@@ -341,7 +344,7 @@ export function JobsOverviewClient({ data }: JobsOverviewClientProps) {
       {queues.length === 0 ? (
         <Card>
           <CardContent className="py-8 text-center">
-            <p className="text-sm text-muted-foreground">No se encontraron colas activas.</p>
+            <p className="text-sm text-muted-foreground">{t("noQueues")}</p>
           </CardContent>
         </Card>
       ) : (

--- a/src/app/(dashboard)/dashboard/system/jobs/history/_components/cron-history-client.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/history/_components/cron-history-client.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { ChevronLeft, ChevronRight, Info } from "lucide-react";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -38,30 +39,40 @@ import type { CronHistoryItem, CronHistoryPage } from "@/lib/api/analytics";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-type JobDefinition = {
-  canonical_name: string;
-  display_name: string;
+type CronJobKey =
+  | "monthly-reports-auto-generate"
+  | "rankings-recalculate"
+  | "data-export-cleanup"
+  | "member-of-month-auto-evaluate"
+  | "finance-period-closing"
+  | "activities-reminder"
+  | "membership-requests-expiry"
+  | "cleanup-expired-records"
+  | "fcm-tokens-cleanup";
+
+const JOB_CANONICAL_NAMES: CronJobKey[] = [
+  "monthly-reports-auto-generate",
+  "rankings-recalculate",
+  "data-export-cleanup",
+  "member-of-month-auto-evaluate",
+  "finance-period-closing",
+  "activities-reminder",
+  "membership-requests-expiry",
+  "cleanup-expired-records",
+  "fcm-tokens-cleanup",
+];
+
+const JOB_I18N_KEYS: Record<CronJobKey, string> = {
+  "monthly-reports-auto-generate":  "jobMonthlyReports",
+  "rankings-recalculate":           "jobRankingsRecalculate",
+  "data-export-cleanup":            "jobDataExportCleanup",
+  "member-of-month-auto-evaluate":  "jobMemberOfMonth",
+  "finance-period-closing":         "jobFinancePeriod",
+  "activities-reminder":            "jobActivitiesReminder",
+  "membership-requests-expiry":     "jobMembershipExpiry",
+  "cleanup-expired-records":        "jobCleanupExpired",
+  "fcm-tokens-cleanup":             "jobFcmCleanup",
 };
-
-const JOB_DEFINITIONS: JobDefinition[] = [
-  { canonical_name: "monthly-reports-auto-generate",  display_name: "Reportes mensuales (auto-generar)" },
-  { canonical_name: "rankings-recalculate",           display_name: "Rankings anuales (recalcular)" },
-  { canonical_name: "data-export-cleanup",            display_name: "Cleanup exportes vencidos" },
-  { canonical_name: "member-of-month-auto-evaluate",  display_name: "Miembro del mes (auto-evaluar)" },
-  { canonical_name: "finance-period-closing",         display_name: "Cierre de periodo financiero" },
-  { canonical_name: "activities-reminder",            display_name: "Recordatorios de actividades" },
-  { canonical_name: "membership-requests-expiry",     display_name: "Expirar solicitudes de membresía" },
-  { canonical_name: "cleanup-expired-records",        display_name: "Cleanup sesiones/tokens vencidos" },
-  { canonical_name: "fcm-tokens-cleanup",             display_name: "Cleanup FCM tokens huérfanos" },
-];
-
-const STATUS_OPTIONS = [
-  { value: "all",       label: "Todos los estados" },
-  { value: "completed", label: "Completado" },
-  { value: "failed",    label: "Fallido" },
-  { value: "skipped",   label: "Omitido" },
-  { value: "running",   label: "Ejecutando" },
-];
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -97,28 +108,25 @@ function statusVariant(
   }
 }
 
-function statusLabel(status: string): string {
-  switch (status) {
-    case "completed": return "Completado";
-    case "failed":    return "Fallido";
-    case "running":   return "Ejecutando";
-    case "skipped":   return "Omitido";
-    default:          return status;
-  }
-}
+// ─── Status Badge ─────────────────────────────────────────────────────────────
 
 function StatusBadge({ status }: { status: string }) {
+  const t = useTranslations("system_jobs.history");
+
+  function getLabel(s: string): string {
+    switch (s) {
+      case "completed": return t("statusCompleted");
+      case "failed":    return t("statusFailed");
+      case "running":   return t("statusRunning");
+      case "skipped":   return t("statusSkipped");
+      default:          return s;
+    }
+  }
+
   return (
     <Badge variant={statusVariant(status)} className="text-xs">
-      {statusLabel(status)}
+      {getLabel(status)}
     </Badge>
-  );
-}
-
-function jobDisplayName(canonicalName: string): string {
-  return (
-    JOB_DEFINITIONS.find((d) => d.canonical_name === canonicalName)
-      ?.display_name ?? canonicalName
   );
 }
 
@@ -130,46 +138,53 @@ interface DetailDialogProps {
 }
 
 function DetailDialog({ item, onClose }: DetailDialogProps) {
+  const t = useTranslations("system_jobs.history");
+
+  function jobDisplayName(canonicalName: string): string {
+    const key = JOB_I18N_KEYS[canonicalName as CronJobKey];
+    return key ? t(key) : canonicalName;
+  }
+
   return (
     <Dialog open={item !== null} onOpenChange={(open) => { if (!open) onClose(); }}>
       <DialogContent className="sm:max-w-lg max-h-[80vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-sm font-semibold">
-            Detalles del run #{item?.run_id}
+            {item ? t("detailTitle", { runId: item.run_id }) : ""}
           </DialogTitle>
         </DialogHeader>
         {item && (
           <div className="space-y-4 text-sm">
             <div className="grid grid-cols-2 gap-2">
               <div>
-                <p className="text-xs text-muted-foreground mb-0.5">Job</p>
+                <p className="text-xs text-muted-foreground mb-0.5">{t("detailLabelJob")}</p>
                 <p className="font-medium">{jobDisplayName(item.job_name)}</p>
                 <p className="text-xs text-muted-foreground font-mono">{item.job_name}</p>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-0.5">Status</p>
+                <p className="text-xs text-muted-foreground mb-0.5">{t("detailLabelStatus")}</p>
                 <StatusBadge status={item.status} />
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-0.5">Inicio</p>
+                <p className="text-xs text-muted-foreground mb-0.5">{t("detailLabelStart")}</p>
                 <p>{formatDate(item.started_at)}</p>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-0.5">Fin</p>
+                <p className="text-xs text-muted-foreground mb-0.5">{t("detailLabelEnd")}</p>
                 <p>{formatDate(item.ended_at)}</p>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-0.5">Duración</p>
+                <p className="text-xs text-muted-foreground mb-0.5">{t("detailLabelDuration")}</p>
                 <p>{formatDuration(item.duration_ms)}</p>
               </div>
               <div>
-                <p className="text-xs text-muted-foreground mb-0.5">Items procesados</p>
+                <p className="text-xs text-muted-foreground mb-0.5">{t("detailLabelItems")}</p>
                 <p>{item.items_processed !== null ? item.items_processed.toLocaleString("es-MX") : "—"}</p>
               </div>
             </div>
             {item.error_message && (
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Mensaje de error</p>
+                <p className="text-xs text-muted-foreground mb-1">{t("detailLabelError")}</p>
                 <pre className="rounded-md bg-destructive/10 border border-destructive/20 p-3 text-xs text-destructive font-mono whitespace-pre-wrap break-all">
                   {item.error_message}
                 </pre>
@@ -177,7 +192,7 @@ function DetailDialog({ item, onClose }: DetailDialogProps) {
             )}
             {item.metadata && (
               <div>
-                <p className="text-xs text-muted-foreground mb-1">Metadata</p>
+                <p className="text-xs text-muted-foreground mb-1">{t("detailLabelMetadata")}</p>
                 <pre className="rounded-md bg-muted border p-3 text-xs font-mono whitespace-pre-wrap break-all overflow-x-auto">
                   {JSON.stringify(item.metadata, null, 2)}
                 </pre>
@@ -211,11 +226,26 @@ export function CronHistoryClient({
   initialData,
   searchParams,
 }: CronHistoryClientProps) {
+  const t = useTranslations("system_jobs.history");
   const router = useRouter();
   const [selectedItem, setSelectedItem] = useState<CronHistoryItem | null>(null);
 
   const currentPage = initialData.page;
   const totalPages = Math.ceil(initialData.total / initialData.limit);
+
+  // Status options built from translations (moved inside component — contains UI strings)
+  const STATUS_OPTIONS = [
+    { value: "all",       label: t("filterAllStatuses") },
+    { value: "completed", label: t("statusCompleted") },
+    { value: "failed",    label: t("statusFailed") },
+    { value: "skipped",   label: t("statusSkipped") },
+    { value: "running",   label: t("statusRunning") },
+  ];
+
+  function jobDisplayName(canonicalName: string): string {
+    const key = JOB_I18N_KEYS[canonicalName as CronJobKey];
+    return key ? t(key) : canonicalName;
+  }
 
   // ── Filter helpers ─────────────────────────────────────────────────────────
 
@@ -252,19 +282,21 @@ export function CronHistoryClient({
             <div className="flex flex-wrap gap-3 items-end">
               {/* Job name filter */}
               <div className="flex flex-col gap-1.5 min-w-[220px]">
-                <span className="text-xs text-muted-foreground font-medium">Job</span>
+                <span className="text-xs text-muted-foreground font-medium">
+                  {t("filterLabelJob")}
+                </span>
                 <Select
                   value={searchParams.job_name ?? "all"}
                   onValueChange={(v) => handleFilterChange("job_name", v)}
                 >
                   <SelectTrigger className="h-8 text-sm">
-                    <SelectValue placeholder="Todos los jobs" />
+                    <SelectValue placeholder={t("filterAllJobs")} />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="all">Todos los jobs</SelectItem>
-                    {JOB_DEFINITIONS.map((def) => (
-                      <SelectItem key={def.canonical_name} value={def.canonical_name}>
-                        {def.display_name}
+                    <SelectItem value="all">{t("filterAllJobs")}</SelectItem>
+                    {JOB_CANONICAL_NAMES.map((canonicalName) => (
+                      <SelectItem key={canonicalName} value={canonicalName}>
+                        {jobDisplayName(canonicalName)}
                       </SelectItem>
                     ))}
                   </SelectContent>
@@ -273,13 +305,15 @@ export function CronHistoryClient({
 
               {/* Status filter */}
               <div className="flex flex-col gap-1.5 min-w-[180px]">
-                <span className="text-xs text-muted-foreground font-medium">Estado</span>
+                <span className="text-xs text-muted-foreground font-medium">
+                  {t("filterLabelStatus")}
+                </span>
                 <Select
                   value={searchParams.status ?? "all"}
                   onValueChange={(v) => handleFilterChange("status", v)}
                 >
                   <SelectTrigger className="h-8 text-sm">
-                    <SelectValue placeholder="Todos los estados" />
+                    <SelectValue placeholder={t("filterAllStatuses")} />
                   </SelectTrigger>
                   <SelectContent>
                     {STATUS_OPTIONS.map((opt) => (
@@ -293,7 +327,9 @@ export function CronHistoryClient({
 
               {/* Since */}
               <div className="flex flex-col gap-1.5">
-                <span className="text-xs text-muted-foreground font-medium">Desde</span>
+                <span className="text-xs text-muted-foreground font-medium">
+                  {t("filterLabelSince")}
+                </span>
                 <Input
                   type="date"
                   className="h-8 text-sm w-[150px]"
@@ -304,7 +340,9 @@ export function CronHistoryClient({
 
               {/* Until */}
               <div className="flex flex-col gap-1.5">
-                <span className="text-xs text-muted-foreground font-medium">Hasta</span>
+                <span className="text-xs text-muted-foreground font-medium">
+                  {t("filterLabelUntil")}
+                </span>
                 <Input
                   type="date"
                   className="h-8 text-sm w-[150px]"
@@ -320,14 +358,14 @@ export function CronHistoryClient({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-0 pt-4">
             <CardTitle className="text-sm font-medium text-muted-foreground">
-              {initialData.total.toLocaleString("es-MX")} registros
+              {t("recordCount", { total: initialData.total.toLocaleString("es-MX") })}
             </CardTitle>
           </CardHeader>
           <CardContent className="p-0">
             {initialData.items.length === 0 ? (
               <div className="py-16 text-center">
                 <p className="text-sm text-muted-foreground">
-                  No se encontraron ejecuciones con los filtros aplicados.
+                  {t("noResults")}
                 </p>
               </div>
             ) : (
@@ -335,13 +373,13 @@ export function CronHistoryClient({
                 <Table>
                   <TableHeader>
                     <TableRow>
-                      <TableHead className="pl-6">Job</TableHead>
-                      <TableHead>Inicio</TableHead>
-                      <TableHead>Estado</TableHead>
-                      <TableHead>Duración</TableHead>
-                      <TableHead className="text-right">Items</TableHead>
-                      <TableHead className="max-w-[200px]">Error</TableHead>
-                      <TableHead className="pr-6 text-right">Detalles</TableHead>
+                      <TableHead className="pl-6">{t("colJob")}</TableHead>
+                      <TableHead>{t("colStart")}</TableHead>
+                      <TableHead>{t("colStatus")}</TableHead>
+                      <TableHead>{t("colDuration")}</TableHead>
+                      <TableHead className="text-right">{t("colItems")}</TableHead>
+                      <TableHead className="max-w-[200px]">{t("colError")}</TableHead>
+                      <TableHead className="pr-6 text-right">{t("colDetails")}</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
@@ -357,17 +395,17 @@ export function CronHistoryClient({
                           </span>
                         </TableCell>
 
-                        {/* Inicio */}
+                        {/* Start */}
                         <TableCell className="text-sm text-muted-foreground whitespace-nowrap">
                           {formatDate(item.started_at)}
                         </TableCell>
 
-                        {/* Estado */}
+                        {/* Status */}
                         <TableCell>
                           <StatusBadge status={item.status} />
                         </TableCell>
 
-                        {/* Duración */}
+                        {/* Duration */}
                         <TableCell className="tabular-nums text-sm">
                           {formatDuration(item.duration_ms)}
                         </TableCell>
@@ -379,7 +417,7 @@ export function CronHistoryClient({
                             : "—"}
                         </TableCell>
 
-                        {/* Error truncado */}
+                        {/* Error truncated */}
                         <TableCell className="max-w-[200px]">
                           {item.error_message ? (
                             <Tooltip>
@@ -400,7 +438,7 @@ export function CronHistoryClient({
                           )}
                         </TableCell>
 
-                        {/* Detalles */}
+                        {/* Details */}
                         <TableCell className="pr-6 text-right">
                           <Button
                             variant="ghost"
@@ -409,7 +447,7 @@ export function CronHistoryClient({
                             className="gap-1.5"
                           >
                             <Info className="size-3" />
-                            Ver
+                            {t("viewButton")}
                           </Button>
                         </TableCell>
                       </TableRow>
@@ -425,7 +463,7 @@ export function CronHistoryClient({
         {totalPages > 1 && (
           <div className="flex items-center justify-between px-1">
             <p className="text-xs text-muted-foreground">
-              Página {currentPage} de {totalPages}
+              {t("pagination", { page: currentPage, totalPages })}
             </p>
             <div className="flex items-center gap-2">
               <Button
@@ -435,7 +473,7 @@ export function CronHistoryClient({
                 onClick={() => handlePageChange(currentPage - 1)}
               >
                 <ChevronLeft className="size-4 mr-1" />
-                Anterior
+                {t("paginationPrev")}
               </Button>
               <Button
                 variant="outline"
@@ -443,7 +481,7 @@ export function CronHistoryClient({
                 disabled={currentPage >= totalPages}
                 onClick={() => handlePageChange(currentPage + 1)}
               >
-                Siguiente
+                {t("paginationNext")}
                 <ChevronRight className="size-4 ml-1" />
               </Button>
             </div>

--- a/src/app/(dashboard)/error.tsx
+++ b/src/app/(dashboard)/error.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { AlertCircle, RotateCcw } from "lucide-react";
 import * as Sentry from "@sentry/nextjs";
+import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/shared/page-header";
 
@@ -12,6 +13,8 @@ interface DashboardErrorProps {
 }
 
 export default function DashboardError({ error, reset }: DashboardErrorProps) {
+  const t = useTranslations("shared.errors");
+
   useEffect(() => {
     Sentry.captureException(error);
   }, [error]);
@@ -19,8 +22,8 @@ export default function DashboardError({ error, reset }: DashboardErrorProps) {
   return (
     <div className="space-y-6">
       <PageHeader
-        title="Algo salió mal"
-        description="Ocurrió un error al cargar esta sección."
+        title={t("dashboardTitle")}
+        description={t("dashboardDescription")}
       />
 
       <div
@@ -31,10 +34,9 @@ export default function DashboardError({ error, reset }: DashboardErrorProps) {
         <div className="flex size-12 items-center justify-center rounded-full bg-destructive/10">
           <AlertCircle className="size-6 text-destructive" aria-hidden="true" />
         </div>
-        <h3 className="mt-4 text-lg font-semibold">No se pudo cargar la página</h3>
+        <h3 className="mt-4 text-lg font-semibold">{t("dashboardHeading")}</h3>
         <p className="mt-1 max-w-md text-sm text-muted-foreground">
-          El error fue reportado automáticamente. Podés reintentar o volver al
-          dashboard.
+          {t("dashboardBody")}
         </p>
         {error.digest && (
           <p className="mt-2 font-mono text-[11px] text-muted-foreground/70">
@@ -44,10 +46,10 @@ export default function DashboardError({ error, reset }: DashboardErrorProps) {
         <div className="mt-5 flex flex-wrap items-center justify-center gap-2">
           <Button onClick={reset} variant="default" size="sm">
             <RotateCcw className="mr-1.5 size-4" aria-hidden="true" />
-            Reintentar
+            {t("dashboardRetry")}
           </Button>
           <Button asChild variant="outline" size="sm">
-            <a href="/dashboard">Ir al dashboard</a>
+            <a href="/dashboard">{t("dashboardGoHome")}</a>
           </Button>
         </div>
       </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Suspense } from "react";
 import { Geist, Geist_Mono, Instrument_Serif } from "next/font/google";
 import { NextIntlClientProvider } from "next-intl";
-import { getLocale, getMessages } from "next-intl/server";
+import { getLocale, getMessages, getTranslations } from "next-intl/server";
 import { Toaster } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AppAlertListener } from "@/components/shared/app-alert-listener";
@@ -29,11 +29,14 @@ const instrumentSerif = Instrument_Serif({
   display: "swap",
 });
 
-export const metadata: Metadata = {
-  title: "SACDIA Panel Administrativo",
-  description: "Panel de administración de SACDIA",
-  icons: { icon: "/logo.ico" },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations("shared.appMetadata");
+  return {
+    title: t("title"),
+    description: t("description"),
+    icons: { icon: "/logo.ico" },
+  };
+}
 
 export default async function RootLayout({
   children,

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,19 +1,20 @@
 import Link from "next/link";
 import { FileQuestion } from "lucide-react";
+import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
 
-export default function NotFound() {
+export default async function NotFound() {
+  const t = await getTranslations("shared.errors");
+
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 px-4 text-center">
       <div className="flex size-16 items-center justify-center rounded-full bg-muted">
         <FileQuestion className="size-8 text-muted-foreground" />
       </div>
-      <h1 className="text-2xl font-bold">Página no encontrada</h1>
-      <p className="max-w-sm text-muted-foreground">
-        La ruta que buscas no existe o fue movida.
-      </p>
+      <h1 className="text-2xl font-bold">{t("notFoundTitle")}</h1>
+      <p className="max-w-sm text-muted-foreground">{t("notFoundBody")}</p>
       <Button asChild>
-        <Link href="/dashboard">Ir al Dashboard</Link>
+        <Link href="/dashboard">{t("notFoundGoHome")}</Link>
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary

next-intl batch 11 — single PR completing i18n migration for all remaining files: catalog delegate pages + loading + auth + app root + _components for achievements/rankings/system-jobs/supervision.

**Stacked on `feat/admin-i18n-batch-10` (PR #95)** — once #95 merges, this PR will show only batch-11 delta. Until then, the diff includes batch-10 changes.

37 files migrated + 11 correctly skipped (no UI strings) + 4 messages JSONs.

## Per-namespace key delta (×4 locales identical)

| Namespace | Before | After | Delta |
|---|---|---|---|
| catalogs | 296 | 323 | +27 |
| settings | 7 | 8 | +1 |
| shared | 14 | 25 | +11 |
| achievements | 34 | 255 | +221 |
| member_of_month | 18 | 47 | +29 |
| reports | 114 | 155 | +41 |
| memberRankingWeights | 44 | 53 | +9 |
| rankings | 64 | 121 | +57 |
| system_jobs | 11 | 115 | +104 |

**~500 new keys per locale.** Cumulative i18n project: ~2835 keys across 24 namespaces.

## Patterns applied

- **`generateMetadata` async export** for 14 catalog/settings delegate pages — no inline `getTranslations` in body, page stays minimal
- `error.tsx` already `'use client'` → `useTranslations("shared.errors")`. Mexican Spanish replaces voseo
- `not-found.tsx` kept as async server component (Next.js 15 supports it)
- `app/layout.tsx`: static `metadata` → `generateMetadata` async with `getTranslations("shared.appMetadata")`
- 8 status badges / sub-components added `'use client'` where needed
- Module-level option arrays (`TYPE_LABELS`, `STATUS_OPTIONS`, `EVENT_OPTIONS`, `TIER_COLORS`, `QUEUE_META`, `STREAK_UNIT_OPTIONS`, `OPERATOR_OPTIONS`) split into value-only arrays + i18n key maps; labels resolved via `t()` in render
- `formatInvestitureScore` helper moved inside component (uses `t()`)
- `validateFile` helper accepts `typeError`/`sizeError` string params
- 8 independent `useTranslations` hooks per `criteria-editor` sub-component (no `t` prop drilling)
- Two-hook pattern for `achievements-crud-page` (list + preview namespaces)
- ICU plurals for counts; ICU interpolation for dynamic strings
- `MONTH_NAMES` from `@/lib/constants` kept (already locale data, no duplication)
- Date helpers (`Intl.DateTimeFormat("es-MX")`) deferred to locale-routing refactor
- Zod schema validation strings deferred to separate cross-PR refactor
- **11 files correctly skipped** (no-migration-needed):
  - 5 `loading.tsx` (pure Skeleton, zero strings)
  - `(auth)/login/page.tsx` + `(auth)/layout.tsx` (delegate / redirect-only)
  - `(dashboard)/layout.tsx` (provider wrapper)
  - `app/global-error.tsx` (delegates to next/error)
  - `app/page.tsx` (pure redirect)
  - `member-rankings/_components/member-ranking-score-badge.tsx` (only renders `{value}%`)

## Test plan

- [x] All 3 sub-agents branched from `feat/admin-i18n-batch-10` HEAD `e27e785` cleanly (CRITICAL header verification)
- [x] Python deep-merge produced 4 locale JSONs in sync (9 namespaces × 4 locales identical counts)
- [x] `pnpm typecheck` produces no new errors (6 pre-existing `vitest` baseline errors unchanged)
- [x] All 4 `messages/*.json` parse as valid JSON
- [ ] Manual smoke: error boundary, not-found, login flow, locale switcher across new routes
- [ ] **Rebase onto development after PR #95 merges** (will reduce this PR to batch-11 delta only)
- [ ] fr/pt-BR translation review (deferred — accumulated across 19 PRs i18n)

## Notes

- Batch 11 closes the i18n migration for sacdia-admin (modulo Zod schemas + locale-routing refactor + native fr/pt-BR review).
- Once PR #95 + this PR merge, all `page.tsx` / `_components` / app root chrome is i18n-ready.