### PR TITLE
test: shadcn Form primitive + 5 migrated dialog integration tests (+97 tests, 219→316)

### DIFF
--- a/src/components/activities/activity-form-dialog.test.tsx
+++ b/src/components/activities/activity-form-dialog.test.tsx
@@ -1,0 +1,602 @@
+/**
+ * Integration tests for ActivityFormDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form + Zod (shadcn <Form>). It calls
+ * `createActivity` / `updateActivity` from "@/lib/api/activities"
+ * via `apiRequestFromClient` (HTTP). Both are mocked at module level.
+ *
+ * Conditional rendering:
+ * - `club_type_id` and `club_section_id` fields only render when
+ *   `activity` prop is undefined/null (create mode).
+ * - `link_meet` field only renders when `platform` watched value is
+ *   1 (Virtual) or 2 (Híbrido). We trigger this via fireEvent.change
+ *   on the underlying hidden <select> that Radix renders for a11y.
+ *
+ * Cross-field reset:
+ * When club_type_id changes, the form calls `form.setValue("club_section_id", ...)`
+ * to reset the section. We verify this by inspecting the value of the
+ * hidden <select> for club_section_id after a club type change.
+ *
+ * Sections prop:
+ * Passed as an array of { club_section_id, name, club_type_id }.
+ * We provide multi-club-type test data so cross-field reset is observable.
+ *
+ * Select (shadcn/Radix) renders a hidden native <select> element for
+ * a11y. We change Select values by firing `change` on that element.
+ * For verifying current value we read that element's `.value`.
+ *
+ * RTL auto-cleanup:
+ * Vitest uses `globals: false` — RTL auto-cleanup is skipped.
+ * We explicitly import `cleanup` and call it in `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { Activity } from "@/lib/api/activities";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — Vitest hoists vi.mock() before imports resolve.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateActivity = vi.fn<(...args: any[]) => Promise<unknown>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdateActivity = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/activities", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/lib/api/activities")>();
+  return {
+    ...original,
+    createActivity: (clubId: number, data: unknown) =>
+      mockCreateActivity(clubId, data),
+    updateActivity: (activityId: number, data: unknown) =>
+      mockUpdateActivity(activityId, data),
+  };
+});
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { ActivityFormDialog } from "@/components/activities/activity-form-dialog";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Multi-club-type sections: 2 for Aventureros (type 1), 1 for Conquistadores (type 2).
+ * This lets us verify cross-field reset when switching club_type_id.
+ */
+const TEST_SECTIONS = [
+  { club_section_id: 10, name: "Ositos", club_type_id: 1 },
+  { club_section_id: 11, name: "Castores", club_type_id: 1 },
+  { club_section_id: 20, name: "Grupo Alpha", club_type_id: 2 },
+];
+
+const EXISTING_ACTIVITY: Activity = {
+  activity_id: 7,
+  name: "Campamento de verano",
+  description: "Actividad anual",
+  club_id: 1,
+  club_type_id: 1,
+  club_section_id: 10,
+  lat: -34.6,
+  long: -58.4,
+  activity_time: "10:00",
+  activity_place: "Parque Norte",
+  image: "https://example.com/img.jpg",
+  platform: 0,
+  activity_type_id: 1,
+  link_meet: null,
+  active: true,
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOptions {
+  open?: boolean;
+  clubId?: number;
+  sections?: typeof TEST_SECTIONS;
+  activity?: Activity | null;
+  onOpenChange?: (open: boolean) => void;
+  onSuccess?: () => void;
+}
+
+function renderActivityDialog(opts: RenderOptions = {}) {
+  const {
+    open = true,
+    clubId = 1,
+    sections = TEST_SECTIONS,
+    activity = null,
+    onOpenChange = vi.fn(),
+    onSuccess = vi.fn(),
+  } = opts;
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <ActivityFormDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        clubId={clubId}
+        sections={sections}
+        activity={activity}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns all hidden Radix <select> elements rendered for combobox a11y. */
+function getHiddenSelects(): HTMLSelectElement[] {
+  return Array.from(
+    document.querySelectorAll<HTMLSelectElement>("select"),
+  );
+}
+
+/** Returns the hidden <select> whose current value matches the given value string. */
+function findSelectByValue(value: string): HTMLSelectElement | undefined {
+  return getHiddenSelects().find((s) => s.value === value);
+}
+
+/**
+ * Returns the hidden <select> that has a specific option value in its option list.
+ * Useful when multiple selects share the same current value.
+ */
+function findSelectByOptionValue(optionValue: string): HTMLSelectElement | undefined {
+  return getHiddenSelects().find((s) =>
+    Array.from(s.options).some((o) => o.value === optionValue),
+  );
+}
+
+/** Changes a Radix Select's value by firing change on the hidden native <select>. */
+function changeSelectTo(selectEl: HTMLSelectElement, value: string) {
+  fireEvent.change(selectEl, { target: { value } });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ActivityFormDialog", () => {
+  beforeEach(() => {
+    mockCreateActivity.mockClear();
+    mockUpdateActivity.mockClear();
+    mockCreateActivity.mockResolvedValue({ activity_id: 99 });
+    mockUpdateActivity.mockResolvedValue({ activity_id: 7 });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── Rendering — create mode ───────────────────────────────────────────────
+
+  it("renders title 'Nueva actividad' and create submit button in create mode", () => {
+    renderActivityDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /nueva actividad/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /crear actividad/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders name, description, place, image URL, time and coordinate fields", () => {
+    renderActivityDialog();
+
+    expect(
+      screen.getByPlaceholderText(messages.activities.placeholders.name),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(messages.activities.placeholders.description),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(messages.activities.placeholders.location),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(
+        messages.activities.placeholders.externalUrl,
+      ),
+    ).toBeInTheDocument();
+
+    // Both lat and long share the "0.000000" placeholder — use getAllByPlaceholderText
+    const coordInputs = screen.getAllByPlaceholderText(
+      messages.activities.placeholders.latitude,
+    );
+    expect(coordInputs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Conditional: club_type_id and club_section_id only in create mode ─────
+
+  it("renders club_type_id and club_section_id selects in create mode", () => {
+    renderActivityDialog({ activity: null });
+
+    expect(
+      screen.getByText(/tipo de club/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/sección del club/i),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT render club_type_id and club_section_id selects in edit mode", () => {
+    renderActivityDialog({ activity: EXISTING_ACTIVITY });
+
+    expect(
+      screen.queryByText(/tipo de club/i),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/sección del club/i),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── Rendering — edit mode ─────────────────────────────────────────────────
+
+  it("renders 'Editar actividad' title and 'Guardar cambios' button in edit mode", () => {
+    renderActivityDialog({ activity: EXISTING_ACTIVITY });
+
+    expect(
+      screen.getByRole("heading", { name: /editar actividad/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /guardar cambios/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("pre-fills name, place, and image fields with existing activity data", () => {
+    renderActivityDialog({ activity: EXISTING_ACTIVITY });
+
+    const nameInput = screen.getByPlaceholderText(
+      messages.activities.placeholders.name,
+    ) as HTMLInputElement;
+    expect(nameInput.value).toBe("Campamento de verano");
+
+    const placeInput = screen.getByPlaceholderText(
+      messages.activities.placeholders.location,
+    ) as HTMLInputElement;
+    expect(placeInput.value).toBe("Parque Norte");
+
+    const imageInput = screen.getByPlaceholderText(
+      messages.activities.placeholders.externalUrl,
+    ) as HTMLInputElement;
+    expect(imageInput.value).toBe("https://example.com/img.jpg");
+  });
+
+  // ── Conditional: link_meet field appears only when platform is virtual/hybrid ─
+
+  it("does NOT render link_meet field when platform is Presencial (0)", () => {
+    renderActivityDialog();
+
+    // Default platform is 0 (Presencial)
+    expect(
+      screen.queryByPlaceholderText(
+        messages.activities.placeholders.meetUrl,
+      ),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders link_meet field when platform is changed to Virtual (1)", async () => {
+    renderActivityDialog();
+
+    // The platform select tracks value "0" initially. Find it and change to "1".
+    const platformSelect = findSelectByValue("0");
+    expect(platformSelect).toBeDefined();
+
+    await act(async () => {
+      changeSelectTo(platformSelect!, "1");
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(
+          messages.activities.placeholders.meetUrl,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders link_meet field when platform is changed to Híbrido (2)", async () => {
+    renderActivityDialog();
+
+    const platformSelect = findSelectByValue("0");
+    expect(platformSelect).toBeDefined();
+
+    await act(async () => {
+      changeSelectTo(platformSelect!, "2");
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(
+          messages.activities.placeholders.meetUrl,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("hides link_meet field again when platform is switched back to Presencial (0)", async () => {
+    renderActivityDialog();
+
+    const platformSelect = findSelectByValue("0");
+
+    // Switch to Virtual
+    await act(async () => {
+      changeSelectTo(platformSelect!, "1");
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByPlaceholderText(messages.activities.placeholders.meetUrl),
+      ).toBeInTheDocument();
+    });
+
+    // Switch back to Presencial
+    await act(async () => {
+      changeSelectTo(platformSelect!, "0");
+    });
+    await waitFor(() => {
+      expect(
+        screen.queryByPlaceholderText(
+          messages.activities.placeholders.meetUrl,
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // ── Cross-field reset: club_type_id change resets club_section_id ─────────
+
+  it("resets club_section_id to the first matching section when club_type_id changes", async () => {
+    renderActivityDialog({ sections: TEST_SECTIONS });
+
+    // In create mode, Radix hidden <select> elements appear in DOM order matching
+    // JSX render order: [0] activity_type_id, [1] club_type_id, [2] club_section_id, [3] platform
+    // We select by index 1 for club_type_id and confirm by verifying options "1","2","3".
+    const selects = getHiddenSelects();
+    const clubTypeSelect = selects[1]; // club_type_id is the second select
+    expect(clubTypeSelect).toBeDefined();
+    expect(Array.from(clubTypeSelect!.options).map((o) => o.value)).toEqual([
+      "1",
+      "2",
+      "3",
+    ]);
+
+    // Switch to Conquistadores (type 2) → section should reset to 20 (first type-2 section)
+    await act(async () => {
+      changeSelectTo(clubTypeSelect!, "2");
+    });
+
+    await waitFor(() => {
+      // club_section_id select is index 2 — its value should now be "20"
+      const sectionSelect = getHiddenSelects()[2];
+      expect(sectionSelect).toBeDefined();
+      expect(sectionSelect!.value).toBe("20");
+    });
+  });
+
+  it("resets club_section_id to 0 when club_type_id changes to a type with no matching sections", async () => {
+    renderActivityDialog({ sections: TEST_SECTIONS });
+
+    // club_type_id is hidden select at index 1 in create mode
+    const selects = getHiddenSelects();
+    const clubTypeSelect = selects[1];
+    expect(clubTypeSelect).toBeDefined();
+
+    // Switch to Guías Mayores (type 3) — TEST_SECTIONS has no entries for type 3
+    await act(async () => {
+      changeSelectTo(clubTypeSelect!, "3");
+    });
+
+    await waitFor(() => {
+      // club_section_id select (index 2) should fall back to value "0"
+      const sectionSelect = getHiddenSelects()[2];
+      expect(sectionSelect).toBeDefined();
+      expect(sectionSelect!.value).toBe("0");
+    });
+  });
+
+  // ── Validation on empty submit ─────────────────────────────────────────────
+
+  it("shows required validation errors for name, place, and image on empty submit", async () => {
+    renderActivityDialog();
+
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(messages.activities.validation.name_required),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.activities.validation.activity_place_required),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(messages.activities.validation.image_required),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("marks required text inputs as aria-invalid after empty submit", async () => {
+    renderActivityDialog();
+
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      const nameInput = screen.getByPlaceholderText(
+        messages.activities.placeholders.name,
+      );
+      expect(nameInput).toHaveAttribute("aria-invalid", "true");
+    });
+  });
+
+  // ── Cancel without submitting ─────────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does not call API when cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderActivityDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateActivity).not.toHaveBeenCalled();
+    expect(mockUpdateActivity).not.toHaveBeenCalled();
+  });
+
+  // ── Submit during pending ─────────────────────────────────────────────────
+
+  it("disables submit button while creation is in progress", async () => {
+    let resolveCreate!: () => void;
+    mockCreateActivity.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveCreate = () => res({ activity_id: 99 });
+      }),
+    );
+
+    renderActivityDialog();
+
+    // Fill required fields
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.activities.placeholders.name),
+      { target: { value: "Actividad test" } },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.activities.placeholders.location),
+      { target: { value: "Sede Central" } },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.activities.placeholders.externalUrl),
+      { target: { value: "https://example.com/img.jpg" } },
+    );
+
+    const submitBtn = screen.getByRole("button", { name: /crear actividad/i });
+
+    const form = document.querySelector("form")!;
+    act(() => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(submitBtn).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveCreate();
+    });
+  });
+
+  // ── Valid submit (create mode) ─────────────────────────────────────────────
+
+  it("calls createActivity with clubId and full payload on valid create submit", async () => {
+    const onSuccess = vi.fn();
+    const onOpenChange = vi.fn();
+    renderActivityDialog({ onSuccess, onOpenChange, clubId: 5 });
+
+    // Fill required fields
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.activities.placeholders.name),
+      { target: { value: "Gran Aventura" } },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.activities.placeholders.location),
+      { target: { value: "Parque Central" } },
+    );
+    fireEvent.change(
+      screen.getByPlaceholderText(messages.activities.placeholders.externalUrl),
+      { target: { value: "https://example.com/img.jpg" } },
+    );
+
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(mockCreateActivity).toHaveBeenCalledOnce();
+    });
+
+    const [clubIdArg, payload] = (mockCreateActivity.mock.calls[0] as unknown) as [
+      number,
+      {
+        name: string;
+        activity_place: string;
+        image: string;
+        club_type_id: number;
+        club_section_id: number;
+      },
+    ];
+    expect(clubIdArg).toBe(5);
+    expect(payload.name).toBe("Gran Aventura");
+    expect(payload.activity_place).toBe("Parque Central");
+    expect(payload.image).toBe("https://example.com/img.jpg");
+    // create mode must include club_type_id and club_section_id
+    expect(payload.club_type_id).toBeDefined();
+    expect(payload.club_section_id).toBeDefined();
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── Valid submit (edit mode) ───────────────────────────────────────────────
+
+  it("calls updateActivity with activity_id and payload WITHOUT club_type_id/club_section_id in edit mode", async () => {
+    const onSuccess = vi.fn();
+    const onOpenChange = vi.fn();
+    renderActivityDialog({
+      activity: EXISTING_ACTIVITY,
+      onSuccess,
+      onOpenChange,
+    });
+
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateActivity).toHaveBeenCalledOnce();
+    });
+
+    const [activityIdArg, payload] = (mockUpdateActivity.mock.calls[0] as unknown) as [
+      number,
+      Record<string, unknown>,
+    ];
+    expect(activityIdArg).toBe(7);
+    expect(payload.name).toBe("Campamento de verano");
+    // edit payload must NOT include club_type_id or club_section_id
+    expect(payload).not.toHaveProperty("club_type_id");
+    expect(payload).not.toHaveProperty("club_section_id");
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/finances/transaction-form-dialog.test.tsx
+++ b/src/components/finances/transaction-form-dialog.test.tsx
@@ -1,0 +1,448 @@
+/**
+ * Integration tests for TransactionFormDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog calls `getFinanceCategories`, `createFinance`, and
+ * `updateFinance` from `@/lib/api/finances`. All three are client-side
+ * functions that call `apiRequest` / `apiRequestFromClient` internally.
+ * We mock the entire module with `vi.mock(...)` so no actual HTTP
+ * requests are issued — MSW is not involved here.
+ *
+ * `getFinanceCategories` is called in a useEffect on mount (when open=true).
+ * Tests that need categories in the dropdown resolve it with a stub list.
+ *
+ * Zod schema uses `z.coerce.number()` for numeric fields.  Submitting a
+ * form without setting `amount` / `finance_category_id` leaves them as
+ * `undefined` — coercion of undefined → NaN, which fails `.positive()` and
+ * `.min(1)` checks respectively, triggering FormMessage errors.
+ *
+ * Shadcn <Form> sets `aria-invalid="true"` on fields that have errors after
+ * a submit attempt. We assert on that attribute to lock the primitive's
+ * behavior.
+ *
+ * RTL auto-cleanup:
+ * Vitest uses `globals: false`. We explicitly import `cleanup` and call it
+ * in `afterEach` to prevent DOM bleed-through between tests.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills required by Radix UI components
+// ---------------------------------------------------------------------------
+
+// Radix UI's Select component uses ResizeObserver internally.
+// jsdom does not implement it — polyfill with a no-op.
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// Radix UI's Select calls scrollIntoView on the active item when the
+// dropdown opens. jsdom does not implement it — polyfill with a no-op.
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = function () {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — Vitest hoists vi.mock() calls before imports resolve.
+// ---------------------------------------------------------------------------
+
+const mockGetFinanceCategories = vi.fn();
+const mockCreateFinance = vi.fn();
+const mockUpdateFinance = vi.fn();
+
+vi.mock("@/lib/api/finances", () => ({
+  getFinanceCategories: () => mockGetFinanceCategories(),
+  createFinance: (clubId: number, payload: unknown) =>
+    mockCreateFinance(clubId, payload),
+  updateFinance: (financeId: number, payload: unknown) =>
+    mockUpdateFinance(financeId, payload),
+}));
+
+// sonner toast — we don't need to render the Toaster; just spy on calls.
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { TransactionFormDialog } from "@/components/finances/transaction-form-dialog";
+import type { ClubSection } from "@/components/finances/transaction-form-dialog";
+import type { FinanceCategory, Finance } from "@/lib/api/finances";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_CATEGORIES: FinanceCategory[] = [
+  { finance_category_id: 1, name: "Cuotas", type: 0 },
+  { finance_category_id: 2, name: "Material", type: 1 },
+];
+
+const STUB_SECTIONS: ClubSection[] = [
+  { club_section_id: 10, club_type_id: 1, name: "Conquistadores" },
+];
+
+const STUB_FINANCE: Finance = {
+  finance_id: 99,
+  year: 2025,
+  month: 3,
+  amount: 5000, // 50.00 in cents
+  description: "Cuota mensual",
+  club_type_id: 1,
+  finance_category_id: 1,
+  finance_date: "2025-03-15T00:00:00.000Z",
+  club_section_id: 10,
+  active: true,
+};
+
+const financeMessages = messages.finances;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderDialogOptions {
+  finance?: Finance | null;
+  sections?: ClubSection[];
+  clubId?: number;
+}
+
+function renderDialog({
+  finance = null,
+  sections = STUB_SECTIONS,
+  clubId = 1,
+}: RenderDialogOptions = {}) {
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <TransactionFormDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        clubId={clubId}
+        sections={sections}
+        finance={finance}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { onOpenChange, onSuccess, ...utils };
+}
+
+// Helper: submit the form element
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TransactionFormDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: categories load successfully
+    mockGetFinanceCategories.mockResolvedValue(STUB_CATEGORIES);
+    // Default: mutations resolve (success path)
+    mockCreateFinance.mockResolvedValue({ ...STUB_FINANCE });
+    mockUpdateFinance.mockResolvedValue({ ...STUB_FINANCE });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog with all fields ─────────────────────────────────────
+
+  it("renders dialog title, all required fields and submit button", async () => {
+    renderDialog();
+
+    // Title
+    await screen.findByRole("heading", {
+      name: financeMessages.form.titleNew,
+    });
+
+    // Key fields
+    expect(screen.getByLabelText(/Monto/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Fecha/)).toBeInTheDocument();
+
+    // Submit button
+    expect(
+      screen.getByRole("button", { name: financeMessages.form.createButton }),
+    ).toBeInTheDocument();
+
+    // Cancel button
+    expect(
+      screen.getByRole("button", { name: financeMessages.form.cancelButton }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders edit title when a finance prop is provided", async () => {
+    renderDialog({ finance: STUB_FINANCE });
+
+    await screen.findByRole("heading", {
+      name: financeMessages.form.titleEdit,
+    });
+
+    expect(
+      screen.getByRole("button", { name: financeMessages.form.saveButton }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Amount validation ───────────────────────────────────────────────────
+
+  it("shows validation error when amount is empty on submit", async () => {
+    renderDialog();
+
+    // Wait for categories to load
+    await waitFor(() => expect(mockGetFinanceCategories).toHaveBeenCalledOnce());
+
+    const amountInput = screen.getByLabelText(/Monto/);
+    // Clear the input so it submits empty
+    await act(async () => {
+      fireEvent.change(amountInput, { target: { value: "" } });
+    });
+
+    await submitForm();
+
+    // aria-invalid must be set on the amount input
+    await waitFor(() => {
+      expect(amountInput).toHaveAttribute("aria-invalid", "true");
+    });
+  });
+
+  it("shows validation error when amount is zero (must be positive)", async () => {
+    renderDialog();
+    await waitFor(() => expect(mockGetFinanceCategories).toHaveBeenCalledOnce());
+
+    const amountInput = screen.getByLabelText(/Monto/);
+    await act(async () => {
+      fireEvent.change(amountInput, { target: { value: "0" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(amountInput).toHaveAttribute("aria-invalid", "true");
+    });
+  });
+
+  // ── 3. finance_date required ───────────────────────────────────────────────
+
+  it("shows aria-invalid on date field when date is cleared", async () => {
+    renderDialog();
+    await waitFor(() => expect(mockGetFinanceCategories).toHaveBeenCalledOnce());
+
+    const dateInput = screen.getByLabelText(/Fecha/);
+    await act(async () => {
+      fireEvent.change(dateInput, { target: { value: "" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(dateInput).toHaveAttribute("aria-invalid", "true");
+    });
+  });
+
+  // ── 4. Successful create ───────────────────────────────────────────────────
+
+  it("calls createFinance with correct payload and closes dialog on success", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    // Wait for categories to load so SelectContent has items.
+    await waitFor(() => expect(mockGetFinanceCategories).toHaveBeenCalledOnce());
+    // Flush React state update so category options appear in the DOM.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50));
+    });
+
+    // Set amount via native input
+    const amountInput = screen.getByLabelText(/Monto/);
+    await user.clear(amountInput);
+    await user.type(amountInput, "50");
+
+    // Open the Category select by clicking the SelectTrigger (role=combobox).
+    // Radix SelectTrigger renders as role="combobox". The first combobox in
+    // the form is the category select.
+    const comboboxes = screen.getAllByRole("combobox");
+    // Use fireEvent.click — userEvent.click fails due to Radix Dialog setting
+    // pointer-events:none on body and SelectValue span having pointer-events:none.
+    await act(async () => {
+      fireEvent.click(comboboxes[0]!);
+    });
+
+    // After click, Radix renders the SelectContent in a portal.
+    // Items render as role="option". Find and click "Cuotas".
+    const categoryOption = await screen.findByRole("option", { name: /Cuotas/ });
+    await act(async () => {
+      fireEvent.click(categoryOption);
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreateFinance).toHaveBeenCalledOnce();
+    });
+
+    // Payload amount should be in cents (50 * 100 = 5000)
+    const [calledClubId, calledPayload] = mockCreateFinance.mock.calls[0] as [
+      number,
+      { amount: number; finance_category_id: number },
+    ];
+    expect(calledClubId).toBe(1);
+    expect(calledPayload.amount).toBe(5000);
+    expect(calledPayload.finance_category_id).toBe(1);
+
+    // Dialog closes and success callback fires
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 5. Successful edit ─────────────────────────────────────────────────────
+
+  it("calls updateFinance with correct payload and closes dialog on success", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ finance: STUB_FINANCE });
+    await waitFor(() => expect(mockGetFinanceCategories).toHaveBeenCalledOnce());
+
+    // Update amount to 100
+    const amountInput = screen.getByLabelText(/Monto/);
+    await act(async () => {
+      fireEvent.change(amountInput, { target: { value: "100" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockUpdateFinance).toHaveBeenCalledOnce();
+    });
+
+    const [calledId, calledPayload] = mockUpdateFinance.mock.calls[0] as [
+      number,
+      { amount: number },
+    ];
+    expect(calledId).toBe(STUB_FINANCE.finance_id);
+    expect(calledPayload.amount).toBe(10000); // 100 * 100
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 6. Submit during pending ──────────────────────────────────────────────
+
+  it("disables submit button while update submission is in flight", async () => {
+    // Use edit mode — finance_category_id is pre-filled, so validation passes immediately.
+    let resolveUpdate!: () => void;
+    mockUpdateFinance.mockReturnValue(
+      new Promise<void>((res) => {
+        resolveUpdate = res;
+      }),
+    );
+
+    renderDialog({ finance: STUB_FINANCE });
+    await waitFor(() => expect(mockGetFinanceCategories).toHaveBeenCalledOnce());
+
+    // Submit with pre-filled data (edit mode has valid defaults from STUB_FINANCE)
+    await submitForm();
+
+    // Button text changes to "Guardando..." — check disabled state
+    await waitFor(() => {
+      const saveBtn = screen.getByRole("button", {
+        name: financeMessages.form.saveButton,
+      });
+      expect(saveBtn).toBeDisabled();
+    });
+
+    // Resolve so React can clean up async state
+    await act(async () => {
+      resolveUpdate();
+    });
+  });
+
+  // ── 7. API error shows toast ───────────────────────────────────────────────
+
+  it("shows error toast when updateFinance rejects with Error instance", async () => {
+    // Use edit mode so validation passes without needing to fill Radix Selects.
+    mockUpdateFinance.mockRejectedValue(new Error("Network error"));
+
+    renderDialog({ finance: STUB_FINANCE });
+    await waitFor(() => expect(mockGetFinanceCategories).toHaveBeenCalledOnce());
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Network error");
+    });
+  });
+
+  it("shows fallback error toast when updateFinance rejects with non-Error", async () => {
+    mockUpdateFinance.mockRejectedValue("string-rejection");
+
+    renderDialog({ finance: STUB_FINANCE });
+    await waitFor(() => expect(mockGetFinanceCategories).toHaveBeenCalledOnce());
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        financeMessages.errors.update_transaction_failed,
+      );
+    });
+  });
+
+  // ── 8. Cancel closes dialog ────────────────────────────────────────────────
+
+  it("calls onOpenChange(false) when cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await waitFor(() => expect(mockGetFinanceCategories).toHaveBeenCalledOnce());
+
+    const cancelBtn = screen.getByRole("button", {
+      name: financeMessages.form.cancelButton,
+    });
+    await user.click(cancelBtn);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateFinance).not.toHaveBeenCalled();
+  });
+
+  // ── 9. Categories load failure ────────────────────────────────────────────
+
+  it("shows error toast when getFinanceCategories rejects", async () => {
+    mockGetFinanceCategories.mockRejectedValue(new Error("Failed"));
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        financeMessages.toasts.categories_load_failed,
+      );
+    });
+  });
+});

--- a/src/components/folders/folder-form-dialog.test.tsx
+++ b/src/components/folders/folder-form-dialog.test.tsx
@@ -1,0 +1,376 @@
+/**
+ * Integration tests for FolderFormDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog calls `createFolder` and `updateFolder` from `@/lib/api/folders`.
+ * IMPORTANT: both functions always throw "Not implemented" — the backend
+ * endpoints are pending. We mock the module so tests control the behavior.
+ *
+ * Because the Zod schema is built with `buildSchema(tVal)` inside the
+ * component (using real translations), `NextIntlClientProvider` with the
+ * real `messages/es.json` is mandatory — without it the schema builder
+ * throws when calling `tVal("name_min", ...)`.
+ *
+ * Shadcn <Form> sets `aria-invalid="true"` on fields with errors after a
+ * submit attempt — we assert on this to lock the primitive's behavior.
+ *
+ * RTL auto-cleanup:
+ * Vitest uses `globals: false`. We explicitly import `cleanup` and call it
+ * in `afterEach` to prevent DOM bleed-through between tests.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+// Radix UI's Switch component (used inside FolderFormDialog) calls
+// ResizeObserver internally. jsdom does not implement it. Polyfill with a
+// no-op so the component mounts without throwing.
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+const mockCreateFolder = vi.fn();
+const mockUpdateFolder = vi.fn();
+
+vi.mock("@/lib/api/folders", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/folders")>();
+  return {
+    ...original,
+    createFolder: (data: unknown) => mockCreateFolder(data),
+    updateFolder: (id: string, data: unknown) => mockUpdateFolder(id, data),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { FolderFormDialog } from "@/components/folders/folder-form-dialog";
+import type { FolderTemplate } from "@/lib/api/folders";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_FOLDER: FolderTemplate = {
+  folder_id: "f-001",
+  name: "Carpeta Conquistadores 2025",
+  description: "Descripción de prueba",
+  active: true,
+  club_type_ids: [1],
+  created_at: null,
+  updated_at: null,
+  modules: [],
+};
+
+const folderMessages = messages.folders;
+const validationMessages = messages.folders.validation;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderFolderDialogOptions {
+  folder?: FolderTemplate | null;
+}
+
+function renderDialog({ folder = null }: RenderFolderDialogOptions = {}) {
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <FolderFormDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        folder={folder}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { onOpenChange, onSuccess, ...utils };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FolderFormDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateFolder.mockResolvedValue(STUB_FOLDER);
+    mockUpdateFolder.mockResolvedValue(STUB_FOLDER);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog with all fields ─────────────────────────────────────
+
+  it("renders dialog title, name field, description field and submit button", () => {
+    renderDialog();
+
+    expect(screen.getByRole("heading", { name: "Nueva carpeta de evidencias" })).toBeInTheDocument();
+
+    // Name field
+    expect(screen.getByPlaceholderText(/Carpeta Conquistadores/i)).toBeInTheDocument();
+
+    // Description field
+    expect(screen.getByPlaceholderText(/Descripción opcional/i)).toBeInTheDocument();
+
+    // Active switch label
+    expect(screen.getByText("Carpeta activa")).toBeInTheDocument();
+
+    // Buttons
+    expect(screen.getByRole("button", { name: "Cancelar" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Crear carpeta" })).toBeInTheDocument();
+  });
+
+  it("renders edit title and edit button when folder prop is provided", () => {
+    renderDialog({ folder: STUB_FOLDER });
+
+    expect(screen.getByRole("heading", { name: "Editar carpeta" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Guardar cambios" })).toBeInTheDocument();
+  });
+
+  it("populates fields with folder data in edit mode", () => {
+    renderDialog({ folder: STUB_FOLDER });
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    expect(nameInput).toHaveValue(STUB_FOLDER.name);
+  });
+
+  // ── 2. Name validation — required and min length ──────────────────────────
+
+  it("shows aria-invalid on name field when submitted empty", async () => {
+    renderDialog();
+
+    await submitForm();
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    await waitFor(() => {
+      expect(nameInput).toHaveAttribute("aria-invalid", "true");
+    });
+  });
+
+  it("shows min-length validation error when name is too short", async () => {
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Ab" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(nameInput).toHaveAttribute("aria-invalid", "true");
+    });
+
+    // Validation message should reference min=3
+    expect(
+      screen.getByText(validationMessages.name_min.replace("{min}", "3")),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT mark name invalid when name meets min length (3+ chars)", async () => {
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "ABC" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreateFolder).toHaveBeenCalledOnce();
+    });
+
+    expect(nameInput).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  // ── 3. Description is optional ─────────────────────────────────────────────
+
+  it("submits successfully without description (description is optional)", async () => {
+    const { onSuccess } = renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Carpeta de prueba" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreateFolder).toHaveBeenCalledOnce();
+    });
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 4. Successful create ───────────────────────────────────────────────────
+
+  it("calls createFolder with correct payload and closes dialog on success", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Carpeta Aventureros 2025" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreateFolder).toHaveBeenCalledOnce();
+    });
+
+    const [calledPayload] = mockCreateFolder.mock.calls[0] as [
+      { name: string; active: boolean },
+    ];
+    expect(calledPayload.name).toBe("Carpeta Aventureros 2025");
+    expect(calledPayload.active).toBe(true);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(mockToastSuccess).toHaveBeenCalledWith(folderMessages.toasts.created);
+  });
+
+  // ── 5. Successful edit ─────────────────────────────────────────────────────
+
+  it("calls updateFolder with folder id and updated payload on save", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ folder: STUB_FOLDER });
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Carpeta Editada" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockUpdateFolder).toHaveBeenCalledOnce();
+    });
+
+    const [calledId, calledPayload] = mockUpdateFolder.mock.calls[0] as [
+      string,
+      { name: string },
+    ];
+    expect(calledId).toBe(STUB_FOLDER.folder_id);
+    expect(calledPayload.name).toBe("Carpeta Editada");
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(mockToastSuccess).toHaveBeenCalledWith(folderMessages.toasts.updated);
+  });
+
+  // ── 6. Submit during pending ───────────────────────────────────────────────
+
+  it("disables submit button while submission is in flight", async () => {
+    let resolveCreate!: () => void;
+    mockCreateFolder.mockReturnValue(
+      new Promise<void>((res) => {
+        resolveCreate = res;
+      }),
+    );
+
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Carpeta Válida" } });
+    });
+
+    await submitForm();
+
+    expect(screen.getByRole("button", { name: "Creando..." })).toBeDisabled();
+
+    await act(async () => {
+      resolveCreate();
+    });
+  });
+
+  // ── 7. API error response ──────────────────────────────────────────────────
+
+  it("shows error toast when createFolder rejects", async () => {
+    mockCreateFolder.mockRejectedValue(new Error("Backend unavailable"));
+
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Carpeta con error" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Backend unavailable");
+    });
+  });
+
+  it("shows fallback error message when createFolder rejects with non-Error", async () => {
+    mockCreateFolder.mockRejectedValue("string error");
+
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(/Carpeta Conquistadores/i);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Carpeta fallback" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Error al crear la carpeta");
+    });
+  });
+
+  // ── 8. Cancel closes dialog ────────────────────────────────────────────────
+
+  it("calls onOpenChange(false) when cancel is clicked without calling createFolder", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "Cancelar" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateFolder).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/insurance/insurance-form-dialog.test.tsx
+++ b/src/components/insurance/insurance-form-dialog.test.tsx
@@ -1,0 +1,481 @@
+/**
+ * Integration tests for InsuranceFormDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form + Zod for validation (shadcn <Form>).
+ * API calls go through `createInsurance` / `updateInsurance` from
+ * "@/lib/api/insurance" — both are async functions that use
+ * `apiRequestFromClient` (HTTP). We mock the module entirely so no
+ * real network calls are made. MSW is active but not needed here.
+ *
+ * File attachment (`evidenceFile`) is kept as unmanaged React state
+ * (a `useRef` + `useState` pair outside <FormProvider>). We simulate
+ * file selection by firing a `change` event on the hidden file input
+ * directly — browser FileList is not natively constructible in jsdom,
+ * so we use Object.defineProperty to inject a synthetic FileList.
+ *
+ * Select (shadcn/Radix) renders a hidden <select> for a11y. We use
+ * RTL's `fireEvent.change` on that element to change Select values.
+ * The Radix portal renders into document.body so `screen.getByRole`
+ * works without scoping.
+ *
+ * RTL auto-cleanup:
+ * Vitest uses `globals: false`, so `afterEach` is not a global.
+ * RTL's auto-cleanup check fails silently. We explicitly import
+ * `cleanup` and call it in `afterEach`.
+ *
+ * Intl provider:
+ * The component reads translations via `useTranslations("insurance")`.
+ * We wrap renders in `NextIntlClientProvider` with real `messages/es.json`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { MemberInsurance } from "@/lib/api/insurance";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks — Vitest hoists vi.mock() before imports resolve.
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateInsurance = vi.fn<(...args: any[]) => Promise<unknown>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdateInsurance = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/insurance", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/lib/api/insurance")>();
+  return {
+    ...original,
+    createInsurance: (memberId: string, payload: unknown) =>
+      mockCreateInsurance(memberId, payload),
+    updateInsurance: (insuranceId: number, payload: unknown) =>
+      mockUpdateInsurance(insuranceId, payload),
+  };
+});
+
+// sonner toast — avoid real toast rendering noise in tests
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { InsuranceFormDialog } from "@/components/insurance/insurance-form-dialog";
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const BASE_MEMBER: MemberInsurance = {
+  user_id: "user-001",
+  name: "Ana",
+  paternal_last_name: "López",
+  maternal_last_name: "Torres",
+  user_image: null,
+  insurance: null,
+};
+
+const MEMBER_WITH_INSURANCE: MemberInsurance = {
+  ...BASE_MEMBER,
+  insurance: {
+    insurance_id: 42,
+    insurance_type: "CAMPOREE",
+    policy_number: "POL-2025-042",
+    provider: "MAPFRE",
+    start_date: "2025-01-01T00:00:00.000Z",
+    end_date: "2025-12-31T00:00:00.000Z",
+    coverage_amount: 5000,
+    active: true,
+    evidence_file_url: null,
+    evidence_file_name: null,
+    created_at: null,
+    modified_at: null,
+    created_by_name: null,
+    modified_by_name: null,
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOptions {
+  open?: boolean;
+  member?: MemberInsurance | null;
+  onOpenChange?: (open: boolean) => void;
+  onSuccess?: () => void;
+}
+
+function renderInsuranceDialog(opts: RenderOptions = {}) {
+  const {
+    open = true,
+    member = BASE_MEMBER,
+    onOpenChange = vi.fn(),
+    onSuccess = vi.fn(),
+  } = opts;
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <InsuranceFormDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        member={member}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("InsuranceFormDialog", () => {
+  beforeEach(() => {
+    mockCreateInsurance.mockClear();
+    mockUpdateInsurance.mockClear();
+    mockCreateInsurance.mockResolvedValue({ insurance_id: 99 });
+    mockUpdateInsurance.mockResolvedValue({ insurance_id: 42 });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── Rendering ─────────────────────────────────────────────────────────────
+
+  it("renders all 6 fields: type select, policy_number, provider, start_date, end_date, file attach", () => {
+    renderInsuranceDialog();
+
+    // Type select trigger
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+
+    // Policy number
+    expect(
+      screen.getByPlaceholderText(
+        messages.insurance.placeholders.policyNumber,
+      ),
+    ).toBeInTheDocument();
+
+    // Provider
+    expect(
+      screen.getByPlaceholderText(messages.insurance.placeholders.provider),
+    ).toBeInTheDocument();
+
+    // Date inputs (start + end)
+    const dateInputs = document
+      .querySelectorAll('input[type="date"]');
+    expect(dateInputs).toHaveLength(2);
+
+    // File attach button
+    expect(
+      screen.getByRole("button", { name: /adjuntar archivo/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Registrar seguro' title and cancel + submit buttons in create mode", () => {
+    renderInsuranceDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /registrar seguro/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /cancelar/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /registrar seguro/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders 'Editar seguro' title and 'Guardar cambios' button in edit mode", () => {
+    renderInsuranceDialog({ member: MEMBER_WITH_INSURANCE });
+
+    expect(
+      screen.getByRole("heading", { name: /editar seguro/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /guardar cambios/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── Type select options ────────────────────────────────────────────────────
+
+  it("hidden native select contains all 3 insurance type options (GENERAL_ACTIVITIES, CAMPOREE, HIGH_RISK)", () => {
+    renderInsuranceDialog();
+
+    // Radix renders a hidden native <select> for a11y alongside the custom trigger.
+    // Opening the custom trigger via userEvent.click in jsdom throws hasPointerCapture;
+    // instead we assert directly on the hidden <select> which always has all option values.
+    const nativeSelect = document.querySelector("select") as HTMLSelectElement;
+    expect(nativeSelect).not.toBeNull();
+
+    const optionValues = Array.from(nativeSelect.options).map((o) => o.value);
+    expect(optionValues).toContain("GENERAL_ACTIVITIES");
+    expect(optionValues).toContain("CAMPOREE");
+    expect(optionValues).toContain("HIGH_RISK");
+  });
+
+  // ── Validation on empty submit ─────────────────────────────────────────────
+
+  it("marks start_date and end_date inputs as aria-invalid after empty submit", async () => {
+    renderInsuranceDialog();
+
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      const startInput = document.querySelector(
+        'input[type="date"][aria-required="true"]',
+      );
+      // Both date inputs should have aria-invalid after failed validation
+      const dateInputs = document.querySelectorAll('input[type="date"]');
+      const anyInvalid = Array.from(dateInputs).some(
+        (el) => el.getAttribute("aria-invalid") === "true",
+      );
+      expect(anyInvalid).toBe(true);
+    });
+  });
+
+  it("shows validation error messages for required date fields on empty submit", async () => {
+    renderInsuranceDialog();
+
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          messages.insurance.validation.start_date_required,
+        ),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          messages.insurance.validation.end_date_required,
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── Edit mode: pre-fills fields ────────────────────────────────────────────
+
+  it("pre-fills policy_number, provider, and dates when editing an existing insurance", () => {
+    renderInsuranceDialog({ member: MEMBER_WITH_INSURANCE });
+
+    const policyInput = screen.getByPlaceholderText(
+      messages.insurance.placeholders.policyNumber,
+    ) as HTMLInputElement;
+    expect(policyInput.value).toBe("POL-2025-042");
+
+    const providerInput = screen.getByPlaceholderText(
+      messages.insurance.placeholders.provider,
+    ) as HTMLInputElement;
+    expect(providerInput.value).toBe("MAPFRE");
+
+    const dateInputs = document.querySelectorAll(
+      'input[type="date"]',
+    ) as NodeListOf<HTMLInputElement>;
+    expect(dateInputs[0]?.value).toBe("2025-01-01");
+    expect(dateInputs[1]?.value).toBe("2025-12-31");
+  });
+
+  // ── File attachment ────────────────────────────────────────────────────────
+
+  it("file attach button triggers the hidden file input click", async () => {
+    const user = userEvent.setup();
+    renderInsuranceDialog();
+
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+
+    const clickSpy = vi.spyOn(fileInput, "click");
+
+    const attachBtn = screen.getByRole("button", { name: /adjuntar archivo/i });
+    await user.click(attachBtn);
+
+    expect(clickSpy).toHaveBeenCalledOnce();
+    clickSpy.mockRestore();
+  });
+
+  it("shows file name badge after selecting a file via the file input", async () => {
+    renderInsuranceDialog();
+
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+
+    const fakeFile = new File(["pdf-content"], "poliza-2025.pdf", {
+      type: "application/pdf",
+    });
+
+    // Inject a synthetic FileList because jsdom cannot construct one directly
+    Object.defineProperty(fileInput, "files", {
+      value: { 0: fakeFile, length: 1, item: () => fakeFile },
+      writable: false,
+      configurable: true,
+    });
+
+    await act(async () => {
+      fireEvent.change(fileInput);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("poliza-2025.pdf")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'Cambiar archivo' button text after a file is selected", async () => {
+    renderInsuranceDialog();
+
+    const fileInput = document.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+
+    const fakeFile = new File(["data"], "evidence.png", {
+      type: "image/png",
+    });
+
+    Object.defineProperty(fileInput, "files", {
+      value: { 0: fakeFile, length: 1, item: () => fakeFile },
+      writable: false,
+      configurable: true,
+    });
+
+    await act(async () => {
+      fireEvent.change(fileInput);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /cambiar archivo/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── Cancel without submit ─────────────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does not call API when cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    renderInsuranceDialog({ onOpenChange });
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateInsurance).not.toHaveBeenCalled();
+    expect(mockUpdateInsurance).not.toHaveBeenCalled();
+  });
+
+  // ── Submit during pending: button disabled ─────────────────────────────────
+
+  it("disables submit button while submission is in progress", async () => {
+    // Delay the mock so we can capture the mid-flight state
+    let resolveCreate!: () => void;
+    mockCreateInsurance.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveCreate = () => res({ insurance_id: 99 });
+      }),
+    );
+
+    renderInsuranceDialog();
+
+    // Fill required fields
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    fireEvent.change(dateInputs[0]!, { target: { value: "2025-01-01" } });
+    fireEvent.change(dateInputs[1]!, { target: { value: "2025-12-31" } });
+
+    const submitBtn = screen.getByRole("button", { name: /registrar seguro/i });
+
+    const form = document.querySelector("form")!;
+    act(() => {
+      fireEvent.submit(form);
+    });
+
+    // Button should disable while the promise is pending
+    await waitFor(() => {
+      expect(submitBtn).toBeDisabled();
+    });
+
+    // Resolve the promise to avoid open handles
+    await act(async () => {
+      resolveCreate();
+    });
+  });
+
+  // ── Valid submit (create mode) ─────────────────────────────────────────────
+
+  it("calls createInsurance with correct member id and form data on valid submit", async () => {
+    const onSuccess = vi.fn();
+    const onOpenChange = vi.fn();
+    renderInsuranceDialog({ onSuccess, onOpenChange });
+
+    // Fill required date fields
+    const dateInputs = document.querySelectorAll('input[type="date"]');
+    fireEvent.change(dateInputs[0]!, { target: { value: "2025-03-01" } });
+    fireEvent.change(dateInputs[1]!, { target: { value: "2025-12-31" } });
+
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(mockCreateInsurance).toHaveBeenCalledOnce();
+    });
+
+    const [memberId, payload] = (mockCreateInsurance.mock.calls[0] as unknown) as [
+      string,
+      { start_date: string; end_date: string; insurance_type: string },
+    ];
+    expect(memberId).toBe("user-001");
+    expect(payload.start_date).toBe("2025-03-01");
+    expect(payload.end_date).toBe("2025-12-31");
+    expect(payload.insurance_type).toBe("GENERAL_ACTIVITIES");
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── Valid submit (edit mode) ───────────────────────────────────────────────
+
+  it("calls updateInsurance with insurance_id on valid submit in edit mode", async () => {
+    const onSuccess = vi.fn();
+    renderInsuranceDialog({
+      member: MEMBER_WITH_INSURANCE,
+      onSuccess,
+    });
+
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateInsurance).toHaveBeenCalledOnce();
+    });
+
+    const [insuranceId] = (mockUpdateInsurance.mock.calls[0] as unknown) as [number, unknown];
+    expect(insuranceId).toBe(42);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/inventory/inventory-form-dialog.test.tsx
+++ b/src/components/inventory/inventory-form-dialog.test.tsx
@@ -1,0 +1,414 @@
+/**
+ * Integration tests for InventoryFormDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog calls `createInventoryItem` and `updateInventoryItem` from
+ * `@/lib/api/inventory`. Both are client-side functions. We mock the
+ * module entirely so no HTTP requests are issued.
+ *
+ * The Zod schema is built with `buildSchema(tVal)` — a factory inside
+ * the component. `NextIntlClientProvider` with the real `messages/es.json`
+ * is required so `tVal(...)` can resolve validation message keys.
+ *
+ * Required props for the dialog:
+ *   - `clubId: number`
+ *   - `instanceType: InstanceType` ("adv" | "pathf" | "mg")
+ *   - `categories: InventoryCategory[]`
+ * Tests provide sensible defaults via the renderDialog helper.
+ *
+ * `amount` default is 0 — valid (min: 0). Only name and category are
+ * required to pass for a clean submit (category defaults to categories[0]).
+ *
+ * Shadcn <Form> sets `aria-invalid="true"` on invalid fields.
+ *
+ * RTL auto-cleanup:
+ * Vitest uses `globals: false`. We explicitly import `cleanup` and call it
+ * in `afterEach` to prevent DOM bleed-through between tests.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+const mockCreateInventoryItem = vi.fn();
+const mockUpdateInventoryItem = vi.fn();
+
+vi.mock("@/lib/api/inventory", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/inventory")>();
+  return {
+    ...original,
+    createInventoryItem: (clubId: number, data: unknown) =>
+      mockCreateInventoryItem(clubId, data),
+    updateInventoryItem: (inventoryId: number, data: unknown) =>
+      mockUpdateInventoryItem(inventoryId, data),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { InventoryFormDialog } from "@/components/inventory/inventory-form-dialog";
+import type { InventoryItem, InventoryCategory } from "@/lib/api/inventory";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_CATEGORIES: InventoryCategory[] = [
+  { inventory_category_id: 1, name: "Equipamiento" },
+  { inventory_category_id: 2, name: "Materiales" },
+];
+
+const STUB_ITEM: InventoryItem = {
+  inventory_id: 42,
+  name: "Carpas 4 personas",
+  description: "Carpas para actividades al aire libre",
+  inventory_category_id: 1,
+  club_id: 1,
+  amount: 5,
+  active: true,
+};
+
+const inventoryMessages = messages.inventory;
+const validationMessages = messages.inventory.validation;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderInventoryDialogOptions {
+  item?: InventoryItem | null;
+  categories?: InventoryCategory[];
+  clubId?: number;
+}
+
+function renderDialog({
+  item = null,
+  categories = STUB_CATEGORIES,
+  clubId = 1,
+}: RenderInventoryDialogOptions = {}) {
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <InventoryFormDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        clubId={clubId}
+        instanceType="pathf"
+        categories={categories}
+        item={item}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { onOpenChange, onSuccess, ...utils };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("InventoryFormDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateInventoryItem.mockResolvedValue({ ...STUB_ITEM });
+    mockUpdateInventoryItem.mockResolvedValue({ ...STUB_ITEM });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog with all fields ─────────────────────────────────────
+
+  it("renders dialog title, all fields and submit button", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: "Nuevo ítem de inventario" }),
+    ).toBeInTheDocument();
+
+    // Name field
+    expect(
+      screen.getByPlaceholderText(inventoryMessages.placeholders.name),
+    ).toBeInTheDocument();
+
+    // Quantity field
+    expect(
+      screen.getByPlaceholderText(inventoryMessages.placeholders.quantity),
+    ).toBeInTheDocument();
+
+    // Category select trigger
+    expect(screen.getByText(/Categoría/)).toBeInTheDocument();
+
+    // Buttons
+    expect(screen.getByRole("button", { name: "Cancelar" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Crear ítem" })).toBeInTheDocument();
+  });
+
+  it("renders edit title and populate fields when item prop is provided", () => {
+    renderDialog({ item: STUB_ITEM });
+
+    expect(
+      screen.getByRole("heading", { name: "Editar ítem" }),
+    ).toBeInTheDocument();
+
+    const nameInput = screen.getByPlaceholderText(inventoryMessages.placeholders.name);
+    expect(nameInput).toHaveValue(STUB_ITEM.name);
+
+    expect(screen.getByRole("button", { name: "Guardar cambios" })).toBeInTheDocument();
+  });
+
+  it("shows instanceType label for create mode", () => {
+    renderDialog();
+    // Shows the label for "pathf" = "Conquistadores"
+    expect(screen.getByText("Conquistadores")).toBeInTheDocument();
+  });
+
+  // ── 2. Name validation ────────────────────────────────────────────────────
+
+  it("marks name field aria-invalid when submitted empty", async () => {
+    renderDialog();
+
+    await submitForm();
+
+    const nameInput = screen.getByPlaceholderText(inventoryMessages.placeholders.name);
+    await waitFor(() => {
+      expect(nameInput).toHaveAttribute("aria-invalid", "true");
+    });
+  });
+
+  it("shows min-length error when name is less than 3 characters", async () => {
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(inventoryMessages.placeholders.name);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "AB" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(nameInput).toHaveAttribute("aria-invalid", "true");
+    });
+
+    expect(
+      screen.getByText(validationMessages.name_min.replace("{min}", "3")),
+    ).toBeInTheDocument();
+  });
+
+  // ── 3. Amount validation — must be integer >= 0 ───────────────────────────
+
+  it("marks amount field aria-invalid when value is negative", async () => {
+    renderDialog();
+
+    const amountInput = screen.getByPlaceholderText(inventoryMessages.placeholders.quantity);
+    await act(async () => {
+      fireEvent.change(amountInput, { target: { value: "-1" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(amountInput).toHaveAttribute("aria-invalid", "true");
+    });
+
+    expect(
+      screen.getByText(validationMessages.amount_min),
+    ).toBeInTheDocument();
+  });
+
+  it("accepts amount of 0 as valid", async () => {
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(inventoryMessages.placeholders.name);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Ítem válido" } });
+    });
+
+    const amountInput = screen.getByPlaceholderText(inventoryMessages.placeholders.quantity);
+    await act(async () => {
+      fireEvent.change(amountInput, { target: { value: "0" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreateInventoryItem).toHaveBeenCalledOnce();
+    });
+
+    const [, calledPayload] = mockCreateInventoryItem.mock.calls[0] as [
+      number,
+      { amount: number },
+    ];
+    expect(calledPayload.amount).toBe(0);
+  });
+
+  // ── 4. Successful create ───────────────────────────────────────────────────
+
+  it("calls createInventoryItem with correct payload and closes on success", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(inventoryMessages.placeholders.name);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Nuevo ítem de prueba" } });
+    });
+
+    const amountInput = screen.getByPlaceholderText(inventoryMessages.placeholders.quantity);
+    await act(async () => {
+      fireEvent.change(amountInput, { target: { value: "10" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreateInventoryItem).toHaveBeenCalledOnce();
+    });
+
+    const [calledClubId, calledPayload] = mockCreateInventoryItem.mock.calls[0] as [
+      number,
+      { name: string; amount: number; instanceType: string },
+    ];
+    expect(calledClubId).toBe(1);
+    expect(calledPayload.name).toBe("Nuevo ítem de prueba");
+    expect(calledPayload.amount).toBe(10);
+    expect(calledPayload.instanceType).toBe("pathf");
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(mockToastSuccess).toHaveBeenCalledWith(inventoryMessages.toasts.item_created);
+  });
+
+  // ── 5. Successful edit ─────────────────────────────────────────────────────
+
+  it("calls updateInventoryItem with correct id and payload on save", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ item: STUB_ITEM });
+
+    const amountInput = screen.getByPlaceholderText(inventoryMessages.placeholders.quantity);
+    await act(async () => {
+      fireEvent.change(amountInput, { target: { value: "8" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockUpdateInventoryItem).toHaveBeenCalledOnce();
+    });
+
+    const [calledId, calledPayload] = mockUpdateInventoryItem.mock.calls[0] as [
+      number,
+      { amount: number },
+    ];
+    expect(calledId).toBe(STUB_ITEM.inventory_id);
+    expect(calledPayload.amount).toBe(8);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(mockToastSuccess).toHaveBeenCalledWith(inventoryMessages.toasts.item_updated);
+  });
+
+  // ── 6. Submit during pending ───────────────────────────────────────────────
+
+  it("disables submit button while submission is in flight", async () => {
+    let resolveCreate!: () => void;
+    mockCreateInventoryItem.mockReturnValue(
+      new Promise<void>((res) => {
+        resolveCreate = res;
+      }),
+    );
+
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(inventoryMessages.placeholders.name);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Ítem en vuelo" } });
+    });
+
+    await submitForm();
+
+    expect(screen.getByRole("button", { name: "Creando..." })).toBeDisabled();
+
+    await act(async () => {
+      resolveCreate();
+    });
+  });
+
+  // ── 7. API error response ──────────────────────────────────────────────────
+
+  it("shows error toast when createInventoryItem rejects with Error instance", async () => {
+    mockCreateInventoryItem.mockRejectedValue(new Error("Connection refused"));
+
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(inventoryMessages.placeholders.name);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Ítem con error" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Connection refused");
+    });
+  });
+
+  it("shows fallback error message when createInventoryItem rejects with non-Error", async () => {
+    mockCreateInventoryItem.mockRejectedValue("unknown failure");
+
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText(inventoryMessages.placeholders.name);
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Ítem fallback" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(inventoryMessages.errors.save_item_failed);
+    });
+  });
+
+  // ── 8. Cancel closes dialog ────────────────────────────────────────────────
+
+  it("calls onOpenChange(false) when cancel is clicked without calling createInventoryItem", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: "Cancelar" }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateInventoryItem).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/ui/form.test.tsx
+++ b/src/components/ui/form.test.tsx
@@ -1,0 +1,650 @@
+/**
+ * Unit/component tests for the shadcn Form primitive.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The Form primitive is a thin adapter over react-hook-form (RHF) and
+ * Radix UI Slot. Every exported part is tested here in isolation against
+ * real RHF state — no mocks of the form machinery itself.
+ *
+ * TestForm helper:
+ * A reusable controlled form that wires together Form → FormField →
+ * FormItem → FormLabel → FormControl → Input → FormDescription →
+ * FormMessage with a Zod schema. Each test renders this helper and
+ * drives state through RHF's standard submit + validation cycle.
+ *
+ * aria-invalid behavior (FormControl):
+ * FormControl ALWAYS renders `aria-invalid={!!error}`. When there is no
+ * error the attribute value is "false" (not absent), because the Slot
+ * passes boolean props as strings. Assertions reflect this contract.
+ *
+ * aria-describedby behavior (FormControl):
+ * FormControl ALWAYS includes the description id in aria-describedby.
+ * When an error is present, it appends the message id as well.
+ *
+ * useFormField outside context:
+ * The check `if (!fieldContext)` runs after `useContext` which returns
+ * the empty-object default `{} as FormFieldContextValue`. The falsy
+ * check catches an empty object (truthy in JS), so the real guard is
+ * the missing `name` key — `getFieldState(undefined, formState)` throws
+ * inside `useFormContext`. We test this by asserting the hook throws
+ * when rendered outside a FormField tree.
+ *
+ * Vitest globals: false → auto-cleanup is not registered by RTL.
+ * We import `cleanup` and call it explicitly in afterEach.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  render,
+  renderHook,
+  screen,
+  fireEvent,
+  waitFor,
+  cleanup,
+  act,
+} from "@testing-library/react";
+import { useForm, useFormContext } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  useFormField,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+// ---------------------------------------------------------------------------
+// Schema and shared types
+// ---------------------------------------------------------------------------
+
+const emailSchema = z.object({
+  email: z.string().email("Invalid email"),
+});
+
+type EmailFormValues = z.infer<typeof emailSchema>;
+
+// ---------------------------------------------------------------------------
+// TestForm — shared helper rendered by most tests
+// ---------------------------------------------------------------------------
+
+/**
+ * A minimal but complete form that exercises the full Form primitive chain.
+ * Props allow customising the default value and wiring a submit callback.
+ *
+ * Structure:
+ *   Form → FormField → FormItem → FormLabel → FormControl → Input
+ *                                            → FormDescription
+ *                                            → FormMessage
+ */
+interface TestFormProps {
+  defaultEmail?: string;
+  onSubmit?: (values: EmailFormValues) => void;
+  /** When true, FormDescription is omitted (tests aria-describedby without it) */
+  hideDescription?: boolean;
+  /** When true, FormMessage is omitted (tests aria-describedby without it) */
+  hideMessage?: boolean;
+}
+
+function TestForm({
+  defaultEmail = "",
+  onSubmit = vi.fn(),
+  hideDescription = false,
+  hideMessage = false,
+}: TestFormProps) {
+  const form = useForm<EmailFormValues>({
+    resolver: zodResolver(emailSchema),
+    defaultValues: { email: defaultEmail },
+  });
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              {!hideDescription && (
+                <FormDescription>Your email address</FormDescription>
+              )}
+              {!hideMessage && <FormMessage />}
+            </FormItem>
+          )}
+        />
+        <button type="submit">Submit</button>
+      </form>
+    </Form>
+  );
+}
+
+/**
+ * Submit the form and wait for RHF validation to run.
+ * Returns after the DOM has updated with any error state.
+ */
+async function submitForm() {
+  const submitBtn = screen.getByRole("button", { name: "Submit" });
+  await act(async () => {
+    fireEvent.click(submitBtn);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup — RTL auto-cleanup is disabled (globals: false in vitest.config.ts)
+// ---------------------------------------------------------------------------
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------------------------------------------------------------------------
+// 1. FormField + Controller integration
+// ---------------------------------------------------------------------------
+
+describe("FormField + Controller integration", () => {
+  it("renders the field input via render prop", () => {
+    render(<TestForm />);
+
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("input reflects defaultValues provided to useForm", () => {
+    render(<TestForm defaultEmail="preset@example.com" />);
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.value).toBe("preset@example.com");
+  });
+
+  it("field.onChange updates the input value (controlled)", async () => {
+    render(<TestForm />);
+
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "typed@example.com" } });
+    });
+
+    expect(input.value).toBe("typed@example.com");
+  });
+
+  it("calls onSubmit with form values when validation passes", async () => {
+    const onSubmit = vi.fn();
+    render(<TestForm defaultEmail="valid@example.com" onSubmit={onSubmit} />);
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledOnce();
+      expect(onSubmit).toHaveBeenCalledWith(
+        { email: "valid@example.com" },
+        expect.anything(),
+      );
+    });
+  });
+
+  it("does NOT call onSubmit when validation fails", async () => {
+    const onSubmit = vi.fn();
+    render(<TestForm defaultEmail="not-an-email" onSubmit={onSubmit} />);
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. FormControl — aria-invalid wiring
+// ---------------------------------------------------------------------------
+
+describe("FormControl aria-invalid", () => {
+  it("sets aria-invalid to false when there is no validation error", () => {
+    render(<TestForm />);
+
+    const input = screen.getByRole("textbox");
+    // FormControl always renders aria-invalid as a boolean prop — the Slot
+    // reflects it as the string "false" on the DOM element when no error.
+    expect(input).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("sets aria-invalid=true on the input after validation fails", async () => {
+    render(<TestForm defaultEmail="not-an-email" />);
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+    });
+  });
+
+  it("clears aria-invalid after the field value becomes valid", async () => {
+    render(<TestForm defaultEmail="not-an-email" />);
+
+    // Trigger validation failure
+    await submitForm();
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+    });
+
+    // Fix the value — RHF re-validates on change when mode is "onChange"
+    // or on next submit. Changing to a valid value and resubmitting clears it.
+    const input = screen.getByRole("textbox");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "fixed@example.com" } });
+    });
+    await submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByRole("textbox")).not.toHaveAttribute(
+        "aria-invalid",
+        "true",
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. FormControl — aria-describedby wiring
+// ---------------------------------------------------------------------------
+
+describe("FormControl aria-describedby", () => {
+  it("contains the description id when FormDescription is present and no error", () => {
+    render(<TestForm hideMessage />);
+
+    const input = screen.getByRole("textbox");
+    const describedBy = input.getAttribute("aria-describedby") ?? "";
+    const descriptionEl = screen.getByText("Your email address");
+
+    expect(describedBy).toContain(descriptionEl.id);
+  });
+
+  it("contains the message id when there is an error", async () => {
+    render(<TestForm defaultEmail="bad" />);
+
+    await submitForm();
+
+    await waitFor(async () => {
+      const input = screen.getByRole("textbox");
+      const describedBy = input.getAttribute("aria-describedby") ?? "";
+      const messageEl = screen.getByText("Invalid email");
+
+      expect(describedBy).toContain(messageEl.id);
+    });
+  });
+
+  it("contains BOTH description and message ids when error is present", async () => {
+    render(<TestForm defaultEmail="bad" />);
+
+    await submitForm();
+
+    await waitFor(async () => {
+      const input = screen.getByRole("textbox");
+      const describedBy = input.getAttribute("aria-describedby") ?? "";
+      const descriptionEl = screen.getByText("Your email address");
+      const messageEl = screen.getByText("Invalid email");
+
+      expect(describedBy).toContain(descriptionEl.id);
+      expect(describedBy).toContain(messageEl.id);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. FormLabel — htmlFor and focus wiring
+// ---------------------------------------------------------------------------
+
+describe("FormLabel", () => {
+  it("renders a label element with text", () => {
+    render(<TestForm />);
+
+    expect(screen.getByText("Email")).toBeInTheDocument();
+  });
+
+  it("label htmlFor matches the input id (FormItemContext stable id)", () => {
+    render(<TestForm />);
+
+    const label = screen.getByText("Email") as HTMLLabelElement;
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // FormLabel sets htmlFor to formItemId, FormControl sets the same id on
+    // the slotted input — they must match for the label to be associated.
+    expect(label.htmlFor).toBe(input.id);
+    expect(label.htmlFor).not.toBe("");
+  });
+
+  it("label for attribute matches the input id (clicking label associates correctly)", () => {
+    render(<TestForm />);
+
+    const label = screen.getByText("Email") as HTMLLabelElement;
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+
+    // jsdom does not implement the native label-click focus behaviour, so we
+    // assert the association at the attribute level — this is what browsers
+    // and AT use to link the label to the input.
+    expect(label.htmlFor).toBe(input.id);
+    expect(label.htmlFor).not.toBe("");
+  });
+
+  it("applies data-error=true directly on the label element when field has a validation error", async () => {
+    render(<TestForm defaultEmail="bad" />);
+
+    await submitForm();
+
+    await waitFor(() => {
+      // FormLabel renders data-error={!!error} on the <label> element itself
+      // (which has data-slot="form-label"). getByText returns that element directly.
+      const label = screen.getByText("Email");
+      expect(label).toHaveAttribute("data-error", "true");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 5. FormMessage
+// ---------------------------------------------------------------------------
+
+describe("FormMessage", () => {
+  it("does not render when the field has no error", () => {
+    render(<TestForm />);
+
+    // No error message paragraph should exist yet.
+    expect(screen.queryByText("Invalid email")).not.toBeInTheDocument();
+  });
+
+  it("renders the error message text after validation fails", async () => {
+    render(<TestForm defaultEmail="bad" />);
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid email")).toBeInTheDocument();
+    });
+  });
+
+  it("renders the error message inside a <p> element with data-slot=form-message", async () => {
+    render(<TestForm defaultEmail="bad" />);
+
+    await submitForm();
+
+    await waitFor(() => {
+      const messageEl = screen.getByText("Invalid email");
+      expect(messageEl.tagName).toBe("P");
+      expect(messageEl).toHaveAttribute("data-slot", "form-message");
+    });
+  });
+
+  it("message id is included in the input aria-describedby when error is present", async () => {
+    render(<TestForm defaultEmail="bad" />);
+
+    await submitForm();
+
+    await waitFor(() => {
+      const messageEl = screen.getByText("Invalid email");
+      const input = screen.getByRole("textbox");
+      const describedBy = input.getAttribute("aria-describedby") ?? "";
+
+      expect(messageEl.id).not.toBe("");
+      expect(describedBy).toContain(messageEl.id);
+    });
+  });
+
+  it("renders children text when no error and children are provided", () => {
+    function FormWithHint() {
+      const form = useForm<EmailFormValues>({
+        resolver: zodResolver(emailSchema),
+        defaultValues: { email: "" },
+      });
+      return (
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(vi.fn())}>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage>Hint text when no error</FormMessage>
+                </FormItem>
+              )}
+            />
+          </form>
+        </Form>
+      );
+    }
+
+    render(<FormWithHint />);
+    expect(screen.getByText("Hint text when no error")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 6. FormDescription
+// ---------------------------------------------------------------------------
+
+describe("FormDescription", () => {
+  it("renders a <p> element with data-slot=form-description", () => {
+    render(<TestForm />);
+
+    const descEl = screen.getByText("Your email address");
+    expect(descEl.tagName).toBe("P");
+    expect(descEl).toHaveAttribute("data-slot", "form-description");
+  });
+
+  it("has a stable non-empty id used in aria-describedby", () => {
+    render(<TestForm />);
+
+    const descEl = screen.getByText("Your email address");
+    expect(descEl.id).not.toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 7. useFormField hook — context assertions
+// ---------------------------------------------------------------------------
+
+describe("useFormField hook", () => {
+  it("throws when used outside FormField + FormItem context", () => {
+    // useFormField calls useFormContext() which throws if there is no
+    // FormProvider ancestor. We suppress the React error boundary console
+    // noise and assert that renderHook captures the error.
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    expect(() => {
+      renderHook(() => useFormField());
+    }).toThrow();
+
+    consoleError.mockRestore();
+  });
+
+  it("returns correct id structure when used inside a full FormField tree", async () => {
+    /**
+     * We extract the hook result by rendering a component that calls
+     * useFormField internally and exposes the ids via data attributes.
+     * This is simpler than renderHook + wrapper because FormField requires
+     * a full RHF controller context.
+     */
+    let capturedIds: ReturnType<typeof useFormField> | null = null;
+
+    function IdCapture() {
+      capturedIds = useFormField();
+      return null;
+    }
+
+    function FormWithCapture() {
+      const form = useForm<EmailFormValues>({
+        resolver: zodResolver(emailSchema),
+        defaultValues: { email: "" },
+      });
+      return (
+        <Form {...form}>
+          <form>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <IdCapture />
+                </FormItem>
+              )}
+            />
+          </form>
+        </Form>
+      );
+    }
+
+    render(<FormWithCapture />);
+
+    expect(capturedIds).not.toBeNull();
+    const ids = capturedIds!;
+
+    // The base id is a React.useId() generated value — just assert it is a
+    // non-empty string and that the derived ids are built from it correctly.
+    expect(ids.id).toBeTruthy();
+    expect(ids.formItemId).toBe(`${ids.id}-form-item`);
+    expect(ids.formDescriptionId).toBe(`${ids.id}-form-item-description`);
+    expect(ids.formMessageId).toBe(`${ids.id}-form-item-message`);
+    expect(ids.name).toBe("email");
+  });
+
+  it("exposes no error when field is valid", async () => {
+    let capturedError: unknown = "NOT_SET";
+
+    function ErrorCapture() {
+      const { error } = useFormField();
+      capturedError = error;
+      return null;
+    }
+
+    function FormWithErrorCapture() {
+      const form = useForm<EmailFormValues>({
+        resolver: zodResolver(emailSchema),
+        defaultValues: { email: "" },
+      });
+      return (
+        <Form {...form}>
+          <form>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <ErrorCapture />
+                </FormItem>
+              )}
+            />
+          </form>
+        </Form>
+      );
+    }
+
+    render(<FormWithErrorCapture />);
+    expect(capturedError).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 8. Form (FormProvider re-export)
+// ---------------------------------------------------------------------------
+
+describe("Form (FormProvider)", () => {
+  it("provides useFormContext() to descendants", () => {
+    let contextReceived = false;
+
+    function ContextConsumer() {
+      const ctx = useFormContext<EmailFormValues>();
+      // If useFormContext does not throw, the provider is in scope.
+      contextReceived = !!ctx.control;
+      return null;
+    }
+
+    function FormWithConsumer() {
+      const form = useForm<EmailFormValues>({
+        resolver: zodResolver(emailSchema),
+        defaultValues: { email: "" },
+      });
+      return (
+        <Form {...form}>
+          <form>
+            <ContextConsumer />
+          </form>
+        </Form>
+      );
+    }
+
+    render(<FormWithConsumer />);
+    expect(contextReceived).toBe(true);
+  });
+
+  it("passes formState down so descendants can read isDirty after change", async () => {
+    let isDirty = false;
+
+    function DirtyCapture() {
+      const { formState } = useFormContext<EmailFormValues>();
+      isDirty = formState.isDirty;
+      return null;
+    }
+
+    function FormWithDirtyCapture() {
+      const form = useForm<EmailFormValues>({
+        resolver: zodResolver(emailSchema),
+        defaultValues: { email: "" },
+      });
+      return (
+        <Form {...form}>
+          <form>
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+            <DirtyCapture />
+          </form>
+        </Form>
+      );
+    }
+
+    render(<FormWithDirtyCapture />);
+    expect(isDirty).toBe(false);
+
+    const input = screen.getByRole("textbox");
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "typed@example.com" } });
+    });
+
+    expect(isDirty).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Locks behavior of PR #118 (shadcn Form primitive scaffolding + 5 dialog migrations to aria-invalid wiring). **Single consolidated PR** combining 3 parallel agent outputs.

## New test files (6)

| File | Tests | Coverage |
|---|---|---|
| `src/components/ui/form.test.tsx` | 27 | shadcn Form primitive contracts (8 describe blocks) |
| `src/components/finances/transaction-form-dialog.test.tsx` | 12 | finances dialog integration |
| `src/components/folders/folder-form-dialog.test.tsx` | 13 | folders dialog integration |
| `src/components/inventory/inventory-form-dialog.test.tsx` | 13 | inventory dialog integration |
| `src/components/insurance/insurance-form-dialog.test.tsx` | 14 | insurance dialog (file attach + types) |
| `src/components/activities/activity-form-dialog.test.tsx` | 18 | activity dialog (12 fields, conditional rendering, cross-field reset) |

## Form primitive coverage

- FormField + Controller integration (defaultValue, onChange wiring)
- FormControl wires `aria-invalid` only when error present
- FormControl wires `aria-describedby` chain (description + message ids)
- FormLabel htmlFor matches Input id (FormItemContext)
- FormMessage renders only on error, with stable id
- useFormField throws outside FormField context

## Patterns documented for future component tests

- **jsdom polyfills (per-file, not vitest.setup.ts)**: `ResizeObserver` + `Element.scrollIntoView` for Radix Select/Switch components
- **Radix Select interaction**: `fireEvent.change` on hidden native `<select>` — `userEvent.click` fails because Radix Dialog sets `pointer-events: none` on body + jsdom missing `hasPointerCapture`
- **FileList polyfill** via `Object.defineProperty` for file attachment tests
- **`vi.mock` at module boundary** for `@/lib/api/*` — MSW not needed when API functions imported directly (vs HTTP fetch through apiRequest)
- **toast (sonner) mocked** as observable side-effect for error assertions
- **Cross-field reset** verified via hidden select index ordering
- **Edit mode** used for tests requiring valid Zod state — pre-fills via `initialData` prop, avoids driving Radix Select UI per-test

## Stats

- 219 → 316 tests (+97), 15 → 21 test files
- All 316 tests pass
- Typecheck clean
- Zero source modifications

## Test plan

- [x] All 316 tests pass (excluding `.claude/worktrees/*` stale fixtures)
- [x] Typecheck clean
- [x] Coordinated namespace ownership across 3 parallel agents (form primitive vs 5 dialogs disjoint)
- [ ] CI Vitest job remains green