### PR TITLE
refactor: migrate 4 high-traffic client pages to TanStack Query

### DIFF
--- a/src/components/membership/membership-requests-client-page.tsx
+++ b/src/components/membership/membership-requests-client-page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { UserPlus } from "lucide-react";
 import { useTranslations } from "next-intl";
+import { useQuery } from "@tanstack/react-query";
 import {
   Select,
   SelectContent,
@@ -41,37 +42,30 @@ export function MembershipRequestsClientPage({
   const [selectedSectionId, setSelectedSectionId] = useState<number>(
     sections[0]?.club_section_id ?? 0,
   );
-  const [requests, setRequests] = useState<MembershipRequest[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const [loadError, setLoadError] = useState<string | null>(null);
 
-  const loadRequests = useCallback(async (sectionId: number) => {
-    setIsLoading(true);
-    setLoadError(null);
-    try {
-      const data = await listMembershipRequestsFromClient(sectionId);
-      setRequests(data);
-    } catch (error) {
-      if (error instanceof ApiError && (error.status === 403 || error.status === 401)) {
-        setLoadError(t("client.load_error_permission"));
-      } else {
-        const message =
-          error instanceof ApiError
-            ? error.message
-            : t("client.load_error_generic");
-        setLoadError(message);
-      }
-      setRequests([]);
-    } finally {
-      setIsLoading(false);
-    }
-  }, [t]);
+  const {
+    data: requests = [],
+    isFetching: isLoading,
+    error: queryError,
+  } = useQuery<MembershipRequest[], Error>({
+    queryKey: ["membership", "requests", selectedSectionId],
+    queryFn: () => listMembershipRequestsFromClient(selectedSectionId),
+    enabled: selectedSectionId > 0,
+    staleTime: 60_000,
+  });
 
-  useEffect(() => {
-    if (selectedSectionId) {
-      loadRequests(selectedSectionId);
+  const loadError = (() => {
+    if (!queryError) return null;
+    if (
+      queryError instanceof ApiError &&
+      (queryError.status === 403 || queryError.status === 401)
+    ) {
+      return t("client.load_error_permission");
     }
-  }, [selectedSectionId, loadRequests]);
+    return queryError instanceof ApiError
+      ? queryError.message
+      : t("client.load_error_generic");
+  })();
 
   return (
     <div className="space-y-4">

--- a/src/components/requests/assignments-client-page.tsx
+++ b/src/components/requests/assignments-client-page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { AssignmentsTable } from "@/components/requests/assignments-table";
@@ -27,37 +28,33 @@ interface AssignmentsClientPageProps {
 export function AssignmentsClientPage({ initialRequests }: AssignmentsClientPageProps) {
   const t = useTranslations("requests");
   const [activeTab, setActiveTab] = useState<StatusTab>("PENDING");
-  const [requests, setRequests] = useState<AssignmentRequest[]>(initialRequests);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const isInitialMount = useRef(true);
+
+  const {
+    data: requests = [],
+    isFetching: isRefreshing,
+    refetch,
+  } = useQuery<AssignmentRequest[], Error>({
+    queryKey: ["requests", "assignments"],
+    queryFn: () => getAssignmentRequests(),
+    initialData: initialRequests,
+    staleTime: 60_000,
+  });
 
   const filteredRequests =
     activeTab === "ALL"
       ? requests
       : requests.filter((r) => r.status === activeTab);
 
-  const refresh = useCallback(async () => {
-    setIsRefreshing(true);
-    try {
-      const fresh = await getAssignmentRequests();
-      setRequests(fresh);
-    } catch (error) {
+  const handleRefresh = async () => {
+    const result = await refetch();
+    if (result.error) {
       const message =
-        error instanceof ApiError
-          ? error.message
+        result.error instanceof ApiError
+          ? result.error.message
           : t("errors.refresh");
       toast.error(message);
-    } finally {
-      setIsRefreshing(false);
     }
-  }, [t]);
-
-  useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      return;
-    }
-  }, []);
+  };
 
   const pendingCount = requests.filter((r) => r.status === "PENDING").length;
   const approvedCount = requests.filter((r) => r.status === "APPROVED").length;
@@ -82,7 +79,7 @@ export function AssignmentsClientPage({ initialRequests }: AssignmentsClientPage
         <Button
           variant="outline"
           size="sm"
-          onClick={refresh}
+          onClick={handleRefresh}
           disabled={isRefreshing}
         >
           <RefreshCw
@@ -116,7 +113,7 @@ export function AssignmentsClientPage({ initialRequests }: AssignmentsClientPage
         </div>
 
         <TabsContent value={activeTab} className="mt-4">
-          <AssignmentsTable requests={filteredRequests} onRefresh={refresh} />
+          <AssignmentsTable requests={filteredRequests} onRefresh={handleRefresh} />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/requests/transfers-client-page.tsx
+++ b/src/components/requests/transfers-client-page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TransfersTable } from "@/components/requests/transfers-table";
@@ -27,37 +28,33 @@ interface TransfersClientPageProps {
 export function TransfersClientPage({ initialRequests }: TransfersClientPageProps) {
   const t = useTranslations("requests");
   const [activeTab, setActiveTab] = useState<StatusTab>("PENDING");
-  const [requests, setRequests] = useState<TransferRequest[]>(initialRequests);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const isInitialMount = useRef(true);
+
+  const {
+    data: requests = [],
+    isFetching: isRefreshing,
+    refetch,
+  } = useQuery<TransferRequest[], Error>({
+    queryKey: ["requests", "transfers"],
+    queryFn: () => getTransferRequests(),
+    initialData: initialRequests,
+    staleTime: 60_000,
+  });
 
   const filteredRequests =
     activeTab === "ALL"
       ? requests
       : requests.filter((r) => r.status === activeTab);
 
-  const refresh = useCallback(async () => {
-    setIsRefreshing(true);
-    try {
-      const fresh = await getTransferRequests();
-      setRequests(fresh);
-    } catch (error) {
+  const handleRefresh = async () => {
+    const result = await refetch();
+    if (result.error) {
       const message =
-        error instanceof ApiError
-          ? error.message
+        result.error instanceof ApiError
+          ? result.error.message
           : t("errors.refresh");
       toast.error(message);
-    } finally {
-      setIsRefreshing(false);
     }
-  }, [t]);
-
-  useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      return;
-    }
-  }, []);
+  };
 
   const pendingCount = requests.filter((r) => r.status === "PENDING").length;
   const approvedCount = requests.filter((r) => r.status === "APPROVED").length;
@@ -82,7 +79,7 @@ export function TransfersClientPage({ initialRequests }: TransfersClientPageProp
         <Button
           variant="outline"
           size="sm"
-          onClick={refresh}
+          onClick={handleRefresh}
           disabled={isRefreshing}
         >
           <RefreshCw
@@ -116,7 +113,7 @@ export function TransfersClientPage({ initialRequests }: TransfersClientPageProp
         </div>
 
         <TabsContent value={activeTab} className="mt-4">
-          <TransfersTable requests={filteredRequests} onRefresh={refresh} />
+          <TransfersTable requests={filteredRequests} onRefresh={handleRefresh} />
         </TabsContent>
       </Tabs>
     </div>

--- a/src/components/validation/validation-client-page.tsx
+++ b/src/components/validation/validation-client-page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import {
@@ -41,13 +42,45 @@ export function ValidationClientPage({
   const t = useTranslations("validation_admin");
   const [activeTab, setActiveTab] = useState<ValidationEntityType>("class");
   const [sectionId, setSectionId] = useState<string>("all");
-  const [classValidations, setClassValidations] =
-    useState<PendingValidation[]>(initialClasses);
-  const [honorValidations, setHonorValidations] =
-    useState<PendingValidation[]>(initialHonors);
-  const [isRefreshing, setIsRefreshing] = useState(false);
-  const isInitialMount = useRef(true);
 
+  const sectionParam =
+    sectionId !== "all" ? parseInt(sectionId, 10) : undefined;
+
+  const {
+    data: classValidations = [],
+    isFetching: isRefreshingClasses,
+    refetch: refetchClasses,
+  } = useQuery<PendingValidation[], Error>({
+    queryKey: ["validation", "classes", sectionParam],
+    queryFn: () =>
+      getPendingValidations({
+        entity_type: "class",
+        ...(sectionParam !== undefined ? { section_id: sectionParam } : {}),
+      }),
+    // initialData only applies when sectionId === "all" (matches server-rendered data)
+    initialData: sectionId === "all" ? initialClasses : undefined,
+    staleTime: 60_000,
+  });
+
+  const {
+    data: honorValidations = [],
+    isFetching: isRefreshingHonors,
+    refetch: refetchHonors,
+  } = useQuery<PendingValidation[], Error>({
+    queryKey: ["validation", "honors", sectionParam],
+    queryFn: () =>
+      getPendingValidations({
+        entity_type: "honor",
+        ...(sectionParam !== undefined ? { section_id: sectionParam } : {}),
+      }),
+    // initialData only applies when sectionId === "all" (matches server-rendered data)
+    initialData: sectionId === "all" ? initialHonors : undefined,
+    staleTime: 60_000,
+  });
+
+  const isRefreshing = isRefreshingClasses || isRefreshingHonors;
+
+  // Filter client-side when section changes (TanStack re-fetches automatically via queryKey)
   const filteredClasses =
     sectionId === "all"
       ? classValidations
@@ -62,45 +95,23 @@ export function ValidationClientPage({
           (v) => v.section?.section_id === parseInt(sectionId, 10),
         );
 
-  const refresh = useCallback(async () => {
-    setIsRefreshing(true);
-    try {
-      const query =
-        sectionId !== "all"
-          ? { section_id: parseInt(sectionId, 10) }
-          : {};
+  const handleRefresh = async () => {
+    const [classResult, honorResult] = await Promise.allSettled([
+      refetchClasses(),
+      refetchHonors(),
+    ]);
 
-      const [classes, honors] = await Promise.allSettled([
-        getPendingValidations({ ...query, entity_type: "class" }),
-        getPendingValidations({ ...query, entity_type: "honor" }),
-      ]);
+    const errors = [classResult, honorResult].filter(
+      (r): r is PromiseRejectedResult => r.status === "rejected",
+    );
 
-      if (classes.status === "fulfilled") {
-        setClassValidations(classes.value);
-      }
-      if (honors.status === "fulfilled") {
-        setHonorValidations(honors.value);
-      }
-    } catch (error) {
+    if (errors.length > 0) {
+      const error = errors[0]?.reason as unknown;
       const message =
-        error instanceof ApiError
-          ? error.message
-          : t("errors.refresh");
+        error instanceof ApiError ? error.message : t("errors.refresh");
       toast.error(message);
-    } finally {
-      setIsRefreshing(false);
     }
-  }, [sectionId, t]);
-
-  // Refresh when section filter changes, skip on initial mount (data comes from server)
-  useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      return;
-    }
-    void refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sectionId]);
+  };
 
   const currentCount =
     activeTab === "class" ? filteredClasses.length : filteredHonors.length;
@@ -134,7 +145,7 @@ export function ValidationClientPage({
           <Button
             variant="outline"
             size="sm"
-            onClick={refresh}
+            onClick={handleRefresh}
             disabled={isRefreshing}
           >
             <RefreshCw
@@ -172,7 +183,7 @@ export function ValidationClientPage({
           <ValidationTable
             validations={filteredClasses}
             entityType="class"
-            onRefresh={refresh}
+            onRefresh={handleRefresh}
           />
         </TabsContent>
 
@@ -180,7 +191,7 @@ export function ValidationClientPage({
           <ValidationTable
             validations={filteredHonors}
             entityType="honor"
-            onRefresh={refresh}
+            onRefresh={handleRefresh}
           />
         </TabsContent>
       </Tabs>


### PR DESCRIPTION
## Summary

Audit C2 found 122 `useEffect`-based manual fetches across 52 files reimplementing loading/error/refetch by hand. Only 16 files used TanStack Query. **This PR migrates 4 highest-traffic client pages**.

## Migrated
- `membership/membership-requests-client-page`
- `requests/transfers-client-page`
- `requests/assignments-client-page`
- `validation/validation-client-page` (dual queries: classes + honors)

## Skipped
- `notifications/notification-history-table` — server async function (`export async function` + `getTranslations` from `next-intl/server`). Migration would require `prefetchQuery + HydrationBoundary` at page level, out of scope.

## QueryKey scheme: `["<feature>", "<entity>", ...params]`

| Page | queryKey |
|---|---|
| membership | `["membership", "requests", selectedSectionId]` |
| transfers | `["requests", "transfers"]` |
| assignments | `["requests", "assignments"]` |
| validation classes | `["validation", "classes", sectionParam]` |
| validation honors | `["validation", "honors", sectionParam]` |

## Patterns applied
- **initialData for server-seeded pages**: transfers/assignments/validation receive server props (`initialRequests`, `initialClasses`, `initialHonors`) — passed as `initialData`, eliminates loading flash on mount. Validation only seeds when no section filter (avoids cross-contamination).
- **Conditional fetching**: `enabled: selectedSectionId > 0` (membership) skips query until prereq met.
- **Dual independent useQuery**: validation replaces single refresh callback w/ `Promise.allSettled([class, honor])` setState pair. `handleRefresh` calls both `refetch()` preserving partial-success semantics.
- **`staleTime: 60_000`**: 1 min for high-traffic request lists (overrides global 5-min default in `query-client.ts`).
- **`apiRequest` is window-aware**: auto-detects `typeof window !== 'undefined'` and delegates to client variant — safe in `useQuery` queryFns directly, no wrapper needed.

## Mutations
Not migrated in this PR — they live in child components (`PendingMembersTable`, `TransfersTable`, `AssignmentsTable`, `ValidationTable`) which are out of scope. Future PR can migrate those + invalidate via documented queryKeys above.

## Stats
LOC delta: **-123/+122** (essentially flat). Complexity reduction significant — manual `useState`×3 + `useCallback` + `useEffect` + try/catch/finally state machinery replaced by single `useQuery` hook per data source.

## Test plan
- [x] Typecheck clean
- [x] No `useEffect`-based fetch remains in 4 target files (verified via rg)
- [ ] Manual: visit each page, verify list loads + filter changes refetch + refresh button works
- [ ] (Future) optimistic updates for child component mutations + invalidation wiring

From audit recommendation P2 (2026-05-08).