### PR TITLE
perf: lazy-load 5 more heavy components via next/dynamic (~399KB deferred)

### DIFF
--- a/src/app/(dashboard)/dashboard/annual-folders/categories/page.tsx
+++ b/src/app/(dashboard)/dashboard/annual-folders/categories/page.tsx
@@ -1,13 +1,36 @@
 import { getTranslations } from "next-intl/server";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/shared/page-header";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
-import { AwardCategoriesClientPage } from "@/components/annual-folders/award-categories-client-page";
 import { requireAdminUser } from "@/lib/auth/session";
 import { ApiError } from "@/lib/api/client";
 import { listClubTypes } from "@/lib/api/catalogs";
 import { getAwardCategories } from "@/lib/api/annual-folders";
 import type { AwardCategory } from "@/lib/api/annual-folders";
 import type { ClubType } from "@/lib/api/catalogs";
+
+const AwardCategoriesClientPage = dynamic(
+  () =>
+    import("@/components/annual-folders/award-categories-client-page").then(
+      (m) => ({ default: m.AwardCategoriesClientPage })
+    ),
+  {
+    loading: () => (
+      <div className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <Skeleton className="h-9 w-36 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/src/app/(dashboard)/dashboard/annual-folders/rankings/page.tsx
+++ b/src/app/(dashboard)/dashboard/annual-folders/rankings/page.tsx
@@ -1,15 +1,39 @@
 import { TrendingUp } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/shared/page-header";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 import { EmptyState } from "@/components/shared/empty-state";
-import { RankingsClientPage } from "@/components/annual-folders/rankings-client-page";
 import { requireAdminUser } from "@/lib/auth/session";
 import { ApiError } from "@/lib/api/client";
 import { listClubTypes, listEcclesiasticalYears } from "@/lib/api/catalogs";
 import { getRankings, getAwardCategories } from "@/lib/api/annual-folders";
 import type { ClubRanking, AwardCategory } from "@/lib/api/annual-folders";
 import type { ClubType, EcclesiasticalYear } from "@/lib/api/catalogs";
+
+const RankingsClientPage = dynamic(
+  () =>
+    import("@/components/annual-folders/rankings-client-page").then((m) => ({
+      default: m.RankingsClientPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-4">
+        <div className="flex flex-wrap gap-2">
+          <Skeleton className="h-9 w-36 rounded-md" />
+          <Skeleton className="h-9 w-36 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/src/app/(dashboard)/dashboard/catalogs/folder-modules/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/folder-modules/page.tsx
@@ -1,7 +1,8 @@
 import { BookOpen } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
-import { PhaseECatalogCrudPage } from "@/components/catalogs/phase-e-catalog-crud-page";
 import { ApiError } from "@/lib/api/client";
 import { listAdminFolderModules } from "@/lib/api/phase-e-catalogs";
 import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
@@ -13,6 +14,28 @@ import {
   updateFolderModuleAction,
   deleteFolderModuleAction,
 } from "@/lib/phase-e-catalogs/actions";
+
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 

--- a/src/app/(dashboard)/dashboard/rbac/roles/page.tsx
+++ b/src/app/(dashboard)/dashboard/rbac/roles/page.tsx
@@ -1,16 +1,33 @@
 import Link from "next/link";
 import { ShieldCheck, Plus } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import dynamic from "next/dynamic";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
-import { RolesTable } from "@/components/rbac/roles-table";
 import { requireAdminUser } from "@/lib/auth/session";
 import { extractRoles, SUPER_ADMIN_ROLE } from "@/lib/auth/roles";
 import { listRoles } from "@/lib/rbac/service";
 import { ApiError } from "@/lib/api/client";
 import type { Role } from "@/lib/rbac/types";
+
+const RolesTable = dynamic(
+  () => import("@/components/rbac/roles-table").then((m) => ({ default: m.RolesTable })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
 
 export default async function RolesPage() {
   const t = await getTranslations("rbac.pages.roles");

--- a/src/components/units/unit-detail-panel.tsx
+++ b/src/components/units/unit-detail-panel.tsx
@@ -34,8 +34,27 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
 import { AddMemberDialog } from "@/components/units/add-member-dialog";
-import { WeeklyRecordsPanel } from "@/components/units/weekly-records-panel";
+
+const WeeklyRecordsPanel = dynamic(
+  () =>
+    import("@/components/units/weekly-records-panel").then((m) => ({
+      default: m.WeeklyRecordsPanel,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-3 pt-1">
+        <Skeleton className="h-9 w-40 rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
 import { useTranslations } from "next-intl";
 import { removeUnitMember, getUnitUserDisplayName } from "@/lib/api/units";
 import type { Unit, UnitMember } from "@/lib/api/units";


### PR DESCRIPTION
## Summary

Round 2 of dynamic imports following PR #108. Wraps 5 more 600-700 LOC components at their page boundary.

## Wrapped (server pages — no `ssr: false` per Next.js 16 lesson from #108)

| Page | Component | LOC | ~gz |
|---|---|---|---|
| rbac/roles | RolesTable | 702 | ~84KB |
| catalogs/folder-modules | PhaseECatalogCrudPage | 668 | ~80KB |
| annual-folders/rankings | RankingsClientPage | 660 | ~79KB |
| annual-folders/categories | AwardCategoriesClientPage | 650 | ~78KB |

## Wrapped (client component — `ssr: false` OK)
- units/unit-detail-panel.tsx → WeeklyRecordsPanel (647 LOC, ~78KB) — lives inside accordion tab, ideal lazy boundary

**Total ~399KB compressed deferred from initial JS shared chunk.**

## Discovery
`PhaseECatalogCrudPage` has 10 page consumers — wrapped only `folder-modules` here. Remaining 9 are follow-up (~800KB additional savings).

## Test plan
- [x] Typecheck clean (6 vitest baseline pre-existing)
- [ ] Manual: navigate each route, verify skeleton flashes briefly then content loads
- [ ] (After #108 baseline run) verify pnpm analyze shows chunk reduction