### PR TITLE
fix(a11y): icon button names + skip link + password tabIndex + heading hierarchy

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -134,6 +134,9 @@
       "switchToLight": "Switch to light mode",
       "switchToDark": "Switch to dark mode",
       "switchTheme": "Toggle theme"
+    },
+    "a11y": {
+      "skipToContent": "Skip to main content"
     }
   },
   "permissions": {
@@ -777,6 +780,10 @@
         "descriptionTemplate": "Modify the data of \"{unitName}\" in {clubName}",
         "back": "Back to club"
       }
+    },
+    "a11y": {
+      "deleteClub": "Delete club {name}",
+      "actionsMenu": "Actions for {name}"
     }
   },
   "dashboardHub": {
@@ -1026,7 +1033,9 @@
       "deleteDialogTitle": "Delete honor?",
       "deleteDialogDescription": "The honor \"{name}\" will be logically deactivated.",
       "deleteDialogCancel": "Cancel",
-      "deleteDialogConfirm": "Delete"
+      "deleteDialogConfirm": "Delete",
+      "deleteAriaLabel": "Delete {name}",
+      "actionsAriaLabel": "More actions for {name}"
     },
     "form": {
       "submitCreate": "Create honor",
@@ -4004,6 +4013,11 @@
     },
     "placeholders": {
       "selectMember": "Select member"
+    },
+    "a11y": {
+      "removeMember": "Remove {name} from unit",
+      "editUnit": "Edit unit {name}",
+      "deleteUnit": "Deactivate unit {name}"
     }
   },
   "system_config": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -134,6 +134,9 @@
       "switchToLight": "Cambiar a modo claro",
       "switchToDark": "Cambiar a modo oscuro",
       "switchTheme": "Cambiar tema"
+    },
+    "a11y": {
+      "skipToContent": "Ir al contenido principal"
     }
   },
   "permissions": {
@@ -777,6 +780,10 @@
         "descriptionTemplate": "Modificar los datos de \"{unitName}\" en {clubName}",
         "back": "Volver al club"
       }
+    },
+    "a11y": {
+      "deleteClub": "Eliminar club {name}",
+      "actionsMenu": "Acciones para {name}"
     }
   },
   "dashboardHub": {
@@ -1026,7 +1033,9 @@
       "deleteDialogTitle": "¿Eliminar especialidad?",
       "deleteDialogDescription": "Se desactivará de forma lógica la especialidad \"{name}\".",
       "deleteDialogCancel": "Cancelar",
-      "deleteDialogConfirm": "Eliminar"
+      "deleteDialogConfirm": "Eliminar",
+      "deleteAriaLabel": "Eliminar {name}",
+      "actionsAriaLabel": "Más acciones para {name}"
     },
     "form": {
       "submitCreate": "Crear especialidad",
@@ -4004,6 +4013,11 @@
     },
     "placeholders": {
       "selectMember": "Seleccionar miembro"
+    },
+    "a11y": {
+      "removeMember": "Remover {name} de la unidad",
+      "editUnit": "Editar unidad {name}",
+      "deleteUnit": "Desactivar unidad {name}"
     }
   },
   "system_config": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -134,6 +134,9 @@
       "switchToLight": "Passer en mode clair",
       "switchToDark": "Passer en mode sombre",
       "switchTheme": "Changer le thème"
+    },
+    "a11y": {
+      "skipToContent": "Aller au contenu principal"
     }
   },
   "permissions": {
@@ -777,6 +780,10 @@
         "descriptionTemplate": "Modifier les données de « {unitName} » dans {clubName}",
         "back": "Retour au club"
       }
+    },
+    "a11y": {
+      "deleteClub": "Supprimer le club {name}",
+      "actionsMenu": "Actions pour {name}"
     }
   },
   "dashboardHub": {
@@ -1026,7 +1033,9 @@
       "deleteDialogTitle": "Supprimer la spécialité ?",
       "deleteDialogDescription": "La spécialité « {name} » sera désactivée de façon logique.",
       "deleteDialogCancel": "Annuler",
-      "deleteDialogConfirm": "Supprimer"
+      "deleteDialogConfirm": "Supprimer",
+      "deleteAriaLabel": "Supprimer {name}",
+      "actionsAriaLabel": "Plus d'actions pour {name}"
     },
     "form": {
       "submitCreate": "Créer la spécialité",
@@ -4004,6 +4013,11 @@
     },
     "placeholders": {
       "selectMember": "Sélectionner un membre"
+    },
+    "a11y": {
+      "removeMember": "Retirer {name} de l'unité",
+      "editUnit": "Modifier l'unité {name}",
+      "deleteUnit": "Désactiver l'unité {name}"
     }
   },
   "system_config": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -134,6 +134,9 @@
       "switchToLight": "Mudar para modo claro",
       "switchToDark": "Mudar para modo escuro",
       "switchTheme": "Alternar tema"
+    },
+    "a11y": {
+      "skipToContent": "Ir para o conteúdo principal"
     }
   },
   "permissions": {
@@ -777,6 +780,10 @@
         "descriptionTemplate": "Modificar os dados de \"{unitName}\" em {clubName}",
         "back": "Voltar ao clube"
       }
+    },
+    "a11y": {
+      "deleteClub": "Excluir clube {name}",
+      "actionsMenu": "Ações para {name}"
     }
   },
   "dashboardHub": {
@@ -1026,7 +1033,9 @@
       "deleteDialogTitle": "Excluir especialidade?",
       "deleteDialogDescription": "A especialidade “{name}” será desativada de forma lógica.",
       "deleteDialogCancel": "Cancelar",
-      "deleteDialogConfirm": "Excluir"
+      "deleteDialogConfirm": "Excluir",
+      "deleteAriaLabel": "Excluir {name}",
+      "actionsAriaLabel": "Mais ações para {name}"
     },
     "form": {
       "submitCreate": "Criar especialidade",
@@ -4004,6 +4013,11 @@
     },
     "placeholders": {
       "selectMember": "Selecionar membro"
+    },
+    "a11y": {
+      "removeMember": "Remover {name} da unidade",
+      "editUnit": "Editar unidade {name}",
+      "deleteUnit": "Desativar unidade {name}"
     }
   },
   "system_config": {

--- a/src/app/(dashboard)/error.tsx
+++ b/src/app/(dashboard)/error.tsx
@@ -34,7 +34,7 @@ export default function DashboardError({ error, reset }: DashboardErrorProps) {
         <div className="flex size-12 items-center justify-center rounded-full bg-destructive/10">
           <AlertCircle className="size-6 text-destructive" aria-hidden="true" />
         </div>
-        <h3 className="mt-4 text-lg font-semibold">{t("dashboardHeading")}</h3>
+        <h2 className="mt-4 text-lg font-semibold">{t("dashboardHeading")}</h2>
         <p className="mt-1 max-w-md text-sm text-muted-foreground">
           {t("dashboardBody")}
         </p>

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,4 +1,5 @@
 import { cookies } from "next/headers";
+import { getTranslations } from "next-intl/server";
 import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { AppSidebar } from "@/components/layout/app-sidebar";
 import { AppHeader } from "@/components/layout/app-header";
@@ -13,6 +14,7 @@ export default async function DashboardLayout({
 }) {
   await requireAdminUser();
 
+  const t = await getTranslations("nav.a11y");
   const cookieStore = await cookies();
   const sidebarState = cookieStore.get("sidebar_state")?.value;
   const defaultOpen = sidebarState !== "false";
@@ -28,10 +30,16 @@ export default async function DashboardLayout({
             } as React.CSSProperties
           }
         >
+          <a
+            href="#main"
+            className="sr-only focus:not-sr-only focus:absolute focus:left-2 focus:top-2 focus:z-50 focus:bg-background focus:px-3 focus:py-2 focus:rounded-md focus:ring-2 focus:ring-ring"
+          >
+            {t("skipToContent")}
+          </a>
           <AppSidebar />
           <SidebarInset>
             <AppHeader />
-            <main className="flex-1 overflow-auto">
+            <main id="main" className="flex-1 overflow-auto">
               <div className="mx-auto max-w-[1536px] px-4 py-4 md:px-6 md:py-6">
                 {children}
               </div>

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -140,11 +140,10 @@ export function LoginForm({ nextParam }: Props) {
             <button
               type="button"
               onClick={() => setShowPassword((v) => !v)}
-              tabIndex={-1}
               aria-label={
                 showPassword ? t("hide_password") : t("show_password")
               }
-              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground/60 transition-colors hover:text-foreground"
+              className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground/60 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:rounded-sm"
             >
               {showPassword ? (
                 <EyeOff className="size-4" />

--- a/src/components/clubs/clubs-table-actions-cell.tsx
+++ b/src/components/clubs/clubs-table-actions-cell.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useState } from "react";
 import { useFormStatus } from "react-dom";
+import { useTranslations } from "next-intl";
 import { Loader2, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -58,6 +59,7 @@ export function ClubsTableActionsCell({
   canEdit,
   canDelete,
 }: ClubsTableActionsCellProps) {
+  const t = useTranslations("clubs.a11y");
   const [deleteItem, setDeleteItem] = useState<ClubActionItem | null>(null);
 
   const editHref = `/dashboard/clubs/${club.id}?tab=edit`;
@@ -86,6 +88,7 @@ export function ClubsTableActionsCell({
             className="size-8 text-destructive hover:text-destructive"
             onClick={() => setDeleteItem(club)}
             title="Eliminar"
+            aria-label={t("deleteClub", { name: club.name })}
           >
             <Trash2 className="size-3.5" />
           </Button>
@@ -96,7 +99,7 @@ export function ClubsTableActionsCell({
       <div className="md:hidden">
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon" className="size-8" title="Acciones">
+            <Button variant="ghost" size="icon" className="size-8" title="Acciones" aria-label={t("actionsMenu", { name: club.name })}>
               <MoreHorizontal className="size-4" />
             </Button>
           </DropdownMenuTrigger>

--- a/src/components/honors/honors-crud-page.tsx
+++ b/src/components/honors/honors-crud-page.tsx
@@ -526,6 +526,7 @@ export function HonorsCrudPage({
                                   disabled={!honorId}
                                   onClick={() => setDeleteItem(item)}
                                   title={t("deleteButton")}
+                                  aria-label={t("deleteAriaLabel", { name: honorName })}
                                 >
                                   <Trash2 className="size-3.5" />
                                 </Button>
@@ -534,7 +535,7 @@ export function HonorsCrudPage({
                             <div className="md:hidden">
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
-                                  <Button variant="ghost" size="icon" className="size-8" title={t("actionsButton")}>
+                                  <Button variant="ghost" size="icon" className="size-8" title={t("actionsButton")} aria-label={t("actionsAriaLabel", { name: honorName })}>
                                     <MoreHorizontal className="size-4" />
                                   </Button>
                                 </DropdownMenuTrigger>

--- a/src/components/units/unit-detail-panel.tsx
+++ b/src/components/units/unit-detail-panel.tsx
@@ -61,6 +61,7 @@ interface MemberRowProps {
 }
 
 function MemberRow({ member, onRemove }: MemberRowProps) {
+  const t = useTranslations("units_admin.a11y");
   const name = getUnitUserDisplayName(member.users ?? undefined);
 
   return (
@@ -80,6 +81,7 @@ function MemberRow({ member, onRemove }: MemberRowProps) {
             variant="ghost"
             className="size-7 text-muted-foreground hover:text-destructive"
             onClick={() => onRemove(member)}
+            aria-label={t("removeMember", { name })}
           >
             <UserMinus className="size-3.5" />
           </Button>
@@ -182,6 +184,7 @@ export function UnitDetailPanel({
                   size="icon-sm"
                   variant="ghost"
                   onClick={() => onEdit(unit)}
+                  aria-label={t("a11y.editUnit", { name: unit.name })}
                 >
                   <Pencil className="size-3.5" />
                 </Button>
@@ -196,6 +199,7 @@ export function UnitDetailPanel({
                   variant="ghost"
                   className="text-muted-foreground hover:text-destructive"
                   onClick={() => onDelete(unit)}
+                  aria-label={t("a11y.deleteUnit", { name: unit.name })}
                 >
                   <Trash2 className="size-3.5" />
                 </Button>


### PR DESCRIPTION
## Summary

Fixes 4 a11y blockers from audit 2026-05-08 (WCAG 2.1 AA failures):

### 1. Skip link (Bypass Blocks 2.4.1)
\`(dashboard)/layout.tsx\` adds \`<a href=\"#main\">\` with \`sr-only focus:not-sr-only\` styling. \`<main>\` gets \`id=\"main\"\`.

### 2. Password toggle keyboard nav (Keyboard 2.1.1)
\`login-form.tsx\` removed \`tabIndex={-1}\` from show/hide button. Added explicit \`focus-visible:ring\` (raw \`<button>\`, not shadcn \`Button\`).

### 3. Icon button accessible names (Name/Role/Value 4.1.2)
4 components — Radix Tooltip uses \`aria-describedby\` (supplemental), NOT \`aria-labelledby\` (authoritative). Added \`aria-label\` directly on Buttons.

- \`clubs-table-actions-cell\` (Delete + MoreHorizontal)
- \`honors-crud-page\` (Delete + MoreHorizontal)
- \`unit-detail-panel/MemberRow\` (Edit + Delete + Remove member)

### 4. Heading hierarchy (Info and Relationships 1.3.1)
\`(dashboard)/error.tsx\` \`<h3>\` → \`<h2>\` (PageHeader provides \`<h1>\`).

### Files already compliant (audit re-verified)
\`requirements-tree\`, \`pipeline-table\`, \`roles-table\`, \`app-sidebar\`, \`bulk-action-bar\` (×2), \`enrolled-users-panel\`, \`camporee-*-tab\`, \`review-split-view\`, \`award-categories-client-page\`.

## Stats

10 files, +85/-14. +8 new keys × 4 locales under \`*.a11y.*\` namespaces only.

## Namespace coordination

This PR only writes to \`*.a11y.*\` keys (\`nav.a11y\`, \`units_admin.a11y\`, \`clubs.a11y\`, \`honors.crud.{deleteAriaLabel,actionsAriaLabel}\`). Zero overlap with admin-i18n-batch-13-sweep PR.

## Test plan

- [x] Typecheck clean
- [x] Locale parity verified
- [x] \`tabIndex={-1}\` removed from login-form
- [x] Skip link present in layout
- [ ] Manual: tab key from page load — first focus is Skip link
- [ ] Manual: VoiceOver/NVDA announces icon buttons by name (not just \"button\")
- [ ] Manual: error boundary shows correct heading hierarchy

From audit P1 (2026-05-08).