### PR TITLE
chore: bundle perf baseline + MSW dialog tests r2 + Form primitive r2

### DIFF
--- a/PERF-BASELINE.md
+++ b/PERF-BASELINE.md
@@ -1,0 +1,244 @@
+# Performance Baseline — sacdia-admin
+
+**Date:** 2026-05-10
+**Branch:** `chore/admin-perf-baseline` (from `origin/development`)
+**Build context:** post-PR #119 (development branch)
+**Next.js:** 16.2.4 (Turbopack)
+**Node:** see `package.json` engines / `pnpm-lock.yaml`
+
+This is the first objective bundle baseline for sacdia-admin after the
+deferred-loading wave (PRs #108, #111, #115, #116) and the analyzer setup
+(#112). Use it as the reference point for the next perf round.
+
+---
+
+## 1. Tooling Status — `pnpm analyze` blocker (mitigated)
+
+`pnpm analyze` (added in #112) wraps `next build` with the `ANALYZE=true`
+env var consumed by `@next/bundle-analyzer`.
+
+> **Blocker:** `@next/bundle-analyzer@16.2.6` is **not compatible with the
+> Turbopack production builder** (Next 16 default). The build succeeds, but
+> the wrapper prints:
+>
+> ```
+> The Next Bundle Analyzer is not compatible with Turbopack builds, no report will be generated.
+> Consider trying the new Turbopack analyzer via `next experimental-analyze`.
+> To run this analysis pass the `--webpack` flag to `next build`
+> ```
+>
+> No `.next/analyze/*.html` files are produced. Two workarounds exist:
+>
+> 1. **`next experimental-analyze -o`** (Next 16 native, Turbopack-compatible).
+>    Produces a binary treemap dataset under `.next/diagnostics/analyze/`
+>    (`analyze.data` per route, `modules.data`, `routes.json`). Designed for
+>    interactive use via `next experimental-analyze` (web UI on :4000). The
+>    `analyze.data` files are TTComp/zstd-compressed and parsed in-browser, so
+>    they aren't human-greppable from the CLI.
+> 2. **`next build --webpack`** to fall back to the legacy Webpack builder so
+>    `@next/bundle-analyzer` works as documented. Slower builds; not used in
+>    CI today.
+>
+> **Recommendation:** rewrite the `analyze` script as
+> `"analyze": "next experimental-analyze"` and drop `@next/bundle-analyzer`,
+> OR keep both: add `analyze:webpack` for the legacy HTML reports.
+
+The numbers below were collected by inspecting the **real Turbopack output**
+(`.next/static/chunks/*.js` with `gzip -c | wc -c` for transfer sizes) and
+the per-route `page_client-reference-manifest.js` dependency lists.
+
+Build artifacts: `.next/static/chunks/` contains 122 `.js` files plus 1 CSS file.
+
+---
+
+## 2. Top 20 client chunks (raw + gzip)
+
+Numbers in bytes. "Used in" = number of `page_client-reference-manifest.js`
+files that reference the chunk (proxy for sharedness).
+
+| Rank | Raw    | Gzip   | Chunk                    | Used in routes | Likely contents                           |
+| ---: | -----: | -----: | ------------------------ | -------------: | ----------------------------------------- |
+|    1 | 423188 | 130190 | `0p6ijvwwtbq-u.js`       |            110 | **react-dom + Next runtime** (rootMain)   |
+|    2 | 339107 |  97728 | `0tvhttx4gjnu3.js`       |              2 | **recharts** (SLA + dashboard charts)     |
+|    3 | 301091 |  73245 | `0mo_gudr43avp.js`       |             23 | **zod** (shared validators)               |
+|    4 | 112594 |  39490 | `03~yq9q893hmn.js`       |            110 | polyfills (rootMain)                      |
+|    5 | 111169 |  29628 | `0~yo8z5b45jp_.js`       |            110 | Next/React framework split (rootMain)     |
+|    6 |  75093 |  20627 | `0~hsvynr4v2wt.js`       |              1 | annual-folders/categories page            |
+|    7 |  73193 |  20504 | `05iz_9ujgg867.js`       |              1 | resources page                            |
+|    8 |  69907 |  19508 | `049vkxg1tfz_g.js`       |              1 | finances page                             |
+|    9 |  69887 |  20410 | `10fite_y6z.4p.js`       |              1 | clubs/[id] page (cmdk visible)            |
+|   10 |  69360 |  19439 | `18515sji~1ph0.js`       |              1 | camporees/[id] page                       |
+|   11 |  69062 |  19723 | `12z21uvzmiqhw.js`       |              1 | settings/scoring-categories page          |
+|   12 |  67786 |  19371 | `0a.~c34se6o1q.js`       |              1 | catalogs/geography/local-fields/[id]      |
+|   13 |  67750 |  19369 | `0rjqx7oz-_~au.js`       |              1 | catalogs/geography/unions/[id]            |
+|   14 |  66475 |  19333 | `0xrn_78nijkb1.js`       |              1 | insurance page                            |
+|   15 |  65395 |  21292 | `0lrwflxl0yp63.js`       |            105 | shared dashboard layout / sidebar         |
+|   16 |  65210 |  18510 | `0q_pn5q3g.8ae.js`       |              1 | achievements/[categoryId]/[id]/edit       |
+|   17 |  64598 |  18131 | `0gctl7mzoc01f.js`       |              1 | camporees/union page                      |
+|   18 |  64450 |  18041 | `0wj.m9yy0o_xq.js`       |              1 | camporees page                            |
+|   19 |  63990 |  18001 | `02z00tbprctef.js`       |              1 | achievements/[categoryId]/new             |
+|   20 |  62931 |  17674 | `0pxbyoa8x86an.js`       |              1 | activities/[id] page                      |
+
+**Shared root (`rootMainFiles` from `build-manifest.json`)**
+
+7 files, **701 692 bytes raw / 209 222 bytes gzip** combined.
+
+> Every route pays this transfer up front. The single largest contributor is
+> `0p6ijvwwtbq-u.js` (react-dom + Next runtime). The 339 KB recharts chunk is
+> NOT in rootMain — it loads only on the 2 routes that statically import it
+> (see Recommendation #1).
+
+---
+
+## 3. Per-route initial JS — top 10 routes (sum of all chunks referenced by `page_client-reference-manifest.js`)
+
+| Rank | Raw    | Gzip   | Chunks | Route                                              |
+| ---: | -----: | -----: | -----: | -------------------------------------------------- |
+|    1 | 893892 | 257632 |     18 | `/dashboard/clubs/[id]`                            |
+|    2 | 867802 | 245223 |     17 | `/dashboard/camporees/[id]`                        |
+|    3 | 846578 | 241844 |     17 | `/dashboard/annual-folders/templates`              |
+|    4 | 834715 | 241424 |     17 | `/dashboard/validation`                            |
+|    5 | 830588 | 238727 |     17 | `/dashboard/evidence-review`                       |
+|    6 | 830529 | 238029 |     16 | `/dashboard/annual-folders/categories`             |
+|    7 | 826518 | 237398 |     16 | `/dashboard/investiture/pipeline`                  |
+|    8 | 825343 | 236910 |     16 | `/dashboard/finances`                              |
+|    9 | 824471 | 237981 |     17 | `/dashboard/investiture`                           |
+|   10 | 821911 | 236735 |     16 | `/dashboard/insurance`                             |
+
+**For comparison:**
+
+- **Lowest route**: `/login` — 249 938 raw / 78 216 gzip (9 chunks).
+- Median dashboard route lands around **210–235 KB gzip**.
+- Routes that statically use `recharts` (only `/dashboard/sla` and `/dashboard`)
+  carry an extra ~98 KB gzip on top.
+
+---
+
+## 4. Verification — deferred components are correctly isolated
+
+PRs #108, #111, #115, #116 wrapped these components in `next/dynamic`:
+
+| PR   | Components dynamically imported                                                                                                                              |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| #108 | First batch — 5 heavy client components (dialogs)                                                                                                            |
+| #111 | `AchievementForm`, `TemplatesClientPage`, `RequirementsTree`, `RequirementEditDialog`, `PipelineClientPage`, `ResourcesCrudPage` (~399 KB deferred)          |
+| #115 | `PhaseECatalogCrudPage` lazy-loaded from 9 catalog routes                                                                                                    |
+| #116 | `RolesTable`, `PhaseECatalogCrudPage` (folder-modules), `RankingsClientPage`, `AwardCategoriesClientPage`, `WeeklyRecordsPanel` (~85–105 KB gzip deferred)   |
+
+**Check**: Searched all 7 `rootMainFiles` chunks for those component names.
+
+```
+0p6ijvwwtbq-u.js: 0 hits
+0~~5nu0326~ow.js: 0 hits
+08f-krk3ed4xj.js: 0 hits
+0~yo8z5b45jp_.js: 0 hits
+... (all 0)
+```
+
+**Confirmed**: no deferred component leaks into the shared root bundle. Each
+lives in its own per-route chunk (e.g., `0r13195.l2cvv.js` for
+`RankingsClientPage` on `/dashboard/annual-folders/rankings`). The dynamic-
+import infrastructure is working as designed.
+
+---
+
+## 5. Recommendations — top 5 candidates for the next perf round
+
+Ranked by estimated gzip savings on first paint of the affected routes.
+
+### 1. Lazy-load `recharts` charts on `/dashboard` and `/dashboard/sla` (~98 KB gzip per route)
+
+**Finding:** `0tvhttx4gjnu3.js` is **339 KB raw / 97.7 KB gzip** and contains
+the recharts library. It's pulled in by exactly two routes:
+
+- `/dashboard` via static import of `RoleDistributionChart`
+  (`src/components/dashboard/role-distribution-chart.tsx`).
+- `/dashboard/sla` via `sla-dashboard-client.tsx`, which statically imports
+  `SlaPipelineChart` and `SlaThroughputChart`.
+
+The home dashboard is the **first page every user lands on after login** —
+charts render below-the-fold and are pure visualization. Same for SLA.
+
+**Action:** wrap `RoleDistributionChart`, `SlaPipelineChart`, and
+`SlaThroughputChart` with `dynamic(() => import(...), { ssr: false })` and a
+skeleton fallback. Expected savings: **~98 KB gzip on `/dashboard` and
+`/dashboard/sla` first paint.**
+
+### 2. Code-split the shared `zod` chunk (~73 KB gzip on 23 routes)
+
+**Finding:** `0mo_gudr43avp.js` is **301 KB raw / 73 KB gzip**, contains
+`zod`, and is referenced by 23 routes (every route that uses a form schema
+through the shared validators). It is currently a module-level shared chunk,
+not deferred.
+
+**Action:** investigate whether form schemas can be co-located per route /
+loaded with the form component itself. Alternatively, evaluate whether
+`zod@4` (already in deps per `package.json`) tree-shakes better than the
+import surface we're using. Expected: shave 20–40 KB gzip off median dashboard
+routes that don't actually need zod at first paint.
+
+### 3. Investigate the 18-chunk `/dashboard/clubs/[id]` route (894 KB raw / 258 KB gzip)
+
+It's the heaviest route in the catalog. Likely candidates inside it: the unit
+detail panel, member tables, and catalog forms. PR #116 already deferred
+`WeeklyRecordsPanel` from `unit-detail-panel.tsx`, so additional wins live
+elsewhere on the page. Audit the static imports in
+`src/app/(dashboard)/dashboard/clubs/[id]/page.tsx` and its child components
+for further `next/dynamic` candidates (member roster, finance widgets, etc.).
+
+### 4. Audit `/dashboard/annual-folders/templates` (847 KB raw / 242 KB gzip, 17 chunks)
+
+Third-largest route. PR #111 already wrapped `TemplatesClientPage` in
+`dynamic()`, so the page-level wrapper is correct. The remaining weight likely
+comes from supporting components rendered inside the template editor (rich
+text? drag-and-drop?). Re-audit the eagerly-imported helpers around the
+dynamic wrapper.
+
+### 5. Replace or defer `cmdk` on `/dashboard/clubs/[id]`
+
+`10fite_y6z.4p.js` (~70 KB raw / 20 KB gzip) is the dominant page-only chunk
+on `/dashboard/clubs/[id]` and is the only chunk in the top-25 to contain
+`cmdk` strings. Evaluate whether the command palette / combobox can be
+deferred (`dynamic(() => import('cmdk'))`) or replaced with a lighter
+selector if it's only used in one secondary panel.
+
+---
+
+## 6. Methodology
+
+Commands actually executed in this branch:
+
+```bash
+pnpm install --frozen-lockfile         # restore node_modules
+pnpm analyze                           # = ANALYZE=true pnpm build
+                                       #   → Turbopack build OK, but
+                                       #   @next/bundle-analyzer skipped.
+npx next experimental-analyze -o       # generates .next/diagnostics/analyze/
+                                       # (binary treemap, not text-readable)
+```
+
+Sizes computed with:
+
+```bash
+# Top chunks (raw + gzip)
+ls -S .next/static/chunks/*.js | head -25 | while read f; do
+  printf "%9d %9d  %s\n" "$(stat -f%z "$f")" \
+    "$(gzip -c "$f" | wc -c)" "$(basename "$f")"
+done
+
+# Per-route initial JS = sum of all chunks referenced by
+#   .next/server/app/<route>/page_client-reference-manifest.js
+```
+
+`gzip -c` uses default compression level (`-6`); a CDN typically uses gzip 6
+or brotli (smaller). These numbers are upper-bound for HTTP transfer.
+
+---
+
+## 7. Next actions (handoff)
+
+- Replace `pnpm analyze` script with `next experimental-analyze` (or add
+  parallel `analyze:webpack`) so the script does what its name promises.
+- File the 5 follow-up items from §5 as separate perf PRs.
+- After the next perf wave, regenerate this baseline and commit a diff so we
+  can see savings by route.

--- a/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-form.tsx
+++ b/src/app/(dashboard)/dashboard/member-ranking-weights/_components/weights-form.tsx
@@ -10,7 +10,6 @@ import { z } from "zod";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -18,6 +17,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { Card, CardContent } from "@/components/ui/card";
 import { WeightSumIndicator } from "./weight-sum-indicator";
 import {
@@ -115,14 +122,7 @@ export function WeightsForm({
     ? rowToFormValues(defaultValues)
     : EMPTY_DEFAULTS;
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors, isDirty },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     // z.coerce.number() splits Zod's input/output types (string-ish in, number out),
     // so zodResolver's inferred Resolver type doesn't match useForm<FormValues>'s
     // unified signature. Cast is safe because runtime behavior is identical.
@@ -130,16 +130,16 @@ export function WeightsForm({
     defaultValues: initialValues,
   });
 
+  const isDirty = form.formState.isDirty;
+
   // Re-seed if the server data changes (e.g. navigating between edit pages)
   useEffect(() => {
-    reset(isEdit && defaultValues ? rowToFormValues(defaultValues) : EMPTY_DEFAULTS);
-  }, [isEdit, defaultValues, reset]);
+    form.reset(isEdit && defaultValues ? rowToFormValues(defaultValues) : EMPTY_DEFAULTS);
+  }, [isEdit, defaultValues, form]);
 
-  const classPct = watch("class_pct");
-  const investiturePct = watch("investiture_pct");
-  const camporeePct = watch("camporee_pct");
-  const clubTypeValue = watch("club_type_id");
-  const yearValue = watch("ecclesiastical_year_id");
+  const classPct = form.watch("class_pct");
+  const investiturePct = form.watch("investiture_pct");
+  const camporeePct = form.watch("camporee_pct");
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -186,158 +186,179 @@ export function WeightsForm({
   return (
     <Card>
       <CardContent className="pt-6">
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-          {/* Porcentajes */}
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="w-class">{t("clasePercent")}</Label>
-              <Input
-                id="w-class"
-                type="number"
-                step="0.01"
-                min={0}
-                max={100}
-                {...register("class_pct")}
-                placeholder="0"
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            {/* Porcentajes */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+              <FormField
+                control={form.control}
+                name="class_pct"
+                render={({ field }) => (
+                  <FormItem className="space-y-1.5">
+                    <FormLabel>{t("clasePercent")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        min={0}
+                        max={100}
+                        placeholder="0"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-              {errors.class_pct && (
-                <p className="text-xs text-destructive">
-                  {errors.class_pct.message}
-                </p>
-              )}
+
+              <FormField
+                control={form.control}
+                name="investiture_pct"
+                render={({ field }) => (
+                  <FormItem className="space-y-1.5">
+                    <FormLabel>{t("investiduraPercent")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        min={0}
+                        max={100}
+                        placeholder="0"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="camporee_pct"
+                render={({ field }) => (
+                  <FormItem className="space-y-1.5">
+                    <FormLabel>{t("campanaPercent")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        min={0}
+                        max={100}
+                        placeholder="0"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </div>
 
-            <div className="space-y-1.5">
-              <Label htmlFor="w-investiture">{t("investiduraPercent")}</Label>
-              <Input
-                id="w-investiture"
-                type="number"
-                step="0.01"
-                min={0}
-                max={100}
-                {...register("investiture_pct")}
-                placeholder="0"
-              />
-              {errors.investiture_pct && (
-                <p className="text-xs text-destructive">
-                  {errors.investiture_pct.message}
-                </p>
-              )}
+            {/* Live sum indicator */}
+            <div className="flex items-center gap-2">
+              <WeightSumIndicator values={sumValues} />
             </div>
 
-            <div className="space-y-1.5">
-              <Label htmlFor="w-camporee">{t("campanaPercent")}</Label>
-              <Input
-                id="w-camporee"
-                type="number"
-                step="0.01"
-                min={0}
-                max={100}
-                {...register("camporee_pct")}
-                placeholder="0"
-              />
-              {errors.camporee_pct && (
-                <p className="text-xs text-destructive">
-                  {errors.camporee_pct.message}
-                </p>
-              )}
-            </div>
-          </div>
-
-          {/* Live sum indicator */}
-          <div className="flex items-center gap-2">
-            <WeightSumIndicator values={sumValues} />
-          </div>
-
-          {/* Tipo de club */}
-          <div className="space-y-1.5">
-            <Label>Tipo de club</Label>
-            <Select
-              value={clubTypeValue}
-              onValueChange={(val) => setValue("club_type_id", val, { shouldDirty: true })}
-              disabled={isEdit && defaultValues?.is_default}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Seleccionar tipo de club" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">{t("allTypes")}</SelectItem>
-                {clubTypes.map((ct) => (
-                  <SelectItem
-                    key={ct.club_type_id}
-                    value={String(ct.club_type_id)}
+            {/* Tipo de club */}
+            <FormField
+              control={form.control}
+              name="club_type_id"
+              render={({ field }) => (
+                <FormItem className="space-y-1.5">
+                  <FormLabel>Tipo de club</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={(val) =>
+                      form.setValue("club_type_id", val, { shouldDirty: true })
+                    }
+                    disabled={isEdit && defaultValues?.is_default}
                   >
-                    {ct.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.club_type_id && (
-              <p className="text-xs text-destructive">
-                {errors.club_type_id.message}
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Seleccionar tipo de club" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="all">{t("allTypes")}</SelectItem>
+                      {clubTypes.map((ct) => (
+                        <SelectItem
+                          key={ct.club_type_id}
+                          value={String(ct.club_type_id)}
+                        >
+                          {ct.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Ano eclesiastico */}
+            <FormField
+              control={form.control}
+              name="ecclesiastical_year_id"
+              render={({ field }) => (
+                <FormItem className="space-y-1.5">
+                  <FormLabel>{t("anoEclesiastico")}</FormLabel>
+                  <Select
+                    value={field.value}
+                    onValueChange={(val) =>
+                      form.setValue("ecclesiastical_year_id", val, { shouldDirty: true })
+                    }
+                    disabled={isEdit && defaultValues?.is_default}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Seleccionar año" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="all">{t("allYears")}</SelectItem>
+                      {ecclesiasticalYears.map((y) => (
+                        <SelectItem
+                          key={y.ecclesiastical_year_id}
+                          value={String(y.ecclesiastical_year_id)}
+                        >
+                          {y.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {isEdit && defaultValues?.is_default && (
+              <p className="text-xs text-muted-foreground">
+                La fila por defecto no puede cambiar su tipo de club ni año eclesiástico.
               </p>
             )}
-          </div>
 
-          {/* Ano eclesiastico */}
-          <div className="space-y-1.5">
-            <Label>{t("anoEclesiastico")}</Label>
-            <Select
-              value={yearValue}
-              onValueChange={(val) =>
-                setValue("ecclesiastical_year_id", val, { shouldDirty: true })
-              }
-              disabled={isEdit && defaultValues?.is_default}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Seleccionar año" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">{t("allYears")}</SelectItem>
-                {ecclesiasticalYears.map((y) => (
-                  <SelectItem
-                    key={y.ecclesiastical_year_id}
-                    value={String(y.ecclesiastical_year_id)}
-                  >
-                    {y.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.ecclesiastical_year_id && (
-              <p className="text-xs text-destructive">
-                {errors.ecclesiastical_year_id.message}
-              </p>
-            )}
-          </div>
-
-          {isEdit && defaultValues?.is_default && (
-            <p className="text-xs text-muted-foreground">
-              La fila por defecto no puede cambiar su tipo de club ni año eclesiástico.
-            </p>
-          )}
-
-          {/* Actions */}
-          <div className="flex items-center justify-end gap-3 pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => router.push(backHref)}
-              disabled={isSubmitting}
-            >
-              Cancelar
-            </Button>
-            <Button type="submit" disabled={submitDisabled}>
-              {isSubmitting
-                ? isEdit
-                  ? "Guardando..."
-                  : "Creando..."
-                : isEdit
-                  ? "Guardar cambios"
-                  : "Crear sobreescritura"}
-            </Button>
-          </div>
-        </form>
+            {/* Actions */}
+            <div className="flex items-center justify-end gap-3 pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => router.push(backHref)}
+                disabled={isSubmitting}
+              >
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={submitDisabled}>
+                {isSubmitting
+                  ? isEdit
+                    ? "Guardando..."
+                    : "Creando..."
+                  : isEdit
+                    ? "Guardar cambios"
+                    : "Crear sobreescritura"}
+              </Button>
+            </div>
+          </form>
+        </Form>
       </CardContent>
     </Card>
   );

--- a/src/components/annual-folders/section-form-dialog.tsx
+++ b/src/components/annual-folders/section-form-dialog.tsx
@@ -21,6 +21,14 @@ import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
 import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
   createTemplateSection,
   updateTemplateSection,
 } from "@/lib/api/annual-folders";
@@ -80,14 +88,7 @@ export function SectionFormDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
@@ -99,12 +100,10 @@ export function SectionFormDialog({
     },
   });
 
-  const requiredValue = watch("required");
-
   useEffect(() => {
     if (open) {
       if (section) {
-        reset({
+        form.reset({
           name: section.name,
           description: section.description ?? "",
           order: section.order,
@@ -113,7 +112,7 @@ export function SectionFormDialog({
           minimum_points: section.minimum_points,
         });
       } else {
-        reset({
+        form.reset({
           name: "",
           description: "",
           order: nextOrder,
@@ -123,7 +122,7 @@ export function SectionFormDialog({
         });
       }
     }
-  }, [open, section, nextOrder, reset]);
+  }, [open, section, nextOrder, form]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -174,137 +173,166 @@ export function SectionFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-          {/* Nombre */}
-          <div className="space-y-1.5">
-            <Label htmlFor="section-name">
-              {t("sectionDialog.fieldName")}{" "}
-              <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="section-name"
-              {...register("name")}
-              placeholder={t("sectionDialog.fieldNamePlaceholder")}
-              aria-required="true"
-            />
-            {errors.name && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
-            )}
-          </div>
-
-          {/* Descripción */}
-          <div className="space-y-1.5">
-            <Label htmlFor="section-description">{t("sectionDialog.fieldDescription")}</Label>
-            <Textarea
-              id="section-description"
-              {...register("description")}
-              placeholder={t("sectionDialog.fieldDescriptionPlaceholder")}
-              rows={3}
-            />
-            {errors.description && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.description.message}
-              </p>
-            )}
-          </div>
-
-          {/* Orden */}
-          <div className="space-y-1.5">
-            <Label htmlFor="section-order">
-              {t("sectionDialog.fieldOrder")}{" "}
-              <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="section-order"
-              type="number"
-              min={1}
-              {...register("order")}
-              placeholder="1"
-              aria-required="true"
-            />
-            {errors.order && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.order.message}</p>
-            )}
-          </div>
-
-          {/* Requerida */}
-          <div className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5">
-            <div className="space-y-0.5">
-              <Label htmlFor="section-required" className="cursor-pointer text-sm font-medium">
-                {t("sectionDialog.fieldRequired")}
-              </Label>
-              <p className="text-xs text-muted-foreground">
-                {t("sectionDialog.fieldRequiredDescription")}
-              </p>
-            </div>
-            <Switch
-              id="section-required"
-              checked={requiredValue}
-              onCheckedChange={(checked) => setValue("required", checked)}
-            />
-          </div>
-
-          {/* Puntos */}
-          <div className="grid grid-cols-2 gap-3">
-            {/* Puntos máximos */}
-            <div className="space-y-1.5">
-              <Label htmlFor="section-max-points">
-                {t("sectionDialog.fieldMaxPoints")}{" "}
-                <span aria-hidden="true" className="text-destructive">*</span>
-              </Label>
-              <Input
-                id="section-max-points"
-                type="number"
-                min={0}
-                {...register("max_points")}
-                placeholder="0"
-                aria-required="true"
-              />
-              {errors.max_points && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.max_points.message}
-                </p>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {/* Nombre */}
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("sectionDialog.fieldName")}{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("sectionDialog.fieldNamePlaceholder")}
+                      aria-required="true"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
+            />
 
-            {/* Puntos mínimos */}
-            <div className="space-y-1.5">
-              <Label htmlFor="section-minimum-points">{t("sectionDialog.fieldMinPoints")}</Label>
-              <Input
-                id="section-minimum-points"
-                type="number"
-                min={0}
-                {...register("minimum_points")}
-                placeholder="0"
-              />
-              {errors.minimum_points && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.minimum_points.message}
-                </p>
+            {/* Descripción */}
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("sectionDialog.fieldDescription")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("sectionDialog.fieldDescriptionPlaceholder")}
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-          </div>
+            />
 
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              {t("sectionDialog.cancel")}
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? isEdit
-                  ? t("sectionDialog.submittingEdit")
-                  : t("sectionDialog.submittingCreate")
-                : isEdit
-                  ? t("sectionDialog.submitEdit")
-                  : t("sectionDialog.submitCreate")}
-            </Button>
-          </DialogFooter>
-        </form>
+            {/* Orden */}
+            <FormField
+              control={form.control}
+              name="order"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("sectionDialog.fieldOrder")}{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={1}
+                      placeholder="1"
+                      aria-required="true"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Requerida */}
+            <FormField
+              control={form.control}
+              name="required"
+              render={({ field }) => (
+                <FormItem className="flex items-center justify-between rounded-lg border border-border px-3 py-2.5 space-y-0">
+                  <div className="space-y-0.5">
+                    <Label htmlFor="section-required" className="cursor-pointer text-sm font-medium">
+                      {t("sectionDialog.fieldRequired")}
+                    </Label>
+                    <p className="text-xs text-muted-foreground">
+                      {t("sectionDialog.fieldRequiredDescription")}
+                    </p>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      id="section-required"
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+
+            {/* Puntos */}
+            <div className="grid grid-cols-2 gap-3">
+              {/* Puntos máximos */}
+              <FormField
+                control={form.control}
+                name="max_points"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("sectionDialog.fieldMaxPoints")}{" "}
+                      <span aria-hidden="true" className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={0}
+                        placeholder="0"
+                        aria-required="true"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              {/* Puntos mínimos */}
+              <FormField
+                control={form.control}
+                name="minimum_points"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("sectionDialog.fieldMinPoints")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        type="number"
+                        min={0}
+                        placeholder="0"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                {t("sectionDialog.cancel")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? isEdit
+                    ? t("sectionDialog.submittingEdit")
+                    : t("sectionDialog.submittingCreate")
+                  : isEdit
+                    ? t("sectionDialog.submitEdit")
+                    : t("sectionDialog.submitCreate")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/membership/membership-reject-dialog.test.tsx
+++ b/src/components/membership/membership-reject-dialog.test.tsx
@@ -1,0 +1,334 @@
+/**
+ * Integration tests for MembershipRejectDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form (no shadcn <Form> wrapper) and
+ * calls `rejectMembershipRequest` from `@/lib/api/membership-requests`,
+ * which internally hits `apiRequestFromClient` (HTTP). We mock the
+ * module entirely so no real network calls happen — MSW remains
+ * active but isn't exercised here (consistent with InsuranceFormDialog
+ * pattern).
+ *
+ * The reason field is OPTIONAL (zod `.optional()`), so there is no
+ * "required field" validation path — the only happy path is "submit
+ * with or without a reason". We assert both flows.
+ *
+ * Component reads translations via `useTranslations("membership")`,
+ * so renders are wrapped in `NextIntlClientProvider` with the real
+ * `messages/es.json`.
+ *
+ * RTL auto-cleanup:
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { MembershipRequest } from "@/lib/api/membership-requests";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver internally)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockReject = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/membership-requests", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/lib/api/membership-requests")>();
+  return {
+    ...original,
+    rejectMembershipRequest: (
+      clubSectionId: number,
+      assignmentId: string,
+      reason?: string,
+    ) => mockReject(clubSectionId, assignmentId, reason),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { MembershipRejectDialog } from "@/components/membership/membership-reject-dialog";
+import { ApiError } from "@/lib/api/client";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_REQUEST: MembershipRequest = {
+  assignment_id: "asg-001",
+  club_section_id: 42,
+  role_id: "role-1",
+  status: "PENDING",
+  created_at: "2026-01-01T00:00:00.000Z",
+  expires_at: null,
+  rejection_reason: null,
+  users: {
+    user_id: "user-001",
+    name: "Ana",
+    paternal_last_name: "López",
+    maternal_last_name: "Torres",
+    email: "ana@example.com",
+    user_image: null,
+  },
+  roles: {
+    role_id: "role-1",
+    role_name: "Conquistador",
+  },
+};
+
+const dialogMessages = messages.membership.dialogs.reject;
+const toastMessages = messages.membership.toasts;
+const errorMessages = messages.membership.errors;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  request?: MembershipRequest;
+  clubSectionId?: number;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    request = STUB_REQUEST,
+    clubSectionId = 42,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <MembershipRejectDialog
+        open={open}
+        clubSectionId={clubSectionId}
+        request={request}
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("MembershipRejectDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReject.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Rendering ──────────────────────────────────────────────────────────
+
+  it("renders title, description with user name, reason field and buttons", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: dialogMessages.title }),
+    ).toBeInTheDocument();
+
+    // Description includes interpolated user name
+    expect(screen.getByText(/Ana López/i)).toBeInTheDocument();
+
+    // Reason label + textarea
+    expect(screen.getByText(dialogMessages.reason_label)).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(dialogMessages.reason_placeholder),
+    ).toBeInTheDocument();
+
+    // Buttons
+    expect(
+      screen.getByRole("button", { name: dialogMessages.cancel }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: dialogMessages.confirm }),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to email when name is missing", () => {
+    const requestNoName: MembershipRequest = {
+      ...STUB_REQUEST,
+      users: {
+        user_id: "user-002",
+        name: null,
+        paternal_last_name: null,
+        maternal_last_name: null,
+        email: "noname@example.com",
+        user_image: null,
+      },
+    };
+    renderDialog({ request: requestNoName });
+
+    expect(screen.getByText(/noname@example.com/i)).toBeInTheDocument();
+  });
+
+  // ── 2. Cancel ─────────────────────────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call API when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: dialogMessages.cancel }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockReject).not.toHaveBeenCalled();
+  });
+
+  // ── 3. Happy path WITHOUT reason (optional field) ─────────────────────────
+
+  it("submits without a reason and calls rejectMembershipRequest with undefined reason", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockReject).toHaveBeenCalledOnce();
+    });
+
+    const [clubSectionId, assignmentId, reason] = mockReject.mock.calls[0] as [
+      number,
+      string,
+      string | undefined,
+    ];
+    expect(clubSectionId).toBe(42);
+    expect(assignmentId).toBe("asg-001");
+    expect(reason).toBeUndefined();
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      toastMessages.rejected.replace("{name}", "Ana López"),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 4. Happy path WITH reason ─────────────────────────────────────────────
+
+  it("submits with a reason and forwards it to the API", async () => {
+    renderDialog();
+
+    const textarea = screen.getByPlaceholderText(
+      dialogMessages.reason_placeholder,
+    );
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "Datos incompletos" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockReject).toHaveBeenCalledOnce();
+    });
+
+    const [, , reason] = mockReject.mock.calls[0] as [
+      number,
+      string,
+      string | undefined,
+    ];
+    expect(reason).toBe("Datos incompletos");
+  });
+
+  // ── 5. Submit during pending: button disabled + loading text ──────────────
+
+  it("disables submit button and shows loading text while in flight", async () => {
+    let resolveReject!: () => void;
+    mockReject.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveReject = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: dialogMessages.confirming }),
+      ).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveReject();
+    });
+  });
+
+  // ── 6. API error path: ApiError surfaces server message ───────────────────
+
+  it("shows API error message via toast.error when API throws ApiError", async () => {
+    mockReject.mockRejectedValue(new ApiError("Conflict from server", 409, null));
+
+    renderDialog();
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Conflict from server");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error path: non-ApiError falls back to translated default ──────
+
+  it("shows fallback translated error when API throws a non-ApiError", async () => {
+    mockReject.mockRejectedValue(new Error("network down"));
+
+    const { onOpenChange } = renderDialog();
+    onOpenChange.mockClear();
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(errorMessages.reject);
+    });
+
+    // Dialog stays open on error (onOpenChange(false) not called from submit handler)
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/reports/manual-data-form.tsx
+++ b/src/components/reports/manual-data-form.tsx
@@ -3,15 +3,22 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { useForm } from "react-hook-form";
-import type { SubmitHandler } from "react-hook-form";
+import type { Control, FieldPath, SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { toast } from "sonner";
 import { Loader2, Save } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import {
   Card,
   CardContent,
@@ -62,57 +69,65 @@ interface ManualDataFormProps {
 
 interface NumberFieldProps {
   label: string;
-  name: keyof FormValues;
-
-  register: ReturnType<typeof useForm<FormValues>>["register"];
-  error?: string;
+  name: FieldPath<FormValues>;
+  control: Control<FormValues>;
   disabled?: boolean;
 }
 
-function NumberField({ label, name, register, error, disabled }: NumberFieldProps) {
+function NumberField({ label, name, control, disabled }: NumberFieldProps) {
   return (
-    <div className="space-y-1.5">
-      <Label htmlFor={name} className="text-sm font-medium">
-        {label}
-      </Label>
-      <Input
-        id={name}
-        type="number"
-        min={0}
-        disabled={disabled}
-        className="h-8"
-        {...register(name)}
-      />
-      {error && <p className="text-xs text-destructive" role="alert" aria-live="polite">{error}</p>}
-    </div>
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className="space-y-1.5">
+          <FormLabel className="text-sm font-medium">{label}</FormLabel>
+          <FormControl>
+            <Input
+              type="number"
+              min={0}
+              disabled={disabled}
+              className="h-8"
+              {...field}
+              value={field.value ?? ""}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   );
 }
 
 interface TextareaFieldProps {
   label: string;
-  name: keyof FormValues;
-
-  register: ReturnType<typeof useForm<FormValues>>["register"];
-  error?: string;
+  name: FieldPath<FormValues>;
+  control: Control<FormValues>;
   disabled?: boolean;
   rows?: number;
 }
 
-function TextareaField({ label, name, register, error, disabled, rows = 3 }: TextareaFieldProps) {
+function TextareaField({ label, name, control, disabled, rows = 3 }: TextareaFieldProps) {
   return (
-    <div className="space-y-1.5">
-      <Label htmlFor={name} className="text-sm font-medium">
-        {label}
-      </Label>
-      <Textarea
-        id={name}
-        rows={rows}
-        disabled={disabled}
-        className="resize-none text-sm"
-        {...register(name)}
-      />
-      {error && <p className="text-xs text-destructive" role="alert" aria-live="polite">{error}</p>}
-    </div>
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem className="space-y-1.5">
+          <FormLabel className="text-sm font-medium">{label}</FormLabel>
+          <FormControl>
+            <Textarea
+              rows={rows}
+              disabled={disabled}
+              className="resize-none text-sm"
+              {...field}
+              value={field.value ?? ""}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   );
 }
 
@@ -127,12 +142,7 @@ export function ManualDataForm({
   const t = useTranslations("reports");
   const [saving, setSaving] = useState(false);
 
-  const {
-    register,
-    handleSubmit,
-    formState: { errors, isDirty },
-  } = useForm<FormValues>({
-
+  const form = useForm<FormValues>({
     resolver: zodResolver(manualDataSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       weekly_meetings_held: initialData?.weekly_meetings_held ?? undefined,
@@ -171,183 +181,171 @@ export function ManualDataForm({
     }
   };
 
+  const isDirty = form.formState.isDirty;
+  const control = form.control;
+
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-6" noValidate>
-      {/* Administración */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">{t("manualData.sectionAdmin")}</CardTitle>
-          <CardDescription>{t("manualData.sectionAdminDescription")}</CardDescription>
-        </CardHeader>
-        <CardContent className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <NumberField
-            label={t("manualData.fieldWeeklyMeetings")}
-            name="weekly_meetings_held"
-            register={register}
-            error={errors.weekly_meetings_held?.message}
-            disabled={disabled || saving}
-          />
-          <NumberField
-            label={t("manualData.fieldLeadershipMeetings")}
-            name="leadership_meetings"
-            register={register}
-            error={errors.leadership_meetings?.message}
-            disabled={disabled || saving}
-          />
-          <NumberField
-            label={t("manualData.fieldParentMeetings")}
-            name="parent_meetings"
-            register={register}
-            error={errors.parent_meetings?.message}
-            disabled={disabled || saving}
-          />
-          <NumberField
-            label={t("manualData.fieldSpecialEvents")}
-            name="special_events"
-            register={register}
-            error={errors.special_events?.message}
-            disabled={disabled || saving}
-          />
-          <div className="col-span-2 sm:col-span-4">
-            <TextareaField
-              label={t("manualData.fieldAdminNotes")}
-              name="administrative_notes"
-              register={register}
-              error={errors.administrative_notes?.message}
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6" noValidate>
+        {/* Administración */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">{t("manualData.sectionAdmin")}</CardTitle>
+            <CardDescription>{t("manualData.sectionAdminDescription")}</CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <NumberField
+              label={t("manualData.fieldWeeklyMeetings")}
+              name="weekly_meetings_held"
+              control={control}
               disabled={disabled || saving}
             />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Actividad misionera */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">{t("manualData.sectionMissionary")}</CardTitle>
-          <CardDescription>{t("manualData.sectionMissionaryDescription")}</CardDescription>
-        </CardHeader>
-        <CardContent className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <NumberField
-            label={t("manualData.fieldBibleStudies")}
-            name="bible_studies_conducted"
-            register={register}
-            error={errors.bible_studies_conducted?.message}
-            disabled={disabled || saving}
-          />
-          <NumberField
-            label={t("manualData.fieldSoulsWon")}
-            name="souls_won"
-            register={register}
-            error={errors.souls_won?.message}
-            disabled={disabled || saving}
-          />
-          <NumberField
-            label={t("manualData.fieldCommunityEvents")}
-            name="community_outreach_events"
-            register={register}
-            error={errors.community_outreach_events?.message}
-            disabled={disabled || saving}
-          />
-          <NumberField
-            label={t("manualData.fieldMissionaryTrips")}
-            name="missionary_trips"
-            register={register}
-            error={errors.missionary_trips?.message}
-            disabled={disabled || saving}
-          />
-          <div className="col-span-2 sm:col-span-4">
-            <TextareaField
-              label={t("manualData.fieldMissionaryNotes")}
-              name="missionary_notes"
-              register={register}
-              error={errors.missionary_notes?.message}
+            <NumberField
+              label={t("manualData.fieldLeadershipMeetings")}
+              name="leadership_meetings"
+              control={control}
               disabled={disabled || saving}
             />
-          </div>
-        </CardContent>
-      </Card>
-
-      {/* Servicio */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">{t("manualData.sectionService")}</CardTitle>
-          <CardDescription>{t("manualData.sectionServiceDescription")}</CardDescription>
-        </CardHeader>
-        <CardContent className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          <NumberField
-            label={t("manualData.fieldServiceHours")}
-            name="service_hours_total"
-            register={register}
-            error={errors.service_hours_total?.message}
-            disabled={disabled || saving}
-          />
-          <NumberField
-            label={t("manualData.fieldServiceProjects")}
-            name="service_projects"
-            register={register}
-            error={errors.service_projects?.message}
-            disabled={disabled || saving}
-          />
-          <NumberField
-            label={t("manualData.fieldVolunteers")}
-            name="volunteers_count"
-            register={register}
-            error={errors.volunteers_count?.message}
-            disabled={disabled || saving}
-          />
-          <div className="col-span-2 sm:col-span-4">
-            <TextareaField
-              label={t("manualData.fieldServiceNotes")}
-              name="service_notes"
-              register={register}
-              error={errors.service_notes?.message}
+            <NumberField
+              label={t("manualData.fieldParentMeetings")}
+              name="parent_meetings"
+              control={control}
               disabled={disabled || saving}
             />
-          </div>
-        </CardContent>
-      </Card>
+            <NumberField
+              label={t("manualData.fieldSpecialEvents")}
+              name="special_events"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <div className="col-span-2 sm:col-span-4">
+              <TextareaField
+                label={t("manualData.fieldAdminNotes")}
+                name="administrative_notes"
+                control={control}
+                disabled={disabled || saving}
+              />
+            </div>
+          </CardContent>
+        </Card>
 
-      {/* Observaciones generales */}
-      <Card>
-        <CardHeader className="pb-3">
-          <CardTitle className="text-base">{t("manualData.sectionGeneral")}</CardTitle>
-          <CardDescription>{t("manualData.sectionGeneralDescription")}</CardDescription>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <TextareaField
-            label={t("manualData.fieldChallenges")}
-            name="challenges"
-            register={register}
-            error={errors.challenges?.message}
-            disabled={disabled || saving}
-          />
-          <TextareaField
-            label={t("manualData.fieldHighlights")}
-            name="highlights"
-            register={register}
-            error={errors.highlights?.message}
-            disabled={disabled || saving}
-          />
-          <TextareaField
-            label={t("manualData.fieldPrayerRequests")}
-            name="prayer_requests"
-            register={register}
-            error={errors.prayer_requests?.message}
-            disabled={disabled || saving}
-          />
-        </CardContent>
-      </Card>
+        {/* Actividad misionera */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">{t("manualData.sectionMissionary")}</CardTitle>
+            <CardDescription>{t("manualData.sectionMissionaryDescription")}</CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <NumberField
+              label={t("manualData.fieldBibleStudies")}
+              name="bible_studies_conducted"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <NumberField
+              label={t("manualData.fieldSoulsWon")}
+              name="souls_won"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <NumberField
+              label={t("manualData.fieldCommunityEvents")}
+              name="community_outreach_events"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <NumberField
+              label={t("manualData.fieldMissionaryTrips")}
+              name="missionary_trips"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <div className="col-span-2 sm:col-span-4">
+              <TextareaField
+                label={t("manualData.fieldMissionaryNotes")}
+                name="missionary_notes"
+                control={control}
+                disabled={disabled || saving}
+              />
+            </div>
+          </CardContent>
+        </Card>
 
-      <div className="flex justify-end">
-        <Button type="submit" disabled={disabled || saving || !isDirty} size="sm">
-          {saving ? (
-            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
-          ) : (
-            <Save className="size-4" aria-hidden="true" />
-          )}
-          {t("manualData.saveButton")}
-        </Button>
-      </div>
-    </form>
+        {/* Servicio */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">{t("manualData.sectionService")}</CardTitle>
+            <CardDescription>{t("manualData.sectionServiceDescription")}</CardDescription>
+          </CardHeader>
+          <CardContent className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <NumberField
+              label={t("manualData.fieldServiceHours")}
+              name="service_hours_total"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <NumberField
+              label={t("manualData.fieldServiceProjects")}
+              name="service_projects"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <NumberField
+              label={t("manualData.fieldVolunteers")}
+              name="volunteers_count"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <div className="col-span-2 sm:col-span-4">
+              <TextareaField
+                label={t("manualData.fieldServiceNotes")}
+                name="service_notes"
+                control={control}
+                disabled={disabled || saving}
+              />
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Observaciones generales */}
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">{t("manualData.sectionGeneral")}</CardTitle>
+            <CardDescription>{t("manualData.sectionGeneralDescription")}</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <TextareaField
+              label={t("manualData.fieldChallenges")}
+              name="challenges"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <TextareaField
+              label={t("manualData.fieldHighlights")}
+              name="highlights"
+              control={control}
+              disabled={disabled || saving}
+            />
+            <TextareaField
+              label={t("manualData.fieldPrayerRequests")}
+              name="prayer_requests"
+              control={control}
+              disabled={disabled || saving}
+            />
+          </CardContent>
+        </Card>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={disabled || saving || !isDirty} size="sm">
+            {saving ? (
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <Save className="size-4" aria-hidden="true" />
+            )}
+            {t("manualData.saveButton")}
+          </Button>
+        </div>
+      </form>
+    </Form>
   );
 }

--- a/src/components/requests/request-review-dialog.test.tsx
+++ b/src/components/requests/request-review-dialog.test.tsx
@@ -1,0 +1,344 @@
+/**
+ * Integration tests for RequestReviewDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Unlike the membership/validation dialogs, this dialog does NOT call
+ * an API module directly — it accepts an `onSubmit` callback as a
+ * prop (parent supplies the API integration). We test the dialog by
+ * passing a `vi.fn()` as `onSubmit` and asserting the dialog
+ * orchestrates form/state correctly. No MSW handler or module mock is
+ * required for the API surface itself.
+ *
+ * Same approve/reject schema split as ValidationReviewDialog:
+ *   - approved → comment optional
+ *   - rejected → comment required (translated message)
+ *
+ * Reject schema is built via `useMemo(buildRejectSchema(tVal), ...)`
+ * using `tVal("comment_required")`. Tests must wrap renders in
+ * `NextIntlClientProvider` with the real `messages/es.json`.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { ReviewAction, ReviewRequestPayload } from "@/lib/api/requests";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { RequestReviewDialog } from "@/components/requests/request-review-dialog";
+import { ApiError } from "@/lib/api/client";
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  action?: ReviewAction;
+  title?: string;
+  description?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onSubmit?: (...args: any[]) => Promise<void>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    action = "approved",
+    title = action === "approved"
+      ? "Aprobar transferencia"
+      : "Rechazar transferencia",
+    description = action === "approved"
+      ? "Se aprobará la solicitud de transferencia de Ana López."
+      : "Se rechazará la solicitud de Ana López. El motivo es obligatorio.",
+    onSubmit = vi.fn<(payload: ReviewRequestPayload) => Promise<void>>().mockResolvedValue(undefined),
+  } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <RequestReviewDialog
+        open={open}
+        action={action}
+        title={title}
+        description={description}
+        onOpenChange={onOpenChange}
+        onSubmit={onSubmit}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess, onSubmit };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RequestReviewDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── APPROVE mode ──────────────────────────────────────────────────────────
+
+  describe("approve mode", () => {
+    it("renders title, description, optional comment label and Approve button", () => {
+      renderDialog({ action: "approved" });
+
+      expect(
+        screen.getByRole("heading", { name: /Aprobar transferencia/i }),
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByText(/Se aprobará la solicitud de transferencia de Ana López/i),
+      ).toBeInTheDocument();
+
+      expect(screen.getByText(/Comentarios \(opcional\)/i)).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("button", { name: /^Cancelar$/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^Aprobar$/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("submits successfully without a comment and forwards correct payload", async () => {
+      const onSubmit = vi
+        .fn<(payload: ReviewRequestPayload) => Promise<void>>()
+        .mockResolvedValue(undefined);
+      const { onOpenChange, onSuccess } = renderDialog({
+        action: "approved",
+        onSubmit,
+      });
+
+      await submitForm();
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledOnce();
+      });
+
+      const [payload] = onSubmit.mock.calls[0] as [ReviewRequestPayload];
+      expect(payload.action).toBe("approved");
+      expect(payload.comment).toBeUndefined();
+
+      expect(mockToastSuccess).toHaveBeenCalledWith("Solicitud aprobada");
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onSuccess).toHaveBeenCalledOnce();
+    });
+
+    it("forwards the comment to onSubmit when provided", async () => {
+      const onSubmit = vi
+        .fn<(payload: ReviewRequestPayload) => Promise<void>>()
+        .mockResolvedValue(undefined);
+      renderDialog({ action: "approved", onSubmit });
+
+      const textarea = screen.getByPlaceholderText(
+        /Añade un comentario opcional/i,
+      );
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: "Aprobado por director" } });
+      });
+
+      await submitForm();
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledOnce();
+      });
+
+      const [payload] = onSubmit.mock.calls[0] as [ReviewRequestPayload];
+      expect(payload.comment).toBe("Aprobado por director");
+    });
+  });
+
+  // ── REJECT mode ───────────────────────────────────────────────────────────
+
+  describe("reject mode", () => {
+    it("renders reject title, required-comment label, and Reject button", () => {
+      renderDialog({ action: "rejected" });
+
+      expect(
+        screen.getByRole("heading", { name: /Rechazar transferencia/i }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByText(/Motivo de rechazo \*/i)).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("button", { name: /^Rechazar$/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows comment_required validation error when submitted empty", async () => {
+      const onSubmit = vi
+        .fn<(payload: ReviewRequestPayload) => Promise<void>>()
+        .mockResolvedValue(undefined);
+      renderDialog({ action: "rejected", onSubmit });
+
+      await submitForm();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(messages.requests.validation.comment_required),
+        ).toBeInTheDocument();
+      });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it("submits successfully with a non-empty comment", async () => {
+      const onSubmit = vi
+        .fn<(payload: ReviewRequestPayload) => Promise<void>>()
+        .mockResolvedValue(undefined);
+      const { onSuccess } = renderDialog({ action: "rejected", onSubmit });
+
+      const textarea = screen.getByPlaceholderText(
+        /Describe el motivo del rechazo/i,
+      );
+      await act(async () => {
+        fireEvent.change(textarea, {
+          target: { value: "Sección destino llena" },
+        });
+      });
+
+      await submitForm();
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledOnce();
+      });
+
+      const [payload] = onSubmit.mock.calls[0] as [ReviewRequestPayload];
+      expect(payload.action).toBe("rejected");
+      expect(payload.comment).toBe("Sección destino llena");
+
+      expect(mockToastSuccess).toHaveBeenCalledWith("Solicitud rechazada");
+      expect(onSuccess).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── Cancel ────────────────────────────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call onSubmit when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi
+      .fn<(payload: ReviewRequestPayload) => Promise<void>>()
+      .mockResolvedValue(undefined);
+    const { onOpenChange } = renderDialog({ action: "approved", onSubmit });
+
+    await user.click(screen.getByRole("button", { name: /^Cancelar$/ }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  // ── Pending state ─────────────────────────────────────────────────────────
+
+  it("disables submit button while submission is in flight", async () => {
+    let resolveSubmit!: () => void;
+    const onSubmit = vi
+      .fn<(payload: ReviewRequestPayload) => Promise<void>>()
+      .mockReturnValue(
+        new Promise<void>((res) => {
+          resolveSubmit = res;
+        }),
+      );
+
+    renderDialog({ action: "approved", onSubmit });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^Aprobar$/ }),
+      ).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveSubmit();
+    });
+  });
+
+  // ── API error paths ───────────────────────────────────────────────────────
+
+  it("shows ApiError message via toast.error when onSubmit throws ApiError", async () => {
+    const onSubmit = vi
+      .fn<(payload: ReviewRequestPayload) => Promise<void>>()
+      .mockRejectedValue(new ApiError("Already processed", 409, null));
+
+    renderDialog({ action: "approved", onSubmit });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Already processed");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("shows fallback translated error and keeps dialog open on non-ApiError", async () => {
+    const onSubmit = vi
+      .fn<(payload: ReviewRequestPayload) => Promise<void>>()
+      .mockRejectedValue(new Error("boom"));
+
+    const { onOpenChange } = renderDialog({ action: "approved", onSubmit });
+    onOpenChange.mockClear();
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        messages.requests.errors.unexpected,
+      );
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/system-config/system-config-edit-dialog.tsx
+++ b/src/components/system-config/system-config-edit-dialog.tsx
@@ -15,8 +15,15 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import { updateSystemConfig, type SystemConfig } from "@/lib/api/system-config";
 import { ApiError } from "@/lib/api/client";
@@ -109,44 +116,50 @@ export function SystemConfigEditDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="config_value">Valor *</Label>
-            <Input
-              id="config_value"
-              {...form.register("config_value")}
-              disabled={isPending}
-              aria-describedby={
-                form.formState.errors.config_value ? "value-error" : undefined
-              }
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+            <FormField
+              control={form.control}
+              name="config_value"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Valor{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      disabled={isPending}
+                      aria-required="true"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                  {config?.value_type && (
+                    <p className="text-xs text-muted-foreground">
+                      Tipo esperado: <span className="font-medium">{config.value_type}</span>
+                    </p>
+                  )}
+                </FormItem>
+              )}
             />
-            {form.formState.errors.config_value && (
-              <p id="value-error" className="text-xs text-destructive">
-                {form.formState.errors.config_value.message}
-              </p>
-            )}
-            {config?.value_type && (
-              <p className="text-xs text-muted-foreground">
-                Tipo esperado: <span className="font-medium">{config.value_type}</span>
-              </p>
-            )}
-          </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleClose(false)}
-              disabled={isPending}
-            >
-              Cancelar
-            </Button>
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Loader2 className="size-4 animate-spin" />}
-              Guardar
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isPending}
+              >
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="size-4 animate-spin" />}
+                Guardar
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/validation/validation-review-dialog.test.tsx
+++ b/src/components/validation/validation-review-dialog.test.tsx
@@ -1,0 +1,354 @@
+/**
+ * Integration tests for ValidationReviewDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form with a Zod schema that switches
+ * between APPROVE (comment optional) and REJECT (comment required)
+ * based on the `action` prop. We exercise both branches.
+ *
+ * API: `reviewValidation(entityType, entityId, payload)` from
+ * `@/lib/api/validation`. We mock the module so MSW is not needed
+ * (consistent with InsuranceFormDialog/FolderFormDialog patterns).
+ *
+ * The reject schema is built inside a `useMemo` from the localized
+ * translator `tVal("comment_required")`, so renders MUST wrap in
+ * `NextIntlClientProvider` with the real `messages/es.json`.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { ValidationAction, ValidationEntityType } from "@/lib/api/validation";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockReview = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/validation", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/validation")>();
+  return {
+    ...original,
+    reviewValidation: (
+      entityType: ValidationEntityType,
+      entityId: number | string,
+      payload: unknown,
+    ) => mockReview(entityType, entityId, payload),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { ValidationReviewDialog } from "@/components/validation/validation-review-dialog";
+import { ApiError } from "@/lib/api/client";
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  entityType?: ValidationEntityType;
+  entityId?: number | string;
+  memberName?: string;
+  entityName?: string;
+  action?: ValidationAction;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    entityType = "class",
+    entityId = 100,
+    memberName = "Ana López",
+    entityName = "Amigo de la Naturaleza",
+    action = "APPROVED",
+  } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <ValidationReviewDialog
+        open={open}
+        entityType={entityType}
+        entityId={entityId}
+        memberName={memberName}
+        entityName={entityName}
+        action={action}
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ValidationReviewDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReview.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── APPROVE mode ──────────────────────────────────────────────────────────
+
+  describe("approve mode", () => {
+    it("renders approve title, optional comment label, comment textarea, and Approve button", () => {
+      renderDialog({ action: "APPROVED" });
+
+      expect(
+        screen.getByRole("heading", { name: /Aprobar validación/i }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByText(/Comentarios \(opcional\)/i)).toBeInTheDocument();
+
+      // Description with interpolated entity + member
+      expect(
+        screen.getByText(/Amigo de la Naturaleza/),
+      ).toBeInTheDocument();
+      expect(screen.getByText(/Ana López/)).toBeInTheDocument();
+
+      // Buttons
+      expect(
+        screen.getByRole("button", { name: /^Cancelar$/ }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^Aprobar$/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("submits successfully without a comment (comment is optional in approve)", async () => {
+      const { onOpenChange, onSuccess } = renderDialog({ action: "APPROVED" });
+
+      await submitForm();
+
+      await waitFor(() => {
+        expect(mockReview).toHaveBeenCalledOnce();
+      });
+
+      const [entityType, entityId, payload] = mockReview.mock.calls[0] as [
+        ValidationEntityType,
+        number,
+        { action: ValidationAction; comment?: string },
+      ];
+      expect(entityType).toBe("class");
+      expect(entityId).toBe(100);
+      expect(payload.action).toBe("APPROVED");
+      expect(payload.comment).toBeUndefined();
+
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Amigo de la Naturaleza aprobado correctamente para Ana López",
+      );
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onSuccess).toHaveBeenCalledOnce();
+    });
+
+    it("forwards the comment to the API when provided", async () => {
+      renderDialog({ action: "APPROVED" });
+
+      const textarea = screen.getByPlaceholderText(
+        /Añade un comentario opcional/i,
+      );
+      await act(async () => {
+        fireEvent.change(textarea, { target: { value: "Buen trabajo" } });
+      });
+
+      await submitForm();
+
+      await waitFor(() => {
+        expect(mockReview).toHaveBeenCalledOnce();
+      });
+
+      const [, , payload] = mockReview.mock.calls[0] as [
+        unknown,
+        unknown,
+        { comment?: string },
+      ];
+      expect(payload.comment).toBe("Buen trabajo");
+    });
+  });
+
+  // ── REJECT mode ───────────────────────────────────────────────────────────
+
+  describe("reject mode", () => {
+    it("renders reject title, required-comment label, and Reject button", () => {
+      renderDialog({ action: "REJECTED" });
+
+      expect(
+        screen.getByRole("heading", { name: /Rechazar validación/i }),
+      ).toBeInTheDocument();
+
+      expect(screen.getByText(/Motivo de rechazo \*/i)).toBeInTheDocument();
+
+      expect(
+        screen.getByRole("button", { name: /^Rechazar$/ }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows comment_required validation error when submitted empty", async () => {
+      renderDialog({ action: "REJECTED" });
+
+      await submitForm();
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(messages.validation_admin.validation.comment_required),
+        ).toBeInTheDocument();
+      });
+
+      expect(mockReview).not.toHaveBeenCalled();
+    });
+
+    it("submits successfully with a non-empty comment", async () => {
+      const { onSuccess } = renderDialog({ action: "REJECTED" });
+
+      const textarea = screen.getByPlaceholderText(
+        /Describe el motivo del rechazo/i,
+      );
+      await act(async () => {
+        fireEvent.change(textarea, {
+          target: { value: "Falta evidencia fotográfica" },
+        });
+      });
+
+      await submitForm();
+
+      await waitFor(() => {
+        expect(mockReview).toHaveBeenCalledOnce();
+      });
+
+      const [, , payload] = mockReview.mock.calls[0] as [
+        unknown,
+        unknown,
+        { action: ValidationAction; comment?: string },
+      ];
+      expect(payload.action).toBe("REJECTED");
+      expect(payload.comment).toBe("Falta evidencia fotográfica");
+
+      expect(mockToastSuccess).toHaveBeenCalledWith(
+        "Amigo de la Naturaleza rechazado",
+      );
+      expect(onSuccess).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── Cancel ────────────────────────────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call API when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog({ action: "APPROVED" });
+
+    await user.click(screen.getByRole("button", { name: /^Cancelar$/ }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockReview).not.toHaveBeenCalled();
+  });
+
+  // ── Pending state ─────────────────────────────────────────────────────────
+
+  it("disables submit button while submission is in flight", async () => {
+    let resolveReview!: () => void;
+    mockReview.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveReview = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog({ action: "APPROVED" });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /^Aprobar$/ }),
+      ).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveReview();
+    });
+  });
+
+  // ── API error paths ───────────────────────────────────────────────────────
+
+  it("shows ApiError message via toast.error when API throws ApiError", async () => {
+    mockReview.mockRejectedValue(
+      new ApiError("Validation already reviewed", 409, null),
+    );
+
+    renderDialog({ action: "APPROVED" });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Validation already reviewed");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("shows fallback translated error and keeps dialog open on non-ApiError", async () => {
+    mockReview.mockRejectedValue(new Error("network down"));
+
+    const { onOpenChange } = renderDialog({ action: "APPROVED" });
+    onOpenChange.mockClear();
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        messages.validation_admin.errors.unexpected,
+      );
+    });
+
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary

Consolidated batch from 3 parallel sub-agents (single-PR pattern, validated in #119).

### A. Perf baseline (docs only)
- Added `PERF-BASELINE.md` (244 lines) with chunk inventory + per-route initial JS sizes captured via Next 16 Turbopack analyzer.
- Top finding: **recharts ~98KB gzip** statically imported on `/dashboard` (`RoleDistributionChart`) and `/dashboard/sla` (`SlaPipelineChart`, `SlaThroughputChart`) — clear next perf-round target.
- Confirms PR #108/#111/#115/#116 deferred components are isolated in per-route chunks (zero leakage into rootMain).
- Notes `@next/bundle-analyzer` incompatibility with Turbopack; recommends rewriting `pnpm analyze` to use `next experimental-analyze`.

### B. MSW dialog tests r2 (+28 tests)
- `membership-reject-dialog.test.tsx` (8 tests)
- `validation-review-dialog.test.tsx` (10 tests)
- `request-review-dialog.test.tsx` (10 tests)
- All use `vi.mock` module-boundary pattern (no new MSW handlers).
- Coverage: render, validation, happy path, ApiError, fallback toast, cancel.
- **Total tests: 316 → 344 (24 files).**

### C. shadcn Form primitive migration r2 (4 forms)
- `system-config-edit-dialog.tsx`
- `weights-form.tsx`
- `manual-data-form.tsx`
- `section-form-dialog.tsx`
- `aria-invalid` + `aria-describedby` auto-wired via `FormControl`. Manual error rendering replaced by `FormMessage`.
- 2 candidates skipped (`achievement-form`, `category-form-dialog`) — they use `useActionState`/Server Actions, structurally incompatible with RHF-backed `Form` primitive.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test --run` — 344/344 pass (24 files)
- [x] `pnpm lint` — 10 errors / 42 warnings, all pre-existing on `development`; **zero regressions** in the 8 files touched
- [ ] Vercel preview build green
- [ ] CI Vitest workflow green
- [ ] CI Typecheck workflow green