### PR TITLE
chore(deps): bump axios to ^1.16.0 (fix 4 HIGH CVEs)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@sentry/nextjs": "^10",
     "@tanstack/react-query": "^5.90.20",
-    "axios": "^1.15.0",
+    "axios": "^1.16.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^5.90.20
         version: 5.90.20(react@19.2.3)
       axios:
-        specifier: ^1.15.0
-        version: 1.15.0
+        specifier: ^1.16.0
+        version: 1.16.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -67,7 +67,7 @@ importers:
         version: 4.6.5(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       recharts:
         specifier: ^3.7.0
-        version: 3.7.0(@types/react@19.2.10)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
+        version: 3.7.0(@types/react@19.2.10)(react-dom@19.2.3(react@19.2.3))(react-is@17.0.2)(react@19.2.3)(redux@5.0.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -2757,8 +2757,8 @@ packages:
     resolution: {integrity: sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==}
     engines: {node: '>=4'}
 
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
+  axios@1.16.0:
+    resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -7398,7 +7398,7 @@ snapshots:
 
   axe-core@4.11.1: {}
 
-  axios@1.15.0:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5
@@ -8964,7 +8964,7 @@ snapshots:
 
   react@19.2.3: {}
 
-  recharts@3.7.0(@types/react@19.2.10)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1):
+  recharts@3.7.0(@types/react@19.2.10)(react-dom@19.2.3(react@19.2.3))(react-is@17.0.2)(react@19.2.3)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.10)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
       clsx: 2.1.1
@@ -8974,7 +8974,7 @@ snapshots:
       immer: 10.2.0
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      react-is: 16.13.1
+      react-is: 17.0.2
       react-redux: 9.2.0(@types/react@19.2.10)(react@19.2.3)(redux@5.0.1)
       reselect: 5.1.1
       tiny-invariant: 1.3.3


### PR DESCRIPTION
## Summary

Patches 4 HIGH CVEs in axios:
- GHSA-pmwg-cvhr-8vh7 — NO_PROXY incomplete fix
- GHSA-q8qp-cvcw-x6jj — prototype pollution gadget
- GHSA-pf86-5x62-jrwf — prototype pollution gadget
- GHSA-6chq-wfr3-2hj9 — header injection via prototype pollution

Bumps \`^1.15.0\` → \`^1.16.0\`. axios 1.x API surface stable; zero source file changes required.

## Audit results

| Severity | Before | After |
|---|---|---|
| HIGH (axios) | 4 | **0** |
| HIGH (transitive sentry/next) | 3 | 3 (unchanged, separate cleanup) |

## Test plan

- [x] \`pnpm install\` clean
- [x] \`pnpm typecheck\` zero new errors (6 vitest baseline pre-existing)
- [x] \`pnpm audit --prod\` confirms 0 axios advisories remain

## Files changed

\`package.json\` + \`pnpm-lock.yaml\` only.

From audit recommendation P0 (2026-05-08).