### PR TITLE
fix(i18n): translate stale Spanish 'Buscar' placeholder in pt-BR resources

### DIFF
--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -2199,7 +2199,7 @@
       "localFieldId": "ID do campo local",
       "videoUrl": "https://youtube.com/watch?v=... ou https://vimeo.com/...",
       "content": "Escreva o conteúdo do recurso aqui...",
-      "searchTitle": "Buscar por título...",
+      "searchTitle": "Pesquisar por título...",
       "filterType": "Todos os tipos",
       "filterStatus": "Todos",
       "filterScope": "Todas",


### PR DESCRIPTION
## Summary

Audit P0-B flagged 29 keys in pt-BR.json as Spanish leaks. Investigation found **28 of those were FALSE POSITIVES** — cognates valid in both languages ("Cancelar", "Verificando…", "Foto de perfil", "Página", "Solicitado por", "Pipeline de Investidura", etc.). The audit heuristic was over-aggressive.

**Only 1 real leak found**: `resources.placeholders.searchTitle`:
- Before: `"Buscar por título..."` (Spanish)
- After: `"Pesquisar por título..."` (matches `catalogs.filterBar` peers)

## Discovery
"Buscar" appears in 14 pt-BR keys but 12 are intentionally "Buscar" (the noun was translated, e.g. "Buscar permissões"). Only this one kept the full Spanish phrase.

## Pattern note for future audits
Don't flag identical es↔pt-BR values without checking cognates. Use stricter heuristic (Spanish-only chars: ñ, ó, etc., or "Está"/"Estás" markers).

## Test plan
- [x] Typecheck clean
- [x] All 4 locale JSONs parse + parity preserved
- [ ] Manual: open Resources page in pt-BR, confirm placeholder reads "Pesquisar por título..."