### PR TITLE
fix(system-config): align frontend with backend config_key field

### DIFF
--- a/src/components/system-config/system-config-client-page.tsx
+++ b/src/components/system-config/system-config-client-page.tsx
@@ -20,7 +20,7 @@ function getPrefix(key: string): string {
 function groupByPrefix(configs: SystemConfig[]): Map<string, SystemConfig[]> {
   const groups = new Map<string, SystemConfig[]>();
   for (const config of configs) {
-    const prefix = getPrefix(config.key);
+    const prefix = getPrefix(config.config_key);
     const existing = groups.get(prefix) ?? [];
     existing.push(config);
     groups.set(prefix, existing);

--- a/src/components/system-config/system-config-edit-dialog.tsx
+++ b/src/components/system-config/system-config-edit-dialog.tsx
@@ -69,8 +69,8 @@ export function SystemConfigEditDialog({
     if (!config) return;
     setIsPending(true);
     try {
-      await updateSystemConfig(config.key, { config_value: values.config_value });
-      toast.success(`Configuración "${config.key}" actualizada`);
+      await updateSystemConfig(config.config_key, { config_value: values.config_value });
+      toast.success(`Configuración "${config.config_key}" actualizada`);
       onOpenChange(false);
       onSuccess();
     } catch (error) {
@@ -98,9 +98,9 @@ export function SystemConfigEditDialog({
             Editar configuración
           </DialogTitle>
           <DialogDescription>
-            {config?.key && (
+            {config?.config_key && (
               <>
-                Modificá el valor de <code className="rounded bg-muted px-1 py-0.5 text-xs">{config.key}</code>.
+                Modificá el valor de <code className="rounded bg-muted px-1 py-0.5 text-xs">{config.config_key}</code>.
                 {config.description && (
                   <span className="mt-1 block text-muted-foreground">{config.description}</span>
                 )}

--- a/src/components/system-config/system-config-table.tsx
+++ b/src/components/system-config/system-config-table.tsx
@@ -73,10 +73,10 @@ export function SystemConfigTable({ configs, onEdit }: SystemConfigTableProps) {
         </TableHeader>
         <TableBody>
           {configs.map((config) => (
-            <TableRow key={config.key} className="hover:bg-muted/30">
+            <TableRow key={config.config_key} className="hover:bg-muted/30">
               <TableCell className="px-3 py-2.5 align-middle">
                 <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
-                  {config.key}
+                  {config.config_key}
                 </code>
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle max-w-52">
@@ -106,7 +106,7 @@ export function SystemConfigTable({ configs, onEdit }: SystemConfigTableProps) {
                         variant="ghost"
                         size="icon-sm"
                         onClick={() => onEdit(config)}
-                        aria-label={t("action_edit_key", { key: config.key })}
+                        aria-label={t("action_edit_key", { key: config.config_key })}
                       >
                         <Pencil className="size-4" />
                       </Button>

--- a/src/lib/api/system-config.ts
+++ b/src/lib/api/system-config.ts
@@ -5,7 +5,7 @@ import { apiRequest, apiRequestFromClient } from "@/lib/api/client";
 export type SystemConfigValueType = "string" | "number" | "boolean" | "json";
 
 export type SystemConfig = {
-  key: string;
+  config_key: string;
   config_value: string;
   description?: string | null;
   value_type?: SystemConfigValueType | string | null;


### PR DESCRIPTION
## Summary
- Backend Prisma model exposes `config_key`, but the frontend `SystemConfig` type used `key`. SSR on `/dashboard/settings` crashed with `Cannot read properties of undefined (reading 'indexOf')` because every config arrived without the expected field.
- Rename `key` -> `config_key` in the type and all four consumers (client-page grouping, table rows, edit dialog title, update call).

## Test plan
- [ ] `/dashboard/settings` renders all system-config groups grouped by prefix.
- [ ] Edit dialog opens, shows the correct config key, and a successful PATCH refreshes the table.
- [ ] `pnpm tsc --noEmit` is clean for the system-config files.