### PR TITLE
fix(a11y): shadcn Form primitive + migrate 5 forms to aria-invalid wiring

### DIFF
--- a/src/components/activities/activity-form-dialog.tsx
+++ b/src/components/activities/activity-form-dialog.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
@@ -25,6 +24,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import { createActivity, updateActivity } from "@/lib/api/activities";
 import type { Activity } from "@/lib/api/activities";
@@ -98,14 +105,7 @@ export function ActivityFormDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
@@ -127,7 +127,7 @@ export function ActivityFormDialog({
   useEffect(() => {
     if (open) {
       if (activity) {
-        reset({
+        form.reset({
           name: activity.name,
           description: activity.description ?? "",
           activity_type_id: activity.activity_type_id,
@@ -142,7 +142,7 @@ export function ActivityFormDialog({
           link_meet: activity.link_meet ?? "",
         });
       } else {
-        reset({
+        form.reset({
           name: "",
           description: "",
           activity_type_id: 1,
@@ -158,7 +158,7 @@ export function ActivityFormDialog({
         });
       }
     }
-  }, [open, activity, sections, reset]);
+  }, [open, activity, sections, form]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -203,10 +203,10 @@ export function ActivityFormDialog({
     } finally {
       setIsSubmitting(false);
     }
-  }
+  };
 
-  const platform = watch("platform");
-  const clubTypeId = watch("club_type_id");
+  const platform = form.watch("platform");
+  const clubTypeId = form.watch("club_type_id");
 
   // Filter sections by selected club type
   const filteredSections = sections.filter(
@@ -227,270 +227,336 @@ export function ActivityFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
-          {/* Nombre */}
-          <div className="space-y-1.5">
-            <Label htmlFor="name">
-              Nombre <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="name"
-              aria-required="true"
-              {...register("name")}
-              placeholder={t("placeholders.name")}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} noValidate className="space-y-4">
+            {/* Nombre */}
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Nombre <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      aria-required="true"
+                      placeholder={t("placeholders.name")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
-            )}
-          </div>
 
-          {/* Descripción */}
-          <div className="space-y-1.5">
-            <Label htmlFor="description">Descripción</Label>
-            <Textarea
-              id="description"
-              {...register("description")}
-              placeholder={t("placeholders.description")}
-              rows={3}
+            {/* Descripción */}
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Descripción</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("placeholders.description")}
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
 
-          {/* Tipo de actividad */}
-          <div className="space-y-1.5">
-            <Label htmlFor="activity_type_id">
-              Tipo de actividad <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Select
-              defaultValue={String(activity?.activity_type_id ?? 1)}
-              onValueChange={(val) => setValue("activity_type_id", Number(val))}
-            >
-              <SelectTrigger id="activity_type_id" aria-required="true">
-                <SelectValue placeholder={t("placeholders.selectType")} />
-              </SelectTrigger>
-              <SelectContent>
-                {ACTIVITY_TYPES.map((t) => (
-                  <SelectItem key={t.value} value={String(t.value)}>
-                    {t.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.activity_type_id && (
-              <p className="text-xs text-destructive">
-                {errors.activity_type_id.message}
-              </p>
-            )}
-          </div>
-
-          {/* Tipo de club + Sección (solo al crear) */}
-          {!isEdit && (
-            <>
-              <div className="space-y-1.5">
-                <Label htmlFor="club_type_id">
-                  Tipo de club <span aria-hidden="true" className="text-destructive">*</span>
-                </Label>
-                <Select
-                  defaultValue={String(sections[0]?.club_type_id ?? 1)}
-                  onValueChange={(val) => {
-                    setValue("club_type_id", Number(val));
-                    // Reset section when club type changes
-                    const firstMatch = sections.find(
-                      (s) => s.club_type_id === Number(val),
-                    );
-                    setValue("club_section_id", firstMatch?.club_section_id ?? 0);
-                  }}
-                >
-                  <SelectTrigger id="club_type_id" aria-required="true">
-                    <SelectValue placeholder={t("placeholders.selectClubType")} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {CLUB_TYPES.map((ct) => (
-                      <SelectItem key={ct.value} value={String(ct.value)}>
-                        {ct.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                {errors.club_type_id && (
-                  <p className="text-xs text-destructive">
-                    {errors.club_type_id.message}
-                  </p>
-                )}
-              </div>
-
-              <div className="space-y-1.5">
-                <Label htmlFor="club_section_id">
-                  Sección del club <span aria-hidden="true" className="text-destructive">*</span>
-                </Label>
-                <Select
-                  value={String(watch("club_section_id"))}
-                  onValueChange={(val) => setValue("club_section_id", Number(val))}
-                >
-                  <SelectTrigger id="club_section_id" aria-required="true">
-                    <SelectValue placeholder={t("placeholders.selectSection")} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {filteredSections.length > 0 ? (
-                      filteredSections.map((s) => (
-                        <SelectItem
-                          key={s.club_section_id}
-                          value={String(s.club_section_id)}
-                        >
-                          {s.name}
+            {/* Tipo de actividad */}
+            <FormField
+              control={form.control}
+              name="activity_type_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Tipo de actividad <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <Select
+                    defaultValue={String(activity?.activity_type_id ?? 1)}
+                    onValueChange={(val) => field.onChange(Number(val))}
+                  >
+                    <FormControl>
+                      <SelectTrigger aria-required="true">
+                        <SelectValue placeholder={t("placeholders.selectType")} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {ACTIVITY_TYPES.map((at) => (
+                        <SelectItem key={at.value} value={String(at.value)}>
+                          {at.label}
                         </SelectItem>
-                      ))
-                    ) : (
-                      <SelectItem value="0" disabled>
-                        No hay secciones para este tipo
-                      </SelectItem>
-                    )}
-                  </SelectContent>
-                </Select>
-                {errors.club_section_id && (
-                  <p className="text-xs text-destructive">
-                    {errors.club_section_id.message}
-                  </p>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Tipo de club + Sección (solo al crear) */}
+            {!isEdit && (
+              <>
+                <FormField
+                  control={form.control}
+                  name="club_type_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        Tipo de club <span aria-hidden="true" className="text-destructive">*</span>
+                      </FormLabel>
+                      <Select
+                        defaultValue={String(sections[0]?.club_type_id ?? 1)}
+                        onValueChange={(val) => {
+                          field.onChange(Number(val));
+                          // Reset section when club type changes
+                          const firstMatch = sections.find(
+                            (s) => s.club_type_id === Number(val),
+                          );
+                          form.setValue("club_section_id", firstMatch?.club_section_id ?? 0);
+                        }}
+                      >
+                        <FormControl>
+                          <SelectTrigger aria-required="true">
+                            <SelectValue placeholder={t("placeholders.selectClubType")} />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {CLUB_TYPES.map((ct) => (
+                            <SelectItem key={ct.value} value={String(ct.value)}>
+                              {ct.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="club_section_id"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>
+                        Sección del club <span aria-hidden="true" className="text-destructive">*</span>
+                      </FormLabel>
+                      <Select
+                        value={String(field.value)}
+                        onValueChange={(val) => field.onChange(Number(val))}
+                      >
+                        <FormControl>
+                          <SelectTrigger aria-required="true">
+                            <SelectValue placeholder={t("placeholders.selectSection")} />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {filteredSections.length > 0 ? (
+                            filteredSections.map((s) => (
+                              <SelectItem
+                                key={s.club_section_id}
+                                value={String(s.club_section_id)}
+                              >
+                                {s.name}
+                              </SelectItem>
+                            ))
+                          ) : (
+                            <SelectItem value="0" disabled>
+                              No hay secciones para este tipo
+                            </SelectItem>
+                          )}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
+
+            {/* Lugar */}
+            <FormField
+              control={form.control}
+              name="activity_place"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Lugar <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      aria-required="true"
+                      placeholder={t("placeholders.location")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Hora */}
+            <FormField
+              control={form.control}
+              name="activity_time"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Hora (HH:mm)</FormLabel>
+                  <FormControl>
+                    <Input type="time" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Coordenadas */}
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="lat"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Latitud <span aria-hidden="true" className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="any"
+                        aria-required="true"
+                        placeholder={t("placeholders.latitude")}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
                 )}
-              </div>
-            </>
-          )}
-
-          {/* Lugar */}
-          <div className="space-y-1.5">
-            <Label htmlFor="activity_place">
-              Lugar <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="activity_place"
-              aria-required="true"
-              {...register("activity_place")}
-              placeholder={t("placeholders.location")}
-            />
-            {errors.activity_place && (
-              <p className="text-xs text-destructive">
-                {errors.activity_place.message}
-              </p>
-            )}
-          </div>
-
-          {/* Hora */}
-          <div className="space-y-1.5">
-            <Label htmlFor="activity_time">Hora (HH:mm)</Label>
-            <Input
-              id="activity_time"
-              type="time"
-              {...register("activity_time")}
-            />
-          </div>
-
-          {/* Coordenadas */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="lat">
-                Latitud <span aria-hidden="true" className="text-destructive">*</span>
-              </Label>
-              <Input
-                id="lat"
-                type="number"
-                step="any"
-                aria-required="true"
-                {...register("lat")}
-                placeholder={t("placeholders.latitude")}
               />
-              {errors.lat && (
-                <p className="text-xs text-destructive">{errors.lat.message}</p>
+
+              <FormField
+                control={form.control}
+                name="long"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Longitud <span aria-hidden="true" className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="any"
+                        aria-required="true"
+                        placeholder={t("placeholders.longitude")}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Modalidad */}
+            <FormField
+              control={form.control}
+              name="platform"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Modalidad</FormLabel>
+                  <Select
+                    defaultValue={String(activity?.platform ?? 0)}
+                    onValueChange={(val) => field.onChange(Number(val))}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t("placeholders.selectModality")} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {PLATFORMS.map((p) => (
+                        <SelectItem key={p.value} value={String(p.value)}>
+                          {p.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="long">
-                Longitud <span aria-hidden="true" className="text-destructive">*</span>
-              </Label>
-              <Input
-                id="long"
-                type="number"
-                step="any"
-                aria-required="true"
-                {...register("long")}
-                placeholder={t("placeholders.longitude")}
-              />
-              {errors.long && (
-                <p className="text-xs text-destructive">
-                  {errors.long.message}
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* Modalidad */}
-          <div className="space-y-1.5">
-            <Label htmlFor="platform">Modalidad</Label>
-            <Select
-              defaultValue={String(activity?.platform ?? 0)}
-              onValueChange={(val) => setValue("platform", Number(val))}
-            >
-              <SelectTrigger id="platform">
-                <SelectValue placeholder={t("placeholders.selectModality")} />
-              </SelectTrigger>
-              <SelectContent>
-                {PLATFORMS.map((p) => (
-                  <SelectItem key={p.value} value={String(p.value)}>
-                    {p.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          {/* Link de reunión — solo si virtual o híbrido */}
-          {(platform === 1 || platform === 2) && (
-            <div className="space-y-1.5">
-              <Label htmlFor="link_meet">Enlace de reunión virtual</Label>
-              <Input
-                id="link_meet"
-                {...register("link_meet")}
-                placeholder={t("placeholders.meetUrl")}
-                type="url"
-              />
-            </div>
-          )}
-
-          {/* URL de imagen */}
-          <div className="space-y-1.5">
-            <Label htmlFor="image">
-              URL de imagen <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="image"
-              aria-required="true"
-              {...register("image")}
-              placeholder={t("placeholders.externalUrl")}
-              type="url"
             />
-            {errors.image && (
-              <p className="text-xs text-destructive">{errors.image.message}</p>
-            )}
-          </div>
 
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              Cancelar
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? isEdit
-                  ? "Guardando..."
-                  : "Creando..."
-                : isEdit
-                  ? "Guardar cambios"
-                  : "Crear actividad"}
-            </Button>
-          </DialogFooter>
-        </form>
+            {/* Link de reunión — solo si virtual o híbrido */}
+            {(platform === 1 || platform === 2) && (
+              <FormField
+                control={form.control}
+                name="link_meet"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Enlace de reunión virtual</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="url"
+                        placeholder={t("placeholders.meetUrl")}
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            {/* URL de imagen */}
+            <FormField
+              control={form.control}
+              name="image"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    URL de imagen <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="url"
+                      aria-required="true"
+                      placeholder={t("placeholders.externalUrl")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? isEdit
+                    ? "Guardando..."
+                    : "Creando..."
+                  : isEdit
+                    ? "Guardar cambios"
+                    : "Crear actividad"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/finances/transaction-form-dialog.tsx
+++ b/src/components/finances/transaction-form-dialog.tsx
@@ -16,8 +16,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
@@ -128,14 +135,7 @@ export function TransactionFormDialog({
 
   const today = new Date().toISOString().split("T")[0];
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       year: currentYear,
@@ -152,7 +152,7 @@ export function TransactionFormDialog({
   // Reset when dialog opens/finance changes
   useEffect(() => {
     if (open) {
-      reset({
+      form.reset({
         year: finance?.year ?? currentYear,
         month: finance?.month ?? new Date().getMonth() + 1,
         amount: finance ? finance.amount / 100 : undefined,
@@ -167,11 +167,6 @@ export function TransactionFormDialog({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, finance]);
-
-  const selectedSectionId = watch("club_section_id");
-  const selectedCategoryId = watch("finance_category_id");
-  const selectedYear = watch("year");
-  const selectedMonth = watch("month");
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -229,218 +224,255 @@ export function TransactionFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-          {/* Categoría */}
-          <div className="space-y-1.5">
-            <Label htmlFor="finance_category_id">
-              {t("form.categoryLabel")}{" "}
-              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-            </Label>
-            <Select
-              value={selectedCategoryId?.toString() ?? ""}
-              onValueChange={(v) => setValue("finance_category_id", Number(v))}
-              disabled={loadingCategories}
-            >
-              <SelectTrigger id="finance_category_id" aria-required="true">
-                <SelectValue
-                  placeholder={
-                    loadingCategories
-                      ? t("form.categoryLoading")
-                      : t("form.categoryPlaceholder")
-                  }
-                />
-              </SelectTrigger>
-              <SelectContent>
-                {categories.map((cat) => (
-                  <SelectItem
-                    key={cat.finance_category_id}
-                    value={cat.finance_category_id.toString()}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {/* Categoría */}
+            <FormField
+              control={form.control}
+              name="finance_category_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("form.categoryLabel")}{" "}
+                    <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                  </FormLabel>
+                  <Select
+                    value={field.value?.toString() ?? ""}
+                    onValueChange={(v) => field.onChange(Number(v))}
+                    disabled={loadingCategories}
                   >
-                    {cat.name} —{" "}
-                    {cat.type === 0
-                      ? t("categoryType.income")
-                      : t("categoryType.expense")}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.finance_category_id && (
-              <p className="text-xs text-destructive">
-                {t("validation.category_required")}
-              </p>
-            )}
-          </div>
-
-          {/* Fecha */}
-          <div className="space-y-1.5">
-            <Label htmlFor="finance_date">
-              {t("form.dateLabel")}{" "}
-              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-            </Label>
-            <Input
-              id="finance_date"
-              type="date"
-              aria-required="true"
-              {...register("finance_date")}
-            />
-            {errors.finance_date && (
-              <p className="text-xs text-destructive">
-                {t("validation.date_required")}
-              </p>
-            )}
-          </div>
-
-          {/* Monto */}
-          <div className="space-y-1.5">
-            <Label htmlFor="amount">
-              {t("form.amountLabel")}{" "}
-              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-            </Label>
-            <Input
-              id="amount"
-              type="number"
-              min="0.01"
-              step="0.01"
-              placeholder="0.00"
-              aria-required="true"
-              {...register("amount")}
-            />
-            {errors.amount && (
-              <p className="text-xs text-destructive">
-                {t("validation.amount_positive")}
-              </p>
-            )}
-          </div>
-
-          {/* Año y Mes */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="year">
-                {t("form.yearLabel")}{" "}
-                <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-              </Label>
-              <Select
-                value={selectedYear?.toString() ?? ""}
-                onValueChange={(v) => setValue("year", Number(v))}
-                disabled={isEdit}
-              >
-                <SelectTrigger id="year" aria-required="true">
-                  <SelectValue placeholder={t("form.yearPlaceholder")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {YEARS.map((y) => (
-                    <SelectItem key={y} value={y.toString()}>
-                      {y}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {errors.year && (
-                <p className="text-xs text-destructive">
-                  {t("validation.year_invalid")}
-                </p>
+                    <FormControl>
+                      <SelectTrigger aria-required="true">
+                        <SelectValue
+                          placeholder={
+                            loadingCategories
+                              ? t("form.categoryLoading")
+                              : t("form.categoryPlaceholder")
+                          }
+                        />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {categories.map((cat) => (
+                        <SelectItem
+                          key={cat.finance_category_id}
+                          value={cat.finance_category_id.toString()}
+                        >
+                          {cat.name} —{" "}
+                          {cat.type === 0
+                            ? t("categoryType.income")
+                            : t("categoryType.expense")}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="month">
-                {t("form.monthLabel")}{" "}
-                <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-              </Label>
-              <Select
-                value={selectedMonth?.toString() ?? ""}
-                onValueChange={(v) => setValue("month", Number(v))}
-                disabled={isEdit}
-              >
-                <SelectTrigger id="month" aria-required="true">
-                  <SelectValue placeholder={t("form.monthPlaceholder")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {MONTH_KEYS.map((key, index) => (
-                    <SelectItem key={key} value={String(index + 1)}>
-                      {t(`months.${key}`)}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {errors.month && (
-                <p className="text-xs text-destructive">
-                  {t("validation.month_invalid")}
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* Sección del club (solo al crear) */}
-          {!isEdit && (
-            <div className="space-y-1.5">
-              <Label htmlFor="club_section_id">
-                {t("form.sectionLabel")}{" "}
-                <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-              </Label>
-              <Select
-                value={selectedSectionId?.toString() ?? ""}
-                onValueChange={(v) => {
-                  const sectionId = Number(v);
-                  setValue("club_section_id", sectionId);
-                  const section = sections.find(
-                    (s) => s.club_section_id === sectionId,
-                  );
-                  if (section) {
-                    setValue("club_type_id", section.club_type_id);
-                  }
-                }}
-              >
-                <SelectTrigger id="club_section_id" aria-required="true">
-                  <SelectValue placeholder={t("form.sectionPlaceholder")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {sections.length > 0 ? (
-                    sections.map((s) => (
-                      <SelectItem
-                        key={s.club_section_id}
-                        value={s.club_section_id.toString()}
-                      >
-                        {s.name}
-                        {s.club_type?.name ? ` (${s.club_type.name})` : ""}
-                      </SelectItem>
-                    ))
-                  ) : (
-                    <SelectItem value="0" disabled>
-                      {t("form.sectionEmpty")}
-                    </SelectItem>
-                  )}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-
-          {/* Descripción */}
-          <div className="space-y-1.5">
-            <Label htmlFor="description">{t("form.descriptionLabel")}</Label>
-            <Textarea
-              id="description"
-              placeholder={t("form.descriptionPlaceholder")}
-              className="min-h-[80px] resize-none"
-              {...register("description")}
             />
-          </div>
 
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              {t("form.cancelButton")}
-            </Button>
-            <Button type="submit" disabled={isSubmitting || loadingCategories}>
-              {isSubmitting && <Loader2 aria-hidden="true" className="size-4 animate-spin" />}
-              {isEdit ? t("form.saveButton") : t("form.createButton")}
-            </Button>
-          </DialogFooter>
-        </form>
+            {/* Fecha */}
+            <FormField
+              control={form.control}
+              name="finance_date"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("form.dateLabel")}{" "}
+                    <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="date"
+                      aria-required="true"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Monto */}
+            <FormField
+              control={form.control}
+              name="amount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("form.amountLabel")}{" "}
+                    <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min="0.01"
+                      step="0.01"
+                      placeholder="0.00"
+                      aria-required="true"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Año y Mes */}
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="year"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("form.yearLabel")}{" "}
+                      <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                    </FormLabel>
+                    <Select
+                      value={field.value?.toString() ?? ""}
+                      onValueChange={(v) => field.onChange(Number(v))}
+                      disabled={isEdit}
+                    >
+                      <FormControl>
+                        <SelectTrigger aria-required="true">
+                          <SelectValue placeholder={t("form.yearPlaceholder")} />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {YEARS.map((y) => (
+                          <SelectItem key={y} value={y.toString()}>
+                            {y}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="month"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("form.monthLabel")}{" "}
+                      <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                    </FormLabel>
+                    <Select
+                      value={field.value?.toString() ?? ""}
+                      onValueChange={(v) => field.onChange(Number(v))}
+                      disabled={isEdit}
+                    >
+                      <FormControl>
+                        <SelectTrigger aria-required="true">
+                          <SelectValue placeholder={t("form.monthPlaceholder")} />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {MONTH_KEYS.map((key, index) => (
+                          <SelectItem key={key} value={String(index + 1)}>
+                            {t(`months.${key}`)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Sección del club (solo al crear) */}
+            {!isEdit && (
+              <FormField
+                control={form.control}
+                name="club_section_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("form.sectionLabel")}{" "}
+                      <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                    </FormLabel>
+                    <Select
+                      value={field.value?.toString() ?? ""}
+                      onValueChange={(v) => {
+                        const sectionId = Number(v);
+                        field.onChange(sectionId);
+                        const section = sections.find(
+                          (s) => s.club_section_id === sectionId,
+                        );
+                        if (section) {
+                          form.setValue("club_type_id", section.club_type_id);
+                        }
+                      }}
+                    >
+                      <FormControl>
+                        <SelectTrigger aria-required="true">
+                          <SelectValue placeholder={t("form.sectionPlaceholder")} />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {sections.length > 0 ? (
+                          sections.map((s) => (
+                            <SelectItem
+                              key={s.club_section_id}
+                              value={s.club_section_id.toString()}
+                            >
+                              {s.name}
+                              {s.club_type?.name ? ` (${s.club_type.name})` : ""}
+                            </SelectItem>
+                          ))
+                        ) : (
+                          <SelectItem value="0" disabled>
+                            {t("form.sectionEmpty")}
+                          </SelectItem>
+                        )}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            {/* Descripción */}
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("form.descriptionLabel")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("form.descriptionPlaceholder")}
+                      className="min-h-[80px] resize-none"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                {t("form.cancelButton")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting || loadingCategories}>
+                {isSubmitting && <Loader2 aria-hidden="true" className="size-4 animate-spin" />}
+                {isEdit ? t("form.saveButton") : t("form.createButton")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/folders/folder-form-dialog.tsx
+++ b/src/components/folders/folder-form-dialog.tsx
@@ -17,9 +17,16 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { createFolder, updateFolder } from "@/lib/api/folders";
 import type { FolderTemplate } from "@/lib/api/folders";
 
@@ -64,14 +71,7 @@ export function FolderFormDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
@@ -80,25 +80,23 @@ export function FolderFormDialog({
     },
   });
 
-  const activeValue = watch("active");
-
   useEffect(() => {
     if (open) {
       if (folder) {
-        reset({
+        form.reset({
           name: folder.name,
           description: folder.description ?? "",
           active: folder.active,
         });
       } else {
-        reset({
+        form.reset({
           name: "",
           description: "",
           active: true,
         });
       }
     }
-  }, [open, folder, reset]);
+  }, [open, folder, form]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -146,79 +144,93 @@ export function FolderFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
-          {/* Nombre */}
-          <div className="space-y-1.5">
-            <Label htmlFor="folder-name">
-              Nombre <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="folder-name"
-              aria-required="true"
-              {...register("name")}
-              placeholder="Ej. Carpeta Conquistadores 2025"
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} noValidate className="space-y-4">
+            {/* Nombre */}
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Nombre <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      aria-required="true"
+                      placeholder="Ej. Carpeta Conquistadores 2025"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
-            )}
-          </div>
 
-          {/* Descripción */}
-          <div className="space-y-1.5">
-            <Label htmlFor="folder-description">Descripción</Label>
-            <Textarea
-              id="folder-description"
-              {...register("description")}
-              placeholder="Descripción opcional de la carpeta"
-              rows={3}
+            {/* Descripción */}
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Descripción</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Descripción opcional de la carpeta"
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.description && (
-              <p className="text-xs text-destructive">
-                {errors.description.message}
-              </p>
-            )}
-          </div>
 
-          {/* Activa */}
-          <div className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5">
-            <div className="space-y-0.5">
-              <Label
-                htmlFor="folder-active"
-                className="cursor-pointer text-sm font-medium"
+            {/* Activa */}
+            <FormField
+              control={form.control}
+              name="active"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5 space-y-0">
+                  <div className="space-y-0.5">
+                    <FormLabel className="cursor-pointer text-sm font-medium">
+                      Carpeta activa
+                    </FormLabel>
+                    <p className="text-xs text-muted-foreground">
+                      Solo las carpetas activas están disponibles para los clubes
+                    </p>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
               >
-                Carpeta activa
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                Solo las carpetas activas están disponibles para los clubes
-              </p>
-            </div>
-            <Switch
-              id="folder-active"
-              checked={activeValue}
-              onCheckedChange={(checked) => setValue("active", checked)}
-            />
-          </div>
-
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              Cancelar
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? isEdit
-                  ? "Guardando..."
-                  : "Creando..."
-                : isEdit
-                  ? "Guardar cambios"
-                  : "Crear carpeta"}
-            </Button>
-          </DialogFooter>
-        </form>
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? isEdit
+                    ? "Guardando..."
+                    : "Creando..."
+                  : isEdit
+                    ? "Guardar cambios"
+                    : "Crear carpeta"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/insurance/insurance-form-dialog.tsx
+++ b/src/components/insurance/insurance-form-dialog.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -25,6 +24,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import { createInsurance, updateInsurance, INSURANCE_TYPE_LABELS } from "@/lib/api/insurance";
 import type { MemberInsurance, InsuranceType } from "@/lib/api/insurance";
@@ -89,14 +96,7 @@ export function InsuranceFormDialog({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       insurance_type: "GENERAL_ACTIVITIES",
@@ -115,7 +115,7 @@ export function InsuranceFormDialog({
       if (fileInputRef.current) fileInputRef.current.value = "";
 
       if (ins) {
-        reset({
+        form.reset({
           insurance_type: (ins.insurance_type ?? "GENERAL_ACTIVITIES") as InsuranceType,
           start_date: toDateInputValue(ins.start_date),
           end_date: toDateInputValue(ins.end_date),
@@ -124,7 +124,7 @@ export function InsuranceFormDialog({
           coverage_amount: ins.coverage_amount ?? undefined,
         });
       } else {
-        reset({
+        form.reset({
           insurance_type: "GENERAL_ACTIVITIES",
           start_date: "",
           end_date: "",
@@ -134,7 +134,7 @@ export function InsuranceFormDialog({
         });
       }
     }
-  }, [open, ins, reset]);
+  }, [open, ins, form]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     if (!member) return;
@@ -175,8 +175,6 @@ export function InsuranceFormDialog({
     }
   };
 
-  const insuranceTypeValue = watch("insurance_type");
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
@@ -193,181 +191,221 @@ export function InsuranceFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-          {/* Tipo de seguro */}
-          <div className="space-y-1.5">
-            <Label htmlFor="insurance_type">
-              Tipo de seguro{" "}
-              <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Select
-              value={insuranceTypeValue}
-              onValueChange={(val) => setValue("insurance_type", val as InsuranceType)}
-            >
-              <SelectTrigger id="insurance_type" aria-required="true">
-                <SelectValue placeholder={t("placeholders.selectType")} />
-              </SelectTrigger>
-              <SelectContent>
-                {INSURANCE_TYPES.map((type) => (
-                  <SelectItem key={type} value={type}>
-                    {INSURANCE_TYPE_LABELS[type]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.insurance_type && (
-              <p className="text-xs text-destructive">{errors.insurance_type.message}</p>
-            )}
-          </div>
-
-          {/* Número de póliza */}
-          <div className="space-y-1.5">
-            <Label htmlFor="policy_number">N° de póliza</Label>
-            <Input
-              id="policy_number"
-              {...register("policy_number")}
-              placeholder={t("placeholders.policyNumber")}
-            />
-          </div>
-
-          {/* Aseguradora */}
-          <div className="space-y-1.5">
-            <Label htmlFor="provider">Aseguradora</Label>
-            <Input
-              id="provider"
-              {...register("provider")}
-              placeholder={t("placeholders.provider")}
-            />
-          </div>
-
-          {/* Fechas */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="start_date">
-                Fecha de inicio{" "}
-                <span aria-hidden="true" className="text-destructive">*</span>
-              </Label>
-              <Input
-                id="start_date"
-                type="date"
-                aria-required="true"
-                {...register("start_date")}
-              />
-              {errors.start_date && (
-                <p className="text-xs text-destructive">{errors.start_date.message}</p>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {/* Tipo de seguro */}
+            <FormField
+              control={form.control}
+              name="insurance_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Tipo de seguro{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={(val) => field.onChange(val as InsuranceType)}
+                  >
+                    <FormControl>
+                      <SelectTrigger aria-required="true">
+                        <SelectValue placeholder={t("placeholders.selectType")} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {INSURANCE_TYPES.map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {INSURANCE_TYPE_LABELS[type]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="end_date">
-                Fecha de vencimiento{" "}
-                <span aria-hidden="true" className="text-destructive">*</span>
-              </Label>
-              <Input
-                id="end_date"
-                type="date"
-                aria-required="true"
-                {...register("end_date")}
-              />
-              {errors.end_date && (
-                <p className="text-xs text-destructive">{errors.end_date.message}</p>
-              )}
-            </div>
-          </div>
-
-          {/* Monto de cobertura */}
-          <div className="space-y-1.5">
-            <Label htmlFor="coverage_amount">Monto de cobertura</Label>
-            <Input
-              id="coverage_amount"
-              type="number"
-              min={0}
-              step="0.01"
-              {...register("coverage_amount")}
-              placeholder={t("placeholders.amount")}
             />
-            {errors.coverage_amount && (
-              <p className="text-xs text-destructive">{errors.coverage_amount.message}</p>
-            )}
-          </div>
 
-          {/* Evidencia */}
-          <div className="space-y-1.5">
-            <Label>Evidencia documental</Label>
-            <div className="flex items-center gap-2">
+            {/* Número de póliza */}
+            <FormField
+              control={form.control}
+              name="policy_number"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>N° de póliza</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("placeholders.policyNumber")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Aseguradora */}
+            <FormField
+              control={form.control}
+              name="provider"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Aseguradora</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("placeholders.provider")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Fechas */}
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="start_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Fecha de inicio{" "}
+                      <span aria-hidden="true" className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="date"
+                        aria-required="true"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="end_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Fecha de vencimiento{" "}
+                      <span aria-hidden="true" className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="date"
+                        aria-required="true"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Monto de cobertura */}
+            <FormField
+              control={form.control}
+              name="coverage_amount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Monto de cobertura</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      placeholder={t("placeholders.amount")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Evidencia — unmanaged by RHF; file input stays as-is */}
+            <div className="space-y-1.5">
+              <span className="text-sm font-medium leading-none">Evidencia documental</span>
+              <div className="flex items-center gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fileInputRef.current?.click()}
+                  className="gap-1.5"
+                >
+                  <Paperclip aria-hidden="true" className="size-3.5" />
+                  {evidenceFile ? "Cambiar archivo" : "Adjuntar archivo"}
+                </Button>
+                {evidenceFile && (
+                  <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 px-2 py-1 text-xs">
+                    <span className="max-w-[160px] truncate text-foreground">{evidenceFile.name}</span>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      onClick={() => {
+                        setEvidenceFile(null);
+                        if (fileInputRef.current) fileInputRef.current.value = "";
+                      }}
+                    >
+                      <X aria-hidden="true" className="size-3" />
+                      <span className="sr-only">Quitar archivo</span>
+                    </Button>
+                  </div>
+                )}
+              </div>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".pdf,.jpg,.jpeg,.png,.webp"
+                className="hidden"
+                onChange={(e) => {
+                  const file = e.target.files?.[0] ?? null;
+                  setEvidenceFile(file);
+                }}
+              />
+              {ins?.evidence_file_name && !evidenceFile && (
+                <p className="text-xs text-muted-foreground">
+                  Archivo actual:{" "}
+                  <a
+                    href={ins.evidence_file_url ?? "#"}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-primary underline-offset-2 hover:underline"
+                  >
+                    {ins.evidence_file_name}
+                  </a>
+                </p>
+              )}
+              <p className="text-xs text-muted-foreground">PDF, JPG, PNG, WEBP hasta 10 MB</p>
+            </div>
+
+            <DialogFooter className="pt-2">
               <Button
                 type="button"
                 variant="outline"
-                size="sm"
-                onClick={() => fileInputRef.current?.click()}
-                className="gap-1.5"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
               >
-                <Paperclip aria-hidden="true" className="size-3.5" />
-                {evidenceFile ? "Cambiar archivo" : "Adjuntar archivo"}
+                Cancelar
               </Button>
-              {evidenceFile && (
-                <div className="flex items-center gap-1.5 rounded-md border border-border bg-muted/50 px-2 py-1 text-xs">
-                  <span className="max-w-[160px] truncate text-foreground">{evidenceFile.name}</span>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    onClick={() => {
-                      setEvidenceFile(null);
-                      if (fileInputRef.current) fileInputRef.current.value = "";
-                    }}
-                  >
-                    <X aria-hidden="true" className="size-3" />
-                    <span className="sr-only">Quitar archivo</span>
-                  </Button>
-                </div>
-              )}
-            </div>
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept=".pdf,.jpg,.jpeg,.png,.webp"
-              className="hidden"
-              onChange={(e) => {
-                const file = e.target.files?.[0] ?? null;
-                setEvidenceFile(file);
-              }}
-            />
-            {ins?.evidence_file_name && !evidenceFile && (
-              <p className="text-xs text-muted-foreground">
-                Archivo actual:{" "}
-                <a
-                  href={ins.evidence_file_url ?? "#"}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-primary underline-offset-2 hover:underline"
-                >
-                  {ins.evidence_file_name}
-                </a>
-              </p>
-            )}
-            <p className="text-xs text-muted-foreground">PDF, JPG, PNG, WEBP hasta 10 MB</p>
-          </div>
-
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              Cancelar
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? isEdit
-                  ? "Guardando..."
-                  : "Registrando..."
-                : isEdit
-                  ? "Guardar cambios"
-                  : "Registrar seguro"}
-            </Button>
-          </DialogFooter>
-        </form>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? isEdit
+                    ? "Guardando..."
+                    : "Registrando..."
+                  : isEdit
+                    ? "Guardar cambios"
+                    : "Registrar seguro"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/inventory/inventory-form-dialog.tsx
+++ b/src/components/inventory/inventory-form-dialog.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
@@ -25,6 +24,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import {
   createInventoryItem,
@@ -81,14 +88,7 @@ export function InventoryFormDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
@@ -102,14 +102,14 @@ export function InventoryFormDialog({
   useEffect(() => {
     if (open) {
       if (item) {
-        reset({
+        form.reset({
           name: item.name,
           description: item.description ?? "",
           inventory_category_id: item.inventory_category_id,
           amount: item.amount,
         });
       } else {
-        reset({
+        form.reset({
           name: "",
           description: "",
           inventory_category_id: categories[0]?.inventory_category_id ?? 0,
@@ -117,7 +117,7 @@ export function InventoryFormDialog({
         });
       }
     }
-  }, [open, item, categories, reset]);
+  }, [open, item, categories, form]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -151,8 +151,6 @@ export function InventoryFormDialog({
     }
   };
 
-  const selectedCategoryId = watch("inventory_category_id");
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-md">
@@ -167,126 +165,145 @@ export function InventoryFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-          {/* Nombre */}
-          <div className="space-y-1.5">
-            <Label htmlFor="name">
-              Nombre{" "}
-              <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="name"
-              aria-required="true"
-              {...register("name")}
-              placeholder={t("placeholders.name")}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {/* Nombre */}
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Nombre{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      aria-required="true"
+                      placeholder={t("placeholders.name")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.name && (
-              <p className="text-xs text-destructive">{errors.name.message}</p>
-            )}
-          </div>
 
-          {/* Descripción */}
-          <div className="space-y-1.5">
-            <Label htmlFor="description">Descripción</Label>
-            <Textarea
-              id="description"
-              {...register("description")}
-              placeholder={t("placeholders.description")}
-              rows={3}
+            {/* Descripción */}
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Descripción</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("placeholders.description")}
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.description && (
-              <p className="text-xs text-destructive">{errors.description.message}</p>
-            )}
-          </div>
 
-          {/* Categoría */}
-          <div className="space-y-1.5">
-            <Label htmlFor="inventory_category_id">
-              Categoría{" "}
-              <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Select
-              value={String(selectedCategoryId)}
-              onValueChange={(val) =>
-                setValue("inventory_category_id", Number(val))
-              }
-            >
-              <SelectTrigger id="inventory_category_id" aria-required="true">
-                <SelectValue placeholder={t("placeholders.selectCategory")} />
-              </SelectTrigger>
-              <SelectContent>
-                {categories.length > 0 ? (
-                  categories.map((cat) => (
-                    <SelectItem
-                      key={cat.inventory_category_id}
-                      value={String(cat.inventory_category_id)}
-                    >
-                      {cat.name}
-                    </SelectItem>
-                  ))
-                ) : (
-                  <SelectItem value="0" disabled>
-                    No hay categorías disponibles
-                  </SelectItem>
-                )}
-              </SelectContent>
-            </Select>
-            {errors.inventory_category_id && (
-              <p className="text-xs text-destructive">
-                {errors.inventory_category_id.message}
-              </p>
-            )}
-          </div>
-
-          {/* Cantidad */}
-          <div className="space-y-1.5">
-            <Label htmlFor="amount">
-              Cantidad{" "}
-              <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="amount"
-              type="number"
-              min={0}
-              aria-required="true"
-              {...register("amount")}
-              placeholder={t("placeholders.quantity")}
+            {/* Categoría */}
+            <FormField
+              control={form.control}
+              name="inventory_category_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Categoría{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <Select
+                    value={String(field.value)}
+                    onValueChange={(val) => field.onChange(Number(val))}
+                  >
+                    <FormControl>
+                      <SelectTrigger aria-required="true">
+                        <SelectValue placeholder={t("placeholders.selectCategory")} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {categories.length > 0 ? (
+                        categories.map((cat) => (
+                          <SelectItem
+                            key={cat.inventory_category_id}
+                            value={String(cat.inventory_category_id)}
+                          >
+                            {cat.name}
+                          </SelectItem>
+                        ))
+                      ) : (
+                        <SelectItem value="0" disabled>
+                          No hay categorías disponibles
+                        </SelectItem>
+                      )}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.amount && (
-              <p className="text-xs text-destructive">{errors.amount.message}</p>
+
+            {/* Cantidad */}
+            <FormField
+              control={form.control}
+              name="amount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Cantidad{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={0}
+                      aria-required="true"
+                      placeholder={t("placeholders.quantity")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Tipo de instancia (solo al crear, informativo) */}
+            {!isEdit && (
+              <div className="rounded-lg border border-border bg-muted/40 px-3 py-2.5 text-sm text-muted-foreground">
+                Se agregará al inventario de{" "}
+                <span className="font-medium text-foreground">
+                  {INSTANCE_TYPE_LABELS[instanceType]}
+                </span>
+              </div>
             )}
-          </div>
 
-          {/* Tipo de instancia (solo al crear, informativo) */}
-          {!isEdit && (
-            <div className="rounded-lg border border-border bg-muted/40 px-3 py-2.5 text-sm text-muted-foreground">
-              Se agregará al inventario de{" "}
-              <span className="font-medium text-foreground">
-                {INSTANCE_TYPE_LABELS[instanceType]}
-              </span>
-            </div>
-          )}
-
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              Cancelar
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? isEdit
-                  ? "Guardando..."
-                  : "Creando..."
-                : isEdit
-                  ? "Guardar cambios"
-                  : "Crear ítem"}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? isEdit
+                    ? "Guardando..."
+                    : "Creando..."
+                  : isEdit
+                    ? "Guardar cambios"
+                    : "Crear ítem"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import * as React from "react";
+import { Slot } from "radix-ui";
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+
+// ─── Form (re-exports FormProvider) ──────────────────────────────────────────
+
+const Form = FormProvider;
+
+// ─── FormFieldContext ─────────────────────────────────────────────────────────
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName;
+};
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue,
+);
+
+// ─── FormField ────────────────────────────────────────────────────────────────
+
+function FormField<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({ ...props }: ControllerProps<TFieldValues, TName>) {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+}
+
+// ─── useFormField ─────────────────────────────────────────────────────────────
+
+function useFormField() {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  if (!fieldContext) {
+    throw new Error("useFormField must be used within a <FormField>");
+  }
+
+  const { id } = itemContext;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+}
+
+// ─── FormItemContext ──────────────────────────────────────────────────────────
+
+type FormItemContextValue = {
+  id: string;
+};
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue,
+);
+
+// ─── FormItem ─────────────────────────────────────────────────────────────────
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId();
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("space-y-1.5", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  );
+}
+
+// ─── FormLabel ────────────────────────────────────────────────────────────────
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+}
+
+// ─── FormControl ─────────────────────────────────────────────────────────────
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot.Root>) {
+  const { error, formItemId, formDescriptionId, formMessageId } =
+    useFormField();
+
+  return (
+    <Slot.Root
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  );
+}
+
+// ─── FormDescription ─────────────────────────────────────────────────────────
+
+function FormDescription({
+  className,
+  ...props
+}: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField();
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-muted-foreground text-xs", className)}
+      {...props}
+    />
+  );
+}
+
+// ─── FormMessage ─────────────────────────────────────────────────────────────
+
+function FormMessage({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField();
+  const body = error ? String(error?.message ?? "") : children;
+
+  if (!body) {
+    return null;
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-destructive text-xs font-medium", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+}
+
+export {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  useFormField,
+};


### PR DESCRIPTION
## Summary

Audit C1 HIGH: form errors not always linked to inputs. `aria-invalid` + `aria-describedby` count was 7 across codebase; most error messages were visual-only paragraphs without programmatic association.

## Fix

Scaffold shadcn/ui Form primitive (`src/components/ui/form.tsx`) — FormProvider + FormField context that auto-wires `aria-invalid={!!error}` + `aria-describedby` linking input to FormMessage.

Adapted from upstream shadcn template to project's radix-ui import patterns (uses `Slot` from `"radix-ui"` matching existing `button.tsx`).

## Migrated 5 react-hook-form dialogs

- `finances/transaction-form-dialog` (full migration from register/watch/setValue)
- `folders/folder-form-dialog` (3 fields incl Switch with field.value/onChange binding)
- `inventory/inventory-form-dialog` (4 fields + useMemo schema factory preserved)
- `insurance/insurance-form-dialog` (6 fields incl unmanaged file attachment kept outside FormProvider)
- `activities/activity-form-dialog` (12 fields, conditional rendering preserved, cross-field reset logic intact, fixed inner var shadow: `ACTIVITY_TYPES.map((at) =>`)

## NOT migrated (correctly out of scope)

5 forms use `useActionState` (React Server Actions), not react-hook-form. Form primitive wraps FormProvider — not applicable:
- login-form, unit-form, create-club-form, edit-club-form, honor-form

## A11y impact

Every Input wrapped in `<FormControl>` receives `aria-invalid="true"` when field has validation error. `aria-describedby` points to FormMessage rendering error text. CSS selectors `aria-invalid:border-destructive` now correctly highlight invalid fields (style hooks were already there in input/textarea/select primitives but the attribute wasn't being set).

## Stats
6 files (+1 new form.tsx), +1212/-856. Typecheck clean.

## Test plan
- [x] Typecheck clean
- [ ] Manual smoke: trigger validation error in each migrated dialog — confirm input gets red border + screen reader announces error
- [ ] (Future) integration tests for the 5 migrated dialogs (extending MSW pattern from PR #113)

From audit C1 P1 (2026-05-08).