### PR TITLE
perf: round 3 — lazy-load 5 more heavy components (~85-105KB gz deferred)

### DIFF
--- a/src/app/(dashboard)/dashboard/annual-folders/evaluate/page.tsx
+++ b/src/app/(dashboard)/dashboard/annual-folders/evaluate/page.tsx
@@ -1,7 +1,41 @@
+import dynamic from "next/dynamic";
 import { getTranslations } from "next-intl/server";
+import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/shared/page-header";
-import { EvaluationClientPage } from "@/components/annual-folders/evaluation-client-page";
 import { requireAdminUser } from "@/lib/auth/session";
+
+const EvaluationClientPage = dynamic(
+  () =>
+    import("@/components/annual-folders/evaluation-client-page").then((m) => ({
+      default: m.EvaluationClientPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <Skeleton className="h-9 w-[220px]" />
+          <Skeleton className="h-9 w-[140px]" />
+          <div className="ml-auto flex gap-2">
+            <Skeleton className="h-9 w-[120px]" />
+          </div>
+        </div>
+        <div className="rounded-md border">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 border-b p-4 last:border-b-0"
+            >
+              <Skeleton className="h-4 w-32" />
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+              <Skeleton className="ml-auto h-8 w-28 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+);
 
 // ─── Page ──────────────────────────────────────────────────────────────────────
 

--- a/src/app/(dashboard)/dashboard/catalogs/honor-categories/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/honor-categories/page.tsx
@@ -1,6 +1,38 @@
+import dynamic from "next/dynamic";
 import { getTranslations } from "next-intl/server";
-import { HonorCategoriesCrudPage } from "@/components/catalogs/honor-categories-crud-page";
+import { Skeleton } from "@/components/ui/skeleton";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+
+const HonorCategoriesCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/honor-categories-crud-page").then((m) => ({
+      default: m.HonorCategoriesCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-9 w-[200px]" />
+          <div className="ml-auto flex gap-2">
+            <Skeleton className="h-9 w-[100px]" />
+          </div>
+        </div>
+        <div className="rounded-md border">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 border-b p-4 last:border-b-0"
+            >
+              <Skeleton className="h-4 w-48" />
+              <Skeleton className="h-5 w-16 rounded-full" />
+              <Skeleton className="ml-auto h-8 w-8 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+);
 import { ApiError } from "@/lib/api/client";
 import {
   listHonorCategoriesAdmin,

--- a/src/app/(dashboard)/dashboard/honors/page.tsx
+++ b/src/app/(dashboard)/dashboard/honors/page.tsx
@@ -6,9 +6,45 @@ import { requireAdminUser } from "@/lib/auth/session";
 import { extractRoles, SUPER_ADMIN_ROLE } from "@/lib/auth/roles";
 import { hasAnyPermission } from "@/lib/auth/permission-utils";
 import { HONORS_CREATE, HONORS_UPDATE } from "@/lib/auth/permissions";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
-import { HonorsCrudPage } from "@/components/honors/honors-crud-page";
 import { deactivateHonorAction } from "@/lib/honors/actions";
+
+const HonorsCrudPage = dynamic(
+  () =>
+    import("@/components/honors/honors-crud-page").then((m) => ({
+      default: m.HonorsCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-4">
+        <div className="flex flex-wrap items-center gap-3">
+          <Skeleton className="h-9 w-[200px]" />
+          <Skeleton className="h-9 w-[160px]" />
+          <Skeleton className="h-9 w-[130px]" />
+          <div className="ml-auto flex gap-2">
+            <Skeleton className="h-9 w-[120px]" />
+          </div>
+        </div>
+        <div className="rounded-md border">
+          {Array.from({ length: 10 }).map((_, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-4 border-b p-4 last:border-b-0"
+            >
+              <Skeleton className="size-10 rounded-md" />
+              <Skeleton className="h-4 w-48" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+              <Skeleton className="hidden h-4 w-24 md:block" />
+              <Skeleton className="ml-auto h-8 w-8 rounded" />
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+  },
+);
 
 type SearchParams = Promise<Record<string, string | string[] | undefined>>;
 type SelectOption = { label: string; value: number };

--- a/src/app/(dashboard)/dashboard/insurance/expiring/page.tsx
+++ b/src/app/(dashboard)/dashboard/insurance/expiring/page.tsx
@@ -3,10 +3,16 @@ import { ShieldAlert } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { PageHeader } from "@/components/shared/page-header";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
-import {
-  ExpiringDashboard,
-  ExpiringDashboardSkeleton,
-} from "@/components/insurance/expiring-dashboard";
+import dynamic from "next/dynamic";
+import { ExpiringDashboardSkeleton } from "@/components/insurance/expiring-dashboard";
+
+const ExpiringDashboard = dynamic(
+  () =>
+    import("@/components/insurance/expiring-dashboard").then((m) => ({
+      default: m.ExpiringDashboard,
+    })),
+  { loading: () => <ExpiringDashboardSkeleton /> },
+);
 import { getExpiringInsurance } from "@/lib/api/insurance";
 import { requireAdminUser } from "@/lib/auth/session";
 import type { ExpiringInsurance } from "@/lib/api/insurance";

--- a/src/app/(dashboard)/dashboard/reports/page.tsx
+++ b/src/app/(dashboard)/dashboard/reports/page.tsx
@@ -1,3 +1,4 @@
+import dynamic from "next/dynamic";
 import { Suspense } from "react";
 import { FileText } from "lucide-react";
 import { getTranslations } from "next-intl/server";
@@ -6,9 +7,16 @@ import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 import { DataTableShell } from "@/components/shared/data-table-shell";
-import { ReportsListClient } from "@/components/reports/reports-list-client";
 import { requireAdminUser } from "@/lib/auth/session";
 import { apiRequest, ApiError } from "@/lib/api/client";
+
+const ReportsListClient = dynamic(
+  () =>
+    import("@/components/reports/reports-list-client").then((m) => ({
+      default: m.ReportsListClient,
+    })),
+  { loading: () => <ReportsPageSkeleton /> },
+);
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Round 3 of dynamic imports following PRs #108, #111. Wraps 5 more 600+ LOC components.

## Wrapped (all server pages — no ssr:false)

| Page | Component | LOC | ~gz |
|---|---|---|---|
| catalogs/honor-categories | HonorCategoriesCrudPage | 631 | ~18-22KB |
| annual-folders/evaluate | EvaluationClientPage | 604 | ~16-20KB |
| insurance/expiring | ExpiringDashboard | 605 | ~17-21KB |
| honors | HonorsCrudPage | 613 | ~19-23KB |
| reports | ReportsListClient | 595 | ~15-19KB |

**Total ~85-105KB gz deferred from initial JS shared chunk.**

## Notes
- insurance/expiring: reuses existing `ExpiringDashboardSkeleton` exported from component
- reports: reuses existing `ReportsPageSkeleton` from page file
- Both already use Suspense for streaming async data — `dynamic()` adds bundle-splitting on top

## Stats
5 pages, +124/-8. Typecheck clean.

## Test plan
- [x] Typecheck clean
- [ ] Manual smoke: navigate each route, verify content loads
- [ ] (After PR #112 merged) confirm chunks moved out of shared bundle via `pnpm analyze`