### PR TITLE
feat(i18n): batch 13.5 sweep — permissions registry + UI primitives + dialogs + placeholders

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1317,6 +1317,190 @@
         "loadError": "Error loading role",
         "emptyLoadTitle": "Could not load role"
       }
+    },
+    "permissionGroups": {
+      "users": "Users",
+      "roles": "Roles & Permissions",
+      "clubs": "Clubs",
+      "units": "Units",
+      "member_of_month": "Member of the Month",
+      "scoring_categories": "Scoring Categories",
+      "requests": "Requests",
+      "user_certifications": "User Certifications (Admin)",
+      "user_folders": "User Folders (Admin)",
+      "geography": "Geographic Hierarchy",
+      "catalogs": "Catalogs",
+      "classes_honors": "Classes & Honors",
+      "activities": "Activities",
+      "camporees": "Camporees",
+      "validation": "Validation",
+      "finances": "Finances",
+      "inventory": "Inventory",
+      "reports": "Reports",
+      "notifications": "Notifications",
+      "resources": "Resources",
+      "system": "System"
+    },
+    "permissions": {
+      "users:read": "View list",
+      "users:read_detail": "View detail",
+      "users:update_profile": "Edit own profile",
+      "users:update_admin": "Admin user management",
+      "health:read": "View health",
+      "health:update": "Update health",
+      "emergency_contacts:read": "View emergency contacts",
+      "emergency_contacts:update": "Update emergency contacts",
+      "legal_representative:read": "View legal representative",
+      "legal_representative:update": "Update legal representative",
+      "post_registration:read": "View post-registration",
+      "registration:complete": "Complete registration",
+      "roles:read": "View roles",
+      "permissions:read": "View permissions",
+      "permissions:assign": "Assign permissions",
+      "clubs:read": "View clubs",
+      "clubs:create": "Create club",
+      "clubs:update": "Edit club",
+      "clubs:delete": "Delete club",
+      "club_sections:read": "View sections",
+      "club_sections:create": "Create section",
+      "club_sections:update": "Edit section",
+      "club_roles:read": "View club roles",
+      "club_roles:assign": "Assign club role",
+      "club_roles:revoke": "Revoke club role",
+      "club_members:approve": "Approve membership",
+      "club_members:reject": "Reject membership",
+      "club_members:list_pending": "View pending requests",
+      "units:read": "View units / member of the month",
+      "mom:read": "View member of the month",
+      "mom:supervise": "Supervise multi-section (admin/coordinator)",
+      "mom:evaluate": "Trigger manual evaluation",
+      "scoring_categories:read": "View scoring categories",
+      "scoring_categories:manage": "Manage scoring categories (unions + local fields)",
+      "requests:read": "View transfer and assignment requests",
+      "requests:review": "Approve/reject requests",
+      "user_certifications:read": "View certification progress",
+      "user_certifications:manage": "Enroll / update / delete certifications",
+      "user_folders:read": "View folder enrollment and progress",
+      "user_folders:manage": "Enroll / update / delete folder assignments",
+      "achievements:read": "View achievements",
+      "achievements:manage": "Manage achievements",
+      "rankings:read": "View rankings",
+      "rankings:recalculate": "Recalculate rankings",
+      "ranking_weights:read": "View institutional ranking weights",
+      "ranking_weights:write": "Edit institutional ranking weights",
+      "member_rankings:read_self": "View my ranking",
+      "member_rankings:read_section": "View section ranking",
+      "member_rankings:read_club": "View club ranking",
+      "member_rankings:read_lf": "View local field ranking",
+      "member_rankings:read_global": "View global ranking",
+      "member_ranking_weights:read": "View member ranking weights",
+      "member_ranking_weights:write": "Edit member ranking weights",
+      "section_rankings:read_club": "View club section rankings",
+      "section_rankings:read_lf": "View local field section rankings",
+      "section_rankings:read_global": "View global section rankings",
+      "award_categories:create": "Create award category",
+      "award_categories:read": "View award categories",
+      "award_categories:update": "Edit award category",
+      "award_categories:delete": "Delete award category",
+      "countries:read": "View countries",
+      "countries:create": "Create country",
+      "countries:update": "Edit country",
+      "countries:delete": "Delete country",
+      "unions:read": "View unions",
+      "unions:create": "Create union",
+      "unions:update": "Edit union",
+      "unions:delete": "Delete union",
+      "local_fields:read": "View local fields",
+      "local_fields:create": "Create local field",
+      "local_fields:update": "Edit local field",
+      "local_fields:delete": "Delete local field",
+      "churches:read": "View churches",
+      "churches:create": "Create church",
+      "churches:update": "Edit church",
+      "churches:delete": "Delete church",
+      "catalogs:read": "View catalogs",
+      "catalogs:create": "Create item",
+      "catalogs:update": "Edit item",
+      "catalogs:delete": "Delete item",
+      "classes:read": "View classes",
+      "classes:submit_progress": "Submit class progress",
+      "classes:manage": "Manage classes",
+      "class_modules:manage": "Manage class modules",
+      "class_sections:manage": "Manage class sections",
+      "honors:read": "View honors",
+      "honors:create": "Create honor",
+      "honors:update": "Edit honor",
+      "honors:delete": "Delete honor",
+      "master_honors:manage": "Manage master honors",
+      "user_honors:submit": "Submit honor progress",
+      "user_honors:validate": "Validate honors",
+      "honor_categories:read": "View categories",
+      "honor_categories:create": "Create category",
+      "honor_categories:update": "Edit category",
+      "honor_categories:delete": "Delete category",
+      "folders:manage": "Manage folders",
+      "folder_modules:manage": "Manage folder modules",
+      "folder_sections:manage": "Manage folder sections",
+      "finance_categories:manage": "Manage finance categories",
+      "inventory_categories:manage": "Manage inventory categories",
+      "activities:read": "View activities",
+      "activities:create": "Create activity",
+      "activities:update": "Edit activity",
+      "activities:delete": "Delete activity",
+      "attendance:read": "View attendance",
+      "attendance:manage": "Manage attendance",
+      "camporees:read": "View camporees",
+      "camporees:create": "Create camporees",
+      "camporees:update": "Update camporees",
+      "camporees:delete": "Deactivate camporees",
+      "validation:submit": "Submit progress for review",
+      "validation:review": "Approve/reject submitted progress",
+      "validation:read": "View pending queue, history and eligibility",
+      "finances:read": "View finances",
+      "finances:create": "Create record",
+      "finances:update": "Edit record",
+      "finances:delete": "Delete record",
+      "inventory:read": "View inventory",
+      "inventory:create": "Create item",
+      "inventory:update": "Edit item",
+      "inventory:delete": "Delete item",
+      "notifications:send": "Send direct",
+      "notifications:broadcast": "Send broadcast",
+      "notifications:club": "Send by club",
+      "reports:read": "Read monthly reports",
+      "reports:download": "Download PDF reports",
+      "dashboard:view": "View dashboard",
+      "resources:read": "View resources",
+      "resources:create": "Upload resource",
+      "resources:update": "Edit resource",
+      "resources:delete": "Delete resource",
+      "resource_categories:read": "View resource categories",
+      "resource_categories:create": "Create resource category",
+      "resource_categories:update": "Edit resource category",
+      "resource_categories:delete": "Delete resource category",
+      "ecclesiastical_years:read": "View ecclesiastical years",
+      "ecclesiastical_years:create": "Create ecclesiastical year",
+      "ecclesiastical_years:update": "Edit ecclesiastical year"
+    },
+    "userPermissionsPanel": {
+      "title": "Direct permissions",
+      "subtitle": "Permissions assigned directly to this user (not through roles)",
+      "addPermission": "Add permission",
+      "noPermissionsTitle": "This user has no direct permissions assigned.",
+      "addDirectPermission": "Add permission",
+      "addDialogTitle": "Add direct permission",
+      "addDialogDescription": "Select a permission to assign directly to this user.",
+      "searchPlaceholder": "Search permission...",
+      "noMatchesSearch": "No matching permissions found.",
+      "noPermissionsAvailable": "No permissions available to assign.",
+      "cancelButton": "Cancel",
+      "assignButton": "Assign permission",
+      "removePermission": "Remove {name}",
+      "removeSrOnly": "Remove",
+      "removeDialogTitle": "Remove direct permission?",
+      "removeDialogDescription": "The permission {name} directly assigned to this user will be removed. The user may still have the permission through their roles.",
+      "removeCancel": "Cancel",
+      "removeConfirm": "Remove"
     }
   },
   "resource_categories": {
@@ -1992,6 +2176,25 @@
       "categories": {
         "forbiddenDetail": "You do not have permission to view resource categories."
       }
+    },
+    "placeholders": {
+      "title": "E.g. Pathfinder Manual 2025",
+      "description": "Brief description of the resource (optional)",
+      "selectType": "Select type",
+      "selectCategory": "No category",
+      "selectClubType": "All clubs",
+      "selectScope": "Scope",
+      "selectUnion": "Select union",
+      "unionId": "Union ID",
+      "selectLocalField": "Select local field",
+      "localFieldId": "Local field ID",
+      "videoUrl": "https://youtube.com/watch?v=... or https://vimeo.com/...",
+      "content": "Write the resource content here...",
+      "searchTitle": "Search by title...",
+      "filterType": "All types",
+      "filterStatus": "All",
+      "filterScope": "All",
+      "filterClubType": "All"
     }
   },
   "investiture": {
@@ -2162,6 +2365,22 @@
       "errorFallback": "Could not load investitures.",
       "emptyTitle": "No investiture requests",
       "emptyDescription": "There are no investiture requests in the system at this time."
+    },
+    "investidoDialog": {
+      "title": "Register investiture",
+      "description": "The investiture of {memberName} will be registered. This action is irreversible and will sync the status in the system.",
+      "commentsLabel": "Comments (optional)",
+      "commentsPlaceholder": "Add an optional comment...",
+      "cancel": "Cancel",
+      "confirm": "Confirm investiture"
+    },
+    "pipelineRejectDialog": {
+      "title": "Reject investiture",
+      "description": "The investiture request for {memberName} will be rejected. The reason is required.",
+      "reasonLabel": "Rejection reason *",
+      "reasonPlaceholder": "Describe the reason for rejection...",
+      "cancel": "Cancel",
+      "confirm": "Reject"
     }
   },
   "evidence_review": {
@@ -2246,6 +2465,14 @@
       "emptyTitle": "No pending evidence",
       "emptyDescription": "There is no evidence pending review at this time.",
       "allReviewed": "All evidence has been reviewed."
+    },
+    "rejectDialog": {
+      "title": "Reject evidence",
+      "description": "You are about to reject the evidence from {memberName} for {sectionName}. The reason is required.",
+      "reasonLabel": "Rejection reason *",
+      "reasonPlaceholder": "Describe the reason for rejection so the member can correct it...",
+      "cancel": "Cancel",
+      "confirm": "Reject"
     }
   },
   "users": {
@@ -2679,6 +2906,43 @@
       "composite_pct_max": "Cannot exceed {max}",
       "order_min_0": "Order must be 0 or greater",
       "composite_pct_invalid": "Minimum percentage must be less than maximum"
+    },
+    "dialogs": {
+      "deleteEvidence": {
+        "title": "Delete evidence",
+        "description": "This action will permanently delete the file {fileName}. This cannot be undone.",
+        "confirm": "Delete",
+        "confirmLoading": "Deleting...",
+        "cancel": "Cancel"
+      },
+      "sendFolder": {
+        "title": "Submit folder",
+        "description": "Once submitted, you will not be able to modify or add evidence until it is reviewed. Make sure you have uploaded everything required.",
+        "confirm": "Submit folder",
+        "confirmLoading": "Submitting...",
+        "cancel": "Cancel"
+      },
+      "closeFolder": {
+        "title": "Close folder",
+        "description": "Closing the folder will mark it as finalized. This action is final and cannot be reversed.",
+        "confirm": "Close folder",
+        "confirmLoading": "Closing...",
+        "cancel": "Cancel"
+      },
+      "deleteCategory": {
+        "title": "Delete category",
+        "description": "This action will delete the category {name}. Existing rankings that reference it may be affected.",
+        "confirm": "Delete category",
+        "confirmLoading": "Deleting...",
+        "cancel": "Cancel"
+      },
+      "recalculateRankings": {
+        "title": "Recalculate rankings",
+        "description": "Rankings will be recalculated for year {year}. This process may take a few seconds. Previous results will be replaced.",
+        "confirm": "Confirm recalculation",
+        "confirmLoading": "Recalculating...",
+        "cancel": "Cancel"
+      }
     }
   },
   "folders": {
@@ -3314,6 +3578,12 @@
     "validation": {
       "start_date_required": "Start date is required",
       "end_date_required": "End date is required"
+    },
+    "placeholders": {
+      "selectType": "Select type",
+      "policyNumber": "E.g. POL-2025-001",
+      "provider": "E.g. MAPFRE, San Cristóbal...",
+      "amount": "0.00"
     }
   },
   "finances": {
@@ -3572,6 +3842,19 @@
       "club_section_required": "Select the section",
       "activity_place_required": "Location is required",
       "image_required": "Image URL is required"
+    },
+    "placeholders": {
+      "name": "Activity name",
+      "description": "Optional description",
+      "selectType": "Select type",
+      "selectClubType": "Select club type",
+      "selectSection": "Select section",
+      "location": "E.g. Central Church",
+      "latitude": "0.000000",
+      "longitude": "0.000000",
+      "selectModality": "Select modality",
+      "meetUrl": "https://meet.google.com/...",
+      "externalUrl": "https://..."
     }
   },
   "year_end": {
@@ -3660,6 +3943,12 @@
       "description_max": "Description cannot exceed {max} characters",
       "category_required": "Select a category",
       "amount_min": "Quantity cannot be negative"
+    },
+    "placeholders": {
+      "name": "E.g. 4-person tents",
+      "description": "Optional item description",
+      "selectCategory": "Select category",
+      "quantity": "0"
     }
   },
   "units_admin": {
@@ -3712,6 +4001,9 @@
       "clubTypeAdventurers": "Adventurers",
       "clubTypePathfinders": "Pathfinders",
       "clubTypeMasterGuides": "Master Guides"
+    },
+    "placeholders": {
+      "selectMember": "Select member"
     }
   },
   "system_config": {
@@ -3777,6 +4069,11 @@
     "appMetadata": {
       "title": "SACDIA Admin Panel",
       "description": "SACDIA administration panel"
+    },
+    "uiPrimitives": {
+      "close": "Close",
+      "more": "More",
+      "toggleSidebar": "Toggle Sidebar"
     }
   },
   "translations": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -1317,6 +1317,190 @@
         "loadError": "Error al cargar el rol",
         "emptyLoadTitle": "No se pudo cargar el rol"
       }
+    },
+    "permissionGroups": {
+      "users": "Usuarios",
+      "roles": "Roles y Permisos",
+      "clubs": "Clubes",
+      "units": "Unidades",
+      "member_of_month": "Miembro del Mes",
+      "scoring_categories": "Categorías de Puntuación",
+      "requests": "Solicitudes",
+      "user_certifications": "Certificaciones de Usuario (Admin)",
+      "user_folders": "Carpetas de Usuario (Admin)",
+      "geography": "Jerarquía Geográfica",
+      "catalogs": "Catálogos",
+      "classes_honors": "Clases y Especialidades",
+      "activities": "Actividades",
+      "camporees": "Camporees",
+      "validation": "Validación",
+      "finances": "Finanzas",
+      "inventory": "Inventario",
+      "reports": "Reportes",
+      "notifications": "Notificaciones",
+      "resources": "Recursos",
+      "system": "Sistema"
+    },
+    "permissions": {
+      "users:read": "Ver listado",
+      "users:read_detail": "Ver detalle",
+      "users:update_profile": "Editar perfil propio",
+      "users:update_admin": "Gestión admin de usuarios",
+      "health:read": "Ver salud",
+      "health:update": "Actualizar salud",
+      "emergency_contacts:read": "Ver contactos de emergencia",
+      "emergency_contacts:update": "Actualizar contactos de emergencia",
+      "legal_representative:read": "Ver representante legal",
+      "legal_representative:update": "Actualizar representante legal",
+      "post_registration:read": "Ver post-registro",
+      "registration:complete": "Completar registro",
+      "roles:read": "Ver roles",
+      "permissions:read": "Ver permisos",
+      "permissions:assign": "Asignar permisos",
+      "clubs:read": "Ver clubes",
+      "clubs:create": "Crear club",
+      "clubs:update": "Editar club",
+      "clubs:delete": "Eliminar club",
+      "club_sections:read": "Ver secciones",
+      "club_sections:create": "Crear sección",
+      "club_sections:update": "Editar sección",
+      "club_roles:read": "Ver roles de club",
+      "club_roles:assign": "Asignar rol de club",
+      "club_roles:revoke": "Revocar rol de club",
+      "club_members:approve": "Aprobar membresía",
+      "club_members:reject": "Rechazar membresía",
+      "club_members:list_pending": "Ver solicitudes pendientes",
+      "units:read": "Ver unidades / miembro del mes",
+      "mom:read": "Ver miembro del mes",
+      "mom:supervise": "Supervisar multi-sección (admin/coordinador)",
+      "mom:evaluate": "Disparar evaluación manual",
+      "scoring_categories:read": "Ver categorías de puntuación",
+      "scoring_categories:manage": "Gestionar categorías de puntuación (uniones + campos locales)",
+      "requests:read": "Ver solicitudes de transferencia y asignación",
+      "requests:review": "Aprobar/rechazar solicitudes",
+      "user_certifications:read": "Ver progreso de certificaciones",
+      "user_certifications:manage": "Inscribir / actualizar / borrar certificaciones",
+      "user_folders:read": "Ver inscripción y progreso de carpetas",
+      "user_folders:manage": "Inscribir / actualizar / borrar asignaciones de carpeta",
+      "achievements:read": "Ver logros",
+      "achievements:manage": "Gestionar logros",
+      "rankings:read": "Ver rankings",
+      "rankings:recalculate": "Recalcular rankings",
+      "ranking_weights:read": "Ver pesos de ranking institucional",
+      "ranking_weights:write": "Editar pesos de ranking institucional",
+      "member_rankings:read_self": "Ver mi ranking",
+      "member_rankings:read_section": "Ver ranking de sección",
+      "member_rankings:read_club": "Ver ranking de club",
+      "member_rankings:read_lf": "Ver ranking de campo local",
+      "member_rankings:read_global": "Ver ranking global",
+      "member_ranking_weights:read": "Ver pesos de ranking de miembros",
+      "member_ranking_weights:write": "Editar pesos de ranking de miembros",
+      "section_rankings:read_club": "Ver ranking de secciones del club",
+      "section_rankings:read_lf": "Ver ranking de secciones del campo local",
+      "section_rankings:read_global": "Ver ranking global de secciones",
+      "award_categories:create": "Crear categoría de premios",
+      "award_categories:read": "Ver categorías de premios",
+      "award_categories:update": "Editar categoría de premios",
+      "award_categories:delete": "Eliminar categoría de premios",
+      "countries:read": "Ver países",
+      "countries:create": "Crear país",
+      "countries:update": "Editar país",
+      "countries:delete": "Eliminar país",
+      "unions:read": "Ver uniones",
+      "unions:create": "Crear unión",
+      "unions:update": "Editar unión",
+      "unions:delete": "Eliminar unión",
+      "local_fields:read": "Ver campos locales",
+      "local_fields:create": "Crear campo local",
+      "local_fields:update": "Editar campo local",
+      "local_fields:delete": "Eliminar campo local",
+      "churches:read": "Ver iglesias",
+      "churches:create": "Crear iglesia",
+      "churches:update": "Editar iglesia",
+      "churches:delete": "Eliminar iglesia",
+      "catalogs:read": "Ver catálogos",
+      "catalogs:create": "Crear ítem",
+      "catalogs:update": "Editar ítem",
+      "catalogs:delete": "Eliminar ítem",
+      "classes:read": "Ver clases",
+      "classes:submit_progress": "Enviar progreso de clase",
+      "classes:manage": "Gestionar clases",
+      "class_modules:manage": "Gestionar módulos de clase",
+      "class_sections:manage": "Gestionar secciones de clase",
+      "honors:read": "Ver especialidades",
+      "honors:create": "Crear especialidad",
+      "honors:update": "Editar especialidad",
+      "honors:delete": "Eliminar especialidad",
+      "master_honors:manage": "Gestionar especialidades maestras",
+      "user_honors:submit": "Enviar progreso de honor",
+      "user_honors:validate": "Validar honores",
+      "honor_categories:read": "Ver categorías",
+      "honor_categories:create": "Crear categoría",
+      "honor_categories:update": "Editar categoría",
+      "honor_categories:delete": "Eliminar categoría",
+      "folders:manage": "Gestionar carpetas",
+      "folder_modules:manage": "Gestionar módulos de carpeta",
+      "folder_sections:manage": "Gestionar secciones de carpeta",
+      "finance_categories:manage": "Gestionar categorías de finanzas",
+      "inventory_categories:manage": "Gestionar categorías de inventario",
+      "activities:read": "Ver actividades",
+      "activities:create": "Crear actividad",
+      "activities:update": "Editar actividad",
+      "activities:delete": "Eliminar actividad",
+      "attendance:read": "Ver asistencia",
+      "attendance:manage": "Gestionar asistencia",
+      "camporees:read": "Ver camporees",
+      "camporees:create": "Crear camporees",
+      "camporees:update": "Actualizar camporees",
+      "camporees:delete": "Desactivar camporees",
+      "validation:submit": "Enviar progreso para revisión",
+      "validation:review": "Aprobar/rechazar progreso enviado",
+      "validation:read": "Ver cola pendiente, historial y elegibilidad",
+      "finances:read": "Ver finanzas",
+      "finances:create": "Crear registro",
+      "finances:update": "Editar registro",
+      "finances:delete": "Eliminar registro",
+      "inventory:read": "Ver inventario",
+      "inventory:create": "Crear ítem",
+      "inventory:update": "Editar ítem",
+      "inventory:delete": "Eliminar ítem",
+      "notifications:send": "Enviar directa",
+      "notifications:broadcast": "Enviar broadcast",
+      "notifications:club": "Enviar por club",
+      "reports:read": "Leer reportes mensuales",
+      "reports:download": "Descargar PDF de reportes",
+      "dashboard:view": "Ver dashboard",
+      "resources:read": "Ver recursos",
+      "resources:create": "Subir recurso",
+      "resources:update": "Editar recurso",
+      "resources:delete": "Eliminar recurso",
+      "resource_categories:read": "Ver categorías de recursos",
+      "resource_categories:create": "Crear categoría de recursos",
+      "resource_categories:update": "Editar categoría de recursos",
+      "resource_categories:delete": "Eliminar categoría de recursos",
+      "ecclesiastical_years:read": "Ver años eclesiásticos",
+      "ecclesiastical_years:create": "Crear año eclesiástico",
+      "ecclesiastical_years:update": "Editar año eclesiástico"
+    },
+    "userPermissionsPanel": {
+      "title": "Permisos directos",
+      "subtitle": "Permisos asignados directamente a este usuario (sin pasar por roles)",
+      "addPermission": "Agregar permiso",
+      "noPermissionsTitle": "Este usuario no tiene permisos directos asignados.",
+      "addDirectPermission": "Agregar permiso",
+      "addDialogTitle": "Agregar permiso directo",
+      "addDialogDescription": "Selecciona un permiso para asignar directamente a este usuario.",
+      "searchPlaceholder": "Buscar permiso...",
+      "noMatchesSearch": "No se encontraron permisos que coincidan.",
+      "noPermissionsAvailable": "No hay permisos disponibles para asignar.",
+      "cancelButton": "Cancelar",
+      "assignButton": "Asignar permiso",
+      "removePermission": "Remover {name}",
+      "removeSrOnly": "Remover",
+      "removeDialogTitle": "¿Remover permiso directo?",
+      "removeDialogDescription": "Se removerá el permiso {name} asignado directamente a este usuario. El usuario puede seguir teniendo el permiso a través de sus roles.",
+      "removeCancel": "Cancelar",
+      "removeConfirm": "Remover"
     }
   },
   "resource_categories": {
@@ -1992,6 +2176,25 @@
       "categories": {
         "forbiddenDetail": "No cuentas con permisos para ver categorías de recursos."
       }
+    },
+    "placeholders": {
+      "title": "Ej. Manual del Conquistador 2025",
+      "description": "Descripción breve del recurso (opcional)",
+      "selectType": "Seleccionar tipo",
+      "selectCategory": "Sin categoría",
+      "selectClubType": "Todos los clubes",
+      "selectScope": "Alcance",
+      "selectUnion": "Seleccionar unión",
+      "unionId": "ID de la unión",
+      "selectLocalField": "Seleccionar campo local",
+      "localFieldId": "ID del campo local",
+      "videoUrl": "https://youtube.com/watch?v=... o https://vimeo.com/...",
+      "content": "Escribe el contenido del recurso aquí...",
+      "searchTitle": "Buscar por título...",
+      "filterType": "Todos los tipos",
+      "filterStatus": "Todos",
+      "filterScope": "Todas",
+      "filterClubType": "Todos"
     }
   },
   "investiture": {
@@ -2162,6 +2365,22 @@
       "errorFallback": "No se pudieron cargar las investiduras.",
       "emptyTitle": "Sin solicitudes de investidura",
       "emptyDescription": "No hay solicitudes de investidura en el sistema en este momento."
+    },
+    "investidoDialog": {
+      "title": "Registrar investidura",
+      "description": "Se registrará la investidura de {memberName}. Esta acción es irreversible y sincronizará el estado en el sistema.",
+      "commentsLabel": "Comentarios (opcional)",
+      "commentsPlaceholder": "Añade un comentario opcional...",
+      "cancel": "Cancelar",
+      "confirm": "Confirmar investidura"
+    },
+    "pipelineRejectDialog": {
+      "title": "Rechazar investidura",
+      "description": "Se rechazará la solicitud de investidura de {memberName}. El motivo es obligatorio.",
+      "reasonLabel": "Motivo de rechazo *",
+      "reasonPlaceholder": "Describe el motivo del rechazo...",
+      "cancel": "Cancelar",
+      "confirm": "Rechazar"
     }
   },
   "evidence_review": {
@@ -2246,6 +2465,14 @@
       "emptyTitle": "Sin evidencias pendientes",
       "emptyDescription": "No hay evidencias pendientes de revisión en este momento.",
       "allReviewed": "Todas las evidencias han sido revisadas."
+    },
+    "rejectDialog": {
+      "title": "Rechazar evidencia",
+      "description": "Vas a rechazar la evidencia de {memberName} para {sectionName}. El motivo es obligatorio.",
+      "reasonLabel": "Motivo de rechazo *",
+      "reasonPlaceholder": "Describe el motivo del rechazo para que el miembro pueda corregirlo...",
+      "cancel": "Cancelar",
+      "confirm": "Rechazar"
     }
   },
   "users": {
@@ -2679,6 +2906,43 @@
       "composite_pct_max": "No puede superar {max}",
       "order_min_0": "El orden debe ser 0 o mayor",
       "composite_pct_invalid": "El porcentaje mínimo debe ser menor que el máximo"
+    },
+    "dialogs": {
+      "deleteEvidence": {
+        "title": "Eliminar evidencia",
+        "description": "Esta acción eliminará permanentemente el archivo {fileName}. No se puede deshacer.",
+        "confirm": "Eliminar",
+        "confirmLoading": "Eliminando...",
+        "cancel": "Cancelar"
+      },
+      "sendFolder": {
+        "title": "Enviar carpeta",
+        "description": "Una vez enviada, no podrás modificar ni agregar evidencias hasta que sea revisada. Asegúrate de haber subido todo lo requerido.",
+        "confirm": "Enviar carpeta",
+        "confirmLoading": "Enviando...",
+        "cancel": "Cancelar"
+      },
+      "closeFolder": {
+        "title": "Cerrar carpeta",
+        "description": "Al cerrar la carpeta se registrará como finalizada. Esta acción es definitiva y no puede revertirse.",
+        "confirm": "Cerrar carpeta",
+        "confirmLoading": "Cerrando...",
+        "cancel": "Cancelar"
+      },
+      "deleteCategory": {
+        "title": "Eliminar categoría",
+        "description": "Esta acción eliminará la categoría {name}. Los rankings existentes que la referencien podrían verse afectados.",
+        "confirm": "Eliminar categoría",
+        "confirmLoading": "Eliminando...",
+        "cancel": "Cancelar"
+      },
+      "recalculateRankings": {
+        "title": "Recalcular rankings",
+        "description": "Se recalcularán los rankings para el año {year}. Este proceso puede tomar unos segundos. Los resultados anteriores serán reemplazados.",
+        "confirm": "Confirmar recálculo",
+        "confirmLoading": "Recalculando...",
+        "cancel": "Cancelar"
+      }
     }
   },
   "folders": {
@@ -3314,6 +3578,12 @@
     "validation": {
       "start_date_required": "La fecha de inicio es obligatoria",
       "end_date_required": "La fecha de fin es obligatoria"
+    },
+    "placeholders": {
+      "selectType": "Seleccionar tipo",
+      "policyNumber": "Ej. POL-2025-001",
+      "provider": "Ej. MAPFRE, San Cristóbal...",
+      "amount": "0.00"
     }
   },
   "finances": {
@@ -3572,6 +3842,19 @@
       "club_section_required": "Selecciona la sección",
       "activity_place_required": "El lugar es obligatorio",
       "image_required": "La URL de imagen es obligatoria"
+    },
+    "placeholders": {
+      "name": "Nombre de la actividad",
+      "description": "Descripción opcional",
+      "selectType": "Seleccionar tipo",
+      "selectClubType": "Seleccionar tipo de club",
+      "selectSection": "Seleccionar sección",
+      "location": "Ej. Iglesia Central",
+      "latitude": "0.000000",
+      "longitude": "0.000000",
+      "selectModality": "Seleccionar modalidad",
+      "meetUrl": "https://meet.google.com/...",
+      "externalUrl": "https://..."
     }
   },
   "year_end": {
@@ -3660,6 +3943,12 @@
       "description_max": "La descripción no puede superar {max} caracteres",
       "category_required": "Selecciona una categoría",
       "amount_min": "La cantidad no puede ser negativa"
+    },
+    "placeholders": {
+      "name": "Ej. Carpas 4 personas",
+      "description": "Descripción opcional del ítem",
+      "selectCategory": "Seleccionar categoría",
+      "quantity": "0"
     }
   },
   "units_admin": {
@@ -3712,6 +4001,9 @@
       "clubTypeAdventurers": "Aventureros",
       "clubTypePathfinders": "Conquistadores",
       "clubTypeMasterGuides": "Guías Mayores"
+    },
+    "placeholders": {
+      "selectMember": "Seleccionar miembro"
     }
   },
   "system_config": {
@@ -3777,6 +4069,11 @@
     "appMetadata": {
       "title": "SACDIA Panel Administrativo",
       "description": "Panel de administración de SACDIA"
+    },
+    "uiPrimitives": {
+      "close": "Cerrar",
+      "more": "Más opciones",
+      "toggleSidebar": "Alternar barra lateral"
     }
   },
   "translations": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1317,6 +1317,190 @@
         "loadError": "Erreur lors du chargement du rôle",
         "emptyLoadTitle": "Impossible de charger le rôle"
       }
+    },
+    "permissionGroups": {
+      "users": "Utilisateurs",
+      "roles": "Rôles et permissions",
+      "clubs": "Clubs",
+      "units": "Unités",
+      "member_of_month": "Membre du mois",
+      "scoring_categories": "Catégories de score",
+      "requests": "Demandes",
+      "user_certifications": "Certifications utilisateur (Admin)",
+      "user_folders": "Dossiers utilisateur (Admin)",
+      "geography": "Hiérarchie géographique",
+      "catalogs": "Catalogues",
+      "classes_honors": "Classes et spécialités",
+      "activities": "Activités",
+      "camporees": "Camporees",
+      "validation": "Validation",
+      "finances": "Finances",
+      "inventory": "Inventaire",
+      "reports": "Rapports",
+      "notifications": "Notifications",
+      "resources": "Ressources",
+      "system": "Système"
+    },
+    "permissions": {
+      "users:read": "Voir la liste",
+      "users:read_detail": "Voir le détail",
+      "users:update_profile": "Modifier son profil",
+      "users:update_admin": "Gestion admin des utilisateurs",
+      "health:read": "Voir santé",
+      "health:update": "Mettre à jour santé",
+      "emergency_contacts:read": "Voir contacts d'urgence",
+      "emergency_contacts:update": "Mettre à jour contacts d'urgence",
+      "legal_representative:read": "Voir représentant légal",
+      "legal_representative:update": "Mettre à jour représentant légal",
+      "post_registration:read": "Voir post-inscription",
+      "registration:complete": "Compléter inscription",
+      "roles:read": "Voir les rôles",
+      "permissions:read": "Voir les permissions",
+      "permissions:assign": "Assigner des permissions",
+      "clubs:read": "Voir les clubs",
+      "clubs:create": "Créer un club",
+      "clubs:update": "Modifier un club",
+      "clubs:delete": "Supprimer un club",
+      "club_sections:read": "Voir les sections",
+      "club_sections:create": "Créer une section",
+      "club_sections:update": "Modifier une section",
+      "club_roles:read": "Voir les rôles de club",
+      "club_roles:assign": "Assigner un rôle de club",
+      "club_roles:revoke": "Révoquer un rôle de club",
+      "club_members:approve": "Approuver une adhésion",
+      "club_members:reject": "Rejeter une adhésion",
+      "club_members:list_pending": "Voir les demandes en attente",
+      "units:read": "Voir unités / membre du mois",
+      "mom:read": "Voir membre du mois",
+      "mom:supervise": "Superviser multi-section (admin/coordinateur)",
+      "mom:evaluate": "Déclencher évaluation manuelle",
+      "scoring_categories:read": "Voir catégories de score",
+      "scoring_categories:manage": "Gérer catégories de score (unions + champs locaux)",
+      "requests:read": "Voir demandes de transfert et d'affectation",
+      "requests:review": "Approuver/rejeter des demandes",
+      "user_certifications:read": "Voir progrès de certifications",
+      "user_certifications:manage": "Inscrire / mettre à jour / supprimer des certifications",
+      "user_folders:read": "Voir inscription et progrès des dossiers",
+      "user_folders:manage": "Inscrire / mettre à jour / supprimer des affectations de dossier",
+      "achievements:read": "Voir réalisations",
+      "achievements:manage": "Gérer réalisations",
+      "rankings:read": "Voir classements",
+      "rankings:recalculate": "Recalculer classements",
+      "ranking_weights:read": "Voir poids classement institutionnel",
+      "ranking_weights:write": "Modifier poids classement institutionnel",
+      "member_rankings:read_self": "Voir mon classement",
+      "member_rankings:read_section": "Voir classement de section",
+      "member_rankings:read_club": "Voir classement de club",
+      "member_rankings:read_lf": "Voir classement de champ local",
+      "member_rankings:read_global": "Voir classement global",
+      "member_ranking_weights:read": "Voir poids classement membres",
+      "member_ranking_weights:write": "Modifier poids classement membres",
+      "section_rankings:read_club": "Voir classements sections du club",
+      "section_rankings:read_lf": "Voir classements sections champ local",
+      "section_rankings:read_global": "Voir classements sections global",
+      "award_categories:create": "Créer catégorie de prix",
+      "award_categories:read": "Voir catégories de prix",
+      "award_categories:update": "Modifier catégorie de prix",
+      "award_categories:delete": "Supprimer catégorie de prix",
+      "countries:read": "Voir les pays",
+      "countries:create": "Créer un pays",
+      "countries:update": "Modifier un pays",
+      "countries:delete": "Supprimer un pays",
+      "unions:read": "Voir les unions",
+      "unions:create": "Créer une union",
+      "unions:update": "Modifier une union",
+      "unions:delete": "Supprimer une union",
+      "local_fields:read": "Voir les champs locaux",
+      "local_fields:create": "Créer un champ local",
+      "local_fields:update": "Modifier un champ local",
+      "local_fields:delete": "Supprimer un champ local",
+      "churches:read": "Voir les églises",
+      "churches:create": "Créer une église",
+      "churches:update": "Modifier une église",
+      "churches:delete": "Supprimer une église",
+      "catalogs:read": "Voir les catalogues",
+      "catalogs:create": "Créer un élément",
+      "catalogs:update": "Modifier un élément",
+      "catalogs:delete": "Supprimer un élément",
+      "classes:read": "Voir les classes",
+      "classes:submit_progress": "Soumettre progrès de classe",
+      "classes:manage": "Gérer les classes",
+      "class_modules:manage": "Gérer les modules de classe",
+      "class_sections:manage": "Gérer les sections de classe",
+      "honors:read": "Voir les spécialités",
+      "honors:create": "Créer une spécialité",
+      "honors:update": "Modifier une spécialité",
+      "honors:delete": "Supprimer une spécialité",
+      "master_honors:manage": "Gérer les spécialités maîtresses",
+      "user_honors:submit": "Soumettre progrès d'honneur",
+      "user_honors:validate": "Valider les honneurs",
+      "honor_categories:read": "Voir les catégories",
+      "honor_categories:create": "Créer une catégorie",
+      "honor_categories:update": "Modifier une catégorie",
+      "honor_categories:delete": "Supprimer une catégorie",
+      "folders:manage": "Gérer les dossiers",
+      "folder_modules:manage": "Gérer les modules de dossier",
+      "folder_sections:manage": "Gérer les sections de dossier",
+      "finance_categories:manage": "Gérer les catégories de finance",
+      "inventory_categories:manage": "Gérer les catégories d'inventaire",
+      "activities:read": "Voir les activités",
+      "activities:create": "Créer une activité",
+      "activities:update": "Modifier une activité",
+      "activities:delete": "Supprimer une activité",
+      "attendance:read": "Voir les présences",
+      "attendance:manage": "Gérer les présences",
+      "camporees:read": "Voir les camporees",
+      "camporees:create": "Créer des camporees",
+      "camporees:update": "Mettre à jour des camporees",
+      "camporees:delete": "Désactiver des camporees",
+      "validation:submit": "Soumettre progrès pour révision",
+      "validation:review": "Approuver/rejeter progrès soumis",
+      "validation:read": "Voir file d'attente, historique et éligibilité",
+      "finances:read": "Voir les finances",
+      "finances:create": "Créer un enregistrement",
+      "finances:update": "Modifier un enregistrement",
+      "finances:delete": "Supprimer un enregistrement",
+      "inventory:read": "Voir l'inventaire",
+      "inventory:create": "Créer un article",
+      "inventory:update": "Modifier un article",
+      "inventory:delete": "Supprimer un article",
+      "notifications:send": "Envoyer directe",
+      "notifications:broadcast": "Envoyer broadcast",
+      "notifications:club": "Envoyer par club",
+      "reports:read": "Lire les rapports mensuels",
+      "reports:download": "Télécharger les rapports PDF",
+      "dashboard:view": "Voir le tableau de bord",
+      "resources:read": "Voir les ressources",
+      "resources:create": "Importer une ressource",
+      "resources:update": "Modifier une ressource",
+      "resources:delete": "Supprimer une ressource",
+      "resource_categories:read": "Voir les catégories de ressources",
+      "resource_categories:create": "Créer une catégorie de ressources",
+      "resource_categories:update": "Modifier une catégorie de ressources",
+      "resource_categories:delete": "Supprimer une catégorie de ressources",
+      "ecclesiastical_years:read": "Voir les années ecclésiastiques",
+      "ecclesiastical_years:create": "Créer une année ecclésiastique",
+      "ecclesiastical_years:update": "Modifier une année ecclésiastique"
+    },
+    "userPermissionsPanel": {
+      "title": "Permissions directes",
+      "subtitle": "Permissions assignées directement à cet utilisateur (pas via des rôles)",
+      "addPermission": "Ajouter une permission",
+      "noPermissionsTitle": "Cet utilisateur n'a pas de permissions directes.",
+      "addDirectPermission": "Ajouter une permission",
+      "addDialogTitle": "Ajouter une permission directe",
+      "addDialogDescription": "Sélectionnez une permission à assigner directement à cet utilisateur.",
+      "searchPlaceholder": "Rechercher une permission...",
+      "noMatchesSearch": "Aucune permission trouvée.",
+      "noPermissionsAvailable": "Aucune permission disponible à assigner.",
+      "cancelButton": "Annuler",
+      "assignButton": "Assigner la permission",
+      "removePermission": "Retirer {name}",
+      "removeSrOnly": "Retirer",
+      "removeDialogTitle": "Retirer la permission directe?",
+      "removeDialogDescription": "La permission {name} assignée directement à cet utilisateur sera retirée. L'utilisateur peut toujours avoir la permission via ses rôles.",
+      "removeCancel": "Annuler",
+      "removeConfirm": "Retirer"
     }
   },
   "resource_categories": {
@@ -1992,6 +2176,25 @@
       "categories": {
         "forbiddenDetail": "Vous n’avez pas les permissions pour voir les catégories de ressources."
       }
+    },
+    "placeholders": {
+      "title": "Ex. Manuel du Pathfinder 2025",
+      "description": "Brève description de la ressource (optionnel)",
+      "selectType": "Sélectionner le type",
+      "selectCategory": "Sans catégorie",
+      "selectClubType": "Tous les clubs",
+      "selectScope": "Portée",
+      "selectUnion": "Sélectionner l'union",
+      "unionId": "ID de l'union",
+      "selectLocalField": "Sélectionner le champ local",
+      "localFieldId": "ID du champ local",
+      "videoUrl": "https://youtube.com/watch?v=... ou https://vimeo.com/...",
+      "content": "Écrivez le contenu de la ressource ici...",
+      "searchTitle": "Rechercher par titre...",
+      "filterType": "Tous les types",
+      "filterStatus": "Tous",
+      "filterScope": "Toutes",
+      "filterClubType": "Tous"
     }
   },
   "investiture": {
@@ -2162,6 +2365,22 @@
       "errorFallback": "Impossible de charger les investitures.",
       "emptyTitle": "Aucune demande d'investiture",
       "emptyDescription": "Il n'y a aucune demande d'investiture dans le système pour l'instant."
+    },
+    "investidoDialog": {
+      "title": "Enregistrer l'investiture",
+      "description": "L'investiture de {memberName} sera enregistrée. Cette action est irréversible et synchronisera le statut dans le système.",
+      "commentsLabel": "Commentaires (optionnel)",
+      "commentsPlaceholder": "Ajoutez un commentaire optionnel...",
+      "cancel": "Annuler",
+      "confirm": "Confirmer l'investiture"
+    },
+    "pipelineRejectDialog": {
+      "title": "Rejeter l'investiture",
+      "description": "La demande d'investiture de {memberName} sera rejetée. Le motif est obligatoire.",
+      "reasonLabel": "Motif de rejet *",
+      "reasonPlaceholder": "Décrivez le motif du rejet...",
+      "cancel": "Annuler",
+      "confirm": "Rejeter"
     }
   },
   "evidence_review": {
@@ -2246,6 +2465,14 @@
       "emptyTitle": "Aucune preuve en attente",
       "emptyDescription": "Il n'y a aucune preuve en attente de révision pour le moment.",
       "allReviewed": "Toutes les preuves ont été révisées."
+    },
+    "rejectDialog": {
+      "title": "Rejeter la preuve",
+      "description": "Vous allez rejeter la preuve de {memberName} pour {sectionName}. Le motif est obligatoire.",
+      "reasonLabel": "Motif de rejet *",
+      "reasonPlaceholder": "Décrivez le motif du rejet pour que le membre puisse le corriger...",
+      "cancel": "Annuler",
+      "confirm": "Rejeter"
     }
   },
   "users": {
@@ -2679,6 +2906,43 @@
       "composite_pct_max": "Ne peut pas dépasser {max}",
       "order_min_0": "L'ordre doit être 0 ou plus",
       "composite_pct_invalid": "Le pourcentage minimum doit être inférieur au maximum"
+    },
+    "dialogs": {
+      "deleteEvidence": {
+        "title": "Supprimer la preuve",
+        "description": "Cette action supprimera définitivement le fichier {fileName}. Impossible d'annuler.",
+        "confirm": "Supprimer",
+        "confirmLoading": "Suppression...",
+        "cancel": "Annuler"
+      },
+      "sendFolder": {
+        "title": "Soumettre le dossier",
+        "description": "Une fois soumis, vous ne pourrez pas modifier ni ajouter des preuves jusqu'à révision. Assurez-vous d'avoir tout téléchargé.",
+        "confirm": "Soumettre le dossier",
+        "confirmLoading": "Envoi...",
+        "cancel": "Annuler"
+      },
+      "closeFolder": {
+        "title": "Fermer le dossier",
+        "description": "La fermeture du dossier le marquera comme finalisé. Cette action est définitive et irréversible.",
+        "confirm": "Fermer le dossier",
+        "confirmLoading": "Fermeture...",
+        "cancel": "Annuler"
+      },
+      "deleteCategory": {
+        "title": "Supprimer la catégorie",
+        "description": "Cette action supprimera la catégorie {name}. Les classements existants qui la référencent pourraient être affectés.",
+        "confirm": "Supprimer la catégorie",
+        "confirmLoading": "Suppression...",
+        "cancel": "Annuler"
+      },
+      "recalculateRankings": {
+        "title": "Recalculer les classements",
+        "description": "Les classements seront recalculés pour l'année {year}. Ce processus peut prendre quelques secondes. Les résultats précédents seront remplacés.",
+        "confirm": "Confirmer le recalcul",
+        "confirmLoading": "Recalcul...",
+        "cancel": "Annuler"
+      }
     }
   },
   "folders": {
@@ -3314,6 +3578,12 @@
     "validation": {
       "start_date_required": "La date de début est obligatoire",
       "end_date_required": "La date de fin est obligatoire"
+    },
+    "placeholders": {
+      "selectType": "Sélectionner le type",
+      "policyNumber": "Ex. POL-2025-001",
+      "provider": "Ex. MAPFRE, San Cristóbal...",
+      "amount": "0.00"
     }
   },
   "finances": {
@@ -3572,6 +3842,19 @@
       "club_section_required": "Sélectionnez la section",
       "activity_place_required": "Le lieu est obligatoire",
       "image_required": "L'URL de l'image est obligatoire"
+    },
+    "placeholders": {
+      "name": "Nom de l'activité",
+      "description": "Description optionnelle",
+      "selectType": "Sélectionner le type",
+      "selectClubType": "Sélectionner le type de club",
+      "selectSection": "Sélectionner la section",
+      "location": "Ex. Église centrale",
+      "latitude": "0.000000",
+      "longitude": "0.000000",
+      "selectModality": "Sélectionner la modalité",
+      "meetUrl": "https://meet.google.com/...",
+      "externalUrl": "https://..."
     }
   },
   "year_end": {
@@ -3660,6 +3943,12 @@
       "description_max": "La description ne peut pas dépasser {max} caractères",
       "category_required": "Sélectionnez une catégorie",
       "amount_min": "La quantité ne peut pas être négative"
+    },
+    "placeholders": {
+      "name": "Ex. Tentes 4 personnes",
+      "description": "Description optionnelle de l'article",
+      "selectCategory": "Sélectionner la catégorie",
+      "quantity": "0"
     }
   },
   "units_admin": {
@@ -3712,6 +4001,9 @@
       "clubTypeAdventurers": "Aventuriers",
       "clubTypePathfinders": "Conquistadores",
       "clubTypeMasterGuides": "Guides Majeurs"
+    },
+    "placeholders": {
+      "selectMember": "Sélectionner un membre"
     }
   },
   "system_config": {
@@ -3777,6 +4069,11 @@
     "appMetadata": {
       "title": "SACDIA Panneau d'administration",
       "description": "Panneau d'administration SACDIA"
+    },
+    "uiPrimitives": {
+      "close": "Fermer",
+      "more": "Plus",
+      "toggleSidebar": "Basculer la barre latérale"
     }
   },
   "translations": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1317,6 +1317,190 @@
         "loadError": "Erro ao carregar a função",
         "emptyLoadTitle": "Não foi possível carregar a função"
       }
+    },
+    "permissionGroups": {
+      "users": "Usuários",
+      "roles": "Funções e permissões",
+      "clubs": "Clubes",
+      "units": "Unidades",
+      "member_of_month": "Membro do Mês",
+      "scoring_categories": "Categorias de pontuação",
+      "requests": "Solicitações",
+      "user_certifications": "Certificações de usuário (Admin)",
+      "user_folders": "Pastas de usuário (Admin)",
+      "geography": "Hierarquia geográfica",
+      "catalogs": "Catálogos",
+      "classes_honors": "Classes e especialidades",
+      "activities": "Atividades",
+      "camporees": "Camporees",
+      "validation": "Validação",
+      "finances": "Finanças",
+      "inventory": "Inventário",
+      "reports": "Relatórios",
+      "notifications": "Notificações",
+      "resources": "Recursos",
+      "system": "Sistema"
+    },
+    "permissions": {
+      "users:read": "Ver lista",
+      "users:read_detail": "Ver detalhe",
+      "users:update_profile": "Editar perfil próprio",
+      "users:update_admin": "Gestão admin de usuários",
+      "health:read": "Ver saúde",
+      "health:update": "Atualizar saúde",
+      "emergency_contacts:read": "Ver contatos de emergência",
+      "emergency_contacts:update": "Atualizar contatos de emergência",
+      "legal_representative:read": "Ver representante legal",
+      "legal_representative:update": "Atualizar representante legal",
+      "post_registration:read": "Ver pós-registro",
+      "registration:complete": "Completar registro",
+      "roles:read": "Ver funções",
+      "permissions:read": "Ver permissões",
+      "permissions:assign": "Atribuir permissões",
+      "clubs:read": "Ver clubes",
+      "clubs:create": "Criar clube",
+      "clubs:update": "Editar clube",
+      "clubs:delete": "Excluir clube",
+      "club_sections:read": "Ver seções",
+      "club_sections:create": "Criar seção",
+      "club_sections:update": "Editar seção",
+      "club_roles:read": "Ver funções do clube",
+      "club_roles:assign": "Atribuir função ao clube",
+      "club_roles:revoke": "Revogar função do clube",
+      "club_members:approve": "Aprovar adesão",
+      "club_members:reject": "Rejeitar adesão",
+      "club_members:list_pending": "Ver solicitações pendentes",
+      "units:read": "Ver unidades / membro do mês",
+      "mom:read": "Ver membro do mês",
+      "mom:supervise": "Supervisionar multi-seção (admin/coordenador)",
+      "mom:evaluate": "Disparar avaliação manual",
+      "scoring_categories:read": "Ver categorias de pontuação",
+      "scoring_categories:manage": "Gerenciar categorias de pontuação (uniões + campos locais)",
+      "requests:read": "Ver solicitações de transferência e atribuição",
+      "requests:review": "Aprovar/rejeitar solicitações",
+      "user_certifications:read": "Ver progresso de certificações",
+      "user_certifications:manage": "Inscrever / atualizar / excluir certificações",
+      "user_folders:read": "Ver inscrição e progresso de pastas",
+      "user_folders:manage": "Inscrever / atualizar / excluir atribuições de pasta",
+      "achievements:read": "Ver conquistas",
+      "achievements:manage": "Gerenciar conquistas",
+      "rankings:read": "Ver classificações",
+      "rankings:recalculate": "Recalcular classificações",
+      "ranking_weights:read": "Ver pesos de classificação institucional",
+      "ranking_weights:write": "Editar pesos de classificação institucional",
+      "member_rankings:read_self": "Ver minha classificação",
+      "member_rankings:read_section": "Ver classificação da seção",
+      "member_rankings:read_club": "Ver classificação do clube",
+      "member_rankings:read_lf": "Ver classificação do campo local",
+      "member_rankings:read_global": "Ver classificação global",
+      "member_ranking_weights:read": "Ver pesos de classificação de membros",
+      "member_ranking_weights:write": "Editar pesos de classificação de membros",
+      "section_rankings:read_club": "Ver classificações de seções do clube",
+      "section_rankings:read_lf": "Ver classificações de seções do campo local",
+      "section_rankings:read_global": "Ver classificações globais de seções",
+      "award_categories:create": "Criar categoria de prêmios",
+      "award_categories:read": "Ver categorias de prêmios",
+      "award_categories:update": "Editar categoria de prêmios",
+      "award_categories:delete": "Excluir categoria de prêmios",
+      "countries:read": "Ver países",
+      "countries:create": "Criar país",
+      "countries:update": "Editar país",
+      "countries:delete": "Excluir país",
+      "unions:read": "Ver uniões",
+      "unions:create": "Criar união",
+      "unions:update": "Editar união",
+      "unions:delete": "Excluir união",
+      "local_fields:read": "Ver campos locais",
+      "local_fields:create": "Criar campo local",
+      "local_fields:update": "Editar campo local",
+      "local_fields:delete": "Excluir campo local",
+      "churches:read": "Ver igrejas",
+      "churches:create": "Criar igreja",
+      "churches:update": "Editar igreja",
+      "churches:delete": "Excluir igreja",
+      "catalogs:read": "Ver catálogos",
+      "catalogs:create": "Criar item",
+      "catalogs:update": "Editar item",
+      "catalogs:delete": "Excluir item",
+      "classes:read": "Ver classes",
+      "classes:submit_progress": "Enviar progresso de classe",
+      "classes:manage": "Gerenciar classes",
+      "class_modules:manage": "Gerenciar módulos de classe",
+      "class_sections:manage": "Gerenciar seções de classe",
+      "honors:read": "Ver especialidades",
+      "honors:create": "Criar especialidade",
+      "honors:update": "Editar especialidade",
+      "honors:delete": "Excluir especialidade",
+      "master_honors:manage": "Gerenciar especialidades mestras",
+      "user_honors:submit": "Enviar progresso de honra",
+      "user_honors:validate": "Validar honras",
+      "honor_categories:read": "Ver categorias",
+      "honor_categories:create": "Criar categoria",
+      "honor_categories:update": "Editar categoria",
+      "honor_categories:delete": "Excluir categoria",
+      "folders:manage": "Gerenciar pastas",
+      "folder_modules:manage": "Gerenciar módulos de pasta",
+      "folder_sections:manage": "Gerenciar seções de pasta",
+      "finance_categories:manage": "Gerenciar categorias de finanças",
+      "inventory_categories:manage": "Gerenciar categorias de inventário",
+      "activities:read": "Ver atividades",
+      "activities:create": "Criar atividade",
+      "activities:update": "Editar atividade",
+      "activities:delete": "Excluir atividade",
+      "attendance:read": "Ver presença",
+      "attendance:manage": "Gerenciar presença",
+      "camporees:read": "Ver camporees",
+      "camporees:create": "Criar camporees",
+      "camporees:update": "Atualizar camporees",
+      "camporees:delete": "Desativar camporees",
+      "validation:submit": "Enviar progresso para revisão",
+      "validation:review": "Aprovar/rejeitar progresso enviado",
+      "validation:read": "Ver fila pendente, histórico e elegibilidade",
+      "finances:read": "Ver finanças",
+      "finances:create": "Criar registro",
+      "finances:update": "Editar registro",
+      "finances:delete": "Excluir registro",
+      "inventory:read": "Ver inventário",
+      "inventory:create": "Criar item",
+      "inventory:update": "Editar item",
+      "inventory:delete": "Excluir item",
+      "notifications:send": "Enviar direta",
+      "notifications:broadcast": "Enviar broadcast",
+      "notifications:club": "Enviar por clube",
+      "reports:read": "Ler relatórios mensais",
+      "reports:download": "Baixar relatórios PDF",
+      "dashboard:view": "Ver painel",
+      "resources:read": "Ver recursos",
+      "resources:create": "Carregar recurso",
+      "resources:update": "Editar recurso",
+      "resources:delete": "Excluir recurso",
+      "resource_categories:read": "Ver categorias de recursos",
+      "resource_categories:create": "Criar categoria de recursos",
+      "resource_categories:update": "Editar categoria de recursos",
+      "resource_categories:delete": "Excluir categoria de recursos",
+      "ecclesiastical_years:read": "Ver anos eclesiásticos",
+      "ecclesiastical_years:create": "Criar ano eclesiástico",
+      "ecclesiastical_years:update": "Editar ano eclesiástico"
+    },
+    "userPermissionsPanel": {
+      "title": "Permissões diretas",
+      "subtitle": "Permissões atribuídas diretamente a este usuário (não por funções)",
+      "addPermission": "Adicionar permissão",
+      "noPermissionsTitle": "Este usuário não tem permissões diretas atribuídas.",
+      "addDirectPermission": "Adicionar permissão",
+      "addDialogTitle": "Adicionar permissão direta",
+      "addDialogDescription": "Selecione uma permissão para atribuir diretamente a este usuário.",
+      "searchPlaceholder": "Buscar permissão...",
+      "noMatchesSearch": "Nenhuma permissão encontrada.",
+      "noPermissionsAvailable": "Nenhuma permissão disponível para atribuir.",
+      "cancelButton": "Cancelar",
+      "assignButton": "Atribuir permissão",
+      "removePermission": "Remover {name}",
+      "removeSrOnly": "Remover",
+      "removeDialogTitle": "Remover permissão direta?",
+      "removeDialogDescription": "A permissão {name} atribuída diretamente a este usuário será removida. O usuário pode ainda ter a permissão por meio de suas funções.",
+      "removeCancel": "Cancelar",
+      "removeConfirm": "Remover"
     }
   },
   "resource_categories": {
@@ -1992,6 +2176,25 @@
       "categories": {
         "forbiddenDetail": "Você não tem permissão para ver categorias de recursos."
       }
+    },
+    "placeholders": {
+      "title": "Ex. Manual do Pathfinder 2025",
+      "description": "Breve descrição do recurso (opcional)",
+      "selectType": "Selecionar tipo",
+      "selectCategory": "Sem categoria",
+      "selectClubType": "Todos os clubes",
+      "selectScope": "Escopo",
+      "selectUnion": "Selecionar união",
+      "unionId": "ID da união",
+      "selectLocalField": "Selecionar campo local",
+      "localFieldId": "ID do campo local",
+      "videoUrl": "https://youtube.com/watch?v=... ou https://vimeo.com/...",
+      "content": "Escreva o conteúdo do recurso aqui...",
+      "searchTitle": "Buscar por título...",
+      "filterType": "Todos os tipos",
+      "filterStatus": "Todos",
+      "filterScope": "Todas",
+      "filterClubType": "Todos"
     }
   },
   "investiture": {
@@ -2162,6 +2365,22 @@
       "errorFallback": "Não foi possível carregar as investiduras.",
       "emptyTitle": "Sem solicitações de investidura",
       "emptyDescription": "Não há solicitações de investidura no sistema no momento."
+    },
+    "investidoDialog": {
+      "title": "Registrar investidura",
+      "description": "A investidura de {memberName} será registrada. Esta ação é irreversível e sincronizará o status no sistema.",
+      "commentsLabel": "Comentários (opcional)",
+      "commentsPlaceholder": "Adicione um comentário opcional...",
+      "cancel": "Cancelar",
+      "confirm": "Confirmar investidura"
+    },
+    "pipelineRejectDialog": {
+      "title": "Rejeitar investidura",
+      "description": "A solicitação de investidura de {memberName} será rejeitada. O motivo é obrigatório.",
+      "reasonLabel": "Motivo da rejeição *",
+      "reasonPlaceholder": "Descreva o motivo da rejeição...",
+      "cancel": "Cancelar",
+      "confirm": "Rejeitar"
     }
   },
   "evidence_review": {
@@ -2246,6 +2465,14 @@
       "emptyTitle": "Sem evidências pendentes",
       "emptyDescription": "Não há evidências pendentes de revisão no momento.",
       "allReviewed": "Todas as evidências foram revisadas."
+    },
+    "rejectDialog": {
+      "title": "Rejeitar evidência",
+      "description": "Você vai rejeitar a evidência de {memberName} para {sectionName}. O motivo é obrigatório.",
+      "reasonLabel": "Motivo da rejeição *",
+      "reasonPlaceholder": "Descreva o motivo da rejeição para que o membro possa corrigir...",
+      "cancel": "Cancelar",
+      "confirm": "Rejeitar"
     }
   },
   "users": {
@@ -2679,6 +2906,43 @@
       "composite_pct_max": "Não pode ultrapassar {max}",
       "order_min_0": "A ordem deve ser 0 ou maior",
       "composite_pct_invalid": "O percentual mínimo deve ser menor que o máximo"
+    },
+    "dialogs": {
+      "deleteEvidence": {
+        "title": "Excluir evidência",
+        "description": "Esta ação excluirá permanentemente o arquivo {fileName}. Não pode ser desfeita.",
+        "confirm": "Excluir",
+        "confirmLoading": "Excluindo...",
+        "cancel": "Cancelar"
+      },
+      "sendFolder": {
+        "title": "Enviar pasta",
+        "description": "Uma vez enviada, você não poderá modificar nem adicionar evidências até que seja revisada. Certifique-se de ter enviado tudo o necessário.",
+        "confirm": "Enviar pasta",
+        "confirmLoading": "Enviando...",
+        "cancel": "Cancelar"
+      },
+      "closeFolder": {
+        "title": "Fechar pasta",
+        "description": "Ao fechar a pasta ela será marcada como finalizada. Esta ação é definitiva e não pode ser revertida.",
+        "confirm": "Fechar pasta",
+        "confirmLoading": "Fechando...",
+        "cancel": "Cancelar"
+      },
+      "deleteCategory": {
+        "title": "Excluir categoria",
+        "description": "Esta ação excluirá a categoria {name}. As classificações existentes que a referenciam podem ser afetadas.",
+        "confirm": "Excluir categoria",
+        "confirmLoading": "Excluindo...",
+        "cancel": "Cancelar"
+      },
+      "recalculateRankings": {
+        "title": "Recalcular classificações",
+        "description": "As classificações serão recalculadas para o ano {year}. Este processo pode levar alguns segundos. Os resultados anteriores serão substituídos.",
+        "confirm": "Confirmar recálculo",
+        "confirmLoading": "Recalculando...",
+        "cancel": "Cancelar"
+      }
     }
   },
   "folders": {
@@ -3314,6 +3578,12 @@
     "validation": {
       "start_date_required": "A data de início é obrigatória",
       "end_date_required": "A data de fim é obrigatória"
+    },
+    "placeholders": {
+      "selectType": "Selecionar tipo",
+      "policyNumber": "Ex. POL-2025-001",
+      "provider": "Ex. MAPFRE, San Cristóbal...",
+      "amount": "0,00"
     }
   },
   "finances": {
@@ -3572,6 +3842,19 @@
       "club_section_required": "Selecione a seção",
       "activity_place_required": "O local é obrigatório",
       "image_required": "A URL da imagem é obrigatória"
+    },
+    "placeholders": {
+      "name": "Nome da atividade",
+      "description": "Descrição opcional",
+      "selectType": "Selecionar tipo",
+      "selectClubType": "Selecionar tipo de clube",
+      "selectSection": "Selecionar seção",
+      "location": "Ex. Igreja Central",
+      "latitude": "0.000000",
+      "longitude": "0.000000",
+      "selectModality": "Selecionar modalidade",
+      "meetUrl": "https://meet.google.com/...",
+      "externalUrl": "https://..."
     }
   },
   "year_end": {
@@ -3660,6 +3943,12 @@
       "description_max": "A descrição não pode ultrapassar {max} caracteres",
       "category_required": "Selecione uma categoria",
       "amount_min": "A quantidade não pode ser negativa"
+    },
+    "placeholders": {
+      "name": "Ex. Barracas 4 pessoas",
+      "description": "Descrição opcional do item",
+      "selectCategory": "Selecionar categoria",
+      "quantity": "0"
     }
   },
   "units_admin": {
@@ -3712,6 +4001,9 @@
       "clubTypeAdventurers": "Aventureiros",
       "clubTypePathfinders": "Conquistadores",
       "clubTypeMasterGuides": "Guias Maiores"
+    },
+    "placeholders": {
+      "selectMember": "Selecionar membro"
     }
   },
   "system_config": {
@@ -3777,6 +4069,11 @@
     "appMetadata": {
       "title": "SACDIA Painel Administrativo",
       "description": "Painel de administração do SACDIA"
+    },
+    "uiPrimitives": {
+      "close": "Fechar",
+      "more": "Mais",
+      "toggleSidebar": "Alternar barra lateral"
     }
   },
   "translations": {

--- a/src/components/activities/activity-form-dialog.tsx
+++ b/src/components/activities/activity-form-dialog.tsx
@@ -237,7 +237,7 @@ export function ActivityFormDialog({
               id="name"
               aria-required="true"
               {...register("name")}
-              placeholder="Nombre de la actividad"
+              placeholder={t("placeholders.name")}
             />
             {errors.name && (
               <p className="text-xs text-destructive">{errors.name.message}</p>
@@ -250,7 +250,7 @@ export function ActivityFormDialog({
             <Textarea
               id="description"
               {...register("description")}
-              placeholder="Descripción opcional"
+              placeholder={t("placeholders.description")}
               rows={3}
             />
           </div>
@@ -265,7 +265,7 @@ export function ActivityFormDialog({
               onValueChange={(val) => setValue("activity_type_id", Number(val))}
             >
               <SelectTrigger id="activity_type_id" aria-required="true">
-                <SelectValue placeholder="Seleccionar tipo" />
+                <SelectValue placeholder={t("placeholders.selectType")} />
               </SelectTrigger>
               <SelectContent>
                 {ACTIVITY_TYPES.map((t) => (
@@ -301,7 +301,7 @@ export function ActivityFormDialog({
                   }}
                 >
                   <SelectTrigger id="club_type_id" aria-required="true">
-                    <SelectValue placeholder="Seleccionar tipo de club" />
+                    <SelectValue placeholder={t("placeholders.selectClubType")} />
                   </SelectTrigger>
                   <SelectContent>
                     {CLUB_TYPES.map((ct) => (
@@ -327,7 +327,7 @@ export function ActivityFormDialog({
                   onValueChange={(val) => setValue("club_section_id", Number(val))}
                 >
                   <SelectTrigger id="club_section_id" aria-required="true">
-                    <SelectValue placeholder="Seleccionar sección" />
+                    <SelectValue placeholder={t("placeholders.selectSection")} />
                   </SelectTrigger>
                   <SelectContent>
                     {filteredSections.length > 0 ? (
@@ -364,7 +364,7 @@ export function ActivityFormDialog({
               id="activity_place"
               aria-required="true"
               {...register("activity_place")}
-              placeholder="Ej. Iglesia Central"
+              placeholder={t("placeholders.location")}
             />
             {errors.activity_place && (
               <p className="text-xs text-destructive">
@@ -395,7 +395,7 @@ export function ActivityFormDialog({
                 step="any"
                 aria-required="true"
                 {...register("lat")}
-                placeholder="0.000000"
+                placeholder={t("placeholders.latitude")}
               />
               {errors.lat && (
                 <p className="text-xs text-destructive">{errors.lat.message}</p>
@@ -411,7 +411,7 @@ export function ActivityFormDialog({
                 step="any"
                 aria-required="true"
                 {...register("long")}
-                placeholder="0.000000"
+                placeholder={t("placeholders.longitude")}
               />
               {errors.long && (
                 <p className="text-xs text-destructive">
@@ -429,7 +429,7 @@ export function ActivityFormDialog({
               onValueChange={(val) => setValue("platform", Number(val))}
             >
               <SelectTrigger id="platform">
-                <SelectValue placeholder="Seleccionar modalidad" />
+                <SelectValue placeholder={t("placeholders.selectModality")} />
               </SelectTrigger>
               <SelectContent>
                 {PLATFORMS.map((p) => (
@@ -448,7 +448,7 @@ export function ActivityFormDialog({
               <Input
                 id="link_meet"
                 {...register("link_meet")}
-                placeholder="https://meet.google.com/..."
+                placeholder={t("placeholders.meetUrl")}
                 type="url"
               />
             </div>
@@ -463,7 +463,7 @@ export function ActivityFormDialog({
               id="image"
               aria-required="true"
               {...register("image")}
-              placeholder="https://..."
+              placeholder={t("placeholders.externalUrl")}
               type="url"
             />
             {errors.image && (

--- a/src/components/annual-folders/award-categories-client-page.tsx
+++ b/src/components/annual-folders/award-categories-client-page.tsx
@@ -622,23 +622,25 @@ export function AwardCategoriesClientPage({
       <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Eliminar categoría</AlertDialogTitle>
+            <AlertDialogTitle>{t("dialogs.deleteCategory.title")}</AlertDialogTitle>
             <AlertDialogDescription>
-              Esta acción eliminará la categoría{" "}
-              <strong>{deletingCategory?.name}</strong>. Los rankings existentes
-              que la referencien podrían verse afectados.
+              {t("dialogs.deleteCategory.description", {
+                name: deletingCategory?.name ?? "",
+              })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isDeleting}>
-              Cancelar
+              {t("dialogs.deleteCategory.cancel")}
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDelete}
               disabled={isDeleting}
               className="bg-destructive text-white hover:bg-destructive/90"
             >
-              {isDeleting ? "Eliminando..." : "Eliminar categoría"}
+              {isDeleting
+                ? t("dialogs.deleteCategory.confirmLoading")
+                : t("dialogs.deleteCategory.confirm")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/annual-folders/folder-client-page.tsx
+++ b/src/components/annual-folders/folder-client-page.tsx
@@ -444,23 +444,25 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
       <AlertDialog open={deleteEvidenceOpen} onOpenChange={setDeleteEvidenceOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Eliminar evidencia</AlertDialogTitle>
+            <AlertDialogTitle>{t("dialogs.deleteEvidence.title")}</AlertDialogTitle>
             <AlertDialogDescription>
-              Esta acción eliminará permanentemente el archivo{" "}
-              <strong>{deletingEvidence?.file_name ?? "seleccionado"}</strong>.
-              No se puede deshacer.
+              {t("dialogs.deleteEvidence.description", {
+                fileName: deletingEvidence?.file_name ?? "seleccionado",
+              })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isDeletingEvidence}>
-              Cancelar
+              {t("dialogs.deleteEvidence.cancel")}
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmDeleteEvidence}
               disabled={isDeletingEvidence}
               className="bg-destructive text-white hover:bg-destructive/90"
             >
-              {isDeletingEvidence ? "Eliminando..." : "Eliminar"}
+              {isDeletingEvidence
+                ? t("dialogs.deleteEvidence.confirmLoading")
+                : t("dialogs.deleteEvidence.confirm")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -470,19 +472,22 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
       <AlertDialog open={submitOpen} onOpenChange={setSubmitOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Enviar carpeta</AlertDialogTitle>
+            <AlertDialogTitle>{t("dialogs.sendFolder.title")}</AlertDialogTitle>
             <AlertDialogDescription>
-              Una vez enviada, no podrás modificar ni agregar evidencias hasta
-              que sea revisada. Asegurate de haber subido todo lo requerido.
+              {t("dialogs.sendFolder.description")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={isActioning}>Cancelar</AlertDialogCancel>
+            <AlertDialogCancel disabled={isActioning}>
+              {t("dialogs.sendFolder.cancel")}
+            </AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmSubmit}
               disabled={isActioning}
             >
-              {isActioning ? "Enviando..." : "Enviar carpeta"}
+              {isActioning
+                ? t("dialogs.sendFolder.confirmLoading")
+                : t("dialogs.sendFolder.confirm")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -492,19 +497,22 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
       <AlertDialog open={closeOpen} onOpenChange={setCloseOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Cerrar carpeta</AlertDialogTitle>
+            <AlertDialogTitle>{t("dialogs.closeFolder.title")}</AlertDialogTitle>
             <AlertDialogDescription>
-              Al cerrar la carpeta se registrará como finalizada. Esta acción es
-              definitiva y no puede revertirse.
+              {t("dialogs.closeFolder.description")}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={isActioning}>Cancelar</AlertDialogCancel>
+            <AlertDialogCancel disabled={isActioning}>
+              {t("dialogs.closeFolder.cancel")}
+            </AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmClose}
               disabled={isActioning}
             >
-              {isActioning ? "Cerrando..." : "Cerrar carpeta"}
+              {isActioning
+                ? t("dialogs.closeFolder.confirmLoading")
+                : t("dialogs.closeFolder.confirm")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/annual-folders/rankings-client-page.tsx
+++ b/src/components/annual-folders/rankings-client-page.tsx
@@ -633,23 +633,24 @@ export function RankingsClientPage({
       <AlertDialog open={recalcOpen} onOpenChange={setRecalcOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Recalcular rankings</AlertDialogTitle>
+            <AlertDialogTitle>{t("dialogs.recalculateRankings.title")}</AlertDialogTitle>
             <AlertDialogDescription>
-              Se recalcularán los rankings para el año{" "}
-              <strong>{activeYear?.name ?? selectedYearId}</strong>. Este proceso
-              puede tomar unos segundos. Los resultados anteriores serán
-              reemplazados.
+              {t("dialogs.recalculateRankings.description", {
+                year: activeYear?.name ?? selectedYearId ?? "",
+              })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel disabled={isRecalculating}>
-              Cancelar
+              {t("dialogs.recalculateRankings.cancel")}
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={confirmRecalculate}
               disabled={isRecalculating}
             >
-              {isRecalculating ? "Recalculando..." : "Confirmar recálculo"}
+              {isRecalculating
+                ? t("dialogs.recalculateRankings.confirmLoading")
+                : t("dialogs.recalculateRankings.confirm")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/src/components/evidence-review/evidence-reject-dialog.tsx
+++ b/src/components/evidence-review/evidence-reject-dialog.tsx
@@ -92,22 +92,19 @@ export function EvidenceRejectDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <XCircle className="size-5 text-destructive" />
-            Rechazar evidencia
+            {t("rejectDialog.title")}
           </DialogTitle>
           <DialogDescription>
-            Vas a rechazar la evidencia de{" "}
-            <span className="font-medium text-foreground">{memberName}</span> para{" "}
-            <span className="font-medium text-foreground">{sectionName}</span>. El
-            motivo es obligatorio.
+            {t("rejectDialog.description", { memberName, sectionName })}
           </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="reject-reason">Motivo de rechazo *</Label>
+            <Label htmlFor="reject-reason">{t("rejectDialog.reasonLabel")}</Label>
             <Textarea
               id="reject-reason"
-              placeholder="Describe el motivo del rechazo para que el miembro pueda corregirlo..."
+              placeholder={t("rejectDialog.reasonPlaceholder")}
               rows={4}
               {...form.register("reason")}
               disabled={isSubmitting}
@@ -129,11 +126,11 @@ export function EvidenceRejectDialog({
               onClick={() => handleClose(false)}
               disabled={isSubmitting}
             >
-              Cancelar
+              {t("rejectDialog.cancel")}
             </Button>
             <Button type="submit" variant="destructive" disabled={isSubmitting}>
               {isSubmitting && <Loader2 className="size-4 animate-spin" />}
-              Rechazar
+              {t("rejectDialog.confirm")}
             </Button>
           </DialogFooter>
         </form>

--- a/src/components/insurance/insurance-form-dialog.tsx
+++ b/src/components/insurance/insurance-form-dialog.tsx
@@ -205,7 +205,7 @@ export function InsuranceFormDialog({
               onValueChange={(val) => setValue("insurance_type", val as InsuranceType)}
             >
               <SelectTrigger id="insurance_type" aria-required="true">
-                <SelectValue placeholder="Seleccionar tipo" />
+                <SelectValue placeholder={t("placeholders.selectType")} />
               </SelectTrigger>
               <SelectContent>
                 {INSURANCE_TYPES.map((type) => (
@@ -226,7 +226,7 @@ export function InsuranceFormDialog({
             <Input
               id="policy_number"
               {...register("policy_number")}
-              placeholder="Ej. POL-2025-001"
+              placeholder={t("placeholders.policyNumber")}
             />
           </div>
 
@@ -236,7 +236,7 @@ export function InsuranceFormDialog({
             <Input
               id="provider"
               {...register("provider")}
-              placeholder="Ej. MAPFRE, San Cristóbal..."
+              placeholder={t("placeholders.provider")}
             />
           </div>
 
@@ -283,7 +283,7 @@ export function InsuranceFormDialog({
               min={0}
               step="0.01"
               {...register("coverage_amount")}
-              placeholder="0.00"
+              placeholder={t("placeholders.amount")}
             />
             {errors.coverage_amount && (
               <p className="text-xs text-destructive">{errors.coverage_amount.message}</p>

--- a/src/components/inventory/inventory-form-dialog.tsx
+++ b/src/components/inventory/inventory-form-dialog.tsx
@@ -178,7 +178,7 @@ export function InventoryFormDialog({
               id="name"
               aria-required="true"
               {...register("name")}
-              placeholder="Ej. Carpas 4 personas"
+              placeholder={t("placeholders.name")}
             />
             {errors.name && (
               <p className="text-xs text-destructive">{errors.name.message}</p>
@@ -191,7 +191,7 @@ export function InventoryFormDialog({
             <Textarea
               id="description"
               {...register("description")}
-              placeholder="Descripción opcional del ítem"
+              placeholder={t("placeholders.description")}
               rows={3}
             />
             {errors.description && (
@@ -212,7 +212,7 @@ export function InventoryFormDialog({
               }
             >
               <SelectTrigger id="inventory_category_id" aria-required="true">
-                <SelectValue placeholder="Seleccionar categoría" />
+                <SelectValue placeholder={t("placeholders.selectCategory")} />
               </SelectTrigger>
               <SelectContent>
                 {categories.length > 0 ? (
@@ -250,7 +250,7 @@ export function InventoryFormDialog({
               min={0}
               aria-required="true"
               {...register("amount")}
-              placeholder="0"
+              placeholder={t("placeholders.quantity")}
             />
             {errors.amount && (
               <p className="text-xs text-destructive">{errors.amount.message}</p>

--- a/src/components/investiture/investido-dialog.tsx
+++ b/src/components/investiture/investido-dialog.tsx
@@ -91,21 +91,19 @@ export function InvestidoDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <Award className="size-5 text-primary" />
-            Registrar investidura
+            {t("investidoDialog.title")}
           </DialogTitle>
           <DialogDescription>
-            Se registrará la investidura de{" "}
-            <span className="font-medium text-foreground">{memberName}</span>.
-            Esta acción es irreversible y sincronizará el estado en el sistema.
+            {t("investidoDialog.description", { memberName })}
           </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="investido-comments">Comentarios (opcional)</Label>
+            <Label htmlFor="investido-comments">{t("investidoDialog.commentsLabel")}</Label>
             <Textarea
               id="investido-comments"
-              placeholder="Añade un comentario opcional..."
+              placeholder={t("investidoDialog.commentsPlaceholder")}
               rows={3}
               {...form.register("comments")}
               disabled={isPending}
@@ -119,11 +117,11 @@ export function InvestidoDialog({
               onClick={() => handleClose(false)}
               disabled={isPending}
             >
-              Cancelar
+              {t("investidoDialog.cancel")}
             </Button>
             <Button type="submit" disabled={isPending}>
               {isPending && <Loader2 className="size-4 animate-spin" />}
-              Confirmar investidura
+              {t("investidoDialog.confirm")}
             </Button>
           </DialogFooter>
         </form>

--- a/src/components/investiture/pipeline-reject-dialog.tsx
+++ b/src/components/investiture/pipeline-reject-dialog.tsx
@@ -90,20 +90,19 @@ export function PipelineRejectDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <XCircle className="size-5 text-destructive" />
-            Rechazar investidura
+            {t("pipelineRejectDialog.title")}
           </DialogTitle>
           <DialogDescription>
-            Se rechazará la solicitud de investidura de {memberName}. El motivo
-            es obligatorio.
+            {t("pipelineRejectDialog.description", { memberName })}
           </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-2">
-            <Label htmlFor="reason">Motivo de rechazo *</Label>
+            <Label htmlFor="reason">{t("pipelineRejectDialog.reasonLabel")}</Label>
             <Textarea
               id="reason"
-              placeholder="Describe el motivo del rechazo..."
+              placeholder={t("pipelineRejectDialog.reasonPlaceholder")}
               rows={3}
               {...form.register("reason")}
               disabled={isPending}
@@ -125,11 +124,11 @@ export function PipelineRejectDialog({
               onClick={() => handleClose(false)}
               disabled={isPending}
             >
-              Cancelar
+              {t("pipelineRejectDialog.cancel")}
             </Button>
             <Button type="submit" variant="destructive" disabled={isPending}>
               {isPending && <Loader2 className="size-4 animate-spin" />}
-              Rechazar
+              {t("pipelineRejectDialog.confirm")}
             </Button>
           </DialogFooter>
         </form>

--- a/src/components/rbac/user-permissions-panel.tsx
+++ b/src/components/rbac/user-permissions-panel.tsx
@@ -141,16 +141,16 @@ export function UserPermissionsPanel({
               <ShieldCheck className="size-4 text-primary" />
             </div>
             <div>
-              <CardTitle className="text-base">Permisos directos</CardTitle>
+              <CardTitle className="text-base">{t("userPermissionsPanel.title")}</CardTitle>
               <p className="text-xs text-muted-foreground">
-                Permisos asignados directamente a este usuario (sin pasar por roles)
+                {t("userPermissionsPanel.subtitle")}
               </p>
             </div>
           </div>
           {availablePermissions.length > 0 && (
             <Button size="sm" onClick={handleOpenAddDialog} disabled={isPending}>
               <Plus className="mr-1 size-3.5" />
-              Agregar permiso
+              {t("userPermissionsPanel.addPermission")}
             </Button>
           )}
         </CardHeader>
@@ -159,12 +159,12 @@ export function UserPermissionsPanel({
             <div className="flex flex-col items-center gap-3 py-6 text-center">
               <ShieldCheck className="size-8 text-muted-foreground/40" />
               <p className="text-sm text-muted-foreground">
-                Este usuario no tiene permisos directos asignados.
+                {t("userPermissionsPanel.noPermissionsTitle")}
               </p>
               {availablePermissions.length > 0 && (
                 <Button size="sm" variant="outline" onClick={handleOpenAddDialog} disabled={isPending}>
                   <Plus className="mr-1 size-3.5" />
-                  Agregar permiso
+                  {t("userPermissionsPanel.addDirectPermission")}
                 </Button>
               )}
             </div>
@@ -182,10 +182,10 @@ export function UserPermissionsPanel({
                     onClick={() => setPermToRemove(up)}
                     disabled={isPending}
                     className="ml-0.5 rounded-sm opacity-60 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none"
-                    title={`Remover ${up.permissions.permission_name}`}
+                    title={t("userPermissionsPanel.removePermission", { name: up.permissions.permission_name })}
                   >
                     <X className="size-3" />
-                    <span className="sr-only">Remover</span>
+                    <span className="sr-only">{t("userPermissionsPanel.removeSrOnly")}</span>
                   </button>
                 </Badge>
               ))}
@@ -198,9 +198,9 @@ export function UserPermissionsPanel({
       <Dialog open={addDialogOpen} onOpenChange={setAddDialogOpen}>
         <DialogContent className="max-h-[80vh] max-w-md">
           <DialogHeader>
-            <DialogTitle>Agregar permiso directo</DialogTitle>
+            <DialogTitle>{t("userPermissionsPanel.addDialogTitle")}</DialogTitle>
             <DialogDescription>
-              Seleccioná un permiso para asignar directamente a este usuario.
+              {t("userPermissionsPanel.addDialogDescription")}
             </DialogDescription>
           </DialogHeader>
 
@@ -208,7 +208,7 @@ export function UserPermissionsPanel({
             <div className="relative">
               <Search className="absolute left-2.5 top-2.5 size-4 text-muted-foreground" />
               <Input
-                placeholder="Buscar permiso..."
+                placeholder={t("userPermissionsPanel.searchPlaceholder")}
                 value={search}
                 onChange={(e) => {
                   setSearch(e.target.value);
@@ -221,8 +221,8 @@ export function UserPermissionsPanel({
             {filteredPermissions.length === 0 ? (
               <p className="py-4 text-center text-sm text-muted-foreground">
                 {search
-                  ? "No se encontraron permisos que coincidan."
-                  : "No hay permisos disponibles para asignar."}
+                  ? t("userPermissionsPanel.noMatchesSearch")
+                  : t("userPermissionsPanel.noPermissionsAvailable")}
               </p>
             ) : (
               <div className="max-h-64 overflow-y-auto rounded-md border">
@@ -262,7 +262,7 @@ export function UserPermissionsPanel({
               onClick={() => setAddDialogOpen(false)}
               disabled={isPending}
             >
-              Cancelar
+              {t("userPermissionsPanel.cancelButton")}
             </Button>
             <Button
               type="button"
@@ -270,7 +270,7 @@ export function UserPermissionsPanel({
               disabled={isPending || !selectedPermId}
             >
               {isPending && <Loader2 className="size-4 animate-spin" />}
-              Asignar permiso
+              {t("userPermissionsPanel.assignButton")}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -286,25 +286,24 @@ export function UserPermissionsPanel({
         >
           <AlertDialogContent>
             <AlertDialogHeader>
-              <AlertDialogTitle>¿Remover permiso directo?</AlertDialogTitle>
+              <AlertDialogTitle>{t("userPermissionsPanel.removeDialogTitle")}</AlertDialogTitle>
               <AlertDialogDescription>
-                Se removerá el permiso{" "}
-                <code className="rounded bg-muted px-1 py-0.5 text-xs font-mono">
-                  {permToRemove.permissions.permission_name}
-                </code>{" "}
-                asignado directamente a este usuario. El usuario puede seguir teniendo el permiso
-                a través de sus roles.
+                {t("userPermissionsPanel.removeDialogDescription", {
+                  name: permToRemove.permissions.permission_name,
+                })}
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+              <AlertDialogCancel disabled={isPending}>
+                {t("userPermissionsPanel.removeCancel")}
+              </AlertDialogCancel>
               <AlertDialogAction
                 onClick={handleRemove}
                 disabled={isPending}
                 className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
               >
                 {isPending && <Loader2 className="size-4 animate-spin" />}
-                Remover
+                {t("userPermissionsPanel.removeConfirm")}
               </AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>

--- a/src/components/resources/resources-crud-page.tsx
+++ b/src/components/resources/resources-crud-page.tsx
@@ -394,6 +394,7 @@ function ResourceFormFields({
   isEdit?: boolean;
   onFileSizeError?: (error: string | null) => void;
 }) {
+  const t = useTranslations("resources");
   const [resourceType, setResourceType] = useState<ResourceType>(
     (item?.resource_type as ResourceType) ?? "document",
   );
@@ -447,7 +448,7 @@ function ResourceFormFields({
           defaultValue={toText(item?.title) ?? ""}
           required
           maxLength={255}
-          placeholder="Ej. Manual del Conquistador 2025"
+          placeholder={t("placeholders.title")}
         />
       </div>
 
@@ -459,7 +460,7 @@ function ResourceFormFields({
           name="description"
           rows={2}
           defaultValue={toText(item?.description) ?? ""}
-          placeholder="Descripción breve del recurso (opcional)"
+          placeholder={t("placeholders.description")}
         />
       </div>
 
@@ -477,7 +478,7 @@ function ResourceFormFields({
             required
           >
             <SelectTrigger id="res-type">
-              <SelectValue placeholder="Seleccionar tipo" />
+              <SelectValue placeholder={t("placeholders.selectType")} />
             </SelectTrigger>
             <SelectContent>
               {(Object.entries(RESOURCE_TYPE_LABELS) as [ResourceType, string][]).map(
@@ -504,7 +505,7 @@ function ResourceFormFields({
             defaultValue={toPositiveNumber(item?.category_id)?.toString() ?? "none"}
           >
             <SelectTrigger id="res-category">
-              <SelectValue placeholder="Sin categoría" />
+              <SelectValue placeholder={t("placeholders.selectCategory")} />
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="none">Sin categoría</SelectItem>
@@ -528,7 +529,7 @@ function ResourceFormFields({
             defaultValue={(item?.club_type as string) ?? "all"}
           >
             <SelectTrigger id="res-club-type">
-              <SelectValue placeholder="Todos los clubes" />
+              <SelectValue placeholder={t("placeholders.selectClubType")} />
             </SelectTrigger>
             <SelectContent>
               {(Object.entries(CLUB_TYPE_LABELS) as [ClubTypeTarget, string][]).map(
@@ -554,7 +555,7 @@ function ResourceFormFields({
             disabled={isEdit}
           >
             <SelectTrigger id="res-scope-level">
-              <SelectValue placeholder="Alcance" />
+              <SelectValue placeholder={t("placeholders.selectScope")} />
             </SelectTrigger>
             <SelectContent>
               {(Object.entries(SCOPE_LEVEL_LABELS) as [ScopeLevel, string][]).map(
@@ -584,7 +585,7 @@ function ResourceFormFields({
                 required
               >
                 <SelectTrigger id="res-scope-id">
-                  <SelectValue placeholder="Seleccionar unión" />
+                  <SelectValue placeholder={t("placeholders.selectUnion")} />
                 </SelectTrigger>
                 <SelectContent>
                   {unions.map((u) => (
@@ -602,7 +603,7 @@ function ResourceFormFields({
                 min={1}
                 defaultValue={currentScopeIdValue}
                 required
-                placeholder="ID de la unión"
+                placeholder={t("placeholders.unionId")}
               />
             )
           ) : localFields.length > 0 ? (
@@ -612,7 +613,7 @@ function ResourceFormFields({
               required
             >
               <SelectTrigger id="res-scope-id">
-                <SelectValue placeholder="Seleccionar campo local" />
+                <SelectValue placeholder={t("placeholders.selectLocalField")} />
               </SelectTrigger>
               <SelectContent>
                 {localFields.map((lf) => (
@@ -630,7 +631,7 @@ function ResourceFormFields({
               min={1}
               defaultValue={currentScopeIdValue}
               required
-              placeholder="ID del campo local"
+              placeholder={t("placeholders.localFieldId")}
             />
           )}
         </div>
@@ -674,7 +675,7 @@ function ResourceFormFields({
             type="url"
             defaultValue={toText(item?.external_url) ?? ""}
             required={showExternalUrl}
-            placeholder="https://youtube.com/watch?v=... o https://vimeo.com/..."
+            placeholder={t("placeholders.videoUrl")}
           />
           <p className="text-xs text-muted-foreground">
             Enlace a YouTube, Vimeo u otro servicio de video.
@@ -694,7 +695,7 @@ function ResourceFormFields({
             rows={8}
             defaultValue={toText(item?.content) ?? ""}
             required={showContent}
-            placeholder="Escribe el contenido del recurso aquí..."
+            placeholder={t("placeholders.content")}
             className="resize-y"
           />
         </div>
@@ -891,7 +892,7 @@ export function ResourcesCrudPage({
                   <Search className="absolute left-3 top-1/2 size-3.5 -translate-y-1/2 text-muted-foreground" />
                   <Input
                     id="res-filter-search"
-                    placeholder="Buscar por título..."
+                    placeholder={t("placeholders.searchTitle")}
                     value={searchInput}
                     onChange={(e) => handleSearchInputChange(e.target.value)}
                     className="bg-background pl-8 h-8 text-sm"
@@ -909,7 +910,7 @@ export function ResourcesCrudPage({
                   onValueChange={(v) => updateParam("resource_type", v)}
                 >
                   <SelectTrigger id="res-filter-type" className="bg-background h-8 text-sm">
-                    <SelectValue placeholder="Todos los tipos" />
+                    <SelectValue placeholder={t("placeholders.filterType")} />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">Todos los tipos</SelectItem>
@@ -934,7 +935,7 @@ export function ResourcesCrudPage({
                   onValueChange={(v) => updateParam("scope_level", v)}
                 >
                   <SelectTrigger id="res-filter-scope" className="bg-background h-8 text-sm">
-                    <SelectValue placeholder="Todos" />
+                    <SelectValue placeholder={t("placeholders.filterStatus")} />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">Todos los alcances</SelectItem>
@@ -960,7 +961,7 @@ export function ResourcesCrudPage({
                     onValueChange={(v) => updateParam("category_id", v)}
                   >
                     <SelectTrigger id="res-filter-category" className="bg-background h-8 text-sm">
-                      <SelectValue placeholder="Todas" />
+                      <SelectValue placeholder={t("placeholders.filterScope")} />
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="all">Todas las categorías</SelectItem>
@@ -987,7 +988,7 @@ export function ResourcesCrudPage({
                   onValueChange={(v) => updateParam("club_type", v)}
                 >
                   <SelectTrigger id="res-filter-club-type" className="bg-background h-8 text-sm">
-                    <SelectValue placeholder="Todos" />
+                    <SelectValue placeholder={t("placeholders.filterClubType")} />
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="all">Todos los clubes</SelectItem>

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -82,8 +82,10 @@ function BreadcrumbSeparator({
 
 function BreadcrumbEllipsis({
   className,
+  /** Localised label for the sr-only text. Defaults to "More" for backwards compat. */
+  srLabel = "More",
   ...props
-}: React.ComponentProps<"span">) {
+}: React.ComponentProps<"span"> & { srLabel?: string }) {
   return (
     <span
       data-slot="breadcrumb-ellipsis"
@@ -93,7 +95,7 @@ function BreadcrumbEllipsis({
       {...props}
     >
       <MoreHorizontal className="size-4" />
-      <span className="sr-only">More</span>
+      <span className="sr-only">{srLabel}</span>
     </span>
   )
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { XIcon } from "lucide-react"
 import { Dialog as DialogPrimitive } from "radix-ui"
+import { useTranslations } from "next-intl"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -55,6 +56,7 @@ function DialogContent({
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean
 }) {
+  const t = useTranslations("shared.uiPrimitives")
   return (
     <DialogPortal data-slot="dialog-portal">
       <DialogOverlay />
@@ -73,7 +75,7 @@ function DialogContent({
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t("close")}</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>
@@ -99,6 +101,7 @@ function DialogFooter({
 }: React.ComponentProps<"div"> & {
   showCloseButton?: boolean
 }) {
+  const t = useTranslations("shared.uiPrimitives")
   return (
     <div
       data-slot="dialog-footer"
@@ -111,7 +114,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button variant="outline">{t("close")}</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -3,6 +3,7 @@
 import * as React from "react"
 import { XIcon } from "lucide-react"
 import { Dialog as SheetPrimitive } from "radix-ui"
+import { useTranslations } from "next-intl"
 
 import { cn } from "@/lib/utils"
 
@@ -54,6 +55,7 @@ function SheetContent({
   side?: "top" | "right" | "bottom" | "left"
   showCloseButton?: boolean
 }) {
+  const t = useTranslations("shared.uiPrimitives")
   return (
     <SheetPortal>
       <SheetOverlay />
@@ -77,7 +79,7 @@ function SheetContent({
         {showCloseButton && (
           <SheetPrimitive.Close className="ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none">
             <XIcon className="size-4" />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">{t("close")}</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Content>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import { cva, type VariantProps } from "class-variance-authority"
 import { PanelLeftIcon } from "lucide-react"
 import { Slot } from "radix-ui"
+import { useTranslations } from "next-intl"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
@@ -259,6 +260,7 @@ function SidebarTrigger({
   ...props
 }: React.ComponentProps<typeof Button>) {
   const { toggleSidebar } = useSidebar()
+  const t = useTranslations("shared.uiPrimitives")
 
   return (
     <Button
@@ -274,22 +276,23 @@ function SidebarTrigger({
       {...props}
     >
       <PanelLeftIcon />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">{t("toggleSidebar")}</span>
     </Button>
   )
 }
 
 function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
   const { toggleSidebar } = useSidebar()
+  const t = useTranslations("shared.uiPrimitives")
 
   return (
     <button
       data-sidebar="rail"
       data-slot="sidebar-rail"
-      aria-label="Toggle Sidebar"
+      aria-label={t("toggleSidebar")}
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title={t("toggleSidebar")}
       className={cn(
         "hover:after:bg-sidebar-border absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear group-data-[side=left]:-right-4 group-data-[side=right]:left-0 after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] sm:flex",
         "in-data-[side=left]:cursor-w-resize in-data-[side=right]:cursor-e-resize",

--- a/src/components/units/weekly-records-panel.tsx
+++ b/src/components/units/weekly-records-panel.tsx
@@ -153,7 +153,7 @@ function AddRecordDialog({
             </Label>
             <Select value={userId} onValueChange={setUserId}>
               <SelectTrigger id="record_user" className="w-full">
-                <SelectValue placeholder="Seleccionar miembro" />
+                <SelectValue placeholder={t("placeholders.selectMember")} />
               </SelectTrigger>
               <SelectContent>
                 {members.map((m) => (

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -214,216 +214,243 @@ export const ECCLESIASTICAL_YEARS_UPDATE = "ecclesiastical_years:update";
 
 // ═══════════════════════════════════════════════════════════════════════════
 // Agrupación por módulo (útil para UI de asignación de permisos)
+// Labels removed — use getPermissionGroupLabel(t, groupKey) and
+// getPermissionLabel(t, permissionKey) for localised display.
 // ═══════════════════════════════════════════════════════════════════════════
 export const PERMISSION_GROUPS = {
   users: {
-    label: "Usuarios",
     permissions: [
-      { key: USERS_READ, label: "Ver listado" },
-      { key: USERS_READ_DETAIL, label: "Ver detalle" },
-      { key: USERS_UPDATE_PROFILE, label: "Editar perfil propio" },
-      { key: USERS_UPDATE_ADMIN, label: "Gestión admin de usuarios" },
+      { key: USERS_READ },
+      { key: USERS_READ_DETAIL },
+      { key: USERS_UPDATE_PROFILE },
+      { key: USERS_UPDATE_ADMIN },
     ],
   },
   roles: {
-    label: "Roles y Permisos",
     permissions: [
-      { key: ROLES_READ, label: "Ver roles" },
-      { key: PERMISSIONS_READ, label: "Ver permisos" },
-      { key: PERMISSIONS_ASSIGN, label: "Asignar permisos" },
+      { key: ROLES_READ },
+      { key: PERMISSIONS_READ },
+      { key: PERMISSIONS_ASSIGN },
     ],
   },
   clubs: {
-    label: "Clubes",
     permissions: [
-      { key: CLUBS_READ, label: "Ver clubes" },
-      { key: CLUBS_CREATE, label: "Crear club" },
-      { key: CLUBS_UPDATE, label: "Editar club" },
-      { key: CLUBS_DELETE, label: "Eliminar club" },
-      { key: CLUB_SECTIONS_READ, label: "Ver secciones" },
-      { key: CLUB_SECTIONS_CREATE, label: "Crear sección" },
-      { key: CLUB_SECTIONS_UPDATE, label: "Editar sección" },
-      { key: CLUB_ROLES_READ, label: "Ver roles de club" },
-      { key: CLUB_ROLES_ASSIGN, label: "Asignar rol de club" },
-      { key: CLUB_ROLES_REVOKE, label: "Revocar rol de club" },
-      { key: CLUB_MEMBERS_APPROVE, label: "Aprobar membresía" },
-      { key: CLUB_MEMBERS_REJECT, label: "Rechazar membresía" },
-      { key: CLUB_MEMBERS_LIST_PENDING, label: "Ver solicitudes pendientes" },
+      { key: CLUBS_READ },
+      { key: CLUBS_CREATE },
+      { key: CLUBS_UPDATE },
+      { key: CLUBS_DELETE },
+      { key: CLUB_SECTIONS_READ },
+      { key: CLUB_SECTIONS_CREATE },
+      { key: CLUB_SECTIONS_UPDATE },
+      { key: CLUB_ROLES_READ },
+      { key: CLUB_ROLES_ASSIGN },
+      { key: CLUB_ROLES_REVOKE },
+      { key: CLUB_MEMBERS_APPROVE },
+      { key: CLUB_MEMBERS_REJECT },
+      { key: CLUB_MEMBERS_LIST_PENDING },
     ],
   },
   units: {
-    label: "Unidades",
     permissions: [
-      { key: UNITS_READ, label: "Ver unidades / miembro del mes" },
+      { key: UNITS_READ },
     ],
   },
   member_of_month: {
-    label: "Miembro del Mes",
     permissions: [
-      { key: MOM_READ,      label: "Ver miembro del mes" },
-      { key: MOM_SUPERVISE, label: "Supervisar multi-sección (admin/coordinador)" },
-      { key: MOM_EVALUATE,  label: "Disparar evaluación manual" },
+      { key: MOM_READ },
+      { key: MOM_SUPERVISE },
+      { key: MOM_EVALUATE },
     ],
   },
   scoring_categories: {
-    label: "Categorías de Puntuación",
     permissions: [
-      { key: SCORING_CATEGORIES_READ,   label: "Ver categorías de puntuación" },
-      { key: SCORING_CATEGORIES_MANAGE, label: "Gestionar categorías de puntuación (unions + campos locales)" },
+      { key: SCORING_CATEGORIES_READ },
+      { key: SCORING_CATEGORIES_MANAGE },
     ],
   },
   requests: {
-    label: "Solicitudes",
     permissions: [
-      { key: REQUESTS_READ,   label: "Ver solicitudes de transferencia y asignación" },
-      { key: REQUESTS_REVIEW, label: "Aprobar/rechazar solicitudes" },
+      { key: REQUESTS_READ },
+      { key: REQUESTS_REVIEW },
     ],
   },
   user_certifications: {
-    label: "Certificaciones de Usuario (Admin)",
     permissions: [
-      { key: USER_CERTIFICATIONS_READ,   label: "Ver progreso de certificaciones" },
-      { key: USER_CERTIFICATIONS_MANAGE, label: "Inscribir / actualizar / borrar certificaciones" },
+      { key: USER_CERTIFICATIONS_READ },
+      { key: USER_CERTIFICATIONS_MANAGE },
     ],
   },
   user_folders: {
-    label: "Carpetas de Usuario (Admin)",
     permissions: [
-      { key: USER_FOLDERS_READ,   label: "Ver inscripción y progreso de carpetas" },
-      { key: USER_FOLDERS_MANAGE, label: "Inscribir / actualizar / borrar asignaciones de carpeta" },
+      { key: USER_FOLDERS_READ },
+      { key: USER_FOLDERS_MANAGE },
     ],
   },
   geography: {
-    label: "Jerarquía Geográfica",
     permissions: [
-      { key: COUNTRIES_READ, label: "Ver países" },
-      { key: COUNTRIES_CREATE, label: "Crear país" },
-      { key: COUNTRIES_UPDATE, label: "Editar país" },
-      { key: COUNTRIES_DELETE, label: "Eliminar país" },
-      { key: UNIONS_READ, label: "Ver uniones" },
-      { key: UNIONS_CREATE, label: "Crear unión" },
-      { key: UNIONS_UPDATE, label: "Editar unión" },
-      { key: UNIONS_DELETE, label: "Eliminar unión" },
-      { key: LOCAL_FIELDS_READ, label: "Ver campos locales" },
-      { key: LOCAL_FIELDS_CREATE, label: "Crear campo local" },
-      { key: LOCAL_FIELDS_UPDATE, label: "Editar campo local" },
-      { key: LOCAL_FIELDS_DELETE, label: "Eliminar campo local" },
-      { key: CHURCHES_READ, label: "Ver iglesias" },
-      { key: CHURCHES_CREATE, label: "Crear iglesia" },
-      { key: CHURCHES_UPDATE, label: "Editar iglesia" },
-      { key: CHURCHES_DELETE, label: "Eliminar iglesia" },
+      { key: COUNTRIES_READ },
+      { key: COUNTRIES_CREATE },
+      { key: COUNTRIES_UPDATE },
+      { key: COUNTRIES_DELETE },
+      { key: UNIONS_READ },
+      { key: UNIONS_CREATE },
+      { key: UNIONS_UPDATE },
+      { key: UNIONS_DELETE },
+      { key: LOCAL_FIELDS_READ },
+      { key: LOCAL_FIELDS_CREATE },
+      { key: LOCAL_FIELDS_UPDATE },
+      { key: LOCAL_FIELDS_DELETE },
+      { key: CHURCHES_READ },
+      { key: CHURCHES_CREATE },
+      { key: CHURCHES_UPDATE },
+      { key: CHURCHES_DELETE },
     ],
   },
   catalogs: {
-    label: "Catálogos",
     permissions: [
-      { key: CATALOGS_READ, label: "Ver catálogos" },
-      { key: CATALOGS_CREATE, label: "Crear ítem" },
-      { key: CATALOGS_UPDATE, label: "Editar ítem" },
-      { key: CATALOGS_DELETE, label: "Eliminar ítem" },
+      { key: CATALOGS_READ },
+      { key: CATALOGS_CREATE },
+      { key: CATALOGS_UPDATE },
+      { key: CATALOGS_DELETE },
     ],
   },
   classes_honors: {
-    label: "Clases y Especialidades",
     permissions: [
-      { key: CLASSES_READ, label: "Ver clases" },
-      { key: CLASSES_SUBMIT_PROGRESS, label: "Enviar progreso de clase" },
-      { key: HONORS_READ, label: "Ver especialidades" },
-      { key: HONORS_CREATE, label: "Crear especialidad" },
-      { key: HONORS_UPDATE, label: "Editar especialidad" },
-      { key: HONORS_DELETE, label: "Eliminar especialidad" },
-      { key: USER_HONORS_SUBMIT, label: "Enviar progreso de honor" },
-      { key: USER_HONORS_VALIDATE, label: "Validar honores" },
-      { key: HONOR_CATEGORIES_READ, label: "Ver categorías" },
-      { key: HONOR_CATEGORIES_CREATE, label: "Crear categoría" },
-      { key: HONOR_CATEGORIES_UPDATE, label: "Editar categoría" },
-      { key: HONOR_CATEGORIES_DELETE, label: "Eliminar categoría" },
+      { key: CLASSES_READ },
+      { key: CLASSES_SUBMIT_PROGRESS },
+      { key: HONORS_READ },
+      { key: HONORS_CREATE },
+      { key: HONORS_UPDATE },
+      { key: HONORS_DELETE },
+      { key: USER_HONORS_SUBMIT },
+      { key: USER_HONORS_VALIDATE },
+      { key: HONOR_CATEGORIES_READ },
+      { key: HONOR_CATEGORIES_CREATE },
+      { key: HONOR_CATEGORIES_UPDATE },
+      { key: HONOR_CATEGORIES_DELETE },
     ],
   },
   activities: {
-    label: "Actividades",
     permissions: [
-      { key: ACTIVITIES_READ, label: "Ver actividades" },
-      { key: ACTIVITIES_CREATE, label: "Crear actividad" },
-      { key: ACTIVITIES_UPDATE, label: "Editar actividad" },
-      { key: ACTIVITIES_DELETE, label: "Eliminar actividad" },
-      { key: ATTENDANCE_READ, label: "Ver asistencia" },
-      { key: ATTENDANCE_MANAGE, label: "Gestionar asistencia" },
+      { key: ACTIVITIES_READ },
+      { key: ACTIVITIES_CREATE },
+      { key: ACTIVITIES_UPDATE },
+      { key: ACTIVITIES_DELETE },
+      { key: ATTENDANCE_READ },
+      { key: ATTENDANCE_MANAGE },
     ],
   },
   camporees: {
-    label: "Camporees",
     permissions: [
-      { key: CAMPOREES_READ,   label: "Ver camporees" },
-      { key: CAMPOREES_CREATE, label: "Crear camporees" },
-      { key: CAMPOREES_UPDATE, label: "Actualizar camporees" },
-      { key: CAMPOREES_DELETE, label: "Desactivar camporees" },
+      { key: CAMPOREES_READ },
+      { key: CAMPOREES_CREATE },
+      { key: CAMPOREES_UPDATE },
+      { key: CAMPOREES_DELETE },
     ],
   },
   validation: {
-    label: "Validación",
     permissions: [
-      { key: VALIDATION_READ,   label: "Ver cola pendiente, historial y elegibilidad" },
-      { key: VALIDATION_SUBMIT, label: "Enviar progreso para revisión" },
-      { key: VALIDATION_REVIEW, label: "Aprobar/rechazar progreso enviado" },
+      { key: VALIDATION_READ },
+      { key: VALIDATION_SUBMIT },
+      { key: VALIDATION_REVIEW },
     ],
   },
   finances: {
-    label: "Finanzas",
     permissions: [
-      { key: FINANCES_READ, label: "Ver finanzas" },
-      { key: FINANCES_CREATE, label: "Crear registro" },
-      { key: FINANCES_UPDATE, label: "Editar registro" },
-      { key: FINANCES_DELETE, label: "Eliminar registro" },
+      { key: FINANCES_READ },
+      { key: FINANCES_CREATE },
+      { key: FINANCES_UPDATE },
+      { key: FINANCES_DELETE },
     ],
   },
   inventory: {
-    label: "Inventario",
     permissions: [
-      { key: INVENTORY_READ, label: "Ver inventario" },
-      { key: INVENTORY_CREATE, label: "Crear ítem" },
-      { key: INVENTORY_UPDATE, label: "Editar ítem" },
-      { key: INVENTORY_DELETE, label: "Eliminar ítem" },
+      { key: INVENTORY_READ },
+      { key: INVENTORY_CREATE },
+      { key: INVENTORY_UPDATE },
+      { key: INVENTORY_DELETE },
     ],
   },
   reports: {
-    label: "Reportes",
     permissions: [
-      { key: REPORTS_READ, label: "Leer reportes mensuales" },
-      { key: REPORTS_DOWNLOAD, label: "Descargar PDF de reportes" },
-      { key: DASHBOARD_VIEW, label: "Ver dashboard" },
+      { key: REPORTS_READ },
+      { key: REPORTS_DOWNLOAD },
+      { key: DASHBOARD_VIEW },
     ],
   },
   notifications: {
-    label: "Notificaciones",
     permissions: [
-      { key: NOTIFICATIONS_SEND, label: "Enviar directa" },
-      { key: NOTIFICATIONS_BROADCAST, label: "Enviar broadcast" },
-      { key: NOTIFICATIONS_CLUB, label: "Enviar por club" },
+      { key: NOTIFICATIONS_SEND },
+      { key: NOTIFICATIONS_BROADCAST },
+      { key: NOTIFICATIONS_CLUB },
     ],
   },
   resources: {
-    label: "Recursos",
     permissions: [
-      { key: RESOURCES_READ, label: "Ver recursos" },
-      { key: RESOURCES_CREATE, label: "Subir recurso" },
-      { key: RESOURCES_UPDATE, label: "Editar recurso" },
-      { key: RESOURCES_DELETE, label: "Eliminar recurso" },
-      { key: RESOURCE_CATEGORIES_READ, label: "Ver categorías de recursos" },
-      { key: RESOURCE_CATEGORIES_CREATE, label: "Crear categoría de recursos" },
-      { key: RESOURCE_CATEGORIES_UPDATE, label: "Editar categoría de recursos" },
-      { key: RESOURCE_CATEGORIES_DELETE, label: "Eliminar categoría de recursos" },
+      { key: RESOURCES_READ },
+      { key: RESOURCES_CREATE },
+      { key: RESOURCES_UPDATE },
+      { key: RESOURCES_DELETE },
+      { key: RESOURCE_CATEGORIES_READ },
+      { key: RESOURCE_CATEGORIES_CREATE },
+      { key: RESOURCE_CATEGORIES_UPDATE },
+      { key: RESOURCE_CATEGORIES_DELETE },
     ],
   },
   system: {
-    label: "Sistema",
     permissions: [
-      { key: ECCLESIASTICAL_YEARS_READ, label: "Ver años eclesiásticos" },
-      { key: ECCLESIASTICAL_YEARS_CREATE, label: "Crear año eclesiástico" },
-      { key: ECCLESIASTICAL_YEARS_UPDATE, label: "Editar año eclesiástico" },
+      { key: ECCLESIASTICAL_YEARS_READ },
+      { key: ECCLESIASTICAL_YEARS_CREATE },
+      { key: ECCLESIASTICAL_YEARS_UPDATE },
     ],
   },
 } as const;
 
 // Tipo derivado de las constantes (acepta cualquier string para compatibilidad con DB)
 export type PermissionKey = string;
+
+// ═══════════════════════════════════════════════════════════════════════════
+// i18n helpers — use these in all UI components instead of hardcoded strings
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * Returns the localised label for a permission key.
+ * Looks up `rbac.permissions.<key>` in the active locale.
+ * Falls back to the raw key string when no translation exists.
+ *
+ * @example
+ *   const t = useTranslations("rbac");
+ *   getPermissionLabel(t, "clubs:read") // → "Ver clubes" (es)
+ */
+export function getPermissionLabel(
+  t: (key: string) => string,
+  permissionKey: string,
+): string {
+  // next-intl colon keys require dot notation for nested lookup
+  const safeKey = permissionKey.replace(":", ".");
+  try {
+    return t(`permissions.${safeKey}` as Parameters<typeof t>[0]);
+  } catch {
+    return permissionKey;
+  }
+}
+
+/**
+ * Returns the localised label for a permission group.
+ * Looks up `rbac.permissionGroups.<groupKey>` in the active locale.
+ * Falls back to the raw groupKey string when no translation exists.
+ *
+ * @example
+ *   const t = useTranslations("rbac");
+ *   getPermissionGroupLabel(t, "clubs") // → "Clubes" (es)
+ */
+export function getPermissionGroupLabel(
+  t: (key: string) => string,
+  groupKey: string,
+): string {
+  try {
+    return t(`permissionGroups.${groupKey}` as Parameters<typeof t>[0]);
+  } catch {
+    return groupKey;
+  }
+}


### PR DESCRIPTION
## Summary

Closes 4 systemic i18n leaks from audit 2026-05-08:

### 1. permissions.ts (123 hardcoded labels)
Removed all \`label:\` literals from PERMISSION_GROUPS / PERMISSIONS registry. Added \`getPermissionLabel(t, key)\` + \`getPermissionGroupLabel(t, key)\` helpers. Permission keys with colon notation (\`clubs:create\`) map to dot notation in \`t()\` calls (\`rbac.permissions.clubs.create\`).

### 2. shadcn UI primitives (4 files)
- \`dialog.tsx\`, \`sheet.tsx\`, \`sidebar.tsx\` use \`useTranslations(\"shared.uiPrimitives\")\`
- \`breadcrumb.tsx\` uses \`srLabel\` prop pattern (server-component compatible) defaulting to \`\"More\"\` — callers pass \`t()\` value

### 3. AlertDialogTitle (3 files)
- \`folder-client-page\`: deleteEvidence/sendFolder/closeFolder
- \`award-categories-client-page\`: deleteCategory
- \`rankings-client-page\`: recalculateRankings
- New \`annual_folders.dialogs.*\` (25 leaf keys)

### 4. Form placeholders (8 files)
- \`resources-crud-page\` (17), \`activity-form-dialog\` (11), \`insurance-form-dialog\` (4), \`inventory-form-dialog\` (4)
- \`weekly-records-panel\` (1), \`evidence-reject-dialog\` (6), \`investido-dialog\` (6), \`pipeline-reject-dialog\` (6)

## Stats

21 files, +1478/-248. ~261 new keys per locale across 13 sub-namespaces.

## Namespace coordination with admin-a11y PR

| Owner | Namespaces |
|---|---|
| this PR | \`rbac.*\`, \`shared.uiPrimitives.*\`, \`<feature>.placeholders.*\`, \`annual_folders.dialogs.*\` |
| a11y PR | \`*.a11y.*\` |

Zero overlap, deep-merge clean.

## Test plan

- [x] Typecheck clean (6 vitest baseline pre-existing)
- [x] All 4 locale JSONs parse + parity verified
- [x] No \`label:\` hardcoded in permissions.ts
- [x] No \`Close\`/\`More\`/\`Toggle Sidebar\` hardcoded in ui primitives
- [ ] Manual smoke: open RBAC roles + user-permissions panel in each locale
- [ ] Manual smoke: trigger AlertDialog in folders/award-categories/rankings
- [ ] Manual smoke: form fields in resources/activities/insurance/inventory show translated placeholders

From audit P1 (2026-05-08).