### PR TITLE
chore(dev): bump Node heap to 8GB

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3001",
+    "dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev -p 3001",
     "build": "next build",
     "start": "next start -p 3001",
     "lint": "eslint",


### PR DESCRIPTION
## Symptom

Turbopack's incremental compilation repeatedly triggered:

```
Server is approaching the used memory threshold, restarting...
```

This caused the dev server to restart mid-session, losing hot-reload state and interrupting the development flow.

## Fix

Prefix the `dev` script with `NODE_OPTIONS='--max-old-space-size=8192'` to raise the V8 old-space cap to 8 GB. Only `scripts.dev` is modified — `build`, `start`, and all other scripts are untouched, and no dependencies changed.

**Before:**
```json
"dev": "next dev -p 3001"
```

**After:**
```json
"dev": "NODE_OPTIONS='--max-old-space-size=8192' next dev -p 3001"
```

## Test plan

- [ ] Run `pnpm dev`, confirm server starts on port 3001 without the memory-threshold restart message during normal usage.