### PR TITLE
test: format-locale hooks + UI primitive tests (+57 tests, 120→177)

### DIFF
--- a/src/components/ui/breadcrumb.test.tsx
+++ b/src/components/ui/breadcrumb.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Breadcrumb primitive — BreadcrumbEllipsis srLabel prop tests
+ *
+ * `BreadcrumbEllipsis` accepts an optional `srLabel` prop (default: "More")
+ * that controls the text of the sr-only `<span>`. Unlike Dialog/Sheet, the
+ * breadcrumb component uses a plain prop — NOT `useTranslations` — so no
+ * NextIntlClientProvider wrapper is required.
+ *
+ * Tests verify:
+ * 1. Default srLabel ("More") renders in the DOM.
+ * 2. Custom srLabel renders correctly.
+ * 3. The outer span has aria-hidden="true" (screen readers see only the
+ *    sr-only child, not the icon).
+ * 4. A click handler on a wrapping button fires correctly (ellipsis is
+ *    typically placed inside a button/menu trigger in real usage).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+
+// RTL globals: false → auto-cleanup not registered; do it explicitly.
+afterEach(() => cleanup());
+
+import {
+  Breadcrumb,
+  BreadcrumbList,
+  BreadcrumbItem,
+  BreadcrumbEllipsis,
+  BreadcrumbLink,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "./breadcrumb";
+
+// ---------------------------------------------------------------------------
+// Helper — render ellipsis inside a minimal breadcrumb tree
+// ---------------------------------------------------------------------------
+
+function renderEllipsis(props: { srLabel?: string; onClick?: () => void } = {}) {
+  return render(
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink href="/">Home</BreadcrumbLink>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          {/*
+           * Wrap in a button for click testing. Use data-testid instead of
+           * aria-label so the button's accessible name doesn't collide with
+           * the sr-only text inside BreadcrumbEllipsis.
+           */}
+          <button type="button" onClick={props.onClick} data-testid="ellipsis-btn">
+            <BreadcrumbEllipsis srLabel={props.srLabel} />
+          </button>
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        <BreadcrumbItem>
+          <BreadcrumbPage>Current</BreadcrumbPage>
+        </BreadcrumbItem>
+      </BreadcrumbList>
+    </Breadcrumb>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("BreadcrumbEllipsis — srLabel prop", () => {
+  it("renders default sr-only text 'More' when srLabel is not provided", () => {
+    renderEllipsis();
+    // The sr-only span text should be accessible in the DOM
+    expect(screen.getByText("More")).toBeInTheDocument();
+  });
+
+  it("renders custom srLabel when prop is provided", () => {
+    renderEllipsis({ srLabel: "Más páginas" });
+    expect(screen.getByText("Más páginas")).toBeInTheDocument();
+    // Default "More" should NOT be present
+    expect(screen.queryByText("More")).not.toBeInTheDocument();
+  });
+
+  it("renders custom English srLabel", () => {
+    renderEllipsis({ srLabel: "Show more pages" });
+    expect(screen.getByText("Show more pages")).toBeInTheDocument();
+  });
+
+  it("ellipsis span has aria-hidden='true' (icon hidden from AT)", () => {
+    renderEllipsis();
+    const ellipsisSpan = document.querySelector("[data-slot='breadcrumb-ellipsis']");
+    expect(ellipsisSpan).toHaveAttribute("aria-hidden", "true");
+  });
+
+  it("ellipsis span has role='presentation'", () => {
+    renderEllipsis();
+    const ellipsisSpan = document.querySelector("[data-slot='breadcrumb-ellipsis']");
+    expect(ellipsisSpan).toHaveAttribute("role", "presentation");
+  });
+
+  it("surrounding button click handler fires", () => {
+    const onClick = vi.fn();
+    renderEllipsis({ onClick });
+    // Find the button wrapping the ellipsis by its data-testid
+    const button = screen.getByTestId("ellipsis-btn");
+    fireEvent.click(button);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("nav has aria-label='breadcrumb'", () => {
+    renderEllipsis();
+    expect(screen.getByRole("navigation", { name: "breadcrumb" })).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/dialog.test.tsx
+++ b/src/components/ui/dialog.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * Dialog primitive — srLabel / sr-only close button tests
+ *
+ * `DialogContent` renders a Radix `DialogPrimitive.Close` button that carries
+ * a `<span className="sr-only">` whose text comes from
+ * `useTranslations("shared.uiPrimitives")("close")`.
+ *
+ * Tests verify:
+ * 1. The sr-only text is present with the default locale translation.
+ * 2. A different locale yields the expected translated string.
+ * 3. The dialog can be dismissed via the close button (callback fires).
+ * 4. `showCloseButton={false}` hides the button entirely.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import React from "react";
+
+// RTL globals: false → auto-cleanup not registered; do it explicitly.
+afterEach(() => cleanup());
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "./dialog";
+
+// ---------------------------------------------------------------------------
+// Messages — only the keys consumed by dialog.tsx
+// ---------------------------------------------------------------------------
+
+const messages = {
+  shared: {
+    uiPrimitives: {
+      close: "Close",
+    },
+  },
+};
+
+const messagesEs = {
+  shared: {
+    uiPrimitives: {
+      close: "Cerrar",
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helper: render an open dialog wrapped with the intl provider
+// ---------------------------------------------------------------------------
+
+function renderDialog(
+  locale: string,
+  msgs: Record<string, unknown>,
+  overrides?: { showCloseButton?: boolean },
+) {
+  return render(
+    <NextIntlClientProvider locale={locale} messages={msgs}>
+      {/* open={true} keeps the content in the DOM without needing a trigger */}
+      <Dialog open>
+        <DialogContent showCloseButton={overrides?.showCloseButton ?? true}>
+          <DialogTitle>Test dialog</DialogTitle>
+          <DialogDescription>Description for accessibility</DialogDescription>
+          <p>Dialog body</p>
+        </DialogContent>
+      </Dialog>
+    </NextIntlClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DialogContent — close button sr-only label", () => {
+  it("renders sr-only 'Close' text in English locale by default", () => {
+    renderDialog("en", messages);
+    // The sr-only span is in the DOM even though it is visually hidden
+    expect(screen.getByText("Close")).toBeInTheDocument();
+  });
+
+  it("renders sr-only 'Cerrar' text in Spanish locale", () => {
+    renderDialog("es", messagesEs);
+    expect(screen.getByText("Cerrar")).toBeInTheDocument();
+  });
+
+  it("close button is present in the DOM with showCloseButton=true (default)", () => {
+    renderDialog("en", messages);
+    // The close button wraps an XIcon + the sr-only span.
+    // We can locate it via the data-slot attribute.
+    const closeBtn = document.querySelector("[data-slot='dialog-close']");
+    expect(closeBtn).toBeInTheDocument();
+  });
+
+  it("close button is NOT rendered when showCloseButton=false", () => {
+    renderDialog("en", messages, { showCloseButton: false });
+    // "Close" sr-only text should be absent
+    expect(screen.queryByText("Close")).not.toBeInTheDocument();
+  });
+
+  it("clicking the close button triggers the Dialog's onOpenChange", () => {
+    const onOpenChange = vi.fn();
+    render(
+      <NextIntlClientProvider locale="en" messages={messages}>
+        <Dialog open onOpenChange={onOpenChange}>
+          <DialogContent>
+            <DialogTitle>Title</DialogTitle>
+            <DialogDescription>Desc</DialogDescription>
+          </DialogContent>
+        </Dialog>
+      </NextIntlClientProvider>,
+    );
+
+    // Find the sr-only close text and click its parent button
+    const srSpan = screen.getByText("Close");
+    fireEvent.click(srSpan.closest("button") ?? srSpan);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/ui/sheet.test.tsx
+++ b/src/components/ui/sheet.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Sheet primitive — srLabel / sr-only close button tests
+ *
+ * `SheetContent` renders a Radix `SheetPrimitive.Close` button that carries
+ * a `<span className="sr-only">` whose text comes from
+ * `useTranslations("shared.uiPrimitives")("close")`.
+ *
+ * Tests verify:
+ * 1. The sr-only text is present with the default locale translation.
+ * 2. A different locale yields the expected translated string.
+ * 3. `showCloseButton={false}` hides the button entirely.
+ * 4. The close button fires the onOpenChange callback on click.
+ * 5. Side variants render (smoke — no crash for each side value).
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import React from "react";
+
+// RTL globals: false → auto-cleanup not registered; do it explicitly.
+afterEach(() => cleanup());
+
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from "./sheet";
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+const messagesEn = {
+  shared: {
+    uiPrimitives: {
+      close: "Close",
+    },
+  },
+};
+
+const messagesEs = {
+  shared: {
+    uiPrimitives: {
+      close: "Cerrar",
+    },
+  },
+};
+
+const messagesFr = {
+  shared: {
+    uiPrimitives: {
+      close: "Fermer",
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function renderSheet(
+  locale: string,
+  msgs: Record<string, unknown>,
+  overrides?: {
+    showCloseButton?: boolean;
+    side?: "top" | "right" | "bottom" | "left";
+    onOpenChange?: (open: boolean) => void;
+  },
+) {
+  return render(
+    <NextIntlClientProvider locale={locale} messages={msgs}>
+      <Sheet open onOpenChange={overrides?.onOpenChange}>
+        <SheetContent
+          showCloseButton={overrides?.showCloseButton ?? true}
+          side={overrides?.side ?? "right"}
+        >
+          <SheetHeader>
+            <SheetTitle>Test Sheet</SheetTitle>
+            <SheetDescription>Sheet description for accessibility</SheetDescription>
+          </SheetHeader>
+          <p>Sheet body content</p>
+        </SheetContent>
+      </Sheet>
+    </NextIntlClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SheetContent — close button sr-only label", () => {
+  it("renders sr-only 'Close' text in English locale", () => {
+    renderSheet("en", messagesEn);
+    expect(screen.getByText("Close")).toBeInTheDocument();
+  });
+
+  it("renders sr-only 'Cerrar' text in Spanish locale", () => {
+    renderSheet("es", messagesEs);
+    expect(screen.getByText("Cerrar")).toBeInTheDocument();
+  });
+
+  it("renders sr-only 'Fermer' text in French locale", () => {
+    renderSheet("fr", messagesFr);
+    expect(screen.getByText("Fermer")).toBeInTheDocument();
+  });
+
+  it("close button is NOT rendered when showCloseButton=false", () => {
+    renderSheet("en", messagesEn, { showCloseButton: false });
+    expect(screen.queryByText("Close")).not.toBeInTheDocument();
+  });
+
+  it("clicking the close button triggers onOpenChange(false)", () => {
+    const onOpenChange = vi.fn();
+    renderSheet("en", messagesEn, { onOpenChange });
+    const srSpan = screen.getByText("Close");
+    // The close button is the closest button ancestor of the sr-only span
+    fireEvent.click(srSpan.closest("button") ?? srSpan);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("renders without crashing for side='left'", () => {
+    renderSheet("en", messagesEn, { side: "left" });
+    expect(screen.getByText("Sheet body content")).toBeInTheDocument();
+  });
+
+  it("renders without crashing for side='top'", () => {
+    renderSheet("en", messagesEn, { side: "top" });
+    expect(screen.getByText("Sheet body content")).toBeInTheDocument();
+  });
+
+  it("renders without crashing for side='bottom'", () => {
+    renderSheet("en", messagesEn, { side: "bottom" });
+    expect(screen.getByText("Sheet body content")).toBeInTheDocument();
+  });
+});

--- a/src/components/ui/sidebar.test.tsx
+++ b/src/components/ui/sidebar.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Sidebar primitive — SidebarTrigger srLabel tests
+ *
+ * `SidebarTrigger` renders a ghost icon button with a sr-only
+ * `<span>` whose text comes from `useTranslations("shared.uiPrimitives")`
+ * (`"toggleSidebar"` key).
+ *
+ * It also uses:
+ * - `useSidebar()` → must be inside `<SidebarProvider>`
+ * - `useIsMobile()` → uses `window.matchMedia` (mocked below)
+ *
+ * `SidebarRail` also reads `t("toggleSidebar")` and sets it as
+ * `aria-label` — tested here as well.
+ *
+ * Tests verify:
+ * 1. SidebarTrigger renders sr-only text from the active locale.
+ * 2. Different locales produce the correct translated sr-only text.
+ * 3. Clicking the trigger calls `toggleSidebar` (state changes).
+ * 4. An additional `onClick` prop is forwarded alongside toggleSidebar.
+ * 5. SidebarRail aria-label reflects the active locale.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import React from "react";
+
+import { SidebarProvider, SidebarTrigger, SidebarRail, Sidebar, SidebarContent } from "./sidebar";
+
+// ---------------------------------------------------------------------------
+// window.matchMedia mock — jsdom does not implement it
+// ---------------------------------------------------------------------------
+
+const matchMediaMock = vi.fn().mockImplementation((query: string) => ({
+  matches: false, // desktop: window.innerWidth >= 768 → not mobile
+  media: query,
+  onchange: null,
+  addListener: vi.fn(),
+  removeListener: vi.fn(),
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+beforeAll(() => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: matchMediaMock,
+  });
+});
+
+// RTL globals: false → auto-cleanup not registered; do it explicitly.
+afterEach(() => cleanup());
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Messages
+// ---------------------------------------------------------------------------
+
+const messagesEn = {
+  shared: {
+    uiPrimitives: {
+      close: "Close",
+      toggleSidebar: "Toggle Sidebar",
+    },
+  },
+};
+
+const messagesEs = {
+  shared: {
+    uiPrimitives: {
+      close: "Cerrar",
+      toggleSidebar: "Alternar barra lateral",
+    },
+  },
+};
+
+const messagesFr = {
+  shared: {
+    uiPrimitives: {
+      close: "Fermer",
+      toggleSidebar: "Basculer la barre latérale",
+    },
+  },
+};
+
+const messagesPtBr = {
+  shared: {
+    uiPrimitives: {
+      close: "Fechar",
+      toggleSidebar: "Alternar barra lateral",
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+function renderTrigger(
+  locale: string,
+  msgs: Record<string, unknown>,
+  overrides?: { onClick?: React.MouseEventHandler<HTMLButtonElement> },
+) {
+  return render(
+    <NextIntlClientProvider locale={locale} messages={msgs}>
+      <SidebarProvider>
+        <Sidebar>
+          <SidebarContent />
+        </Sidebar>
+        <SidebarTrigger onClick={overrides?.onClick} />
+      </SidebarProvider>
+    </NextIntlClientProvider>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests — SidebarTrigger sr-only label
+// ---------------------------------------------------------------------------
+
+describe("SidebarTrigger — sr-only toggleSidebar label", () => {
+  it("en locale — renders 'Toggle Sidebar' sr-only text", () => {
+    renderTrigger("en", messagesEn);
+    expect(screen.getByText("Toggle Sidebar")).toBeInTheDocument();
+  });
+
+  it("es locale — renders 'Alternar barra lateral' sr-only text", () => {
+    renderTrigger("es", messagesEs);
+    expect(screen.getByText("Alternar barra lateral")).toBeInTheDocument();
+  });
+
+  it("fr locale — renders 'Basculer la barre latérale' sr-only text", () => {
+    renderTrigger("fr", messagesFr);
+    expect(screen.getByText("Basculer la barre latérale")).toBeInTheDocument();
+  });
+
+  it("pt-BR locale — renders 'Alternar barra lateral' sr-only text", () => {
+    renderTrigger("pt-BR", messagesPtBr);
+    // Both SidebarTrigger (sr-only span) and possibly SidebarRail share the
+    // same translation. getAllByText is safe here — at least one match required.
+    const matches = screen.getAllByText("Alternar barra lateral");
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+    matches.forEach((el) => expect(el).toBeInTheDocument());
+  });
+
+  it("clicking trigger toggles sidebar state (data-state changes)", () => {
+    renderTrigger("en", messagesEn);
+    // Before click: sidebar starts expanded (defaultOpen=true in SidebarProvider)
+    const sidebarEl = document.querySelector("[data-slot='sidebar']");
+    expect(sidebarEl).toHaveAttribute("data-state", "expanded");
+
+    // Find the trigger button and click it
+    const triggerBtn = document.querySelector("[data-slot='sidebar-trigger']");
+    expect(triggerBtn).toBeInTheDocument();
+    fireEvent.click(triggerBtn!);
+
+    // After click: state should be collapsed
+    expect(sidebarEl).toHaveAttribute("data-state", "collapsed");
+  });
+
+  it("additional onClick prop is called when trigger is clicked", () => {
+    const onClick = vi.fn();
+    renderTrigger("en", messagesEn, { onClick });
+    const triggerBtn = document.querySelector("[data-slot='sidebar-trigger']");
+    fireEvent.click(triggerBtn!);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("trigger button has data-sidebar='trigger'", () => {
+    renderTrigger("en", messagesEn);
+    const triggerBtn = document.querySelector("[data-sidebar='trigger']");
+    expect(triggerBtn).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — SidebarRail aria-label
+// ---------------------------------------------------------------------------
+
+describe("SidebarRail — toggleSidebar aria-label", () => {
+  function renderRail(locale: string, msgs: Record<string, unknown>) {
+    return render(
+      <NextIntlClientProvider locale={locale} messages={msgs}>
+        <SidebarProvider>
+          <Sidebar>
+            <SidebarContent />
+            <SidebarRail />
+          </Sidebar>
+        </SidebarProvider>
+      </NextIntlClientProvider>,
+    );
+  }
+
+  it("en locale — SidebarRail has aria-label='Toggle Sidebar'", () => {
+    renderRail("en", messagesEn);
+    const rail = document.querySelector("[data-slot='sidebar-rail']");
+    expect(rail).toHaveAttribute("aria-label", "Toggle Sidebar");
+  });
+
+  it("es locale — SidebarRail has aria-label='Alternar barra lateral'", () => {
+    renderRail("es", messagesEs);
+    const rail = document.querySelector("[data-slot='sidebar-rail']");
+    expect(rail).toHaveAttribute("aria-label", "Alternar barra lateral");
+  });
+});

--- a/src/lib/format-locale.hooks.test.tsx
+++ b/src/lib/format-locale.hooks.test.tsx
@@ -1,0 +1,310 @@
+/**
+ * format-locale — React hook variants
+ *
+ * Tests `useFormatDate`, `useFormatDateTime`, `useFormatNumber`, and
+ * `useFormatCurrency`. Each hook calls `useLocale()` from next-intl internally,
+ * so every test wraps with `NextIntlClientProvider` to supply the locale.
+ *
+ * All 4 supported locales are exercised (es, en, fr, pt-BR).
+ */
+
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import React from "react";
+
+import {
+  useFormatDate,
+  useFormatDateTime,
+  useFormatNumber,
+  useFormatCurrency,
+} from "./format-locale";
+
+// ---------------------------------------------------------------------------
+// Wrapper factory
+// ---------------------------------------------------------------------------
+
+function makeWrapper(locale: string) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <NextIntlClientProvider locale={locale} messages={{}}>
+        {children}
+      </NextIntlClientProvider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixed reference values
+// ---------------------------------------------------------------------------
+
+// 2024-06-15T12:00:00Z — June 15 2024 at noon UTC. Chosen because the month
+// name ("june / juin / junho / junio") is unambiguous across locales.
+const FIXED_DATE = new Date("2024-06-15T12:00:00Z");
+
+// ---------------------------------------------------------------------------
+// useFormatDate
+// ---------------------------------------------------------------------------
+
+describe("useFormatDate()", () => {
+  it("es locale — result contains 2024 and a Spanish month abbreviation", () => {
+    const { result } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("es"),
+    });
+    const formatted = result.current(FIXED_DATE);
+    expect(formatted).toContain("2024");
+    // es-MX short month for June → "jun."
+    expect(formatted.toLowerCase()).toMatch(/jun/);
+  });
+
+  it("en locale — result contains 2024 and an English month abbreviation", () => {
+    const { result } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("en"),
+    });
+    const formatted = result.current(FIXED_DATE);
+    expect(formatted).toContain("2024");
+    expect(formatted).toMatch(/Jun/i);
+  });
+
+  it("fr locale — result contains 2024 and a French month token", () => {
+    const { result } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("fr"),
+    });
+    const formatted = result.current(FIXED_DATE);
+    expect(formatted).toContain("2024");
+    // fr-FR short month for June → "juin"
+    expect(formatted.toLowerCase()).toMatch(/juin/);
+  });
+
+  it("pt-BR locale — result contains 2024", () => {
+    const { result } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("pt-BR"),
+    });
+    const formatted = result.current(FIXED_DATE);
+    expect(formatted).toContain("2024");
+    // pt-BR short month for June → "jun."
+    expect(formatted.toLowerCase()).toMatch(/jun/);
+  });
+
+  it("accepts an ISO string as input", () => {
+    const { result } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("en"),
+    });
+    const formatted = result.current("2024-06-15T12:00:00Z");
+    expect(formatted).toContain("2024");
+  });
+
+  it("accepts a numeric timestamp as input", () => {
+    const { result } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("en"),
+    });
+    const formatted = result.current(FIXED_DATE.getTime());
+    expect(formatted).toContain("2024");
+  });
+
+  it("respects custom DateTimeFormatOptions", () => {
+    const { result } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("en"),
+    });
+    const formatted = result.current(FIXED_DATE, { year: "numeric" });
+    expect(formatted).toBe("2024");
+  });
+
+  it("returns the raw string for an invalid date", () => {
+    const { result } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("es"),
+    });
+    expect(result.current("not-a-date")).toBe("not-a-date");
+  });
+
+  it("different locales produce different output for the same date", () => {
+    const { result: resultEs } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("es"),
+    });
+    const { result: resultFr } = renderHook(() => useFormatDate(), {
+      wrapper: makeWrapper("fr"),
+    });
+    const formattedEs = resultEs.current(FIXED_DATE);
+    const formattedFr = resultFr.current(FIXED_DATE);
+    // Both contain the year but the month tokens differ
+    expect(formattedEs.toLowerCase()).toMatch(/jun/);
+    expect(formattedFr.toLowerCase()).toMatch(/juin/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useFormatDateTime
+// ---------------------------------------------------------------------------
+
+describe("useFormatDateTime()", () => {
+  it("es locale — result contains both date and time parts", () => {
+    const { result } = renderHook(() => useFormatDateTime(), {
+      wrapper: makeWrapper("es"),
+    });
+    const formatted = result.current(FIXED_DATE);
+    expect(formatted).toContain("2024");
+    expect(formatted).toMatch(/:/); // time separator
+  });
+
+  it("en locale — result contains AM/PM or 24-h colon", () => {
+    const { result } = renderHook(() => useFormatDateTime(), {
+      wrapper: makeWrapper("en"),
+    });
+    const formatted = result.current(FIXED_DATE);
+    expect(formatted).toContain("2024");
+    expect(formatted).toMatch(/:/);
+  });
+
+  it("fr locale — result contains the year and a colon", () => {
+    const { result } = renderHook(() => useFormatDateTime(), {
+      wrapper: makeWrapper("fr"),
+    });
+    const formatted = result.current(FIXED_DATE);
+    expect(formatted).toContain("2024");
+    expect(formatted).toMatch(/:/);
+  });
+
+  it("pt-BR locale — result contains the year and a colon", () => {
+    const { result } = renderHook(() => useFormatDateTime(), {
+      wrapper: makeWrapper("pt-BR"),
+    });
+    const formatted = result.current(FIXED_DATE);
+    expect(formatted).toContain("2024");
+    expect(formatted).toMatch(/:/);
+  });
+
+  it("returns the raw string fallback for an invalid date", () => {
+    const { result } = renderHook(() => useFormatDateTime(), {
+      wrapper: makeWrapper("en"),
+    });
+    expect(result.current("garbage")).toBe("garbage");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useFormatNumber
+// ---------------------------------------------------------------------------
+
+describe("useFormatNumber()", () => {
+  it("es locale — 1234 formatted as es-MX with comma thousands separator", () => {
+    const { result } = renderHook(() => useFormatNumber(), {
+      wrapper: makeWrapper("es"),
+    });
+    expect(result.current(1234)).toBe("1,234");
+  });
+
+  it("en locale — 1234567 formatted with commas", () => {
+    const { result } = renderHook(() => useFormatNumber(), {
+      wrapper: makeWrapper("en"),
+    });
+    expect(result.current(1_234_567)).toBe("1,234,567");
+  });
+
+  it("fr locale — digits present (thousands separator varies by ICU build)", () => {
+    const { result } = renderHook(() => useFormatNumber(), {
+      wrapper: makeWrapper("fr"),
+    });
+    const formatted = result.current(1234);
+    // Strip all whitespace variants to compare digits only
+    expect(formatted.replace(/\s| | /g, "")).toContain("1234");
+  });
+
+  it("pt-BR locale — 1234 digits present", () => {
+    const { result } = renderHook(() => useFormatNumber(), {
+      wrapper: makeWrapper("pt-BR"),
+    });
+    const formatted = result.current(1234);
+    expect(formatted).toContain("234");
+  });
+
+  it("respects custom NumberFormatOptions — maximumFractionDigits", () => {
+    const { result } = renderHook(() => useFormatNumber(), {
+      wrapper: makeWrapper("en"),
+    });
+    expect(result.current(3.14159, { maximumFractionDigits: 2 })).toBe("3.14");
+  });
+
+  it("formats 0", () => {
+    const { result } = renderHook(() => useFormatNumber(), {
+      wrapper: makeWrapper("es"),
+    });
+    expect(result.current(0)).toBe("0");
+  });
+
+  it("formats negative numbers", () => {
+    const { result } = renderHook(() => useFormatNumber(), {
+      wrapper: makeWrapper("en"),
+    });
+    const formatted = result.current(-42);
+    expect(formatted).toContain("42");
+    expect(formatted).toContain("-");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useFormatCurrency
+// ---------------------------------------------------------------------------
+
+describe("useFormatCurrency()", () => {
+  it("es locale with MXN — contains peso symbol and amount", () => {
+    const { result } = renderHook(() => useFormatCurrency(), {
+      wrapper: makeWrapper("es"),
+    });
+    const formatted = result.current(100, "MXN");
+    expect(formatted).toMatch(/\$|MX\$|MXN/);
+    expect(formatted).toContain("100");
+  });
+
+  it("en locale with USD — contains dollar sign and amount", () => {
+    const { result } = renderHook(() => useFormatCurrency(), {
+      wrapper: makeWrapper("en"),
+    });
+    const formatted = result.current(100, "USD");
+    expect(formatted).toContain("$");
+    expect(formatted).toContain("100");
+  });
+
+  it("fr locale with EUR — contains euro symbol and amount", () => {
+    const { result } = renderHook(() => useFormatCurrency(), {
+      wrapper: makeWrapper("fr"),
+    });
+    const formatted = result.current(100, "EUR");
+    expect(formatted).toContain("€");
+    expect(formatted).toContain("100");
+  });
+
+  it("pt-BR locale with BRL — contains R$ symbol and amount", () => {
+    const { result } = renderHook(() => useFormatCurrency(), {
+      wrapper: makeWrapper("pt-BR"),
+    });
+    const formatted = result.current(100, "BRL");
+    expect(formatted).toContain("R$");
+    expect(formatted).toContain("100");
+  });
+
+  it("defaults to MXN when currency argument is omitted", () => {
+    const { result } = renderHook(() => useFormatCurrency(), {
+      wrapper: makeWrapper("es"),
+    });
+    const withExplicit = result.current(50, "MXN");
+    const withDefault = result.current(50);
+    expect(withDefault).toBe(withExplicit);
+  });
+
+  it("formats 0 correctly", () => {
+    const { result } = renderHook(() => useFormatCurrency(), {
+      wrapper: makeWrapper("en"),
+    });
+    const formatted = result.current(0, "USD");
+    expect(formatted).toContain("0");
+  });
+
+  it("formats negative amounts", () => {
+    const { result } = renderHook(() => useFormatCurrency(), {
+      wrapper: makeWrapper("en"),
+    });
+    const formatted = result.current(-25, "USD");
+    expect(formatted).toContain("25");
+    expect(formatted).toMatch(/-|\(/);
+  });
+});


### PR DESCRIPTION
## Summary

Extends test coverage from PR #109. Covers what #109 explicitly skipped (React hook variants of format-locale) + new `srLabel` prop pattern from PR #105 (shadcn UI primitives).

## 5 new test files

| File | Tests | Coverage |
|---|---|---|
| `format-locale.hooks.test.tsx` | 28 | useFormatDate/DateTime/Number/Currency, all 4 locales, switching |
| `ui/dialog.test.tsx` | 5 | DialogClose srLabel + i18n hook |
| `ui/sheet.test.tsx` | 8 | SheetClose srLabel + i18n hook |
| `ui/breadcrumb.test.tsx` | 7 | BreadcrumbEllipsis srLabel prop (no hook) |
| `ui/sidebar.test.tsx` | 9 | SidebarTrigger + SidebarRail |

## Pattern decisions

- **renderHook + makeWrapper(locale) factory** wraps with NextIntlClientProvider (empty messages OK — hooks call useLocale only)
- **Dialog/Sheet** use useTranslations directly → inline minimal messages `{shared:{uiPrimitives:{close:'...'}}}`
- **Breadcrumb**: srLabel is plain prop (no hook) → no provider needed
- **Sidebar**: 3 contexts required (SidebarProvider + NextIntlClientProvider + window.matchMedia mock for useIsMobile)
- **Explicit afterEach(cleanup)** per file — vitest `globals: false` breaks RTL auto-cleanup (RTL checks `typeof afterEach === 'function'` at import-time)

## Out of scope
Server async getters (`getFormat*`) still skipped — need server-side mocking of next-intl request pipeline. Separate PR.

## Stats
120 → 177 tests (+57), 8 → 13 test files. Typecheck clean. Zero source modifications.

## Test plan
- [x] All 177 tests pass
- [x] Typecheck clean