### PR TITLE
chore: migrate middleware.ts to proxy.ts (Next 16)

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse, type NextRequest } from "next/server";
 import { ACCESS_TOKEN_COOKIE } from "@/lib/auth/cookies";
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const token = request.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
 


### PR DESCRIPTION
## Summary

- Next.js 16 deprecated the `middleware.ts` file convention and renamed it to `proxy.ts` ([docs](https://nextjs.org/docs/messages/middleware-to-proxy))
- Renamed `src/middleware.ts` → `src/proxy.ts`
- Renamed the exported function from `middleware` to `proxy` (required by the new convention)
- Matcher config and auth/redirect logic are **unchanged**

## What changed

| Before | After |
|--------|-------|
| `src/middleware.ts` | `src/proxy.ts` |
| `export function middleware(...)` | `export function proxy(...)` |

No other files required updates. The one reference to "middleware" found in `src/app/api/auth/token/route.ts` is a JSDoc comment describing call context — not a routing/convention reference.

## Test plan

- [ ] `pnpm tsc --noEmit` passes with no new errors (only pre-existing vitest module errors)
- [ ] `pnpm dev` boots without a Next.js deprecation warning about `middleware.ts`
- [ ] Unauthenticated request to `/dashboard/*` redirects to `/login?next=...`
- [ ] Authenticated request to `/dashboard/*` passes through normally
- [ ] `x-pathname` header is set on all matched requests