### PR TITLE
chore: ignore Claude Code .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ next-env.d.ts
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# Claude Code local state (worktrees, plugins, transcripts)
+.claude/


### PR DESCRIPTION
## Summary

\`.claude/\` is per-developer Claude Code local state (worktree clones, plugin caches, transcripts). Adding it to \`.gitignore\` so it stops appearing as untracked.

## Test plan

- [ ] After merge, \`git status\` no longer reports \`.claude/\` as untracked.