### PR TITLE
feat(i18n): locale-aware date/currency formatters + Zod schema refactor (45 files)

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1914,6 +1914,18 @@
         "pageFailed": "Could not load the page.",
         "emptyTitle": "Could not load union camporees"
       }
+    },
+    "validation": {
+      "member_required": "Select a member",
+      "amount_positive": "Amount must be greater than zero",
+      "name_required": "Name is required",
+      "start_date_required": "Start date is required",
+      "end_date_required": "End date is required",
+      "union_required": "Union is required",
+      "place_required": "Location is required",
+      "local_field_required": "Local field is required",
+      "end_date_after_start": "End date must be equal to or after the start date",
+      "end_date_after_start_full": "End date must be equal to or after the start date"
     }
   },
   "resources": {
@@ -2023,7 +2035,9 @@
       "local_field_required": "Select a local field",
       "year_required": "Select an ecclesiastical year",
       "submission_deadline_required": "Enter the submission deadline",
-      "investiture_date_required": "Enter the investiture date"
+      "investiture_date_required": "Enter the investiture date",
+      "comments_required": "Rejection reason is required",
+      "reason_required": "Rejection reason is required"
     },
     "configClient": {
       "countSingular": "configuration",
@@ -2648,6 +2662,23 @@
       "description": "Component detail for enrollment {enrollmentId}",
       "errorFallback": "Could not load the ranking breakdown. Check your server connection.",
       "paramsRequired": "The enrollmentId and year_id parameters are required."
+    },
+    "validation": {
+      "name_min": "Name must be at least {min} characters",
+      "name_max": "Name cannot exceed {max} characters",
+      "description_max": "Description cannot exceed {max} characters",
+      "order_min": "Order must be at least {min}",
+      "max_points_min": "Maximum points cannot be negative",
+      "minimum_points_min": "Minimum points cannot be negative",
+      "club_type_required": "Select a club type",
+      "ecclesiastical_year_required": "Select an ecclesiastical year",
+      "owner_union_required": "Select a union",
+      "owner_local_field_required": "Select a local field",
+      "name_min_2": "Name must be at least {min} characters",
+      "composite_pct_min": "Must be 0 or greater",
+      "composite_pct_max": "Cannot exceed {max}",
+      "order_min_0": "Order must be 0 or greater",
+      "composite_pct_invalid": "Minimum percentage must be less than maximum"
     }
   },
   "folders": {
@@ -2716,6 +2747,11 @@
     },
     "pageDetail": {
       "errorLoad": "Could not load the evidence folder."
+    },
+    "validation": {
+      "name_min": "Name must be at least {min} characters",
+      "name_max": "Name cannot exceed {max} characters",
+      "description_max": "Description cannot exceed {max} characters"
     }
   },
   "validation_admin": {
@@ -2780,6 +2816,9 @@
       "errorLoadGeneric": "Could not load pending validations.",
       "emptyTitle": "No pending validations",
       "emptyDescription": "There are no classes or honors pending validation at this time."
+    },
+    "validation": {
+      "comment_required": "Rejection reason is required"
     }
   },
   "scoring_categories": {
@@ -3173,6 +3212,9 @@
       "errorLoad": "Could not load role assignment requests.",
       "emptyTitle": "No requests",
       "emptyDescription": "There are no role assignment requests registered at this time."
+    },
+    "validation": {
+      "comment_required": "Rejection reason is required"
     }
   },
   "insurance": {
@@ -3268,6 +3310,10 @@
       "description": "Active insurance policies expiring soon, sorted by urgency.",
       "window_label": "Window: {days} days",
       "error_load_failed": "Could not load the expiring insurance list."
+    },
+    "validation": {
+      "start_date_required": "Start date is required",
+      "end_date_required": "End date is required"
     }
   },
   "finances": {
@@ -3518,6 +3564,14 @@
       "info_meet_link": "Meeting link",
       "info_coordinates": "Coordinates",
       "error_attendance_load": "Could not load the attendance list."
+    },
+    "validation": {
+      "name_required": "Name is required",
+      "activity_type_required": "Select a type",
+      "club_type_required": "Select the club type",
+      "club_section_required": "Select the section",
+      "activity_place_required": "Location is required",
+      "image_required": "Image URL is required"
     }
   },
   "year_end": {
@@ -3599,6 +3653,13 @@
       "description": "Manage inventory by club.",
       "empty_no_clubs_title": "No clubs registered",
       "empty_no_clubs_description": "Register at least one club to manage its inventory."
+    },
+    "validation": {
+      "name_min": "Name must be at least {min} characters",
+      "name_max": "Name cannot exceed {max} characters",
+      "description_max": "Description cannot exceed {max} characters",
+      "category_required": "Select a category",
+      "amount_min": "Quantity cannot be negative"
     }
   },
   "units_admin": {
@@ -3674,6 +3735,9 @@
       "entry_count": "{count, plural, one {# entry} other {# entries}}",
       "btn_refresh": "Refresh",
       "error_refresh": "Could not refresh the configuration"
+    },
+    "validation": {
+      "config_value_required": "Value cannot be empty"
     }
   },
   "shared": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -1914,6 +1914,18 @@
         "pageFailed": "No se pudo cargar la página.",
         "emptyTitle": "No se pudieron cargar los camporees de unión"
       }
+    },
+    "validation": {
+      "member_required": "Seleccione un miembro",
+      "amount_positive": "El monto debe ser mayor a cero",
+      "name_required": "El nombre es obligatorio",
+      "start_date_required": "La fecha de inicio es obligatoria",
+      "end_date_required": "La fecha de fin es obligatoria",
+      "union_required": "La unión es obligatoria",
+      "place_required": "El lugar es obligatorio",
+      "local_field_required": "El campo local es obligatorio",
+      "end_date_after_start": "La fecha de fin debe ser igual o posterior a la de inicio",
+      "end_date_after_start_full": "La fecha de fin debe ser igual o posterior a la fecha de inicio"
     }
   },
   "resources": {
@@ -2023,7 +2035,9 @@
       "local_field_required": "Seleccioná un campo local",
       "year_required": "Seleccioná un año eclesiástico",
       "submission_deadline_required": "Ingresá la fecha límite de envío",
-      "investiture_date_required": "Ingresá la fecha de investidura"
+      "investiture_date_required": "Ingresá la fecha de investidura",
+      "comments_required": "El motivo de rechazo es obligatorio",
+      "reason_required": "El motivo de rechazo es obligatorio"
     },
     "configClient": {
       "countSingular": "configuración",
@@ -2648,6 +2662,23 @@
       "description": "Detalle por componente para la inscripción {enrollmentId}",
       "errorFallback": "No se pudo cargar el breakdown de ranking. Verificá la conexión con el servidor.",
       "paramsRequired": "Los parámetros enrollmentId y year_id son requeridos."
+    },
+    "validation": {
+      "name_min": "El nombre debe tener al menos {min} caracteres",
+      "name_max": "El nombre no puede superar {max} caracteres",
+      "description_max": "La descripción no puede superar {max} caracteres",
+      "order_min": "El orden debe ser al menos {min}",
+      "max_points_min": "Los puntos máximos no pueden ser negativos",
+      "minimum_points_min": "Los puntos mínimos no pueden ser negativos",
+      "club_type_required": "Selecciona un tipo de club",
+      "ecclesiastical_year_required": "Selecciona un año eclesiástico",
+      "owner_union_required": "Selecciona una unión",
+      "owner_local_field_required": "Selecciona un campo local",
+      "name_min_2": "El nombre debe tener al menos {min} caracteres",
+      "composite_pct_min": "Debe ser 0 o mayor",
+      "composite_pct_max": "No puede superar {max}",
+      "order_min_0": "El orden debe ser 0 o mayor",
+      "composite_pct_invalid": "El porcentaje mínimo debe ser menor que el máximo"
     }
   },
   "folders": {
@@ -2716,6 +2747,11 @@
     },
     "pageDetail": {
       "errorLoad": "No se pudo cargar la carpeta de evidencias."
+    },
+    "validation": {
+      "name_min": "El nombre debe tener al menos {min} caracteres",
+      "name_max": "El nombre no puede superar {max} caracteres",
+      "description_max": "La descripción no puede superar {max} caracteres"
     }
   },
   "validation_admin": {
@@ -2780,6 +2816,9 @@
       "errorLoadGeneric": "No se pudieron cargar las validaciones pendientes.",
       "emptyTitle": "Sin validaciones pendientes",
       "emptyDescription": "No hay clases ni especialidades pendientes de validación en este momento."
+    },
+    "validation": {
+      "comment_required": "El motivo de rechazo es obligatorio"
     }
   },
   "scoring_categories": {
@@ -3173,6 +3212,9 @@
       "errorLoad": "No se pudieron cargar las solicitudes de asignación de rol.",
       "emptyTitle": "Sin solicitudes",
       "emptyDescription": "No hay solicitudes de asignación de rol registradas en este momento."
+    },
+    "validation": {
+      "comment_required": "El motivo de rechazo es obligatorio"
     }
   },
   "insurance": {
@@ -3268,6 +3310,10 @@
       "description": "Seguros activos próximos a vencer ordenados por urgencia.",
       "window_label": "Ventana: {days} días",
       "error_load_failed": "No se pudo cargar la lista de seguros por vencer."
+    },
+    "validation": {
+      "start_date_required": "La fecha de inicio es obligatoria",
+      "end_date_required": "La fecha de fin es obligatoria"
     }
   },
   "finances": {
@@ -3518,6 +3564,14 @@
       "info_meet_link": "Enlace de reunión",
       "info_coordinates": "Coordenadas",
       "error_attendance_load": "No se pudo cargar la lista de asistencia."
+    },
+    "validation": {
+      "name_required": "El nombre es obligatorio",
+      "activity_type_required": "Selecciona un tipo",
+      "club_type_required": "Selecciona el tipo de club",
+      "club_section_required": "Selecciona la sección",
+      "activity_place_required": "El lugar es obligatorio",
+      "image_required": "La URL de imagen es obligatoria"
     }
   },
   "year_end": {
@@ -3599,6 +3653,13 @@
       "description": "Gestión de inventario por club.",
       "empty_no_clubs_title": "No hay clubes registrados",
       "empty_no_clubs_description": "Registra al menos un club para gestionar su inventario."
+    },
+    "validation": {
+      "name_min": "El nombre debe tener al menos {min} caracteres",
+      "name_max": "El nombre no puede superar {max} caracteres",
+      "description_max": "La descripción no puede superar {max} caracteres",
+      "category_required": "Selecciona una categoría",
+      "amount_min": "La cantidad no puede ser negativa"
     }
   },
   "units_admin": {
@@ -3674,6 +3735,9 @@
       "entry_count": "{count, plural, one {# entrada} other {# entradas}}",
       "btn_refresh": "Actualizar",
       "error_refresh": "No se pudo actualizar la configuración"
+    },
+    "validation": {
+      "config_value_required": "El valor no puede estar vacío"
     }
   },
   "shared": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1914,6 +1914,18 @@
         "pageFailed": "Impossible de charger la page.",
         "emptyTitle": "Impossible de charger les camporees de l’union"
       }
+    },
+    "validation": {
+      "member_required": "Sélectionnez un membre",
+      "amount_positive": "Le montant doit être supérieur à zéro",
+      "name_required": "Le nom est obligatoire",
+      "start_date_required": "La date de début est obligatoire",
+      "end_date_required": "La date de fin est obligatoire",
+      "union_required": "L'union est obligatoire",
+      "place_required": "Le lieu est obligatoire",
+      "local_field_required": "Le champ local est obligatoire",
+      "end_date_after_start": "La date de fin doit être égale ou postérieure à la date de début",
+      "end_date_after_start_full": "La date de fin doit être égale ou postérieure à la date de début"
     }
   },
   "resources": {
@@ -2023,7 +2035,9 @@
       "local_field_required": "Sélectionnez un champ local",
       "year_required": "Sélectionnez une année ecclésiastique",
       "submission_deadline_required": "Saisissez la date limite de soumission",
-      "investiture_date_required": "Saisissez la date de l'investiture"
+      "investiture_date_required": "Saisissez la date de l'investiture",
+      "comments_required": "Le motif de rejet est obligatoire",
+      "reason_required": "Le motif de rejet est obligatoire"
     },
     "configClient": {
       "countSingular": "configuration",
@@ -2648,6 +2662,23 @@
       "description": "Détail par composant pour l'inscription {enrollmentId}",
       "errorFallback": "Impossible de charger le détail du classement. Vérifiez la connexion au serveur.",
       "paramsRequired": "Les paramètres enrollmentId et year_id sont requis."
+    },
+    "validation": {
+      "name_min": "Le nom doit contenir au moins {min} caractères",
+      "name_max": "Le nom ne peut pas dépasser {max} caractères",
+      "description_max": "La description ne peut pas dépasser {max} caractères",
+      "order_min": "L'ordre doit être au moins {min}",
+      "max_points_min": "Les points maximum ne peuvent pas être négatifs",
+      "minimum_points_min": "Les points minimum ne peuvent pas être négatifs",
+      "club_type_required": "Sélectionnez un type de club",
+      "ecclesiastical_year_required": "Sélectionnez une année ecclésiastique",
+      "owner_union_required": "Sélectionnez une union",
+      "owner_local_field_required": "Sélectionnez un champ local",
+      "name_min_2": "Le nom doit contenir au moins {min} caractères",
+      "composite_pct_min": "Doit être 0 ou plus",
+      "composite_pct_max": "Ne peut pas dépasser {max}",
+      "order_min_0": "L'ordre doit être 0 ou plus",
+      "composite_pct_invalid": "Le pourcentage minimum doit être inférieur au maximum"
     }
   },
   "folders": {
@@ -2716,6 +2747,11 @@
     },
     "pageDetail": {
       "errorLoad": "Impossible de charger le dossier de preuves."
+    },
+    "validation": {
+      "name_min": "Le nom doit contenir au moins {min} caractères",
+      "name_max": "Le nom ne peut pas dépasser {max} caractères",
+      "description_max": "La description ne peut pas dépasser {max} caractères"
     }
   },
   "validation_admin": {
@@ -2780,6 +2816,9 @@
       "errorLoadGeneric": "Impossible de charger les validations en attente.",
       "emptyTitle": "Aucune validation en attente",
       "emptyDescription": "Il n'y a aucune classe ni spécialité en attente de validation pour le moment."
+    },
+    "validation": {
+      "comment_required": "Le motif de rejet est obligatoire"
     }
   },
   "scoring_categories": {
@@ -3173,6 +3212,9 @@
       "errorLoad": "Impossible de charger les demandes d'attribution de rôle.",
       "emptyTitle": "Aucune demande",
       "emptyDescription": "Il n'y a aucune demande d'attribution de rôle enregistrée pour le moment."
+    },
+    "validation": {
+      "comment_required": "Le motif de rejet est obligatoire"
     }
   },
   "insurance": {
@@ -3268,6 +3310,10 @@
       "description": "Assurances actives proches de l'expiration, triées par urgence.",
       "window_label": "Fenêtre : {days} jours",
       "error_load_failed": "Impossible de charger la liste des assurances expirant bientôt."
+    },
+    "validation": {
+      "start_date_required": "La date de début est obligatoire",
+      "end_date_required": "La date de fin est obligatoire"
     }
   },
   "finances": {
@@ -3518,6 +3564,14 @@
       "info_meet_link": "Lien de réunion",
       "info_coordinates": "Coordonnées",
       "error_attendance_load": "Impossible de charger la liste de présences."
+    },
+    "validation": {
+      "name_required": "Le nom est obligatoire",
+      "activity_type_required": "Sélectionnez un type",
+      "club_type_required": "Sélectionnez le type de club",
+      "club_section_required": "Sélectionnez la section",
+      "activity_place_required": "Le lieu est obligatoire",
+      "image_required": "L'URL de l'image est obligatoire"
     }
   },
   "year_end": {
@@ -3599,6 +3653,13 @@
       "description": "Gestion de l'inventaire par club.",
       "empty_no_clubs_title": "Aucun club enregistré",
       "empty_no_clubs_description": "Enregistrez au moins un club pour gérer son inventaire."
+    },
+    "validation": {
+      "name_min": "Le nom doit contenir au moins {min} caractères",
+      "name_max": "Le nom ne peut pas dépasser {max} caractères",
+      "description_max": "La description ne peut pas dépasser {max} caractères",
+      "category_required": "Sélectionnez une catégorie",
+      "amount_min": "La quantité ne peut pas être négative"
     }
   },
   "units_admin": {
@@ -3674,6 +3735,9 @@
       "entry_count": "{count, plural, one {# entrée} other {# entrées}}",
       "btn_refresh": "Actualiser",
       "error_refresh": "Impossible de mettre à jour la configuration"
+    },
+    "validation": {
+      "config_value_required": "La valeur ne peut pas être vide"
     }
   },
   "shared": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1914,6 +1914,18 @@
         "pageFailed": "Não foi possível carregar a página.",
         "emptyTitle": "Não foi possível carregar os camporees da união"
       }
+    },
+    "validation": {
+      "member_required": "Selecione um membro",
+      "amount_positive": "O valor deve ser maior que zero",
+      "name_required": "O nome é obrigatório",
+      "start_date_required": "A data de início é obrigatória",
+      "end_date_required": "A data de fim é obrigatória",
+      "union_required": "A união é obrigatória",
+      "place_required": "O local é obrigatório",
+      "local_field_required": "O campo local é obrigatório",
+      "end_date_after_start": "A data de fim deve ser igual ou posterior à data de início",
+      "end_date_after_start_full": "A data de fim deve ser igual ou posterior à data de início"
     }
   },
   "resources": {
@@ -2023,7 +2035,9 @@
       "local_field_required": "Selecione um campo local",
       "year_required": "Selecione um ano eclesiástico",
       "submission_deadline_required": "Insira a data-limite de envio",
-      "investiture_date_required": "Insira a data da investidura"
+      "investiture_date_required": "Insira a data da investidura",
+      "comments_required": "O motivo da rejeição é obrigatório",
+      "reason_required": "O motivo da rejeição é obrigatório"
     },
     "configClient": {
       "countSingular": "configuração",
@@ -2648,6 +2662,23 @@
       "description": "Detalhe por componente para a inscrição {enrollmentId}",
       "errorFallback": "Não foi possível carregar o detalhamento do ranking. Verifique a conexão com o servidor.",
       "paramsRequired": "Os parâmetros enrollmentId e year_id são obrigatórios."
+    },
+    "validation": {
+      "name_min": "O nome deve ter pelo menos {min} caracteres",
+      "name_max": "O nome não pode ultrapassar {max} caracteres",
+      "description_max": "A descrição não pode ultrapassar {max} caracteres",
+      "order_min": "A ordem deve ser pelo menos {min}",
+      "max_points_min": "Os pontos máximos não podem ser negativos",
+      "minimum_points_min": "Os pontos mínimos não podem ser negativos",
+      "club_type_required": "Selecione um tipo de clube",
+      "ecclesiastical_year_required": "Selecione um ano eclesiástico",
+      "owner_union_required": "Selecione uma união",
+      "owner_local_field_required": "Selecione um campo local",
+      "name_min_2": "O nome deve ter pelo menos {min} caracteres",
+      "composite_pct_min": "Deve ser 0 ou maior",
+      "composite_pct_max": "Não pode ultrapassar {max}",
+      "order_min_0": "A ordem deve ser 0 ou maior",
+      "composite_pct_invalid": "O percentual mínimo deve ser menor que o máximo"
     }
   },
   "folders": {
@@ -2716,6 +2747,11 @@
     },
     "pageDetail": {
       "errorLoad": "Não foi possível carregar a pasta de evidências."
+    },
+    "validation": {
+      "name_min": "O nome deve ter pelo menos {min} caracteres",
+      "name_max": "O nome não pode ultrapassar {max} caracteres",
+      "description_max": "A descrição não pode ultrapassar {max} caracteres"
     }
   },
   "validation_admin": {
@@ -2780,6 +2816,9 @@
       "errorLoadGeneric": "Não foi possível carregar as validações pendentes.",
       "emptyTitle": "Sem validações pendentes",
       "emptyDescription": "Não há classes nem especialidades pendentes de validação no momento."
+    },
+    "validation": {
+      "comment_required": "O motivo da rejeição é obrigatório"
     }
   },
   "scoring_categories": {
@@ -3173,6 +3212,9 @@
       "errorLoad": "Não foi possível carregar as solicitações de atribuição de função.",
       "emptyTitle": "Sem solicitações",
       "emptyDescription": "Não há solicitações de atribuição de função registradas no momento."
+    },
+    "validation": {
+      "comment_required": "O motivo da rejeição é obrigatório"
     }
   },
   "insurance": {
@@ -3268,6 +3310,10 @@
       "description": "Seguros ativos prestes a vencer, ordenados por urgência.",
       "window_label": "Janela: {days} dias",
       "error_load_failed": "Não foi possível carregar a lista de seguros a vencer."
+    },
+    "validation": {
+      "start_date_required": "A data de início é obrigatória",
+      "end_date_required": "A data de fim é obrigatória"
     }
   },
   "finances": {
@@ -3518,6 +3564,14 @@
       "info_meet_link": "Link da reunião",
       "info_coordinates": "Coordenadas",
       "error_attendance_load": "Não foi possível carregar a lista de presença."
+    },
+    "validation": {
+      "name_required": "O nome é obrigatório",
+      "activity_type_required": "Selecione um tipo",
+      "club_type_required": "Selecione o tipo de clube",
+      "club_section_required": "Selecione a seção",
+      "activity_place_required": "O local é obrigatório",
+      "image_required": "A URL da imagem é obrigatória"
     }
   },
   "year_end": {
@@ -3599,6 +3653,13 @@
       "description": "Gestão de inventário por clube.",
       "empty_no_clubs_title": "Nenhum clube cadastrado",
       "empty_no_clubs_description": "Cadastre pelo menos um clube para gerenciar seu inventário."
+    },
+    "validation": {
+      "name_min": "O nome deve ter pelo menos {min} caracteres",
+      "name_max": "O nome não pode ultrapassar {max} caracteres",
+      "description_max": "A descrição não pode ultrapassar {max} caracteres",
+      "category_required": "Selecione uma categoria",
+      "amount_min": "A quantidade não pode ser negativa"
     }
   },
   "units_admin": {
@@ -3674,6 +3735,9 @@
       "entry_count": "{count, plural, one {# entrada} other {# entradas}}",
       "btn_refresh": "Atualizar",
       "error_refresh": "Não foi possível atualizar a configuração"
+    },
+    "validation": {
+      "config_value_required": "O valor não pode estar vazio"
     }
   },
   "shared": {

--- a/src/app/(dashboard)/dashboard/member-of-month/_components/member-of-month-supervision-client.tsx
+++ b/src/app/(dashboard)/dashboard/member-of-month/_components/member-of-month-supervision-client.tsx
@@ -27,13 +27,7 @@ import { MONTH_NAMES } from "@/lib/constants";
 import type { AdminMomPage, AdminMomItem } from "@/lib/api/member-of-month";
 import type { ClubType } from "@/lib/api/catalogs";
 import type { LocalField } from "@/lib/api/geography";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatPeriod(month: number, year: number): string {
-  const date = new Date(year, month - 1, 1);
-  return new Intl.DateTimeFormat("es-MX", { month: "long", year: "numeric" }).format(date);
-}
+import { useFormatDate, useFormatNumber } from "@/lib/format-locale";
 
 function getInitials(name: string | null): string {
   if (!name) return "?";
@@ -89,6 +83,8 @@ export function MemberOfMonthSupervisionClient({
 }: MemberOfMonthSupervisionClientProps) {
   const t = useTranslations("member_of_month.supervision");
   const router = useRouter();
+  const formatDate = useFormatDate();
+  const formatNumber = useFormatNumber();
 
   const currentPage = Number(searchParams.page ?? "1");
   const { total, limit, items } = initialData;
@@ -271,10 +267,10 @@ export function MemberOfMonthSupervisionClient({
                   <TableCell>{item.club_name ?? "—"}</TableCell>
                   <TableCell>{item.local_field ?? "—"}</TableCell>
                   <TableCell className="capitalize">
-                    {formatPeriod(item.month, item.year)}
+                    {formatDate(new Date(item.year, item.month - 1, 1), { month: "long", year: "numeric" })}
                   </TableCell>
                   <TableCell className="text-right tabular-nums">
-                    {item.total_points.toLocaleString("es-MX")}
+                    {formatNumber(item.total_points)}
                   </TableCell>
                   <TableCell>
                     <NotifiedBadge notified={item.notified} />

--- a/src/app/(dashboard)/dashboard/reports/supervision/_components/reports-supervision-client.tsx
+++ b/src/app/(dashboard)/dashboard/reports/supervision/_components/reports-supervision-client.tsx
@@ -30,23 +30,7 @@ import { getReportPdfUrl } from "@/lib/api/monthly-reports";
 import type { AdminReportsPage, AdminReportItem } from "@/lib/api/monthly-reports";
 import type { ClubType } from "@/lib/api/catalogs";
 import type { LocalField } from "@/lib/api/geography";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatPeriod(month: number, year: number): string {
-  const date = new Date(year, month - 1, 1);
-  return new Intl.DateTimeFormat("es-MX", { month: "long", year: "numeric" }).format(date);
-}
-
-function formatShortDate(iso: string | null): string {
-  if (!iso) return "—";
-  const date = new Date(iso);
-  return new Intl.DateTimeFormat("es-MX", {
-    day: "2-digit",
-    month: "short",
-    year: "numeric",
-  }).format(date);
-}
+import { useFormatDate } from "@/lib/format-locale";
 
 function ReportStatusBadge({ status }: { status: AdminReportItem["status"] }) {
   const t = useTranslations("reports.supervisionClient");
@@ -85,6 +69,7 @@ export function ReportsSupervisionClient({
 }: ReportsSupervisionClientProps) {
   const t = useTranslations("reports.supervisionClient");
   const router = useRouter();
+  const formatDate = useFormatDate();
 
   const currentPage = Number(searchParams.page ?? "1");
   const { total, limit, items } = initialData;
@@ -257,13 +242,13 @@ export function ReportsSupervisionClient({
                   <TableCell>{item.club_type ?? "—"}</TableCell>
                   <TableCell>{item.local_field ?? "—"}</TableCell>
                   <TableCell className="capitalize">
-                    {formatPeriod(item.month, item.year)}
+                    {formatDate(new Date(item.year, item.month - 1, 1), { month: "long", year: "numeric" })}
                   </TableCell>
                   <TableCell>
                     <ReportStatusBadge status={item.status} />
                   </TableCell>
-                  <TableCell>{formatShortDate(item.generated_at)}</TableCell>
-                  <TableCell>{formatShortDate(item.submitted_at)}</TableCell>
+                  <TableCell>{item.generated_at ? formatDate(item.generated_at) : "—"}</TableCell>
+                  <TableCell>{item.submitted_at ? formatDate(item.submitted_at) : "—"}</TableCell>
                   <TableCell>
                     <div className="flex items-center justify-end gap-2">
                       <Button asChild variant="outline" size="sm">

--- a/src/app/(dashboard)/dashboard/system/jobs/_components/cron-runs-section.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/_components/cron-runs-section.tsx
@@ -18,6 +18,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { CronRunsSummary, CronRecentRun, CronJobStats } from "@/lib/api/analytics";
+import { useFormatDateTime, useFormatNumber } from "@/lib/format-locale";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -61,17 +62,6 @@ interface CronRunsSectionProps {
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-const dateFormatter = new Intl.DateTimeFormat("es-MX", {
-  dateStyle: "short",
-  timeStyle: "short",
-});
-
-function formatDate(iso: string | null): string {
-  if (!iso) return "—";
-  const d = new Date(iso);
-  return isNaN(d.getTime()) ? "—" : dateFormatter.format(d);
-}
 
 function formatDuration(ms: number | null): string {
   if (ms === null) return "—";
@@ -156,6 +146,14 @@ function StatusBadge({
 
 export function CronRunsSection({ data }: CronRunsSectionProps) {
   const t = useTranslations("system_jobs.cronRuns");
+  const formatDateTime = useFormatDateTime();
+  const formatNumber = useFormatNumber();
+
+  function formatDate(iso: string | null): string {
+    if (!iso) return "—";
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? "—" : formatDateTime(d, { dateStyle: "short", timeStyle: "short" });
+  }
 
   // Index server data by job_name for O(1) lookups
   const recentByName = new Map<string, CronRecentRun>(
@@ -223,7 +221,7 @@ export function CronRunsSection({ data }: CronRunsSectionProps) {
                     {/* Items processed */}
                     <TableCell className="text-right tabular-nums text-sm">
                       {run?.items_processed !== undefined && run.items_processed !== null
-                        ? run.items_processed.toLocaleString("es-MX")
+                        ? formatNumber(run.items_processed)
                         : "—"}
                     </TableCell>
 
@@ -244,7 +242,7 @@ export function CronRunsSection({ data }: CronRunsSectionProps) {
 
                     {/* Runs 7d */}
                     <TableCell className="text-right tabular-nums text-sm pr-6">
-                      {stats !== null ? stats.total_runs_7d.toLocaleString("es-MX") : "—"}
+                      {stats !== null ? formatNumber(stats.total_runs_7d) : "—"}
                     </TableCell>
                   </TableRow>
                 );

--- a/src/app/(dashboard)/dashboard/system/jobs/_components/jobs-overview-client.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/_components/jobs-overview-client.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import type { JobsOverview, JobCounts, FailedJob, KnownQueueName } from "@/lib/api/analytics";
 import { retryJob } from "@/lib/api/analytics";
+import { useFormatDateTime, useFormatNumber } from "@/lib/format-locale";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -51,22 +52,6 @@ const QUEUE_I18N_KEYS: Record<KnownQueueName, { labelKey: string; descKey: strin
   'background-jobs': { labelKey: 'queueBackgroundJobs',   descKey: 'queueBackgroundJobsDesc' },
 };
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-const dateFormatter = new Intl.DateTimeFormat("es-MX", {
-  day: "2-digit",
-  month: "short",
-  year: "numeric",
-  hour: "2-digit",
-  minute: "2-digit",
-});
-
-function formatDate(timestamp: string | null): string {
-  if (!timestamp) return "—";
-  const date = new Date(timestamp);
-  return isNaN(date.getTime()) ? "—" : dateFormatter.format(date);
-}
-
 // ─── Queue Card ───────────────────────────────────────────────────────────────
 
 type QueueStatRowProps = {
@@ -76,6 +61,7 @@ type QueueStatRowProps = {
 };
 
 function QueueStatRow({ label, value, destructive }: QueueStatRowProps) {
+  const formatNumber = useFormatNumber();
   return (
     <div className="flex items-center justify-between py-0.5">
       <span className="text-xs text-muted-foreground">{label}</span>
@@ -83,7 +69,7 @@ function QueueStatRow({ label, value, destructive }: QueueStatRowProps) {
         variant={destructive && value > 0 ? "destructive" : "secondary"}
         className="text-xs tabular-nums"
       >
-        {value.toLocaleString("es-MX")}
+        {formatNumber(value)}
       </Badge>
     </div>
   );
@@ -177,6 +163,13 @@ function FailedJobsTable({ jobs }: { jobs: FailedJob[] }) {
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [pendingRowId, setPendingRowId] = useState<string | number | null>(null);
+  const formatDateTime = useFormatDateTime();
+
+  function formatDate(timestamp: string | null): string {
+    if (!timestamp) return "—";
+    const date = new Date(timestamp);
+    return isNaN(date.getTime()) ? "—" : formatDateTime(date);
+  }
 
   function handleRetry(job: FailedJob) {
     if (job.job_id === null) return;

--- a/src/app/(dashboard)/dashboard/system/jobs/history/_components/cron-history-client.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/history/_components/cron-history-client.tsx
@@ -36,6 +36,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { CronHistoryItem, CronHistoryPage } from "@/lib/api/analytics";
+import { useFormatDateTime, useFormatNumber } from "@/lib/format-locale";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -75,17 +76,6 @@ const JOB_I18N_KEYS: Record<CronJobKey, string> = {
 };
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-const dateFormatter = new Intl.DateTimeFormat("es-MX", {
-  dateStyle: "short",
-  timeStyle: "short",
-});
-
-function formatDate(iso: string | null): string {
-  if (!iso) return "—";
-  const d = new Date(iso);
-  return isNaN(d.getTime()) ? "—" : dateFormatter.format(d);
-}
 
 function formatDuration(ms: number | null): string {
   if (ms === null) return "—";
@@ -139,6 +129,14 @@ interface DetailDialogProps {
 
 function DetailDialog({ item, onClose }: DetailDialogProps) {
   const t = useTranslations("system_jobs.history");
+  const formatDateTime = useFormatDateTime();
+  const formatNumber = useFormatNumber();
+
+  function formatDate(iso: string | null): string {
+    if (!iso) return "—";
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? "—" : formatDateTime(d, { dateStyle: "short", timeStyle: "short" });
+  }
 
   function jobDisplayName(canonicalName: string): string {
     const key = JOB_I18N_KEYS[canonicalName as CronJobKey];
@@ -179,7 +177,7 @@ function DetailDialog({ item, onClose }: DetailDialogProps) {
               </div>
               <div>
                 <p className="text-xs text-muted-foreground mb-0.5">{t("detailLabelItems")}</p>
-                <p>{item.items_processed !== null ? item.items_processed.toLocaleString("es-MX") : "—"}</p>
+                <p>{item.items_processed !== null ? formatNumber(item.items_processed) : "—"}</p>
               </div>
             </div>
             {item.error_message && (
@@ -229,6 +227,14 @@ export function CronHistoryClient({
   const t = useTranslations("system_jobs.history");
   const router = useRouter();
   const [selectedItem, setSelectedItem] = useState<CronHistoryItem | null>(null);
+  const formatDateTime = useFormatDateTime();
+  const formatNumber = useFormatNumber();
+
+  function formatDate(iso: string | null): string {
+    if (!iso) return "—";
+    const d = new Date(iso);
+    return isNaN(d.getTime()) ? "—" : formatDateTime(d, { dateStyle: "short", timeStyle: "short" });
+  }
 
   const currentPage = initialData.page;
   const totalPages = Math.ceil(initialData.total / initialData.limit);
@@ -358,7 +364,7 @@ export function CronHistoryClient({
         <Card>
           <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-0 pt-4">
             <CardTitle className="text-sm font-medium text-muted-foreground">
-              {t("recordCount", { total: initialData.total.toLocaleString("es-MX") })}
+              {t("recordCount", { total: formatNumber(initialData.total) })}
             </CardTitle>
           </CardHeader>
           <CardContent className="p-0">
@@ -413,7 +419,7 @@ export function CronHistoryClient({
                         {/* Items */}
                         <TableCell className="text-right tabular-nums text-sm">
                           {item.items_processed !== null
-                            ? item.items_processed.toLocaleString("es-MX")
+                            ? formatNumber(item.items_processed)
                             : "—"}
                         </TableCell>
 

--- a/src/components/activities/activity-form-dialog.tsx
+++ b/src/components/activities/activity-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -28,24 +28,26 @@ import { useTranslations } from "next-intl";
 import { createActivity, updateActivity } from "@/lib/api/activities";
 import type { Activity } from "@/lib/api/activities";
 
-// ─── Schema ───────────────────────────────────────────────────────────────────
+// ─── Schema factory ───────────────────────────────────────────────────────────
 
-const formSchema = z.object({
-  name: z.string().min(1, "El nombre es obligatorio"),
-  description: z.string().optional(),
-  activity_type_id: z.coerce.number().int().min(1, "Selecciona un tipo"),
-  club_type_id: z.coerce.number().int().min(1, "Selecciona el tipo de club"),
-  club_section_id: z.coerce.number().int().min(1, "Selecciona la sección"),
-  lat: z.coerce.number().min(-90).max(90),
-  long: z.coerce.number().min(-180).max(180),
-  activity_time: z.string().optional(),
-  activity_place: z.string().min(1, "El lugar es obligatorio"),
-  image: z.string().min(1, "La URL de imagen es obligatoria"),
-  platform: z.coerce.number().int().min(0).max(2).optional(),
-  link_meet: z.string().optional(),
-});
+function buildSchema(t: ReturnType<typeof useTranslations<"activities.validation">>) {
+  return z.object({
+    name: z.string().min(1, t("name_required")),
+    description: z.string().optional(),
+    activity_type_id: z.coerce.number().int().min(1, t("activity_type_required")),
+    club_type_id: z.coerce.number().int().min(1, t("club_type_required")),
+    club_section_id: z.coerce.number().int().min(1, t("club_section_required")),
+    lat: z.coerce.number().min(-90).max(90),
+    long: z.coerce.number().min(-180).max(180),
+    activity_time: z.string().optional(),
+    activity_place: z.string().min(1, t("activity_place_required")),
+    image: z.string().min(1, t("image_required")),
+    platform: z.coerce.number().int().min(0).max(2).optional(),
+    link_meet: z.string().optional(),
+  });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Catalog options ──────────────────────────────────────────────────────────
 
@@ -91,7 +93,9 @@ export function ActivityFormDialog({
 }: ActivityFormDialogProps) {
   const isEdit = !!activity;
   const t = useTranslations("activities");
+  const tVal = useTranslations("activities.validation");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const {
     register,
@@ -101,7 +105,7 @@ export function ActivityFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/annual-folders/award-category-form-dialog.tsx
+++ b/src/components/annual-folders/award-category-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
@@ -32,62 +32,64 @@ import {
 import type { AwardCategory, AwardCategoryScope, AwardTier } from "@/lib/api/annual-folders";
 import type { ClubType } from "@/lib/api/catalogs";
 
-// ─── Schema ───────────────────────────────────────────────────────────────────
+// ─── Schema factory ───────────────────────────────────────────────────────────
 
-const formSchema = z
-  .object({
-    name: z
-      .string()
-      .min(2, "El nombre debe tener al menos 2 caracteres")
-      .max(200, "El nombre no puede superar 200 caracteres"),
-    description: z
-      .string()
-      .max(500, "La descripción no puede superar 500 caracteres")
-      .optional(),
-    // ── 8.4-A scope (member / section / club) ────────────────────────────────
-    scope: z.enum(["club", "section", "member"] as const),
-    club_type_id: z.string(), // "all" | stringified number
-    min_points: z.coerce.number().int().min(0, "Debe ser 0 o mayor"),
-    max_points: z.coerce
-      .number()
-      .int()
-      .min(0, "Debe ser 0 o mayor")
-      .optional()
-      .nullable(),
-    icon: z
-      .string()
-      .max(100, "El ícono no puede superar 100 caracteres")
-      .optional(),
-    order: z.coerce.number().int().min(0, "El orden debe ser 0 o mayor"),
-    // ── 8.4-C composite scoring ──────────────────────────────────────────────
-    min_composite_pct: z.coerce
-      .number()
-      .min(0, "Debe ser 0 o mayor")
-      .max(100, "No puede superar 100")
-      .optional()
-      .nullable(),
-    max_composite_pct: z.coerce
-      .number()
-      .min(0, "Debe ser 0 o mayor")
-      .max(100, "No puede superar 100")
-      .optional()
-      .nullable(),
-    // ── 8.4-C Phase C — visual tier ──────────────────────────────────────────
-    tier: z.enum(["BRONZE", "SILVER", "GOLD", "DIAMOND"] as const).nullable().optional(),
-  })
-  .superRefine((data, ctx) => {
-    const min = data.min_composite_pct;
-    const max = data.max_composite_pct;
-    if (min != null && max != null && min >= max) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "El min_composite_pct debe ser menor que el max_composite_pct.",
-        path: ["min_composite_pct"],
-      });
-    }
-  });
+function buildSchema(t: ReturnType<typeof useTranslations<"annual_folders.validation">>) {
+  return z
+    .object({
+      name: z
+        .string()
+        .min(2, t("name_min", { min: 2 }))
+        .max(200, t("name_max", { max: 200 })),
+      description: z
+        .string()
+        .max(500, t("description_max", { max: 500 }))
+        .optional(),
+      // ── 8.4-A scope (member / section / club) ────────────────────────────────
+      scope: z.enum(["club", "section", "member"] as const),
+      club_type_id: z.string(), // "all" | stringified number
+      min_points: z.coerce.number().int().min(0, t("composite_pct_min")),
+      max_points: z.coerce
+        .number()
+        .int()
+        .min(0, t("composite_pct_min"))
+        .optional()
+        .nullable(),
+      icon: z
+        .string()
+        .max(100, t("name_max", { max: 100 }))
+        .optional(),
+      order: z.coerce.number().int().min(0, t("order_min_0")),
+      // ── 8.4-C composite scoring ──────────────────────────────────────────────
+      min_composite_pct: z.coerce
+        .number()
+        .min(0, t("composite_pct_min"))
+        .max(100, t("composite_pct_max", { max: 100 }))
+        .optional()
+        .nullable(),
+      max_composite_pct: z.coerce
+        .number()
+        .min(0, t("composite_pct_min"))
+        .max(100, t("composite_pct_max", { max: 100 }))
+        .optional()
+        .nullable(),
+      // ── 8.4-C Phase C — visual tier ──────────────────────────────────────────
+      tier: z.enum(["BRONZE", "SILVER", "GOLD", "DIAMOND"] as const).nullable().optional(),
+    })
+    .superRefine((data, ctx) => {
+      const min = data.min_composite_pct;
+      const max = data.max_composite_pct;
+      if (min != null && max != null && min >= max) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: t("composite_pct_invalid"),
+          path: ["min_composite_pct"],
+        });
+      }
+    });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -112,8 +114,10 @@ export function AwardCategoryFormDialog({
   onSuccess,
 }: AwardCategoryFormDialogProps) {
   const t = useTranslations("annual_folders");
+  const tVal = useTranslations("annual_folders.validation");
   const isEdit = !!category;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const {
     register,
@@ -123,7 +127,7 @@ export function AwardCategoryFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/annual-folders/section-form-dialog.tsx
+++ b/src/components/annual-folders/section-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
@@ -25,30 +25,32 @@ import {
 } from "@/lib/api/annual-folders";
 import type { FolderTemplateSection } from "@/lib/api/annual-folders";
 
-// ─── Schema ───────────────────────────────────────────────────────────────────
+// ─── Schema factory ───────────────────────────────────────────────────────────
 
-const formSchema = z.object({
-  name: z
-    .string()
-    .min(3, "El nombre debe tener al menos 3 caracteres")
-    .max(100, "El nombre no puede superar 100 caracteres"),
-  description: z
-    .string()
-    .max(500, "La descripción no puede superar 500 caracteres")
-    .optional(),
-  order: z.coerce.number().int().min(1, "El orden debe ser al menos 1"),
-  required: z.boolean(),
-  max_points: z.coerce
-    .number()
-    .int()
-    .min(0, "Los puntos máximos no pueden ser negativos"),
-  minimum_points: z.coerce
-    .number()
-    .int()
-    .min(0, "Los puntos mínimos no pueden ser negativos"),
-});
+function buildSchema(t: ReturnType<typeof useTranslations<"annual_folders.validation">>) {
+  return z.object({
+    name: z
+      .string()
+      .min(3, t("name_min", { min: 3 }))
+      .max(100, t("name_max", { max: 100 })),
+    description: z
+      .string()
+      .max(500, t("description_max", { max: 500 }))
+      .optional(),
+    order: z.coerce.number().int().min(1, t("order_min", { min: 1 })),
+    required: z.boolean(),
+    max_points: z.coerce
+      .number()
+      .int()
+      .min(0, t("max_points_min")),
+    minimum_points: z.coerce
+      .number()
+      .int()
+      .min(0, t("minimum_points_min")),
+  });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -72,8 +74,10 @@ export function SectionFormDialog({
   onSuccess,
 }: SectionFormDialogProps) {
   const t = useTranslations("annual_folders");
+  const tVal = useTranslations("annual_folders.validation");
   const isEdit = !!section;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const {
     register,
@@ -83,7 +87,7 @@ export function SectionFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/annual-folders/template-form-dialog.tsx
+++ b/src/components/annual-folders/template-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useForm, Controller } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
@@ -31,51 +31,53 @@ import type { ClubType, EcclesiasticalYear } from "@/lib/api/catalogs";
 import { listUnions, listLocalFields } from "@/lib/api/geography";
 import type { Union, LocalField } from "@/lib/api/geography";
 
-// ─── Schema ───────────────────────────────────────────────────────────────────
+// ─── Schema factory ───────────────────────────────────────────────────────────
 
 const ownerTierSchema = z.enum(["union", "local_field"]);
 
-const formSchema = z
-  .object({
-    name: z
-      .string()
-      .min(3, "El nombre debe tener al menos 3 caracteres")
-      .max(100, "El nombre no puede superar 100 caracteres"),
-    club_type_id: z.coerce.number().int().positive("Selecciona un tipo de club"),
-    ecclesiastical_year_id: z.coerce
-      .number()
-      .int()
-      .positive("Selecciona un año eclesiástico"),
-    minimum_points: z.coerce
-      .number()
-      .int()
-      .min(0, "Los puntos mínimos no pueden ser negativos"),
-    closing_date: z.string().optional(),
-    owner_tier: ownerTierSchema,
-    owner_union_id: z.coerce.number().int().nullable().optional(),
-    owner_local_field_id: z.coerce.number().int().nullable().optional(),
-  })
-  .superRefine((data, ctx) => {
-    if (data.owner_tier === "union") {
-      if (!data.owner_union_id || data.owner_union_id <= 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["owner_union_id"],
-          message: "Selecciona una unión",
-        });
+function buildSchema(t: ReturnType<typeof useTranslations<"annual_folders.validation">>) {
+  return z
+    .object({
+      name: z
+        .string()
+        .min(3, t("name_min", { min: 3 }))
+        .max(100, t("name_max", { max: 100 })),
+      club_type_id: z.coerce.number().int().positive(t("club_type_required")),
+      ecclesiastical_year_id: z.coerce
+        .number()
+        .int()
+        .positive(t("ecclesiastical_year_required")),
+      minimum_points: z.coerce
+        .number()
+        .int()
+        .min(0, t("minimum_points_min")),
+      closing_date: z.string().optional(),
+      owner_tier: ownerTierSchema,
+      owner_union_id: z.coerce.number().int().nullable().optional(),
+      owner_local_field_id: z.coerce.number().int().nullable().optional(),
+    })
+    .superRefine((data, ctx) => {
+      if (data.owner_tier === "union") {
+        if (!data.owner_union_id || data.owner_union_id <= 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["owner_union_id"],
+            message: t("owner_union_required"),
+          });
+        }
+      } else {
+        if (!data.owner_local_field_id || data.owner_local_field_id <= 0) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["owner_local_field_id"],
+            message: t("owner_local_field_required"),
+          });
+        }
       }
-    } else {
-      if (!data.owner_local_field_id || data.owner_local_field_id <= 0) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          path: ["owner_local_field_id"],
-          message: "Selecciona un campo local",
-        });
-      }
-    }
-  });
+    });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -108,8 +110,10 @@ export function TemplateFormDialog({
   onSuccess,
 }: TemplateFormDialogProps) {
   const t = useTranslations("annual_folders");
+  const tVal = useTranslations("annual_folders.validation");
   const isEdit = Boolean(template);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   // Owner catalog data
   const [unions, setUnions] = useState<Union[]>([]);
@@ -142,7 +146,7 @@ export function TemplateFormDialog({
     control,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues,
   });
 

--- a/src/components/camporees/camporee-form-dialog.tsx
+++ b/src/components/camporees/camporee-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -22,27 +22,29 @@ import { useTranslations } from "next-intl";
 import { createCamporee, updateCamporee } from "@/lib/api/camporees";
 import type { Camporee } from "@/lib/api/camporees";
 
-// ─── Schema ────────────────────────────────────────────────────────────────────
+// ─── Schema factory ────────────────────────────────────────────────────────────
 
-const formSchema = z
-  .object({
-    name: z.string().min(1, "El nombre es obligatorio"),
-    description: z.string().optional(),
-    start_date: z.string().min(1, "La fecha de inicio es obligatoria"),
-    end_date: z.string().min(1, "La fecha de fin es obligatoria"),
-    local_camporee_place: z.string().min(1, "El lugar es obligatorio"),
-    local_field_id: z.coerce.number().int().min(1, "El campo local es obligatorio"),
-    registration_cost: z.coerce.number().min(0).optional(),
-    includes_adventurers: z.boolean(),
-    includes_pathfinders: z.boolean(),
-    includes_master_guides: z.boolean(),
-  })
-  .refine((data) => data.start_date <= data.end_date, {
-    message: "La fecha de fin debe ser igual o posterior a la fecha de inicio",
-    path: ["end_date"],
-  });
+function buildSchema(t: ReturnType<typeof useTranslations<"camporees.validation">>) {
+  return z
+    .object({
+      name: z.string().min(1, t("name_required")),
+      description: z.string().optional(),
+      start_date: z.string().min(1, t("start_date_required")),
+      end_date: z.string().min(1, t("end_date_required")),
+      local_camporee_place: z.string().min(1, t("place_required")),
+      local_field_id: z.coerce.number().int().min(1, t("local_field_required")),
+      registration_cost: z.coerce.number().min(0).optional(),
+      includes_adventurers: z.boolean(),
+      includes_pathfinders: z.boolean(),
+      includes_master_guides: z.boolean(),
+    })
+    .refine((data) => data.start_date <= data.end_date, {
+      message: t("end_date_after_start_full"),
+      path: ["end_date"],
+    });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
@@ -70,8 +72,10 @@ export function CamporeeFormDialog({
   onSuccess,
 }: CamporeeFormDialogProps) {
   const t = useTranslations("camporees");
+  const tVal = useTranslations("camporees.validation");
   const isEdit = !!camporee;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const {
     register,
@@ -81,7 +85,7 @@ export function CamporeeFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/camporees/camporee-payments-panel.tsx
+++ b/src/components/camporees/camporee-payments-panel.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/camporees/camporee-approval-dialog";
 import { useTranslations } from "next-intl";
 import { ApiError } from "@/lib/api/client";
+import { useFormatDate, useFormatCurrency } from "@/lib/format-locale";
 
 // ─── Payment type badge ────────────────────────────────────────────────────────
 
@@ -69,29 +70,6 @@ function PaymentStatusBadge({ status, t }: { status?: string | null; t: ReturnTy
   );
 }
 
-// ─── Date helper ───────────────────────────────────────────────────────────────
-
-function formatDate(dateStr?: string | null): string {
-  if (!dateStr) return "—";
-  try {
-    return new Date(dateStr).toLocaleDateString("es-MX", {
-      day: "numeric",
-      month: "short",
-      year: "numeric",
-    });
-  } catch {
-    return "—";
-  }
-}
-
-function formatCurrency(amount: number): string {
-  return amount.toLocaleString("es-MX", {
-    style: "currency",
-    currency: "MXN",
-    minimumFractionDigits: 2,
-  });
-}
-
 // ─── Summary ───────────────────────────────────────────────────────────────────
 
 interface PaymentSummaryProps {
@@ -100,6 +78,7 @@ interface PaymentSummaryProps {
 }
 
 function PaymentSummary({ payments, t }: PaymentSummaryProps) {
+  const formatCurrency = useFormatCurrency();
   const total = payments.reduce((sum, p) => sum + p.amount, 0);
 
   const byType = payments.reduce<Record<string, number>>((acc, p) => {
@@ -166,8 +145,19 @@ export function CamporeePaymentsPanel({
   isUnionCamporee = false,
 }: CamporeePaymentsPanelProps) {
   const t = useTranslations("camporees");
+  const formatDateLocale = useFormatDate();
+  const formatCurrency = useFormatCurrency();
   const [approvingId, setApprovingId] = useState<string | null>(null);
   const [dialog, setDialog] = useState<DialogState>(null);
+
+  function formatDate(dateStr?: string | null): string {
+    if (!dateStr) return "—";
+    try {
+      return formatDateLocale(dateStr, { day: "numeric", month: "short", year: "numeric" });
+    } catch {
+      return "—";
+    }
+  }
 
   async function handleApprove(payment: CamporeePayment) {
     const paymentUuid = payment.camporee_payment_id;

--- a/src/components/camporees/payment-dialog.tsx
+++ b/src/components/camporees/payment-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -28,20 +28,22 @@ import { useTranslations } from "next-intl";
 import { createPayment, updatePayment } from "@/lib/api/camporees";
 import type { CamporeePayment, CamporeeMember, PaymentType } from "@/lib/api/camporees";
 
-// ─── Schema ────────────────────────────────────────────────────────────────────
+// ─── Schema factory ────────────────────────────────────────────────────────────
 
-const formSchema = z.object({
-  member_id: z.string().min(1, "Seleccione un miembro"),
-  amount: z.coerce
-    .number()
-    .positive("El monto debe ser mayor a cero"),
-  payment_type: z.enum(["inscription", "materials", "other"] as const),
-  reference: z.string().optional(),
-  notes: z.string().optional(),
-  paid_at: z.string().optional(),
-});
+function buildSchema(t: ReturnType<typeof useTranslations<"camporees.validation">>) {
+  return z.object({
+    member_id: z.string().min(1, t("member_required")),
+    amount: z.coerce
+      .number()
+      .positive(t("amount_positive")),
+    payment_type: z.enum(["inscription", "materials", "other"] as const),
+    reference: z.string().optional(),
+    notes: z.string().optional(),
+    paid_at: z.string().optional(),
+  });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Labels ───────────────────────────────────────────────────────────────────
 
@@ -85,8 +87,10 @@ export function PaymentDialog({
   onSuccess,
 }: PaymentDialogProps) {
   const t = useTranslations("camporees");
+  const tVal = useTranslations("camporees.validation");
   const isEditing = payment != null;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const {
     register,
@@ -96,7 +100,7 @@ export function PaymentDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       member_id: "",
       amount: undefined,

--- a/src/components/camporees/union-camporee-form-dialog.tsx
+++ b/src/components/camporees/union-camporee-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -30,27 +30,29 @@ import { createUnionCamporee, updateUnionCamporee } from "@/lib/api/camporees";
 import type { UnionCamporee } from "@/lib/api/camporees";
 import type { Union } from "@/lib/api/geography";
 
-// ─── Schema ────────────────────────────────────────────────────────────────────
+// ─── Schema factory ────────────────────────────────────────────────────────────
 
-const formSchema = z
-  .object({
-    name: z.string().min(1, "El nombre es obligatorio"),
-    description: z.string().optional(),
-    start_date: z.string().min(1, "La fecha de inicio es obligatoria"),
-    end_date: z.string().min(1, "La fecha de fin es obligatoria"),
-    union_id: z.coerce.number().int().min(1, "La unión es obligatoria"),
-    place: z.string().min(1, "El lugar es obligatorio"),
-    registration_cost: z.coerce.number().min(0).optional(),
-    includes_adventurers: z.boolean(),
-    includes_pathfinders: z.boolean(),
-    includes_master_guides: z.boolean(),
-  })
-  .refine((data) => data.start_date <= data.end_date, {
-    message: "La fecha de fin debe ser igual o posterior a la de inicio",
-    path: ["end_date"],
-  });
+function buildSchema(t: ReturnType<typeof useTranslations<"camporees.validation">>) {
+  return z
+    .object({
+      name: z.string().min(1, t("name_required")),
+      description: z.string().optional(),
+      start_date: z.string().min(1, t("start_date_required")),
+      end_date: z.string().min(1, t("end_date_required")),
+      union_id: z.coerce.number().int().min(1, t("union_required")),
+      place: z.string().min(1, t("place_required")),
+      registration_cost: z.coerce.number().min(0).optional(),
+      includes_adventurers: z.boolean(),
+      includes_pathfinders: z.boolean(),
+      includes_master_guides: z.boolean(),
+    })
+    .refine((data) => data.start_date <= data.end_date, {
+      message: t("end_date_after_start"),
+      path: ["end_date"],
+    });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
@@ -79,8 +81,10 @@ export function UnionCamporeeFormDialog({
   onSuccess,
 }: UnionCamporeeFormDialogProps) {
   const t = useTranslations("camporees");
+  const tVal = useTranslations("camporees.validation");
   const isEdit = !!camporee;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const {
     register,
@@ -90,7 +94,7 @@ export function UnionCamporeeFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/clubs/club-sections-panel.tsx
+++ b/src/components/clubs/club-sections-panel.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/select";
 import { createClubSectionAction, type ClubActionState } from "@/lib/clubs/actions";
 import { MemberOfMonthCard } from "@/components/member-of-month/member-of-month-card";
-import { formatCurrency } from "@/lib/currency";
+import { useFormatCurrency } from "@/lib/format-locale";
 
 type Section = {
   club_section_id?: number;
@@ -149,6 +149,7 @@ interface ClubSectionsPanelProps {
 
 export function ClubSectionsPanel({ clubId, sections, clubTypes }: ClubSectionsPanelProps) {
   const t = useTranslations("clubs");
+  const formatCurrency = useFormatCurrency();
   const [openForms, setOpenForms] = useState<Set<number>>(new Set());
   const [refreshKey, setRefreshKey] = useState(0);
 

--- a/src/components/enrollments/enrollments-table.tsx
+++ b/src/components/enrollments/enrollments-table.tsx
@@ -28,6 +28,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { validateEnrollment, type Enrollment, type InvestitureStatus } from "@/lib/api/enrollments";
 import { ApiError } from "@/lib/api/client";
+import { useFormatDate } from "@/lib/format-locale";
 
 // ─── Status badge ─────────────────────────────────────────────────────────────
 
@@ -71,19 +72,6 @@ function resolveEmail(enrollment: Enrollment): string {
 
 function resolveClassName(enrollment: Enrollment): string {
   return enrollment.class?.name ?? enrollment.classes?.name ?? "—";
-}
-
-function resolveDate(dateStr: string | null | undefined): string {
-  if (!dateStr) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    }).format(new Date(dateStr));
-  } catch {
-    return dateStr;
-  }
 }
 
 // ─── Reject confirmation dialog ───────────────────────────────────────────────
@@ -137,6 +125,7 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
   const [processingId, setProcessingId] = useState<number | null>(null);
+  const formatDate = useFormatDate();
 
   const handleAction = async (
     enrollmentId: number,
@@ -239,12 +228,12 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
 
                 {/* Enrollment date */}
                 <TableCell className="text-sm text-muted-foreground">
-                  {resolveDate(enrollment.enrollment_date)}
+                  {enrollment.enrollment_date ? formatDate(enrollment.enrollment_date) : "—"}
                 </TableCell>
 
                 {/* Submitted at */}
                 <TableCell className="text-sm text-muted-foreground">
-                  {resolveDate(enrollment.submitted_at)}
+                  {enrollment.submitted_at ? formatDate(enrollment.submitted_at) : "—"}
                 </TableCell>
 
                 {/* Actions */}

--- a/src/components/evidence-review/evidence-detail-dialog.tsx
+++ b/src/components/evidence-review/evidence-detail-dialog.tsx
@@ -24,23 +24,7 @@ import { getEvidenceDetail, type EvidenceDetail, type EvidenceType } from "@/lib
 import { EvidenceStatusBadge } from "@/components/evidence-review/evidence-status-badge";
 import { EvidenceTypeBadge } from "@/components/evidence-review/evidence-type-badge";
 import { ApiError } from "@/lib/api/client";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatDate(iso?: string | null): string {
-  if (!iso) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
-}
+import { useFormatDateTime } from "@/lib/format-locale";
 
 function isImageFile(fileType: string, fileUrl: string): boolean {
   const imageTypes = ["image", "image/jpeg", "image/png", "image/webp", "image/gif"];
@@ -141,6 +125,7 @@ export function EvidenceDetailDialog({
   onOpenChange,
 }: EvidenceDetailDialogProps) {
   const t = useTranslations("evidence_review");
+  const formatDate = useFormatDateTime();
   const [detail, setDetail] = useState<EvidenceDetail | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -222,7 +207,7 @@ export function EvidenceDetailDialog({
                 <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
                 <div>
                   <p className="text-xs text-muted-foreground">Enviado el</p>
-                  <p>{formatDate(detail.submitted_at)}</p>
+                  <p>{detail.submitted_at ? formatDate(detail.submitted_at) : "—"}</p>
                 </div>
               </div>
 

--- a/src/components/evidence-review/evidence-history-dialog.tsx
+++ b/src/components/evidence-review/evidence-history-dialog.tsx
@@ -17,22 +17,7 @@ import {
   type EvidenceType,
 } from "@/lib/api/evidence-review";
 import { ApiError } from "@/lib/api/client";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatDate(iso: string): string {
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
-}
+import { useFormatDateTime } from "@/lib/format-locale";
 
 // Action intent data (no user-facing strings here — labels resolved via t() below)
 const actionIntentMap: Record<
@@ -89,6 +74,7 @@ export function EvidenceHistoryDialog({
   onOpenChange,
 }: EvidenceHistoryDialogProps) {
   const t = useTranslations("evidence_review.history");
+  const formatDate = useFormatDateTime();
 
   // Evidence history is append-only — once fetched it never changes.
   const { data: entries = [], isLoading: loading } = useQuery({

--- a/src/components/evidence-review/evidence-review-table.tsx
+++ b/src/components/evidence-review/evidence-review-table.tsx
@@ -30,21 +30,7 @@ import { EvidenceDetailDialog } from "@/components/evidence-review/evidence-deta
 import { EvidenceHistoryDialog } from "@/components/evidence-review/evidence-history-dialog";
 import { EvidenceBulkActionBar } from "@/components/evidence-review/evidence-bulk-action-bar";
 import type { EvidenceItem, EvidenceType } from "@/lib/api/evidence-review";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatDate(iso?: string | null): string {
-  if (!iso) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
-}
+import { useFormatDate } from "@/lib/format-locale";
 
 function isPending(status: string, type: EvidenceType): boolean {
   if (status === "SUBMITTED") return true;
@@ -169,6 +155,7 @@ interface EvidenceReviewTableProps {
 
 export function EvidenceReviewTable({ items, onRefresh }: EvidenceReviewTableProps) {
   const t = useTranslations("evidence_review.table");
+  const formatDate = useFormatDate();
   const [dialog, setDialog] = useState<DialogState>(null);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
@@ -314,7 +301,7 @@ export function EvidenceReviewTable({ items, onRefresh }: EvidenceReviewTablePro
                   </TableCell>
 
                   <TableCell className="px-3 py-2.5 align-middle tabular-nums text-sm text-muted-foreground">
-                    {formatDate(item.submitted_at)}
+                    {item.submitted_at ? formatDate(item.submitted_at) : "—"}
                   </TableCell>
 
                   <TableCell className="px-3 py-2.5 align-middle">

--- a/src/components/finances/delete-transaction-dialog.tsx
+++ b/src/components/finances/delete-transaction-dialog.tsx
@@ -15,11 +15,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useTranslations } from "next-intl";
 import { deleteFinance, type Finance } from "@/lib/api/finances";
-import { formatCurrency } from "@/lib/currency";
-
-function formatAmount(cents: number): string {
-  return formatCurrency(cents / 100);
-}
+import { useFormatCurrency } from "@/lib/format-locale";
 
 interface DeleteTransactionDialogProps {
   open: boolean;
@@ -35,7 +31,12 @@ export function DeleteTransactionDialog({
   onSuccess,
 }: DeleteTransactionDialogProps) {
   const t = useTranslations("finances");
+  const formatCurrency = useFormatCurrency();
   const [isDeleting, setIsDeleting] = useState(false);
+
+  function formatAmount(cents: number): string {
+    return formatCurrency(cents / 100);
+  }
 
   async function handleDelete() {
     if (!finance) return;

--- a/src/components/finances/finances-summary-cards.tsx
+++ b/src/components/finances/finances-summary-cards.tsx
@@ -4,14 +4,8 @@ import { TrendingUp, TrendingDown, Wallet } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { FinanceSummary } from "@/lib/api/finances";
-import { formatCurrency } from "@/lib/currency";
+import { useFormatCurrency } from "@/lib/format-locale";
 import { useTranslations } from "next-intl";
-
-// ─── Amount formatter ─────────────────────────────────────────────────────────
-
-function formatAmount(cents: number): string {
-  return formatCurrency(cents / 100);
-}
 
 // ─── Skeleton ─────────────────────────────────────────────────────────────────
 
@@ -44,7 +38,12 @@ interface FinancesSummaryCardsProps {
 
 export function FinancesSummaryCards({ summary }: FinancesSummaryCardsProps) {
   const t = useTranslations("finances");
+  const formatCurrency = useFormatCurrency();
   const isPositiveBalance = summary.balance >= 0;
+
+  function formatAmount(cents: number): string {
+    return formatCurrency(cents / 100);
+  }
 
   const movementsSub =
     summary.movement_count === 1

--- a/src/components/finances/transactions-table.tsx
+++ b/src/components/finances/transactions-table.tsx
@@ -28,23 +28,12 @@ import { DollarSign } from "lucide-react";
 import type { Finance, FinanceSortField } from "@/lib/api/finances";
 import { formatCurrency } from "@/lib/currency";
 import { useTranslations } from "next-intl";
+import { useFormatDate } from "@/lib/format-locale";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function formatAmount(cents: number): string {
   return formatCurrency(cents / 100);
-}
-
-function formatDate(dateStr: string): string {
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "2-digit",
-      year: "numeric",
-    }).format(new Date(dateStr));
-  } catch {
-    return dateStr;
-  }
 }
 
 const MONTH_KEYS: Record<number, string> = {
@@ -138,6 +127,7 @@ export function TransactionsTable({
   onSort,
 }: TransactionsTableProps) {
   const t = useTranslations("finances");
+  const formatDate = useFormatDate();
 
   if (items.length === 0) {
     return (
@@ -239,7 +229,7 @@ export function TransactionsTable({
             return (
               <TableRow key={finance.finance_id} className="hover:bg-muted/30">
                 <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums">
-                  {formatDate(finance.finance_date)}
+                  {formatDate(finance.finance_date, { day: "2-digit", month: "2-digit", year: "numeric" })}
                 </TableCell>
                 <TableCell className="max-w-xs px-3 py-2.5 align-middle">
                   <span className="truncate text-sm">

--- a/src/components/folders/folder-form-dialog.tsx
+++ b/src/components/folders/folder-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
@@ -22,21 +22,23 @@ import { Switch } from "@/components/ui/switch";
 import { createFolder, updateFolder } from "@/lib/api/folders";
 import type { FolderTemplate } from "@/lib/api/folders";
 
-// ─── Schema ───────────────────────────────────────────────────────────────────
+// ─── Schema factory ───────────────────────────────────────────────────────────
 
-const formSchema = z.object({
-  name: z
-    .string()
-    .min(3, "El nombre debe tener al menos 3 caracteres")
-    .max(100, "El nombre no puede superar 100 caracteres"),
-  description: z
-    .string()
-    .max(500, "La descripción no puede superar 500 caracteres")
-    .optional(),
-  active: z.boolean(),
-});
+function buildSchema(t: ReturnType<typeof useTranslations<"folders.validation">>) {
+  return z.object({
+    name: z
+      .string()
+      .min(3, t("name_min", { min: 3 }))
+      .max(100, t("name_max", { max: 100 })),
+    description: z
+      .string()
+      .max(500, t("description_max", { max: 500 }))
+      .optional(),
+    active: z.boolean(),
+  });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -56,8 +58,10 @@ export function FolderFormDialog({
   onSuccess,
 }: FolderFormDialogProps) {
   const t = useTranslations("folders");
+  const tVal = useTranslations("folders.validation");
   const isEdit = !!folder;
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const {
     register,
@@ -67,7 +71,7 @@ export function FolderFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/insurance/insurance-form-dialog.tsx
+++ b/src/components/insurance/insurance-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -28,7 +28,7 @@ import { useTranslations } from "next-intl";
 import { createInsurance, updateInsurance, INSURANCE_TYPE_LABELS } from "@/lib/api/insurance";
 import type { MemberInsurance, InsuranceType } from "@/lib/api/insurance";
 
-// ─── Schema ───────────────────────────────────────────────────────────────────
+// ─── Schema factory ───────────────────────────────────────────────────────────
 
 const INSURANCE_TYPES: InsuranceType[] = [
   "GENERAL_ACTIVITIES",
@@ -36,16 +36,18 @@ const INSURANCE_TYPES: InsuranceType[] = [
   "HIGH_RISK",
 ];
 
-const formSchema = z.object({
-  insurance_type: z.enum(["GENERAL_ACTIVITIES", "CAMPOREE", "HIGH_RISK"]),
-  start_date: z.string().min(1, "La fecha de inicio es obligatoria"),
-  end_date: z.string().min(1, "La fecha de fin es obligatoria"),
-  policy_number: z.string().optional(),
-  provider: z.string().optional(),
-  coverage_amount: z.coerce.number().min(0).optional(),
-});
+function buildSchema(t: ReturnType<typeof useTranslations<"insurance.validation">>) {
+  return z.object({
+    insurance_type: z.enum(["GENERAL_ACTIVITIES", "CAMPOREE", "HIGH_RISK"]),
+    start_date: z.string().min(1, t("start_date_required")),
+    end_date: z.string().min(1, t("end_date_required")),
+    policy_number: z.string().optional(),
+    provider: z.string().optional(),
+    coverage_amount: z.coerce.number().min(0).optional(),
+  });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -80,9 +82,11 @@ export function InsuranceFormDialog({
   const ins = member?.insurance ?? null;
   const isEdit = !!ins;
   const t = useTranslations("insurance");
+  const tVal = useTranslations("insurance.validation");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [evidenceFile, setEvidenceFile] = useState<File | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const {
     register,
@@ -92,7 +96,7 @@ export function InsuranceFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       insurance_type: "GENERAL_ACTIVITIES",
       start_date: "",

--- a/src/components/insurance/insurance-table.tsx
+++ b/src/components/insurance/insurance-table.tsx
@@ -19,28 +19,8 @@ import {
 } from "@/components/shared/sortable-header";
 import { INSURANCE_TYPE_LABELS } from "@/lib/api/insurance";
 import type { MemberInsurance, InsuranceType } from "@/lib/api/insurance";
-import { formatCurrency as formatCurrencyUtil } from "@/lib/currency";
+import { useFormatDate, useFormatCurrency } from "@/lib/format-locale";
 import { useTranslations } from "next-intl";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatDate(value: string | null | undefined): string {
-  if (!value) return "—";
-  try {
-    return new Date(value).toLocaleDateString("es-MX", {
-      day: "2-digit",
-      month: "2-digit",
-      year: "numeric",
-    });
-  } catch {
-    return value;
-  }
-}
-
-function formatCurrency(value: number | null | undefined): string {
-  if (value == null) return "—";
-  return formatCurrencyUtil(value);
-}
 
 function memberFullName(member: MemberInsurance): string {
   const parts = [member.name, member.paternal_last_name, member.maternal_last_name].filter(Boolean);
@@ -97,8 +77,24 @@ interface InsuranceTableProps {
 
 export function InsuranceTable({ items, onEdit, onDelete }: InsuranceTableProps) {
   const t = useTranslations("insurance");
+  const formatDateLocale = useFormatDate();
+  const formatCurrencyLocale = useFormatCurrency();
   const [sortField, setSortField] = useState<SortField>("member_name");
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+
+  function formatDate(value: string | null | undefined): string {
+    if (!value) return "—";
+    try {
+      return formatDateLocale(value, { day: "2-digit", month: "2-digit", year: "numeric" });
+    } catch {
+      return value;
+    }
+  }
+
+  function formatCurrency(value: number | null | undefined): string {
+    if (value == null) return "—";
+    return formatCurrencyLocale(value);
+  }
 
   const handleSort = (field: SortField, direction: SortDirection) => {
     setSortField(field);

--- a/src/components/inventory/inventory-form-dialog.tsx
+++ b/src/components/inventory/inventory-form-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -32,22 +32,24 @@ import {
 } from "@/lib/api/inventory";
 import type { InventoryItem, InventoryCategory, InstanceType } from "@/lib/api/inventory";
 
-// ─── Schema ───────────────────────────────────────────────────────────────────
+// ─── Schema factory ───────────────────────────────────────────────────────────
 
-const formSchema = z.object({
-  name: z
-    .string()
-    .min(3, "El nombre debe tener al menos 3 caracteres")
-    .max(100, "El nombre no puede superar 100 caracteres"),
-  description: z.string().max(500, "La descripción no puede superar 500 caracteres").optional(),
-  inventory_category_id: z.coerce
-    .number()
-    .int()
-    .positive("Selecciona una categoría"),
-  amount: z.coerce.number().int().min(0, "La cantidad no puede ser negativa"),
-});
+function buildSchema(t: ReturnType<typeof useTranslations<"inventory.validation">>) {
+  return z.object({
+    name: z
+      .string()
+      .min(3, t("name_min", { min: 3 }))
+      .max(100, t("name_max", { max: 100 })),
+    description: z.string().max(500, t("description_max", { max: 500 })).optional(),
+    inventory_category_id: z.coerce
+      .number()
+      .int()
+      .positive(t("category_required")),
+    amount: z.coerce.number().int().min(0, t("amount_min")),
+  });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
@@ -74,7 +76,9 @@ export function InventoryFormDialog({
 }: InventoryFormDialogProps) {
   const isEdit = !!item;
   const t = useTranslations("inventory");
+  const tVal = useTranslations("inventory.validation");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const {
     register,
@@ -84,7 +88,7 @@ export function InventoryFormDialog({
     watch,
     formState: { errors },
   } = useForm<FormValues>({
-    resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
+    resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
       description: "",

--- a/src/components/inventory/inventory-history-dialog.tsx
+++ b/src/components/inventory/inventory-history-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { getInventoryHistory } from "@/lib/api/inventory";
 import type { InventoryHistoryEntry, InventoryAction } from "@/lib/api/inventory";
+import { useFormatDateTime } from "@/lib/format-locale";
 
 // ─── Action config (visual/structural constants — labels resolved via t() inside component) ──
 
@@ -46,20 +47,6 @@ const ACTION_META: Record<
 };
 
 // ─── Helpers ────────────────────────────────────────────────────────────────────
-
-function formatDate(isoDate: string): string {
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(isoDate));
-  } catch {
-    return isoDate;
-  }
-}
 
 function getPerformerName(
   entry: InventoryHistoryEntry,
@@ -97,6 +84,7 @@ interface HistoryTimelineProps {
 
 function HistoryTimeline({ entries }: HistoryTimelineProps) {
   const t = useTranslations("inventory");
+  const formatDate = useFormatDateTime();
 
   if (entries.length === 0) {
     return (

--- a/src/components/investiture/config-table.tsx
+++ b/src/components/investiture/config-table.tsx
@@ -16,21 +16,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { EmptyState } from "@/components/shared/empty-state";
 import { Settings2 } from "lucide-react";
 import type { InvestitureConfig } from "@/lib/api/investiture";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatDate(iso?: string | null): string {
-  if (!iso) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
-}
+import { useFormatDate } from "@/lib/format-locale";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -44,6 +30,7 @@ interface ConfigTableProps {
 
 export function ConfigTable({ configs, onEdit, onDelete }: ConfigTableProps) {
   const t = useTranslations("investiture");
+  const formatDate = useFormatDate();
 
   if (configs.length === 0) {
     return (
@@ -90,10 +77,10 @@ export function ConfigTable({ configs, onEdit, onDelete }: ConfigTableProps) {
                 {config.ecclesiastical_years?.name ?? t("configTable.yearFallback", { id: config.ecclesiastical_year_id })}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
-                {formatDate(config.submission_deadline)}
+                {config.submission_deadline ? formatDate(config.submission_deadline) : "—"}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
-                {formatDate(config.investiture_date)}
+                {config.investiture_date ? formatDate(config.investiture_date) : "—"}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle">
                 {config.active ? (

--- a/src/components/investiture/history-timeline.tsx
+++ b/src/components/investiture/history-timeline.tsx
@@ -4,20 +4,7 @@ import { CheckCircle2, XCircle, Send, RefreshCw, Clock } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { cn } from "@/lib/utils";
 import type { InvestitureHistoryEntry, InvestitureAction } from "@/lib/api/investiture";
-
-function formatDate(isoDate: string): string {
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(isoDate));
-  } catch {
-    return isoDate;
-  }
-}
+import { useFormatDateTime } from "@/lib/format-locale";
 
 function getPerformerName(entry: InvestitureHistoryEntry, systemLabel: string): string {
   if (entry.performer?.first_name || entry.performer?.last_name) {
@@ -35,6 +22,7 @@ interface HistoryTimelineProps {
 
 export function HistoryTimeline({ entries }: HistoryTimelineProps) {
   const t = useTranslations("investiture");
+  const formatDate = useFormatDateTime();
 
   const actionConfig: Record<
     InvestitureAction,

--- a/src/components/investiture/pending-table.tsx
+++ b/src/components/investiture/pending-table.tsx
@@ -33,6 +33,7 @@ import {
   type ValidateAction,
 } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
+import { useFormatDate } from "@/lib/format-locale";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -41,19 +42,6 @@ function getMemberName(enrollment: PendingEnrollment, fallback: string): string 
   if (!u) return fallback;
   const full = [u.first_name, u.last_name].filter(Boolean).join(" ");
   return full || u.email || fallback;
-}
-
-function formatDate(iso?: string | null): string {
-  if (!iso) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -75,6 +63,7 @@ type DialogState =
 
 export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
   const t = useTranslations("investiture");
+  const formatDate = useFormatDate();
   const [dialog, setDialog] = useState<DialogState>(null);
   const [historyEntries, setHistoryEntries] = useState<InvestitureHistoryEntry[]>([]);
   const [loadingHistory, setLoadingHistory] = useState(false);
@@ -171,7 +160,7 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
                     {enrollment.club?.name ?? "—"}
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
-                    {formatDate(enrollment.submitted_at)}
+                    {enrollment.submitted_at ? formatDate(enrollment.submitted_at) : "—"}
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle">
                     <InvestitureStatusBadge

--- a/src/components/investiture/pipeline-history-dialog.tsx
+++ b/src/components/investiture/pipeline-history-dialog.tsx
@@ -21,22 +21,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { getPipelineHistory, type PipelineHistoryEntry } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatDate(iso: string): string {
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
-}
+import { useFormatDateTime } from "@/lib/format-locale";
 
 function getPerformerName(
   entry: PipelineHistoryEntry,
@@ -81,6 +66,7 @@ export function PipelineHistoryDialog({
   onOpenChange,
 }: PipelineHistoryDialogProps) {
   const t = useTranslations("investiture");
+  const formatDate = useFormatDateTime();
 
   const actionConfig: Record<string, ActionEntryConfig> = {
     SUBMITTED: {

--- a/src/components/investiture/pipeline-reject-dialog.tsx
+++ b/src/components/investiture/pipeline-reject-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -21,13 +21,15 @@ import { Textarea } from "@/components/ui/textarea";
 import { pipelineReject } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
 
-// ─── Schema ───────────────────────────────────────────────────────────────────
+// ─── Schema factory ───────────────────────────────────────────────────────────
 
-const schema = z.object({
-  reason: z.string().min(1, "El motivo de rechazo es obligatorio"),
-});
+function buildSchema(t: ReturnType<typeof useTranslations<"investiture.validation">>) {
+  return z.object({
+    reason: z.string().min(1, t("reason_required")),
+  });
+}
 
-type FormValues = z.infer<typeof schema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -49,7 +51,9 @@ export function PipelineRejectDialog({
   onSuccess,
 }: PipelineRejectDialogProps) {
   const t = useTranslations("investiture");
+  const tVal = useTranslations("investiture.validation");
   const [isPending, setIsPending] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const form = useForm<FormValues>({
     resolver: zodResolver(schema),

--- a/src/components/investiture/pipeline-table.tsx
+++ b/src/components/investiture/pipeline-table.tsx
@@ -36,6 +36,7 @@ import {
   type PipelineStatus,
 } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
+import { useFormatDate } from "@/lib/format-locale";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -44,19 +45,6 @@ function getMemberName(e: PipelineEnrollment): string {
   if (!u) return `Inscripción #${e.enrollment_id}`;
   const full = [u.first_name, u.last_name].filter(Boolean).join(" ");
   return full || u.email || `Inscripción #${e.enrollment_id}`;
-}
-
-function formatDate(iso?: string | null): string {
-  if (!iso) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -283,6 +271,7 @@ export function PipelineTable({
   userRole,
   onRefresh,
 }: PipelineTableProps) {
+  const formatDate = useFormatDate();
   const [dialog, setDialog] = useState<DialogState>(null);
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
@@ -428,7 +417,7 @@ export function PipelineTable({
                     {enrollment.section?.name ?? "—"}
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
-                    {formatDate(enrollment.submitted_at)}
+                    {enrollment.submitted_at ? formatDate(enrollment.submitted_at) : "—"}
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle">
                     <PipelineStatusBadge status={enrollment.status} />

--- a/src/components/investiture/validate-dialog.tsx
+++ b/src/components/investiture/validate-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -21,18 +21,20 @@ import { Textarea } from "@/components/ui/textarea";
 import { validateEnrollment, type ValidateAction } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
 
-// ─── Schemas ──────────────────────────────────────────────────────────────────
+// ─── Schema factories ─────────────────────────────────────────────────────────
 
 const approveSchema = z.object({
   comments: z.string().optional(),
 });
 
-const rejectSchema = z.object({
-  comments: z.string().min(1, "El motivo de rechazo es obligatorio"),
-});
+function buildRejectSchema(t: ReturnType<typeof useTranslations<"investiture.validation">>) {
+  return z.object({
+    comments: z.string().min(1, t("comments_required")),
+  });
+}
 
 type ApproveFormValues = z.infer<typeof approveSchema>;
-type RejectFormValues = z.infer<typeof rejectSchema>;
+type RejectFormValues = z.infer<ReturnType<typeof buildRejectSchema>>;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -56,9 +58,11 @@ export function ValidateDialog({
   onSuccess,
 }: ValidateDialogProps) {
   const t = useTranslations("investiture");
+  const tVal = useTranslations("investiture.validation");
   const [isPending, setIsPending] = useState(false);
 
   const isApprove = action === "APPROVED";
+  const rejectSchema = useMemo(() => buildRejectSchema(tVal), [tVal]);
   const schema = isApprove ? approveSchema : rejectSchema;
 
   const form = useForm<ApproveFormValues | RejectFormValues>({

--- a/src/components/membership/pending-members-table.tsx
+++ b/src/components/membership/pending-members-table.tsx
@@ -34,6 +34,7 @@ import {
   type MembershipRequest,
 } from "@/lib/api/membership-requests";
 import { ApiError } from "@/lib/api/client";
+import { useFormatDate, useFormatDateTime } from "@/lib/format-locale";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -46,34 +47,6 @@ function getUserName(user?: MembershipRequest["users"]): string {
 
 function getUserEmail(user?: MembershipRequest["users"]): string {
   return user?.email ?? "\u2014";
-}
-
-function formatDate(iso?: string | null): string {
-  if (!iso) return "\u2014";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
-}
-
-function formatDatetime(iso?: string | null): string {
-  if (!iso) return "\u2014";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
 }
 
 function getRoleName(role?: MembershipRequest["roles"]): string {
@@ -101,6 +74,8 @@ export function PendingMembersTable({
   initialRequests,
 }: PendingMembersTableProps) {
   const t = useTranslations("membership");
+  const formatDate = useFormatDate();
+  const formatDatetime = useFormatDateTime();
   const [requests, setRequests] = useState<MembershipRequest[]>(initialRequests);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [processingId, setProcessingId] = useState<string | null>(null);
@@ -223,7 +198,7 @@ export function PendingMembersTable({
 
                     {/* Requested date */}
                     <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
-                      {formatDate(req.created_at)}
+                      {req.created_at ? formatDate(req.created_at) : "—"}
                     </TableCell>
 
                     {/* Expires at */}
@@ -239,7 +214,7 @@ export function PendingMembersTable({
                               : "text-muted-foreground"
                           }`}
                         >
-                          {formatDatetime(req.expires_at)}
+                          {req.expires_at ? formatDatetime(req.expires_at) : "—"}
                         </span>
                       </div>
                     </TableCell>

--- a/src/components/notifications/notification-history-table.tsx
+++ b/src/components/notifications/notification-history-table.tsx
@@ -15,6 +15,7 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 import { getNotificationHistory, type NotificationLog } from "@/lib/api/notifications";
 import { ApiError } from "@/lib/api/client";
+import { getFormatDateTime } from "@/lib/format-locale";
 
 interface NotificationHistoryTableProps {
   page: number;
@@ -25,20 +26,6 @@ function typeVariant(type: string): "default" | "secondary" | "outline" {
   if (type === "BROADCAST") return "default";
   if (type === "USER") return "secondary";
   return "outline";
-}
-
-function formatDate(isoDate: string): string {
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(isoDate));
-  } catch {
-    return isoDate;
-  }
 }
 
 function senderName(log: NotificationLog): string {
@@ -64,6 +51,7 @@ export async function NotificationHistoryTable({
   limit,
 }: NotificationHistoryTableProps) {
   const t = await getTranslations("notifications.history");
+  const formatDate = await getFormatDateTime();
 
   let result: Awaited<ReturnType<typeof getNotificationHistory>> | null = null;
   let errorMessage: string | null = null;

--- a/src/components/reports/report-detail-client.tsx
+++ b/src/components/reports/report-detail-client.tsx
@@ -29,23 +29,15 @@ import {
   type MonthlyReport,
   type MonthlyReportAutoData,
 } from "@/lib/api/monthly-reports";
+import { useFormatDateTime } from "@/lib/format-locale";
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatDate(dateStr?: string | null): string {
-  if (!dateStr) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "2-digit",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(dateStr));
-  } catch {
-    return dateStr;
-  }
-}
+const REPORT_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+};
 
 // ─── Auto-data card ────────────────────────────────────────────────────────────
 
@@ -126,6 +118,7 @@ interface ReportDetailClientProps {
 export function ReportDetailClient({ report: initialReport }: ReportDetailClientProps) {
   const t = useTranslations("reports");
   const router = useRouter();
+  const formatDate = useFormatDateTime();
   const [report, setReport] = useState<MonthlyReport>(initialReport);
   const [generating, setGenerating] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -226,7 +219,7 @@ export function ReportDetailClient({ report: initialReport }: ReportDetailClient
             <div className="text-sm text-muted-foreground">
               {t("detail.labelGenerated")}{" "}
               <span className="font-medium text-foreground">
-                {formatDate(report.generated_at)}
+                {report.generated_at ? formatDate(report.generated_at, REPORT_DATE_OPTIONS) : "—"}
               </span>
             </div>
           </>
@@ -237,7 +230,7 @@ export function ReportDetailClient({ report: initialReport }: ReportDetailClient
             <div className="text-sm text-muted-foreground">
               {t("detail.labelSubmitted")}{" "}
               <span className="font-medium text-foreground">
-                {formatDate(report.submitted_at)}
+                {report.submitted_at ? formatDate(report.submitted_at, REPORT_DATE_OPTIONS) : "—"}
               </span>
             </div>
           </>

--- a/src/components/reports/reports-list-client.tsx
+++ b/src/components/reports/reports-list-client.tsx
@@ -48,6 +48,7 @@ import {
   type MonthlyReport,
   type ReportStatus,
 } from "@/lib/api/monthly-reports";
+import { useFormatDate } from "@/lib/format-locale";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -56,20 +57,11 @@ const YEARS = Array.from({ length: 5 }, (_, i) => currentYear - 2 + i);
 
 const MONTH_NUMBERS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;
 
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatDate(dateStr?: string | null): string {
-  if (!dateStr) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "2-digit",
-      year: "numeric",
-    }).format(new Date(dateStr));
-  } catch {
-    return dateStr;
-  }
-}
+const REPORTS_DATE_OPTIONS: Intl.DateTimeFormatOptions = {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+};
 
 // ─── Skeleton ─────────────────────────────────────────────────────────────────
 
@@ -112,6 +104,7 @@ interface ReportsListClientProps {
 export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
   const t = useTranslations("reports");
   const router = useRouter();
+  const formatDate = useFormatDate();
 
   // Filters
   const [filterYear, setFilterYear] = useState<number | undefined>(currentYear);
@@ -405,10 +398,10 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                           </Badge>
                         </TableCell>
                         <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
-                          {formatDate(report.generated_at)}
+                          {report.generated_at ? formatDate(report.generated_at, REPORTS_DATE_OPTIONS) : "—"}
                         </TableCell>
                         <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
-                          {formatDate(report.submitted_at)}
+                          {report.submitted_at ? formatDate(report.submitted_at, REPORTS_DATE_OPTIONS) : "—"}
                         </TableCell>
                         <TableCell>
                           <div className="flex items-center gap-1.5">
@@ -524,13 +517,13 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                       {report.generated_at && (
                         <div>
                           <dt className="text-muted-foreground">{t("list.tableHeaderGenerated")}</dt>
-                          <dd>{formatDate(report.generated_at)}</dd>
+                          <dd>{formatDate(report.generated_at, REPORTS_DATE_OPTIONS)}</dd>
                         </div>
                       )}
                       {report.submitted_at && (
                         <div>
                           <dt className="text-muted-foreground">{t("list.tableHeaderSubmitted")}</dt>
-                          <dd>{formatDate(report.submitted_at)}</dd>
+                          <dd>{formatDate(report.submitted_at, REPORTS_DATE_OPTIONS)}</dd>
                         </div>
                       )}
                     </dl>

--- a/src/components/requests/assignments-table.tsx
+++ b/src/components/requests/assignments-table.tsx
@@ -22,6 +22,7 @@ import {
   type ReviewAction,
   type ReviewRequestPayload,
 } from "@/lib/api/requests";
+import { useFormatDate } from "@/lib/format-locale";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -29,19 +30,6 @@ function getUserName(user?: AssignmentRequest["target_user"] | AssignmentRequest
   if (!user) return "—";
   const full = [user.first_name, user.last_name].filter(Boolean).join(" ");
   return full || user.email || "—";
-}
-
-function formatDate(iso?: string | null): string {
-  if (!iso) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -60,6 +48,7 @@ interface AssignmentsTableProps {
 
 export function AssignmentsTable({ requests, onRefresh }: AssignmentsTableProps) {
   const t = useTranslations("requests");
+  const formatDate = useFormatDate();
   const [dialog, setDialog] = useState<DialogState>(null);
 
   if (requests.length === 0) {
@@ -130,7 +119,7 @@ export function AssignmentsTable({ requests, onRefresh }: AssignmentsTableProps)
                     <RequestStatusBadge status={req.status} />
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
-                    {formatDate(req.created_at)}
+                    {req.created_at ? formatDate(req.created_at) : "—"}
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle">
                     <div className="flex items-center justify-end gap-1">

--- a/src/components/requests/request-review-dialog.tsx
+++ b/src/components/requests/request-review-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -21,15 +21,17 @@ import { Textarea } from "@/components/ui/textarea";
 import { ApiError } from "@/lib/api/client";
 import type { ReviewAction, ReviewRequestPayload } from "@/lib/api/requests";
 
-// ─── Schemas ──────────────────────────────────────────────────────────────────
+// ─── Schema factories ─────────────────────────────────────────────────────────
 
 const approveSchema = z.object({
   comment: z.string().optional(),
 });
 
-const rejectSchema = z.object({
-  comment: z.string().min(1, "El motivo de rechazo es obligatorio"),
-});
+function buildRejectSchema(t: ReturnType<typeof useTranslations<"requests.validation">>) {
+  return z.object({
+    comment: z.string().min(1, t("comment_required")),
+  });
+}
 
 type FormValues = { comment?: string };
 
@@ -57,8 +59,10 @@ export function RequestReviewDialog({
   onSuccess,
 }: RequestReviewDialogProps) {
   const t = useTranslations("requests");
+  const tVal = useTranslations("requests.validation");
   const [isPending, setIsPending] = useState(false);
   const isApprove = action === "approved";
+  const rejectSchema = useMemo(() => buildRejectSchema(tVal), [tVal]);
   const schema = isApprove ? approveSchema : rejectSchema;
 
   const form = useForm<FormValues>({

--- a/src/components/requests/transfers-table.tsx
+++ b/src/components/requests/transfers-table.tsx
@@ -22,6 +22,7 @@ import {
   type ReviewAction,
   type ReviewRequestPayload,
 } from "@/lib/api/requests";
+import { useFormatDate } from "@/lib/format-locale";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -29,19 +30,6 @@ function getUserName(user?: TransferRequest["requester"]): string {
   if (!user) return "—";
   const full = [user.first_name, user.last_name].filter(Boolean).join(" ");
   return full || user.email || "—";
-}
-
-function formatDate(iso?: string | null): string {
-  if (!iso) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -60,6 +48,7 @@ interface TransfersTableProps {
 
 export function TransfersTable({ requests, onRefresh }: TransfersTableProps) {
   const t = useTranslations("requests");
+  const formatDate = useFormatDate();
   const [dialog, setDialog] = useState<DialogState>(null);
 
   if (requests.length === 0) {
@@ -132,7 +121,7 @@ export function TransfersTable({ requests, onRefresh }: TransfersTableProps) {
                     <RequestStatusBadge status={req.status} />
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
-                    {formatDate(req.created_at)}
+                    {req.created_at ? formatDate(req.created_at) : "—"}
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle">
                     <div className="flex items-center justify-end gap-1">

--- a/src/components/system-config/system-config-edit-dialog.tsx
+++ b/src/components/system-config/system-config-edit-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -21,13 +21,15 @@ import { useTranslations } from "next-intl";
 import { updateSystemConfig, type SystemConfig } from "@/lib/api/system-config";
 import { ApiError } from "@/lib/api/client";
 
-// ─── Schema ───────────────────────────────────────────────────────────────────
+// ─── Schema factory ───────────────────────────────────────────────────────────
 
-const formSchema = z.object({
-  config_value: z.string().min(1, "El valor no puede estar vacío"),
-});
+function buildSchema(t: ReturnType<typeof useTranslations<"system_config.validation">>) {
+  return z.object({
+    config_value: z.string().min(1, t("config_value_required")),
+  });
+}
 
-type FormValues = z.infer<typeof formSchema>;
+type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -47,10 +49,12 @@ export function SystemConfigEditDialog({
   onSuccess,
 }: SystemConfigEditDialogProps) {
   const t = useTranslations("system_config");
+  const tVal = useTranslations("system_config.validation");
   const [isPending, setIsPending] = useState(false);
+  const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
   const form = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
+    resolver: zodResolver(schema),
     defaultValues: { config_value: config?.config_value ?? "" },
   });
 

--- a/src/components/validation/validation-history-dialog.tsx
+++ b/src/components/validation/validation-history-dialog.tsx
@@ -18,22 +18,7 @@ import {
   type ValidationHistoryEntry,
 } from "@/lib/api/validation";
 import { ApiError } from "@/lib/api/client";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function formatDate(iso: string): string {
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-      hour: "2-digit",
-      minute: "2-digit",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
-}
+import { useFormatDateTime } from "@/lib/format-locale";
 
 // ─── Action config (visual/structural only — labels resolved via t()) ─────────
 
@@ -80,6 +65,7 @@ export function ValidationHistoryDialog({
   onOpenChange,
 }: ValidationHistoryDialogProps) {
   const t = useTranslations("validation_admin");
+  const formatDateTime = useFormatDateTime();
 
   function getPerformerName(entry: ValidationHistoryEntry): string {
     if (entry.performer?.first_name || entry.performer?.last_name) {
@@ -171,7 +157,7 @@ export function ValidationHistoryDialog({
                         {getActionLabel(entry.action)}
                       </p>
                       <p className="mt-0.5 text-xs text-muted-foreground">
-                        {getPerformerName(entry)} &middot; {formatDate(entry.created_at)}
+                        {getPerformerName(entry)} &middot; {formatDateTime(entry.created_at)}
                       </p>
                       {entry.comment && (
                         <p className="mt-1.5 rounded-md bg-muted px-3 py-2 text-xs text-foreground">

--- a/src/components/validation/validation-review-dialog.tsx
+++ b/src/components/validation/validation-review-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -25,15 +25,17 @@ import {
 } from "@/lib/api/validation";
 import { ApiError } from "@/lib/api/client";
 
-// ─── Schemas ──────────────────────────────────────────────────────────────────
+// ─── Schema factories ─────────────────────────────────────────────────────────
 
 const approveSchema = z.object({
   comment: z.string().optional(),
 });
 
-const rejectSchema = z.object({
-  comment: z.string().min(1, "El motivo de rechazo es obligatorio"),
-});
+function buildRejectSchema(t: ReturnType<typeof useTranslations<"validation_admin.validation">>) {
+  return z.object({
+    comment: z.string().min(1, t("comment_required")),
+  });
+}
 
 type FormValues = { comment?: string };
 
@@ -63,8 +65,10 @@ export function ValidationReviewDialog({
   onSuccess,
 }: ValidationReviewDialogProps) {
   const t = useTranslations("validation_admin");
+  const tVal = useTranslations("validation_admin.validation");
   const [isPending, setIsPending] = useState(false);
   const isApprove = action === "APPROVED";
+  const rejectSchema = useMemo(() => buildRejectSchema(tVal), [tVal]);
   const schema = isApprove ? approveSchema : rejectSchema;
 
   const form = useForm<FormValues>({

--- a/src/components/validation/validation-table.tsx
+++ b/src/components/validation/validation-table.tsx
@@ -23,6 +23,7 @@ import type {
   ValidationAction,
   ValidationEntityType,
 } from "@/lib/api/validation";
+import { useFormatDate } from "@/lib/format-locale";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -31,19 +32,6 @@ function getMemberName(v: PendingValidation): string {
   if (!u) return `Validación #${String(v.validation_id)}`;
   const full = [u.first_name, u.last_name].filter(Boolean).join(" ");
   return full || u.email || `Validación #${String(v.validation_id)}`;
-}
-
-function formatDate(iso?: string | null): string {
-  if (!iso) return "—";
-  try {
-    return new Intl.DateTimeFormat("es-MX", {
-      day: "2-digit",
-      month: "short",
-      year: "numeric",
-    }).format(new Date(iso));
-  } catch {
-    return iso;
-  }
 }
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -67,6 +55,7 @@ export function ValidationTable({
   onRefresh,
 }: ValidationTableProps) {
   const t = useTranslations("validation_admin");
+  const formatDate = useFormatDate();
   const [dialog, setDialog] = useState<DialogState>(null);
 
   function closeDialog() {
@@ -135,7 +124,7 @@ export function ValidationTable({
                     {v.section?.name ?? "—"}
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums text-muted-foreground">
-                    {formatDate(v.submitted_at)}
+                    {v.submitted_at ? formatDate(v.submitted_at) : "—"}
                   </TableCell>
                   <TableCell className="px-3 py-2.5 align-middle">
                     <ValidationStatusBadge status={v.status} />

--- a/src/lib/currency.ts
+++ b/src/lib/currency.ts
@@ -1,10 +1,18 @@
+/**
+ * @deprecated Use `useFormatCurrency` hook (client) or `getFormatCurrency` (server)
+ * from `@/lib/format-locale` instead. This shim exists only for callers not yet
+ * migrated to the locale-aware utilities (e.g. transactions-table.tsx).
+ *
+ * NOTE: The old signature `formatCurrency(amount, currency?, locale?)` is preserved
+ * here for backward compat. New callers should use the hook variant which reads
+ * locale from context automatically.
+ */
+import { formatCurrency as _formatCurrency } from "./format-locale";
+
 export function formatCurrency(
   amount: number,
   currency: string = "MXN",
   locale: string = "es-MX",
 ): string {
-  return new Intl.NumberFormat(locale, {
-    style: "currency",
-    currency,
-  }).format(amount);
+  return _formatCurrency(amount, locale, currency);
 }

--- a/src/lib/format-locale.ts
+++ b/src/lib/format-locale.ts
@@ -1,0 +1,105 @@
+import { useLocale } from "next-intl";
+import { getLocale } from "next-intl/server";
+import type { Locale } from "@/i18n/request";
+
+const LOCALE_TO_BCP47: Record<Locale, string> = {
+  es: "es-MX",
+  en: "en-US",
+  fr: "fr-FR",
+  "pt-BR": "pt-BR",
+};
+
+export function localeToBcp47(locale: Locale | string): string {
+  return LOCALE_TO_BCP47[locale as Locale] ?? "es-MX";
+}
+
+export function formatDate(
+  value: Date | string | number,
+  locale: Locale | string,
+  options: Intl.DateTimeFormatOptions = { day: "2-digit", month: "short", year: "numeric" },
+): string {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value);
+  return new Intl.DateTimeFormat(localeToBcp47(locale), options).format(date);
+}
+
+export function formatDateTime(
+  value: Date | string | number,
+  locale: Locale | string,
+  options: Intl.DateTimeFormatOptions = {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  },
+): string {
+  return formatDate(value, locale, options);
+}
+
+export function formatNumber(
+  value: number,
+  locale: Locale | string,
+  options: Intl.NumberFormatOptions = {},
+): string {
+  return new Intl.NumberFormat(localeToBcp47(locale), options).format(value);
+}
+
+export function formatCurrency(
+  amount: number,
+  locale: Locale | string,
+  currency: string = "MXN",
+): string {
+  return new Intl.NumberFormat(localeToBcp47(locale), {
+    style: "currency",
+    currency,
+  }).format(amount);
+}
+
+export function useFormatDate() {
+  const locale = useLocale();
+  return (value: Date | string | number, options?: Intl.DateTimeFormatOptions) =>
+    formatDate(value, locale, options);
+}
+
+export function useFormatDateTime() {
+  const locale = useLocale();
+  return (value: Date | string | number, options?: Intl.DateTimeFormatOptions) =>
+    formatDateTime(value, locale, options);
+}
+
+export function useFormatNumber() {
+  const locale = useLocale();
+  return (value: number, options?: Intl.NumberFormatOptions) =>
+    formatNumber(value, locale, options);
+}
+
+export function useFormatCurrency() {
+  const locale = useLocale();
+  return (amount: number, currency: string = "MXN") =>
+    formatCurrency(amount, locale, currency);
+}
+
+export async function getFormatDate() {
+  const locale = await getLocale();
+  return (value: Date | string | number, options?: Intl.DateTimeFormatOptions) =>
+    formatDate(value, locale, options);
+}
+
+export async function getFormatDateTime() {
+  const locale = await getLocale();
+  return (value: Date | string | number, options?: Intl.DateTimeFormatOptions) =>
+    formatDateTime(value, locale, options);
+}
+
+export async function getFormatNumber() {
+  const locale = await getLocale();
+  return (value: number, options?: Intl.NumberFormatOptions) =>
+    formatNumber(value, locale, options);
+}
+
+export async function getFormatCurrency() {
+  const locale = await getLocale();
+  return (amount: number, currency: string = "MXN") =>
+    formatCurrency(amount, locale, currency);
+}


### PR DESCRIPTION
## Summary

Closes the two remaining i18n cleanup tracks deferred from prior batches:

1. **Locale-routing** (30 files): replace hardcoded `Intl.DateTimeFormat("es-MX", ...)`, `toLocaleDateString("es-MX", ...)`, and currency formatters with locale-aware utilities. Active locale now drives date/number/currency formatting.
2. **Zod schemas** (15 dialogs + 4 messages JSONs): move schemas inside components via `buildSchema(t)` factory pattern. Validation messages translatable.

3 parallel agents on `feat/admin-locale-routing-zod` worktrees, no overlap, combined into single PR.

49 files changed (45 + 4 messages JSONs), +768/-713.

## New utility — `src/lib/format-locale.ts` (105 lines)

```ts
// Client hooks
useFormatDate()     →  (value, options?) => string
useFormatDateTime() →  (value, options?) => string  // default has hour/minute
useFormatNumber()   →  (value, options?) => string
useFormatCurrency() →  (amount, currency = "MXN") => string

// Server async getters
await getFormatDate()
await getFormatDateTime()
await getFormatNumber()
await getFormatCurrency()

// Pure functions (when locale must be passed explicitly)
formatDate(value, locale, options?)
formatDateTime(value, locale, options?)
formatNumber(value, locale, options?)
formatCurrency(amount, locale, currency?)
```

Locale → BCP-47 mapping: `es → es-MX`, `en → en-US`, `fr → fr-FR`, `pt-BR → pt-BR`.

`src/lib/currency.ts` kept as backward-compat shim (re-exports `formatCurrency` from `format-locale.ts`).

## Tracks

### Locale-routing — 30 components

**Group A (17 files)**: enrollments, evidence-review (×3), finances/transactions-table, inventory-history-dialog, investiture (×5), membership/pending-members-table, notifications/notification-history-table (server async), reports (×2), requests (×2)

**Group B (13 files)**: validation (×2), member-of-month/supervision, reports/supervision, system/jobs/_components (×3), 5 currency callers (clubs/club-sections-panel, insurance/insurance-table, finances/{delete-transaction-dialog, finances-summary-cards}, camporees/camporee-payments-panel)

### Zod refactor — 15 dialogs

`validation-review-dialog`, `system-config-edit-dialog`, `folder-form-dialog`, `insurance-form-dialog`, `request-review-dialog`, `activity-form-dialog`, `investiture/{validate,pipeline-reject}-dialog`, `inventory-form-dialog`, `camporees/{payment, union-camporee-form, camporee-form}-dialog`, `annual-folders/{section, template, award-category}-form-dialog`

## New validation keys (×4 locales identical)

| Namespace | New keys |
|---|---|
| validation_admin.validation | +1 |
| system_config.validation | +1 |
| folders.validation | +3 |
| insurance.validation | +2 |
| requests.validation | +1 |
| activities.validation | +6 |
| investiture.validation | +2 (extends prior 4) |
| inventory.validation | +5 |
| camporees.validation | +10 |
| annual_folders.validation | +15 |

**46 new validation keys per locale.** Cumulative i18n project: ~2881 keys across 24 namespaces.

## Patterns applied

- Client components → `use*` hook variants. Server async → `get*` async getters.
- Module-level `Intl.DateTimeFormat` consts removed → hook calls inside component body.
- Local `formatDate`/`formatDatetime` helpers deleted when no other callers.
- Null-guards preserved at call sites: `value ? formatDate(value) : "—"`.
- Non-default options preserved via 2nd arg: `formatDate(value, { month: "2-digit" })`.
- **Zod schema factory pattern**: `buildSchema(t)` + `useMemo([t])` + `z.infer<ReturnType<typeof buildSchema>>` for stable type.
- For `z.coerce.*` fields: `zodResolver(schema as z.ZodType<FormValues, FormValues>)` cast resolves overload mismatch.
- ICU interpolation for min/max validation messages (`{min}`, `{max}`).
- Approve/reject dual-schema dialogs: only translated reject schema gets factory; approve stays module-level const.

## Test plan

- [x] All 3 sub-agents branched from `feat/admin-locale-routing-zod` HEAD `2a8815d` (CRITICAL header verification)
- [x] No file overlap between 3 worktrees (verified via `comm` after fixing cwd bug)
- [x] Python deep-merge produced 4 locale JSONs in sync (10 namespaces × 4 locales identical counts)
- [x] `pnpm typecheck` produces no new errors (6 pre-existing `vitest` baseline errors unchanged)
- [x] All 4 `messages/*.json` parse as valid JSON
- [x] `rg 'es-MX' src/` returns zero in migrated files (only `format-locale.ts` LOCALE_TO_BCP47 map keeps the literal — intentional)
- [ ] Manual smoke: locale switcher confirms date/currency change format across 30 routes
- [ ] fr/pt-BR native review (deferred — accumulated across 20 PRs i18n)