### PR TITLE
fix(a11y): add Description to all DialogContent

### DIFF
--- a/src/app/(dashboard)/dashboard/system/jobs/history/_components/cron-history-client.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/history/_components/cron-history-client.tsx
@@ -32,6 +32,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -150,6 +151,9 @@ function DetailDialog({ item, onClose }: DetailDialogProps) {
           <DialogTitle className="text-sm font-semibold">
             {item ? t("detailTitle", { runId: item.run_id }) : ""}
           </DialogTitle>
+          <DialogDescription>
+            {item ? `Detalles de la ejecución del job ${item.job_name}` : ""}
+          </DialogDescription>
         </DialogHeader>
         {item && (
           <div className="space-y-4 text-sm">

--- a/src/components/activities/activity-form-dialog.tsx
+++ b/src/components/activities/activity-form-dialog.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -219,6 +220,11 @@ export function ActivityFormDialog({
           <DialogTitle>
             {isEdit ? "Editar actividad" : "Nueva actividad"}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Modificá los datos de la actividad y guardá los cambios."
+              : "Completá el formulario para registrar una nueva actividad en el club."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">

--- a/src/components/annual-folders/award-category-form-dialog.tsx
+++ b/src/components/annual-folders/award-category-form-dialog.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -241,6 +242,11 @@ export function AwardCategoryFormDialog({
           <DialogTitle>
             {isEdit ? "Editar categoría de premio" : "Nueva categoría de premio"}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Modificá los parámetros de la categoría de premio."
+              : "Definí una nueva categoría de premio para las carpetas anuales."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>

--- a/src/components/annual-folders/evaluate-section-dialog.tsx
+++ b/src/components/annual-folders/evaluate-section-dialog.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -130,9 +131,9 @@ export function EvaluateSectionDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Evaluar sección</DialogTitle>
-          <p className="text-sm text-muted-foreground">
+          <DialogDescription>
             {sectionName}
-          </p>
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/components/annual-folders/evidence-upload-dialog.tsx
+++ b/src/components/annual-folders/evidence-upload-dialog.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -104,9 +105,9 @@ export function EvidenceUploadDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Subir evidencia</DialogTitle>
-          <p className="text-sm text-muted-foreground">
+          <DialogDescription>
             Sección: <span className="font-medium text-foreground">{sectionName}</span>
-          </p>
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/components/annual-folders/section-form-dialog.tsx
+++ b/src/components/annual-folders/section-form-dialog.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -166,6 +167,11 @@ export function SectionFormDialog({
           <DialogTitle>
             {isEdit ? t("sectionDialog.titleEdit") : t("sectionDialog.titleCreate")}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Modificá los datos de la sección de la plantilla."
+              : "Completá el formulario para agregar una nueva sección a la plantilla."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>

--- a/src/components/annual-folders/template-form-dialog.tsx
+++ b/src/components/annual-folders/template-form-dialog.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -234,6 +235,11 @@ export function TemplateFormDialog({
           <DialogTitle>
             {isEdit ? t("templateDialog.titleEdit") : t("templateDialog.titleCreate")}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Modificá los datos de la plantilla de carpeta anual."
+              : "Completá el formulario para crear una nueva plantilla de carpeta anual."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>

--- a/src/components/camporees/camporee-form-dialog.tsx
+++ b/src/components/camporees/camporee-form-dialog.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -187,6 +188,11 @@ export function CamporeeFormDialog({
           <DialogTitle>
             {isEdit ? t("form.titleEdit") : t("form.titleCreate")}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Modificá los datos del camporee local."
+              : "Completá el formulario para crear un nuevo camporee local."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>

--- a/src/components/camporees/enroll-club-dialog.tsx
+++ b/src/components/camporees/enroll-club-dialog.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -90,6 +91,9 @@ export function EnrollClubDialog({
       <DialogContent className="sm:max-w-sm">
         <DialogHeader>
           <DialogTitle>{t("enrollDialog.title")}</DialogTitle>
+          <DialogDescription>
+            Ingresá el ID de sección del club para inscribirlo en este camporee.
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>

--- a/src/components/camporees/payment-dialog.tsx
+++ b/src/components/camporees/payment-dialog.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -179,6 +180,11 @@ export function PaymentDialog({
           <DialogTitle>
             {isEditing ? t("paymentDialog.titleEdit") : t("paymentDialog.titleCreate")}
           </DialogTitle>
+          <DialogDescription>
+            {isEditing
+              ? "Modificá los datos del pago registrado."
+              : "Registrá un nuevo pago para un participante del camporee."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">

--- a/src/components/camporees/register-member-dialog.tsx
+++ b/src/components/camporees/register-member-dialog.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -125,6 +126,9 @@ export function RegisterMemberDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{t("registerMemberDialog.title")}</DialogTitle>
+          <DialogDescription>
+            Ingresá el UUID del usuario y los datos necesarios para inscribirlo en el camporee.
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">

--- a/src/components/camporees/union-camporee-form-dialog.tsx
+++ b/src/components/camporees/union-camporee-form-dialog.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -189,6 +190,11 @@ export function UnionCamporeeFormDialog({
           <DialogTitle>
             {isEdit ? t("unionForm.titleEdit") : t("unionForm.titleCreate")}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Modificá los datos del camporee de unión."
+              : "Completá el formulario para crear un nuevo camporee de unión."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>

--- a/src/components/evidence-review/evidence-detail-dialog.tsx
+++ b/src/components/evidence-review/evidence-detail-dialog.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -168,6 +169,9 @@ export function EvidenceDetailDialog({
               </>
             )}
           </DialogTitle>
+          <DialogDescription>
+            Revisá los archivos y metadatos de la evidencia enviada por el miembro.
+          </DialogDescription>
         </DialogHeader>
 
         {isLoading && (

--- a/src/components/evidence-review/evidence-history-dialog.tsx
+++ b/src/components/evidence-review/evidence-history-dialog.tsx
@@ -7,6 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -104,7 +105,7 @@ export function EvidenceHistoryDialog({
             <History className="size-5 text-muted-foreground" />
             {t("title")}
           </DialogTitle>
-          <p className="text-sm text-muted-foreground">{memberName}</p>
+          <DialogDescription>{memberName}</DialogDescription>
         </DialogHeader>
 
         <ScrollArea className="max-h-96 pr-2">

--- a/src/components/folders/folder-form-dialog.tsx
+++ b/src/components/folders/folder-form-dialog.tsx
@@ -10,6 +10,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -138,6 +139,11 @@ export function FolderFormDialog({
           <DialogTitle>
             {isEdit ? "Editar carpeta" : "Nueva carpeta de evidencias"}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Modificá los datos de la carpeta de evidencias."
+              : "Completá el formulario para crear una nueva carpeta de evidencias."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">

--- a/src/components/insurance/insurance-form-dialog.tsx
+++ b/src/components/insurance/insurance-form-dialog.tsx
@@ -10,6 +10,7 @@ import { Paperclip, X } from "lucide-react";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -183,11 +184,13 @@ export function InsuranceFormDialog({
           <DialogTitle>
             {isEdit ? "Editar seguro" : "Registrar seguro"}
           </DialogTitle>
-          {member && (
-            <p className="text-sm text-muted-foreground">
-              Miembro: <span className="font-medium text-foreground">{memberFullName(member)}</span>
-            </p>
-          )}
+          <DialogDescription>
+            {member
+              ? `Miembro: ${memberFullName(member)}`
+              : isEdit
+                ? "Modificá los datos de la póliza de seguro."
+                : "Completá el formulario para registrar una nueva póliza de seguro."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>

--- a/src/components/inventory/inventory-form-dialog.tsx
+++ b/src/components/inventory/inventory-form-dialog.tsx
@@ -9,6 +9,7 @@ import { toast } from "sonner";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -159,6 +160,11 @@ export function InventoryFormDialog({
           <DialogTitle>
             {isEdit ? "Editar ítem" : "Nuevo ítem de inventario"}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Modificá los datos del ítem de inventario."
+              : "Completá el formulario para agregar un nuevo ítem al inventario del club."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>

--- a/src/components/inventory/inventory-history-dialog.tsx
+++ b/src/components/inventory/inventory-history-dialog.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -244,6 +245,9 @@ export function InventoryHistoryDialog({
               </span>
             )}
           </DialogTitle>
+          <DialogDescription>
+            Registro de movimientos del ítem en el inventario del club.
+          </DialogDescription>
         </DialogHeader>
 
         <div className="pt-2">

--- a/src/components/investiture/pending-table.tsx
+++ b/src/components/investiture/pending-table.tsx
@@ -17,6 +17,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -304,13 +305,13 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
           <DialogHeader>
             <DialogTitle>{t("pendingTable.historyTitle")}</DialogTitle>
             {activeEnrollment && (
-              <p className="text-sm text-muted-foreground">
+              <DialogDescription>
                 {memberName} &middot;{" "}
                 <InvestitureStatusBadge
                   status={activeEnrollment.investiture_status}
                   className="align-middle"
                 />
-              </p>
+              </DialogDescription>
             )}
           </DialogHeader>
           <ScrollArea className="max-h-96 pr-2">

--- a/src/components/investiture/pipeline-history-dialog.tsx
+++ b/src/components/investiture/pipeline-history-dialog.tsx
@@ -14,6 +14,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -138,7 +139,7 @@ export function PipelineHistoryDialog({
             <History className="size-5 text-muted-foreground" />
             {t("historyDialog.title")}
           </DialogTitle>
-          <p className="text-sm text-muted-foreground">{memberName}</p>
+          <DialogDescription>{memberName}</DialogDescription>
         </DialogHeader>
 
         <ScrollArea className="max-h-96 pr-2">

--- a/src/components/scoring-categories/scoring-category-dialog.tsx
+++ b/src/components/scoring-categories/scoring-category-dialog.tsx
@@ -10,6 +10,7 @@ import { Label } from "@/components/ui/label";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -133,6 +134,11 @@ export function ScoringCategoryDialog({
           <DialogTitle>
             {isEdit ? "Editar categoría" : "Nueva categoría de puntuación"}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? "Modificá el nombre y los puntos máximos de la categoría."
+              : "Completá el formulario para crear una nueva categoría de puntuación."}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/components/units/add-member-dialog.tsx
+++ b/src/components/units/add-member-dialog.tsx
@@ -6,6 +6,7 @@ import { UserPlus } from "lucide-react";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -87,6 +88,9 @@ export function AddMemberDialog({
             <UserPlus className="size-4 text-muted-foreground" />
             Agregar miembro
           </DialogTitle>
+          <DialogDescription>
+            Buscá y seleccioná un miembro del club para agregarlo a la unidad {unitName}.
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/components/units/weekly-records-panel.tsx
+++ b/src/components/units/weekly-records-panel.tsx
@@ -25,6 +25,7 @@ import {
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   DialogFooter,
@@ -139,6 +140,9 @@ function AddRecordDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Nuevo registro semanal</DialogTitle>
+          <DialogDescription>
+            Registrá la asistencia, puntualidad y puntajes de categorías para un miembro de la unidad.
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">

--- a/src/components/validation/validation-history-dialog.tsx
+++ b/src/components/validation/validation-history-dialog.tsx
@@ -7,6 +7,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -113,7 +114,7 @@ export function ValidationHistoryDialog({
             <History className="size-5 text-muted-foreground" />
             {t("history.title")}
           </DialogTitle>
-          <p className="text-sm text-muted-foreground">{title}</p>
+          <DialogDescription>{title}</DialogDescription>
         </DialogHeader>
 
         <ScrollArea className="max-h-96 pr-2">


### PR DESCRIPTION
## Summary

Radix UI's `Dialog` component emits a browser console warning when `<DialogContent>` is rendered without a `<DialogDescription>` child or an explicit `aria-describedby={undefined}` prop. This is a WCAG accessibility requirement — screen readers need either a described-by reference or an explicit opt-out.

This PR adds `<DialogDescription>` to every `<DialogContent>` across the codebase that was missing it.

### Approach

- Where a `<p>` element inside `<DialogHeader>` was already acting as a description, it was promoted to `<DialogDescription>` (proper semantic element, same visual output via shadcn styles).
- All other dialogs received a meaningful plain Spanish description string matching the dialog's purpose.
- No translations files were modified — plain strings are used where i18n keys did not exist.
- No unrelated code, styling, or configuration was touched.

### Dialogs fixed (24 total)

| File | Description added |
|------|------------------|
| `cron-history-client.tsx` | Job execution detail |
| `activity-form-dialog.tsx` | Create / edit activity |
| `award-category-form-dialog.tsx` | Create / edit award category |
| `evaluate-section-dialog.tsx` | Promoted existing `<p>` to `<DialogDescription>` |
| `evidence-upload-dialog.tsx` | Promoted existing `<p>` to `<DialogDescription>` |
| `section-form-dialog.tsx` | Create / edit template section |
| `template-form-dialog.tsx` | Create / edit folder template |
| `camporee-form-dialog.tsx` | Create / edit local camporee |
| `enroll-club-dialog.tsx` | Enroll club in camporee |
| `payment-dialog.tsx` | Create / edit payment |
| `register-member-dialog.tsx` | Register member in camporee |
| `union-camporee-form-dialog.tsx` | Create / edit union camporee |
| `evidence-detail-dialog.tsx` | Evidence detail view |
| `evidence-history-dialog.tsx` | Promoted existing `<p>` to `<DialogDescription>` |
| `folder-form-dialog.tsx` | Create / edit evidence folder |
| `insurance-form-dialog.tsx` | Promoted existing `<p>` to `<DialogDescription>` |
| `inventory-form-dialog.tsx` | Create / edit inventory item |
| `inventory-history-dialog.tsx` | Inventory item history |
| `pending-table.tsx` | Promoted existing `<p>` to `<DialogDescription>` |
| `pipeline-history-dialog.tsx` | Promoted existing `<p>` to `<DialogDescription>` |
| `scoring-category-dialog.tsx` | Create / edit scoring category |
| `add-member-dialog.tsx` | Add member to unit |
| `weekly-records-panel.tsx` | New weekly record |
| `validation-history-dialog.tsx` | Promoted existing `<p>` to `<DialogDescription>` |

## Test plan

- [ ] Open each affected dialog in the browser — no Radix `Missing Description` warning in console
- [ ] Verify description text renders correctly below the dialog title
- [ ] Screen reader announces the description when dialog opens
- [ ] `pnpm tsc --noEmit` passes with zero new errors
- [ ] No visual regressions in dialog layout or styling