### PR TITLE
chore: perf r4 charts + analyze fix + Form r3 + MSW r3 (+28 tests)

### DIFF
--- a/PERF-BASELINE.md
+++ b/PERF-BASELINE.md
@@ -12,36 +12,21 @@ deferred-loading wave (PRs #108, #111, #115, #116) and the analyzer setup
 
 ---
 
-## 1. Tooling Status — `pnpm analyze` blocker (mitigated)
+## 1. Tooling Status — `pnpm analyze` (fixed in perf/admin-r4-charts-analyze)
 
-`pnpm analyze` (added in #112) wraps `next build` with the `ANALYZE=true`
-env var consumed by `@next/bundle-analyzer`.
+`pnpm analyze` now runs `next experimental-analyze -o` — the Turbopack-native
+analyzer built into Next 16. Output lands under `.next/diagnostics/analyze/`
+(`analyze.data` per route, `modules.data`, `routes.json`). Launch the
+interactive treemap UI with:
 
-> **Blocker:** `@next/bundle-analyzer@16.2.6` is **not compatible with the
-> Turbopack production builder** (Next 16 default). The build succeeds, but
-> the wrapper prints:
->
-> ```
-> The Next Bundle Analyzer is not compatible with Turbopack builds, no report will be generated.
-> Consider trying the new Turbopack analyzer via `next experimental-analyze`.
-> To run this analysis pass the `--webpack` flag to `next build`
-> ```
->
-> No `.next/analyze/*.html` files are produced. Two workarounds exist:
->
-> 1. **`next experimental-analyze -o`** (Next 16 native, Turbopack-compatible).
->    Produces a binary treemap dataset under `.next/diagnostics/analyze/`
->    (`analyze.data` per route, `modules.data`, `routes.json`). Designed for
->    interactive use via `next experimental-analyze` (web UI on :4000). The
->    `analyze.data` files are TTComp/zstd-compressed and parsed in-browser, so
->    they aren't human-greppable from the CLI.
-> 2. **`next build --webpack`** to fall back to the legacy Webpack builder so
->    `@next/bundle-analyzer` works as documented. Slower builds; not used in
->    CI today.
->
-> **Recommendation:** rewrite the `analyze` script as
-> `"analyze": "next experimental-analyze"` and drop `@next/bundle-analyzer`,
-> OR keep both: add `analyze:webpack` for the legacy HTML reports.
+```bash
+pnpm analyze          # generates .next/diagnostics/analyze/
+next experimental-analyze   # serves the UI at http://localhost:4000
+```
+
+`@next/bundle-analyzer` has been removed from `package.json` (devDependencies)
+and from `next.config.ts` — it is not compatible with Turbopack and produced
+no output.
 
 The numbers below were collected by inspecting the **real Turbopack output**
 (`.next/static/chunks/*.js` with `gzip -c | wc -c` for transfer sizes) and
@@ -140,13 +125,21 @@ lives in its own per-route chunk (e.g., `0r13195.l2cvv.js` for
 `RankingsClientPage` on `/dashboard/annual-folders/rankings`). The dynamic-
 import infrastructure is working as designed.
 
+**Perf round 4 addition (perf/admin-r4-charts-analyze):** `RoleDistributionChart`,
+`SlaPipelineChart`, and `SlaThroughputChart` were converted to dynamic imports
+(`ssr: false`) with Skeleton placeholders. Each chart file was split into a
+thin wrapper (holds `next/dynamic`) and an `*-inner.tsx` (holds the recharts
+import). The recharts chunk (~98 KB gzip) is no longer pulled at parse time on
+`/dashboard` or `/dashboard/sla`. Expected first-paint saving: ~98 KB gzip on
+both routes.
+
 ---
 
 ## 5. Recommendations — top 5 candidates for the next perf round
 
 Ranked by estimated gzip savings on first paint of the affected routes.
 
-### 1. Lazy-load `recharts` charts on `/dashboard` and `/dashboard/sla` (~98 KB gzip per route)
+### 1. ~~Lazy-load `recharts` charts on `/dashboard` and `/dashboard/sla` (~98 KB gzip per route)~~ DONE (perf/admin-r4-charts-analyze)
 
 **Finding:** `0tvhttx4gjnu3.js` is **339 KB raw / 97.7 KB gzip** and contains
 the recharts library. It's pulled in by exactly two routes:
@@ -159,10 +152,9 @@ the recharts library. It's pulled in by exactly two routes:
 The home dashboard is the **first page every user lands on after login** —
 charts render below-the-fold and are pure visualization. Same for SLA.
 
-**Action:** wrap `RoleDistributionChart`, `SlaPipelineChart`, and
-`SlaThroughputChart` with `dynamic(() => import(...), { ssr: false })` and a
-skeleton fallback. Expected savings: **~98 KB gzip on `/dashboard` and
-`/dashboard/sla` first paint.**
+**Resolution:** All three charts converted to `next/dynamic` (`ssr: false`) with
+Skeleton fallbacks. Each split into wrapper + `*-inner.tsx`. Expected savings:
+**~98 KB gzip on `/dashboard` and `/dashboard/sla` first paint.**
 
 ### 2. Code-split the shared `zod` chunk (~73 KB gzip on 23 routes)
 
@@ -237,8 +229,8 @@ or brotli (smaller). These numbers are upper-bound for HTTP transfer.
 
 ## 7. Next actions (handoff)
 
-- Replace `pnpm analyze` script with `next experimental-analyze` (or add
-  parallel `analyze:webpack`) so the script does what its name promises.
-- File the 5 follow-up items from §5 as separate perf PRs.
+- ~~Replace `pnpm analyze` script with `next experimental-analyze`~~ DONE.
+- ~~Recharts dynamic imports (#1 in §5)~~ DONE.
+- File remaining follow-up items from §5 (#2–#5) as separate perf PRs.
 - After the next perf wave, regenerate this baseline and commit a diff so we
   can see savings by route.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,6 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 import createNextIntlPlugin from "next-intl/plugin";
-import bundleAnalyzer from "@next/bundle-analyzer";
-
-const withBundleAnalyzer = bundleAnalyzer({
-  enabled: process.env.ANALYZE === "true",
-  openAnalyzer: false,
-});
 
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
@@ -138,7 +132,7 @@ const nextConfig: NextConfig = {
   },
 };
 
-export default withBundleAnalyzer(withSentryConfig(withNextIntl(nextConfig), {
+export default withSentryConfig(withNextIntl(nextConfig), {
   // For all available options, see:
   // https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
@@ -174,4 +168,4 @@ export default withBundleAnalyzer(withSentryConfig(withNextIntl(nextConfig), {
       removeDebugLogging: true,
     },
   },
-}));
+});

--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e:smoke": "node scripts/e2e-smoke.mjs",
-    "analyze": "ANALYZE=true pnpm build",
-    "analyze:server": "ANALYZE=true BUNDLE_ANALYZE=server pnpm build",
-    "analyze:browser": "ANALYZE=true BUNDLE_ANALYZE=browser pnpm build"
+    "analyze": "next experimental-analyze -o"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -45,7 +43,6 @@
     }
   },
   "devDependencies": {
-    "@next/bundle-analyzer": "^16.2.6",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
-      '@next/bundle-analyzer':
-        specifier: ^16.2.6
-        version: 16.2.6
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.1.18
@@ -259,10 +256,6 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
-
-  '@discoveryjs/json-ext@0.5.7':
-    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
-    engines: {node: '>=10.0.0'}
 
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
@@ -734,9 +727,6 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/bundle-analyzer@16.2.6':
-    resolution: {integrity: sha512-amPkVtHCTJAdBwyhhl5+qztHk24O4JlASgrWqh15AmnYi74apfZR46NGC0u4pM6BMAU1mYld4WdzD3cRBP3dOA==}
-
   '@next/env@16.2.4':
     resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
 
@@ -1108,9 +1098,6 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
-
-  '@polka/url@1.0.0-next.29':
-    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
   '@prisma/instrumentation@7.6.0':
     resolution: {integrity: sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==}
@@ -2722,10 +2709,6 @@ packages:
     peerDependencies:
       acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
 
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -2963,10 +2946,6 @@ packages:
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
-  commander@7.2.0:
-    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
-    engines: {node: '>= 10'}
-
   commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
 
@@ -3063,9 +3042,6 @@ packages:
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
-  debounce@1.2.1:
-    resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
-
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -3136,9 +3112,6 @@ packages:
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
-
-  duplexer@0.1.2:
-    resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
 
   electron-to-chromium@1.5.283:
     resolution: {integrity: sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==}
@@ -3516,10 +3489,6 @@ packages:
     resolution: {integrity: sha512-BBvQ/406p+4CZbTpCbVPSxfzrZrbnuWSP1ELYgyS6B+hNeKzgrdB4JczCa5VZUBQrDa9hUngm0KnexY6pJRN5Q==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  gzip-size@6.0.0:
-    resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
-    engines: {node: '>=10'}
-
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -3559,9 +3528,6 @@ packages:
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
     engines: {node: '>=18'}
-
-  html-escaper@2.0.2:
-    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
@@ -3699,10 +3665,6 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-
-  is-plain-object@5.0.0:
-    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
-    engines: {node: '>=0.10.0'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -3993,10 +3955,6 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
-  mrmime@2.0.1:
-    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
-    engines: {node: '>=10'}
-
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -4123,10 +4081,6 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
-
-  opener@1.5.2:
-    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
-    hasBin: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4515,10 +4469,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  sirv@2.0.4:
-    resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
-    engines: {node: '>= 10'}
-
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
@@ -4711,10 +4661,6 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
-
-  totalist@3.0.1:
-    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
-    engines: {node: '>=6'}
 
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
@@ -4929,11 +4875,6 @@ packages:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
 
-  webpack-bundle-analyzer@4.10.1:
-    resolution: {integrity: sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==}
-    engines: {node: '>= 10.13.0'}
-    hasBin: true
-
   webpack-sources@3.3.4:
     resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
     engines: {node: '>=10.13.0'}
@@ -4997,18 +4938,6 @@ packages:
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
-
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
-    engines: {node: '>=8.3.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -5210,8 +5139,6 @@ snapshots:
   '@csstools/css-tokenizer@3.0.4': {}
 
   '@date-fns/tz@1.4.1': {}
-
-  '@discoveryjs/json-ext@0.5.7': {}
 
   '@emnapi/core@1.8.1':
     dependencies:
@@ -5571,13 +5498,6 @@ snapshots:
       '@emnapi/runtime': 1.8.1
       '@tybys/wasm-util': 0.10.1
     optional: true
-
-  '@next/bundle-analyzer@16.2.6':
-    dependencies:
-      webpack-bundle-analyzer: 4.10.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@next/env@16.2.4': {}
 
@@ -5948,8 +5868,6 @@ snapshots:
       '@parcel/watcher-win32-arm64': 2.5.6
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
-
-  '@polka/url@1.0.0-next.29': {}
 
   '@prisma/instrumentation@7.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7604,10 +7522,6 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-walk@8.3.5:
-    dependencies:
-      acorn: 8.16.0
-
   acorn@8.15.0: {}
 
   acorn@8.16.0: {}
@@ -7869,8 +7783,6 @@ snapshots:
 
   commander@2.20.3: {}
 
-  commander@7.2.0: {}
-
   commondir@1.0.1: {}
 
   concat-map@0.0.1: {}
@@ -7961,8 +7873,6 @@ snapshots:
 
   date-fns@4.1.0: {}
 
-  debounce@1.2.1: {}
-
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -8014,8 +7924,6 @@ snapshots:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-
-  duplexer@0.1.2: {}
 
   electron-to-chromium@1.5.283: {}
 
@@ -8550,10 +8458,6 @@ snapshots:
 
   graphql@16.14.0: {}
 
-  gzip-size@6.0.0:
-    dependencies:
-      duplexer: 0.1.2
-
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -8590,8 +8494,6 @@ snapshots:
   html-encoding-sniffer@4.0.0:
     dependencies:
       whatwg-encoding: 3.1.1
-
-  html-escaper@2.0.2: {}
 
   http-proxy-agent@7.0.2:
     dependencies:
@@ -8742,8 +8644,6 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
-
-  is-plain-object@5.0.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -9004,8 +8904,6 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
-  mrmime@2.0.1: {}
-
   ms@2.1.3: {}
 
   msw@2.14.5(@types/node@20.19.30)(typescript@5.9.3):
@@ -9145,8 +9043,6 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
-
-  opener@1.5.2: {}
 
   optionator@0.9.4:
     dependencies:
@@ -9647,12 +9543,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  sirv@2.0.4:
-    dependencies:
-      '@polka/url': 1.0.0-next.29
-      mrmime: 2.0.1
-      totalist: 3.0.1
-
   sonner@2.0.7(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -9832,8 +9722,6 @@ snapshots:
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
-
-  totalist@3.0.1: {}
 
   tough-cookie@5.1.2:
     dependencies:
@@ -10100,25 +9988,6 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-bundle-analyzer@4.10.1:
-    dependencies:
-      '@discoveryjs/json-ext': 0.5.7
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-      commander: 7.2.0
-      debounce: 1.2.1
-      escape-string-regexp: 4.0.0
-      gzip-size: 6.0.0
-      html-escaper: 2.0.2
-      is-plain-object: 5.0.0
-      opener: 1.5.2
-      picocolors: 1.1.1
-      sirv: 2.0.4
-      ws: 7.5.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   webpack-sources@3.3.4: {}
 
   webpack@5.106.2:
@@ -10225,8 +10094,6 @@ snapshots:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-
-  ws@7.5.10: {}
 
   ws@8.20.0: {}
 

--- a/src/components/camporees/payment-dialog.test.tsx
+++ b/src/components/camporees/payment-dialog.test.tsx
@@ -1,0 +1,409 @@
+/**
+ * Integration tests for PaymentDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form + Zod (schema built via buildSchema).
+ * It calls `createPayment` or `updatePayment` from `@/lib/api/camporees`
+ * (HTTP). We mock the module entirely — MSW remains active but is not
+ * exercised here (consistent with MembershipRejectDialog / InsuranceFormDialog
+ * patterns).
+ *
+ * The dialog has two modes:
+ *   - Create: member_id (required via Select), amount (required), payment_type
+ *   - Edit:   member_id is read-only, amount (required), payment_type
+ *
+ * Renders are wrapped in `NextIntlClientProvider` with the real `messages/es.json`.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { CamporeePayment, CamporeeMember } from "@/lib/api/camporees";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreatePayment = vi.fn<(...args: any[]) => Promise<unknown>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdatePayment = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/camporees", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/camporees")>();
+  return {
+    ...original,
+    createPayment: (...args: unknown[]) => mockCreatePayment(...args),
+    updatePayment: (...args: unknown[]) => mockUpdatePayment(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { PaymentDialog } from "@/components/camporees/payment-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_MEMBERS: CamporeeMember[] = [
+  { user_id: "user-001", name: "Ana López" },
+  { user_id: "user-002", name: "Carlos Díaz" },
+];
+
+const STUB_PAYMENT: CamporeePayment = {
+  payment_id: 99,
+  camporee_id: 5,
+  member_id: "user-001",
+  member_name: "Ana López",
+  amount: 150,
+  payment_type: "inscription",
+  reference: "REF-001",
+  notes: "Pago completo",
+  paid_at: "2026-03-15T00:00:00.000Z",
+};
+
+const t = messages.camporees;
+
+// ---------------------------------------------------------------------------
+// Render helpers
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  camporeeId?: number;
+  members?: CamporeeMember[];
+  payment?: CamporeePayment | null;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    camporeeId = 5,
+    members = STUB_MEMBERS,
+    payment = null,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <PaymentDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        camporeeId={camporeeId}
+        members={members}
+        payment={payment}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PaymentDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreatePayment.mockResolvedValue({ ok: true });
+    mockUpdatePayment.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Create mode — rendering ────────────────────────────────────────────
+
+  it("renders create mode title, member selector, amount input and register button", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: t.paymentDialog.titleCreate }),
+    ).toBeInTheDocument();
+
+    // Member select trigger is present — Radix SelectTrigger renders as combobox.
+    // shadcn FormControl forwards id to the trigger but aria-name may not propagate
+    // reliably in jsdom; query by role without name constraint, relying on position.
+    expect(screen.getAllByRole("combobox").length).toBeGreaterThanOrEqual(1);
+
+    // Amount input — RHF spreads name attr so query by name attribute
+    expect(document.querySelector('input[name="amount"]')).toBeInTheDocument();
+
+    // Submit button shows "Registrar pago"
+    expect(
+      screen.getByRole("button", { name: t.paymentDialog.registerPayment }),
+    ).toBeInTheDocument();
+
+    // Cancel button
+    expect(
+      screen.getByRole("button", { name: t.paymentDialog.cancel }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Edit mode — rendering ──────────────────────────────────────────────
+
+  it("renders edit mode title, member as read-only text, and save-changes button", () => {
+    renderDialog({ payment: STUB_PAYMENT });
+
+    expect(
+      screen.getByRole("heading", { name: t.paymentDialog.titleEdit }),
+    ).toBeInTheDocument();
+
+    // Member displayed as read-only text
+    expect(screen.getByText("Ana López")).toBeInTheDocument();
+
+    // No select trigger for member in edit mode
+    expect(
+      screen.queryByRole("combobox", { name: new RegExp(t.paymentDialog.labelMember, "i") }),
+    ).not.toBeInTheDocument();
+
+    // Submit button shows "Guardar cambios"
+    expect(
+      screen.getByRole("button", { name: t.paymentDialog.saveChanges }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 3. Validation — amount required ──────────────────────────────────────
+
+  it("shows amount validation error when amount is empty on submit", async () => {
+    renderDialog();
+
+    // Set amount to 0 so z.coerce.number().positive() fires the custom message
+    // (undefined → NaN produces a different error; 0 produces the expected positive error)
+    const amountInput = document.querySelector('input[name="amount"]') as HTMLInputElement | null;
+    if (amountInput) {
+      await act(async () => {
+        fireEvent.change(amountInput, { target: { value: "0" } });
+      });
+    }
+
+    await submitForm();
+
+    await waitFor(() => {
+      // FormMessage renders the Zod error inside a <p>; use regex to be text-break tolerant
+      expect(
+        screen.getByText(new RegExp(messages.camporees.validation.amount_positive, "i")),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockCreatePayment).not.toHaveBeenCalled();
+  });
+
+  // ── 4. Happy path — create payment ───────────────────────────────────────
+
+  it("calls createPayment with correct args and shows success toast", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    // Radix renders hidden native <select> elements for a11y.
+    // In create mode: first select = member_id, second = payment_type.
+    const allNativeSelects = document.querySelectorAll("select");
+    const memberNative = allNativeSelects[0] as HTMLSelectElement | undefined;
+    if (memberNative) {
+      await act(async () => {
+        fireEvent.change(memberNative, { target: { value: "user-001" } });
+      });
+    }
+
+    // RHF spreads name="amount" onto the input — use name attribute to find it
+    const amountInput = document.querySelector('input[name="amount"]') as HTMLInputElement | null;
+    if (amountInput) {
+      await act(async () => {
+        fireEvent.change(amountInput, { target: { value: "200" } });
+      });
+    }
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreatePayment).toHaveBeenCalledOnce();
+    });
+
+    const [camporeeId, memberId, payload] = mockCreatePayment.mock.calls[0] as [
+      number,
+      string,
+      { amount: number; payment_type: string },
+    ];
+    expect(camporeeId).toBe(5);
+    expect(memberId).toBe("user-001");
+    expect(payload.amount).toBe(200);
+    expect(payload.payment_type).toBe("inscription");
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.payment_created);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 5. Happy path — edit payment ─────────────────────────────────────────
+
+  it("calls updatePayment (not createPayment) in edit mode and shows update toast", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ payment: STUB_PAYMENT });
+
+    // Amount is pre-filled (150); change it via name attribute (RHF spreads name onto input)
+    const amountInput = document.querySelector('input[name="amount"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (amountInput) fireEvent.change(amountInput, { target: { value: "300" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockUpdatePayment).toHaveBeenCalledOnce();
+    });
+
+    expect(mockCreatePayment).not.toHaveBeenCalled();
+
+    const [paymentId, payload] = mockUpdatePayment.mock.calls[0] as [
+      number,
+      { amount: number },
+    ];
+    expect(paymentId).toBe(99);
+    expect(payload.amount).toBe(300);
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.payment_updated);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 6. Cancel closes dialog without API call ──────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call API when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: t.paymentDialog.cancel }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreatePayment).not.toHaveBeenCalled();
+    expect(mockUpdatePayment).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Submit button disabled while in flight ─────────────────────────────
+
+  it("disables submit button while submission is in flight (edit mode)", async () => {
+    let resolveUpdate!: () => void;
+    mockUpdatePayment.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveUpdate = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog({ payment: STUB_PAYMENT });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: new RegExp(t.paymentDialog.saving, "i") }),
+      ).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveUpdate();
+    });
+  });
+
+  // ── 8. API error path — shows error toast ────────────────────────────────
+
+  it("shows error toast with server message when createPayment throws", async () => {
+    mockCreatePayment.mockRejectedValue(new Error("Insufficient funds"));
+
+    renderDialog();
+
+    // member_id = first native select, amount = #amount input
+    const memberNative = document.querySelector("select") as HTMLSelectElement | null;
+    if (memberNative) {
+      await act(async () => {
+        fireEvent.change(memberNative, { target: { value: "user-001" } });
+      });
+    }
+
+    const amountInput = document.querySelector('input[name="amount"]') as HTMLInputElement | null;
+    if (amountInput) {
+      await act(async () => {
+        fireEvent.change(amountInput, { target: { value: "50" } });
+      });
+    }
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Insufficient funds");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error path — fallback message ────────────────────────────────
+
+  it("shows fallback translated error when createPayment throws non-Error", async () => {
+    mockCreatePayment.mockRejectedValue("unexpected string error");
+
+    renderDialog();
+
+    const memberNative = document.querySelector("select") as HTMLSelectElement | null;
+    if (memberNative) {
+      await act(async () => {
+        fireEvent.change(memberNative, { target: { value: "user-001" } });
+      });
+    }
+
+    const amountInput = document.querySelector('input[name="amount"]') as HTMLInputElement | null;
+    if (amountInput) {
+      await act(async () => {
+        fireEvent.change(amountInput, { target: { value: "50" } });
+      });
+    }
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.save_payment);
+    });
+  });
+});

--- a/src/components/camporees/payment-dialog.tsx
+++ b/src/components/camporees/payment-dialog.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
@@ -25,6 +24,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import { createPayment, updatePayment } from "@/lib/api/camporees";
 import type { CamporeePayment, CamporeeMember, PaymentType } from "@/lib/api/camporees";
@@ -93,14 +100,7 @@ export function PaymentDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       member_id: "",
@@ -112,20 +112,17 @@ export function PaymentDialog({
     },
   });
 
-  const paymentType = watch("payment_type");
-  const memberId = watch("member_id");
-
   // Pre-fill form when editing
   useEffect(() => {
     if (open && payment) {
-      setValue("member_id", payment.member_id);
-      setValue("amount", payment.amount);
-      setValue("payment_type", payment.payment_type);
-      setValue("reference", payment.reference ?? "");
-      setValue("notes", payment.notes ?? "");
-      setValue("paid_at", toDateInputValue(payment.paid_at));
+      form.setValue("member_id", payment.member_id);
+      form.setValue("amount", payment.amount);
+      form.setValue("payment_type", payment.payment_type);
+      form.setValue("reference", payment.reference ?? "");
+      form.setValue("notes", payment.notes ?? "");
+      form.setValue("paid_at", toDateInputValue(payment.paid_at));
     } else if (open && !payment) {
-      reset({
+      form.reset({
         member_id: "",
         amount: undefined,
         payment_type: "inscription",
@@ -134,11 +131,11 @@ export function PaymentDialog({
         paid_at: "",
       });
     }
-  }, [open, payment, reset, setValue]);
+  }, [open, payment, form]);
 
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {
-      reset();
+      form.reset();
     }
     onOpenChange(nextOpen);
   }
@@ -187,138 +184,180 @@ export function PaymentDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
-          {/* Member */}
-          <div className="space-y-1.5">
-            <Label htmlFor="member_id">
-              {t("paymentDialog.labelMember")} <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            {isEditing ? (
-              <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm">
-                {payment?.member_name ?? payment?.member_id}
-              </p>
-            ) : (
-              <Select
-                value={memberId}
-                onValueChange={(val) => setValue("member_id", val)}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} noValidate className="space-y-4">
+            {/* Member */}
+            <FormField
+              control={form.control}
+              name="member_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("paymentDialog.labelMember")} <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    {isEditing ? (
+                      <p className="rounded-md border border-border bg-muted/40 px-3 py-2 text-sm">
+                        {payment?.member_name ?? payment?.member_id}
+                      </p>
+                    ) : (
+                      <Select
+                        value={field.value}
+                        onValueChange={field.onChange}
+                      >
+                        <SelectTrigger aria-required="true">
+                          <SelectValue placeholder={t("paymentDialog.placeholderMember")} />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {members.map((m) => (
+                            <SelectItem key={m.user_id} value={m.user_id}>
+                              {m.name ?? m.user_id}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    )}
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Amount */}
+            <FormField
+              control={form.control}
+              name="amount"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("paymentDialog.labelAmount")} <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={0.01}
+                      step={0.01}
+                      aria-required="true"
+                      placeholder="0.00"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Payment type */}
+            <FormField
+              control={form.control}
+              name="payment_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("paymentDialog.labelPaymentType")} <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Select
+                      value={field.value}
+                      onValueChange={(val) => field.onChange(val as PaymentType)}
+                    >
+                      <SelectTrigger aria-required="true">
+                        <SelectValue placeholder={t("paymentDialog.placeholderPaymentType")} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {(Object.keys(PAYMENT_TYPE_LABELS) as PaymentType[]).map((key) => {
+                          const typeLabels: Record<PaymentType, string> = {
+                            inscription: t("paymentDialog.paymentTypeInscription"),
+                            materials: t("paymentDialog.paymentTypeMaterials"),
+                            other: t("paymentDialog.paymentTypeOther"),
+                          };
+                          return (
+                            <SelectItem key={key} value={key}>
+                              {typeLabels[key]}
+                            </SelectItem>
+                          );
+                        })}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Reference */}
+            <FormField
+              control={form.control}
+              name="reference"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("paymentDialog.labelReference")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("paymentDialog.placeholderReference")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Paid at */}
+            <FormField
+              control={form.control}
+              name="paid_at"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("paymentDialog.labelPaidAt")}</FormLabel>
+                  <FormControl>
+                    <Input type="date" {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Notes */}
+            <FormField
+              control={form.control}
+              name="notes"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("paymentDialog.labelNotes")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("paymentDialog.placeholderNotes")}
+                      rows={2}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSubmitting}
               >
-                <SelectTrigger id="member_id" aria-required="true">
-                  <SelectValue placeholder={t("paymentDialog.placeholderMember")} />
-                </SelectTrigger>
-                <SelectContent>
-                  {members.map((m) => (
-                    <SelectItem key={m.user_id} value={m.user_id}>
-                      {m.name ?? m.user_id}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-            {errors.member_id && (
-              <p className="text-xs text-destructive">{errors.member_id.message}</p>
-            )}
-          </div>
-
-          {/* Amount */}
-          <div className="space-y-1.5">
-            <Label htmlFor="amount">
-              {t("paymentDialog.labelAmount")} <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="amount"
-              type="number"
-              min={0.01}
-              step={0.01}
-              aria-required="true"
-              {...register("amount")}
-              placeholder="0.00"
-            />
-            {errors.amount && (
-              <p className="text-xs text-destructive">{errors.amount.message}</p>
-            )}
-          </div>
-
-          {/* Payment type */}
-          <div className="space-y-1.5">
-            <Label htmlFor="payment_type">
-              {t("paymentDialog.labelPaymentType")} <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Select
-              value={paymentType}
-              onValueChange={(val) =>
-                setValue("payment_type", val as PaymentType)
-              }
-            >
-              <SelectTrigger id="payment_type" aria-required="true">
-                <SelectValue placeholder={t("paymentDialog.placeholderPaymentType")} />
-              </SelectTrigger>
-              <SelectContent>
-                {(Object.keys(PAYMENT_TYPE_LABELS) as PaymentType[]).map((key) => {
-                  const typeLabels: Record<PaymentType, string> = {
-                    inscription: t("paymentDialog.paymentTypeInscription"),
-                    materials: t("paymentDialog.paymentTypeMaterials"),
-                    other: t("paymentDialog.paymentTypeOther"),
-                  };
-                  return (
-                    <SelectItem key={key} value={key}>
-                      {typeLabels[key]}
-                    </SelectItem>
-                  );
-                })}
-              </SelectContent>
-            </Select>
-            {errors.payment_type && (
-              <p className="text-xs text-destructive">{errors.payment_type.message}</p>
-            )}
-          </div>
-
-          {/* Reference */}
-          <div className="space-y-1.5">
-            <Label htmlFor="reference">{t("paymentDialog.labelReference")}</Label>
-            <Input
-              id="reference"
-              {...register("reference")}
-              placeholder={t("paymentDialog.placeholderReference")}
-            />
-          </div>
-
-          {/* Paid at */}
-          <div className="space-y-1.5">
-            <Label htmlFor="paid_at">{t("paymentDialog.labelPaidAt")}</Label>
-            <Input id="paid_at" type="date" {...register("paid_at")} />
-          </div>
-
-          {/* Notes */}
-          <div className="space-y-1.5">
-            <Label htmlFor="notes">{t("paymentDialog.labelNotes")}</Label>
-            <Textarea
-              id="notes"
-              {...register("notes")}
-              placeholder={t("paymentDialog.placeholderNotes")}
-              rows={2}
-            />
-          </div>
-
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              {t("paymentDialog.cancel")}
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? isEditing
-                  ? t("paymentDialog.saving")
-                  : t("paymentDialog.registering")
-                : isEditing
-                  ? t("paymentDialog.saveChanges")
-                  : t("paymentDialog.registerPayment")}
-            </Button>
-          </DialogFooter>
-        </form>
+                {t("paymentDialog.cancel")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? isEditing
+                    ? t("paymentDialog.saving")
+                    : t("paymentDialog.registering")
+                  : isEditing
+                    ? t("paymentDialog.saveChanges")
+                    : t("paymentDialog.registerPayment")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/camporees/register-member-dialog.test.tsx
+++ b/src/components/camporees/register-member-dialog.test.tsx
@@ -1,0 +1,371 @@
+/**
+ * Integration tests for RegisterMemberDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form + Zod (static schema, no useMemo).
+ * It calls `registerCamporeeMember` from `@/lib/api/camporees` (HTTP).
+ * We mock the module entirely — no MSW needed.
+ *
+ * Special behavior:
+ *   - Insurance-related errors (containing "seguro"/"insurance"/"póliza")
+ *     render a dedicated alert callout (role="alert") instead of toast.
+ *   - Generic errors go to toast.error.
+ *   - `camporee_type` defaults to "local"; the "union" type shows a hint
+ *     on the club_name label.
+ *
+ * Renders are wrapped in `NextIntlClientProvider` with real `messages/es.json`.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockRegister = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/camporees", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/camporees")>();
+  return {
+    ...original,
+    registerCamporeeMember: (...args: unknown[]) => mockRegister(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { RegisterMemberDialog } from "@/components/camporees/register-member-dialog";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const t = messages.camporees;
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  camporeeId?: number;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, camporeeId = 10 } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <RegisterMemberDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        camporeeId={camporeeId}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RegisterMemberDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRegister.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Rendering ──────────────────────────────────────────────────────────
+
+  it("renders title, user-id input, camporee-type select, club-name and insurance inputs", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: t.registerMemberDialog.title }),
+    ).toBeInTheDocument();
+
+    // Use placeholder text to find inputs — avoids issues with label + <span> children
+    expect(
+      screen.getByPlaceholderText("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByPlaceholderText(t.registerMemberDialog.placeholderClubName),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByPlaceholderText(t.registerMemberDialog.placeholderInsuranceId),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: t.registerMemberDialog.register }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: t.registerMemberDialog.cancel }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Validation — invalid UUID ─────────────────────────────────────────
+
+  it("shows UUID validation error when user_id is not a valid UUID", async () => {
+    renderDialog();
+
+    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (userIdInput) fireEvent.change(userIdInput, { target: { value: "not-a-uuid" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      // The Zod uuid error is "El ID de usuario debe ser un UUID válido"
+      expect(
+        screen.getByText(/El ID de usuario debe ser un UUID válido/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  // ── 3. Happy path — local camporee ───────────────────────────────────────
+
+  it("calls registerCamporeeMember with correct args for local type", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
+    });
+
+    // camporee_type defaults to "local" — no change needed
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockRegister).toHaveBeenCalledOnce();
+    });
+
+    const [camporeeId, payload] = mockRegister.mock.calls[0] as [
+      number,
+      { user_id: string; camporee_type: string; club_name?: string; insurance_id?: number },
+    ];
+    expect(camporeeId).toBe(10);
+    expect(payload.user_id).toBe(VALID_UUID);
+    expect(payload.camporee_type).toBe("local");
+    expect(payload.club_name).toBeUndefined();
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.member_registered);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 4. Happy path — union camporee with club name ─────────────────────────
+
+  it("forwards club_name and insurance_id when provided for union type", async () => {
+    renderDialog();
+
+    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
+    });
+
+    // Switch camporee_type to "union" via the hidden Radix native <select>
+    // (only one select in this form — for camporee_type)
+    const typeNative = document.querySelector("select") as HTMLSelectElement | null;
+    if (typeNative) {
+      await act(async () => {
+        fireEvent.change(typeNative, { target: { value: "union" } });
+      });
+    }
+
+    const clubNameInput = document.querySelector('input[name="club_name"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (clubNameInput) fireEvent.change(clubNameInput, { target: { value: "Club Central" } });
+    });
+
+    const insuranceInput = document.querySelector('input[name="insurance_id"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (insuranceInput) fireEvent.change(insuranceInput, { target: { value: "42" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockRegister).toHaveBeenCalledOnce();
+    });
+
+    const [, payload] = mockRegister.mock.calls[0] as [
+      number,
+      { camporee_type: string; club_name?: string; insurance_id?: number },
+    ];
+    expect(payload.camporee_type).toBe("union");
+    expect(payload.club_name).toBe("Club Central");
+    expect(payload.insurance_id).toBe(42);
+  });
+
+  // ── 5. Cancel closes dialog ───────────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call API when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: t.registerMemberDialog.cancel }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  // ── 6. Submit button disabled while in flight ─────────────────────────────
+
+  it("disables submit button while submission is in flight", async () => {
+    let resolveRegister!: () => void;
+    mockRegister.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveRegister = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", {
+          name: new RegExp(t.registerMemberDialog.registering, "i"),
+        }),
+      ).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveRegister();
+    });
+  });
+
+  // ── 7. Insurance error — renders dedicated alert callout ─────────────────
+
+  it("shows insurance error callout (not toast) when error message contains 'seguro'", async () => {
+    mockRegister.mockRejectedValue(
+      new Error("El seguro no está validado para este usuario"),
+    );
+
+    renderDialog();
+
+    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(t.registerMemberDialog.insuranceErrorTitle),
+    ).toBeInTheDocument();
+
+    // Toast must NOT be called for insurance errors
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  // ── 8. Generic API error — routes to toast ────────────────────────────────
+
+  it("shows toast.error for generic non-insurance errors", async () => {
+    mockRegister.mockRejectedValue(new Error("Duplicate member"));
+
+    renderDialog();
+
+    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Duplicate member");
+    });
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  // ── 9. Fallback translated error ──────────────────────────────────────────
+
+  it("shows fallback translated error when non-Error is thrown", async () => {
+    mockRegister.mockRejectedValue("string error");
+
+    renderDialog();
+
+    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.register_member);
+    });
+  });
+});

--- a/src/components/camporees/register-member-dialog.tsx
+++ b/src/components/camporees/register-member-dialog.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -24,6 +23,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import { registerCamporeeMember } from "@/lib/api/camporees";
 
@@ -59,14 +67,7 @@ export function RegisterMemberDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [insuranceError, setInsuranceError] = useState<string | null>(null);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       user_id: "",
@@ -76,11 +77,11 @@ export function RegisterMemberDialog({
     },
   });
 
-  const camporeeType = watch("camporee_type");
+  const camporeeType = form.watch("camporee_type");
 
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {
-      reset();
+      form.reset();
       setInsuranceError(null);
     }
     onOpenChange(nextOpen);
@@ -131,113 +132,131 @@ export function RegisterMemberDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} noValidate className="space-y-4">
-          {/* Insurance error callout */}
-          {insuranceError && (
-            <div
-              role="alert"
-              aria-live="polite"
-              className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
-            >
-              <p className="font-medium">{t("registerMemberDialog.insuranceErrorTitle")}</p>
-              <p className="mt-0.5">{insuranceError}</p>
-            </div>
-          )}
-
-          {/* User ID */}
-          <div className="space-y-1.5">
-            <Label htmlFor="user_id">
-              {t("registerMemberDialog.labelUserId")} <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Input
-              id="user_id"
-              aria-required="true"
-              {...register("user_id")}
-              placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-              className="font-mono text-sm"
-            />
-            {errors.user_id && (
-              <p className="text-xs text-destructive">
-                {errors.user_id.message}
-              </p>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} noValidate className="space-y-4">
+            {/* Insurance error callout */}
+            {insuranceError && (
+              <div
+                role="alert"
+                aria-live="polite"
+                className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+              >
+                <p className="font-medium">{t("registerMemberDialog.insuranceErrorTitle")}</p>
+                <p className="mt-0.5">{insuranceError}</p>
+              </div>
             )}
-          </div>
 
-          {/* Tipo de camporee */}
-          <div className="space-y-1.5">
-            <Label htmlFor="camporee_type">
-              {t("registerMemberDialog.labelCamporeeType")} <span aria-hidden="true" className="text-destructive">*</span>
-            </Label>
-            <Select
-              value={camporeeType}
-              onValueChange={(val) =>
-                setValue("camporee_type", val as "local" | "union")
-              }
-            >
-              <SelectTrigger id="camporee_type" aria-required="true">
-                <SelectValue placeholder={t("registerMemberDialog.placeholderCamporeeType")} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="local">{t("registerMemberDialog.typeLocal")}</SelectItem>
-                <SelectItem value="union">{t("registerMemberDialog.typeUnion")}</SelectItem>
-              </SelectContent>
-            </Select>
-            {errors.camporee_type && (
-              <p className="text-xs text-destructive">
-                {errors.camporee_type.message}
-              </p>
-            )}
-          </div>
-
-          {/* Club name (required for union) */}
-          <div className="space-y-1.5">
-            <Label htmlFor="club_name">
-              {t("registerMemberDialog.labelClubName")}
-              {camporeeType === "union" && (
-                <span className="text-muted-foreground"> {t("registerMemberDialog.clubNameRequiredForUnion")}</span>
+            {/* User ID */}
+            <FormField
+              control={form.control}
+              name="user_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("registerMemberDialog.labelUserId")} <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      aria-required="true"
+                      placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                      className="font-mono text-sm"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </Label>
-            <Input
-              id="club_name"
-              {...register("club_name")}
-              placeholder={t("registerMemberDialog.placeholderClubName")}
             />
-          </div>
 
-          {/* Insurance ID */}
-          <div className="space-y-1.5">
-            <Label htmlFor="insurance_id">{t("registerMemberDialog.labelInsuranceId")}</Label>
-            <Input
-              id="insurance_id"
-              type="number"
-              min={1}
-              {...register("insurance_id")}
-              placeholder={t("registerMemberDialog.placeholderInsuranceId")}
+            {/* Tipo de camporee */}
+            <FormField
+              control={form.control}
+              name="camporee_type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("registerMemberDialog.labelCamporeeType")} <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Select
+                      value={field.value}
+                      onValueChange={(val) => field.onChange(val as "local" | "union")}
+                    >
+                      <SelectTrigger aria-required="true">
+                        <SelectValue placeholder={t("registerMemberDialog.placeholderCamporeeType")} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="local">{t("registerMemberDialog.typeLocal")}</SelectItem>
+                        <SelectItem value="union">{t("registerMemberDialog.typeUnion")}</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            <p className="text-xs text-muted-foreground">
-              {t("registerMemberDialog.helpInsurance")}
-            </p>
-            {errors.insurance_id && (
-              <p className="text-xs text-destructive">
-                {errors.insurance_id.message}
-              </p>
-            )}
-          </div>
 
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              {t("registerMemberDialog.cancel")}
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? t("registerMemberDialog.registering") : t("registerMemberDialog.register")}
-            </Button>
-          </DialogFooter>
-        </form>
+            {/* Club name (required for union) */}
+            <FormField
+              control={form.control}
+              name="club_name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("registerMemberDialog.labelClubName")}
+                    {camporeeType === "union" && (
+                      <span className="text-muted-foreground"> {t("registerMemberDialog.clubNameRequiredForUnion")}</span>
+                    )}
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("registerMemberDialog.placeholderClubName")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Insurance ID */}
+            <FormField
+              control={form.control}
+              name="insurance_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("registerMemberDialog.labelInsuranceId")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={1}
+                      placeholder={t("registerMemberDialog.placeholderInsuranceId")}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    {t("registerMemberDialog.helpInsurance")}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                {t("registerMemberDialog.cancel")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? t("registerMemberDialog.registering") : t("registerMemberDialog.register")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/camporees/union-camporee-form-dialog.tsx
+++ b/src/components/camporees/union-camporee-form-dialog.tsx
@@ -16,7 +16,6 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -26,6 +25,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import { createUnionCamporee, updateUnionCamporee } from "@/lib/api/camporees";
 import type { UnionCamporee } from "@/lib/api/camporees";
@@ -87,14 +94,7 @@ export function UnionCamporeeFormDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
@@ -110,15 +110,10 @@ export function UnionCamporeeFormDialog({
     },
   });
 
-  const includesAdventurers = watch("includes_adventurers");
-  const includesPathfinders = watch("includes_pathfinders");
-  const includesMasterGuides = watch("includes_master_guides");
-  const unionId = watch("union_id");
-
   useEffect(() => {
     if (open) {
       if (camporee) {
-        reset({
+        form.reset({
           name: camporee.name,
           description: camporee.description ?? "",
           start_date: toDateInput(camporee.start_date),
@@ -131,7 +126,7 @@ export function UnionCamporeeFormDialog({
           includes_master_guides: camporee.includes_master_guides ?? false,
         });
       } else {
-        reset({
+        form.reset({
           name: "",
           description: "",
           start_date: "",
@@ -145,7 +140,7 @@ export function UnionCamporeeFormDialog({
         });
       }
     }
-  }, [open, camporee, reset]);
+  }, [open, camporee, form]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -197,175 +192,246 @@ export function UnionCamporeeFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-          {/* Nombre */}
-          <div className="space-y-1.5">
-            <Label htmlFor="uc-name">{t("unionForm.labelName")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-            <Input
-              id="uc-name"
-              {...register("name")}
-              placeholder={t("unionForm.placeholderName")}
-              aria-required="true"
-            />
-            {errors.name && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
-            )}
-          </div>
-
-          {/* Descripción */}
-          <div className="space-y-1.5">
-            <Label htmlFor="uc-description">{t("unionForm.labelDescription")}</Label>
-            <Textarea
-              id="uc-description"
-              {...register("description")}
-              placeholder={t("unionForm.placeholderDescription")}
-              rows={3}
-            />
-          </div>
-
-          {/* Fechas */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="uc-start_date">{t("unionForm.labelStartDate")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-              <Input id="uc-start_date" type="date" {...register("start_date")} aria-required="true" />
-              {errors.start_date && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.start_date.message}</p>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {/* Nombre */}
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("unionForm.labelName")} <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("unionForm.placeholderName")}
+                      aria-required="true"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="uc-end_date">{t("unionForm.labelEndDate")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-              <Input id="uc-end_date" type="date" {...register("end_date")} aria-required="true" />
-              {errors.end_date && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.end_date.message}</p>
+            />
+
+            {/* Descripción */}
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("unionForm.labelDescription")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("unionForm.placeholderDescription")}
+                      rows={3}
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-          </div>
-
-          {/* Unión */}
-          <div className="space-y-1.5">
-            <Label htmlFor="uc-union_id">{t("unionForm.labelUnion")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-            <Select
-              value={unionId > 0 ? String(unionId) : ""}
-              onValueChange={(val) => setValue("union_id", Number(val))}
-            >
-              <SelectTrigger id="uc-union_id" className="w-full" aria-required="true">
-                <SelectValue placeholder={t("unionForm.placeholderUnion")} />
-              </SelectTrigger>
-              <SelectContent>
-                {unions.map((u) => (
-                  <SelectItem key={u.union_id} value={String(u.union_id)}>
-                    {u.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.union_id && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.union_id.message}</p>
-            )}
-          </div>
-
-          {/* Lugar */}
-          <div className="space-y-1.5">
-            <Label htmlFor="uc-place">{t("unionForm.labelPlace")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-            <Input
-              id="uc-place"
-              {...register("place")}
-              placeholder={t("unionForm.placeholderPlace")}
-              aria-required="true"
             />
-            {errors.place && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.place.message}</p>
-            )}
-          </div>
 
-          {/* Costo de inscripción */}
-          <div className="space-y-1.5">
-            <Label htmlFor="uc-registration_cost">{t("unionForm.labelRegistrationCost")}</Label>
-            <Input
-              id="uc-registration_cost"
-              type="number"
-              min={0}
-              step="0.01"
-              {...register("registration_cost")}
-              placeholder="0.00"
+            {/* Fechas */}
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="start_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("unionForm.labelStartDate")} <span aria-hidden="true" className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input type="date" aria-required="true" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="end_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("unionForm.labelEndDate")} <span aria-hidden="true" className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input type="date" aria-required="true" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            {/* Unión */}
+            <FormField
+              control={form.control}
+              name="union_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("unionForm.labelUnion")} <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Select
+                      value={field.value > 0 ? String(field.value) : ""}
+                      onValueChange={(val) => field.onChange(Number(val))}
+                    >
+                      <SelectTrigger className="w-full" aria-required="true">
+                        <SelectValue placeholder={t("unionForm.placeholderUnion")} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {unions.map((u) => (
+                          <SelectItem key={u.union_id} value={String(u.union_id)}>
+                            {u.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.registration_cost && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.registration_cost.message}</p>
-            )}
-          </div>
 
-          {/* Tipos de club */}
-          <div className="space-y-2">
-            <Label>{t("unionForm.labelIncludes")}</Label>
-            <div className="space-y-2 rounded-md border border-border p-3">
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="uc-includes_adventurers"
-                  checked={includesAdventurers}
-                  onCheckedChange={(checked) =>
-                    setValue("includes_adventurers", checked === true)
-                  }
+            {/* Lugar */}
+            <FormField
+              control={form.control}
+              name="place"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("unionForm.labelPlace")} <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder={t("unionForm.placeholderPlace")}
+                      aria-required="true"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Costo de inscripción */}
+            <FormField
+              control={form.control}
+              name="registration_cost"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("unionForm.labelRegistrationCost")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      placeholder="0.00"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Tipos de club */}
+            <div className="space-y-2">
+              <p className="text-sm font-medium leading-none">{t("unionForm.labelIncludes")}</p>
+              <div className="space-y-2 rounded-md border border-border p-3">
+                <FormField
+                  control={form.control}
+                  name="includes_adventurers"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center gap-2 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          id="uc-includes_adventurers"
+                          checked={field.value}
+                          onCheckedChange={(checked) => field.onChange(checked === true)}
+                        />
+                      </FormControl>
+                      <FormLabel
+                        htmlFor="uc-includes_adventurers"
+                        className="cursor-pointer font-normal"
+                      >
+                        {t("unionForm.adventurers")}
+                      </FormLabel>
+                    </FormItem>
+                  )}
                 />
-                <Label
-                  htmlFor="uc-includes_adventurers"
-                  className="cursor-pointer font-normal"
-                >
-                  {t("unionForm.adventurers")}
-                </Label>
-              </div>
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="uc-includes_pathfinders"
-                  checked={includesPathfinders}
-                  onCheckedChange={(checked) =>
-                    setValue("includes_pathfinders", checked === true)
-                  }
+                <FormField
+                  control={form.control}
+                  name="includes_pathfinders"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center gap-2 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          id="uc-includes_pathfinders"
+                          checked={field.value}
+                          onCheckedChange={(checked) => field.onChange(checked === true)}
+                        />
+                      </FormControl>
+                      <FormLabel
+                        htmlFor="uc-includes_pathfinders"
+                        className="cursor-pointer font-normal"
+                      >
+                        {t("unionForm.pathfinders")}
+                      </FormLabel>
+                    </FormItem>
+                  )}
                 />
-                <Label
-                  htmlFor="uc-includes_pathfinders"
-                  className="cursor-pointer font-normal"
-                >
-                  {t("unionForm.pathfinders")}
-                </Label>
-              </div>
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="uc-includes_master_guides"
-                  checked={includesMasterGuides}
-                  onCheckedChange={(checked) =>
-                    setValue("includes_master_guides", checked === true)
-                  }
+                <FormField
+                  control={form.control}
+                  name="includes_master_guides"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center gap-2 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          id="uc-includes_master_guides"
+                          checked={field.value}
+                          onCheckedChange={(checked) => field.onChange(checked === true)}
+                        />
+                      </FormControl>
+                      <FormLabel
+                        htmlFor="uc-includes_master_guides"
+                        className="cursor-pointer font-normal"
+                      >
+                        {t("unionForm.masterGuides")}
+                      </FormLabel>
+                    </FormItem>
+                  )}
                 />
-                <Label
-                  htmlFor="uc-includes_master_guides"
-                  className="cursor-pointer font-normal"
-                >
-                  {t("unionForm.masterGuides")}
-                </Label>
               </div>
             </div>
-          </div>
 
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              {t("unionForm.cancel")}
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? isEdit
-                  ? t("unionForm.saving")
-                  : t("unionForm.creating")
-                : isEdit
-                  ? t("unionForm.saveChanges")
-                  : t("unionForm.createCamporee")}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                {t("unionForm.cancel")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? isEdit
+                    ? t("unionForm.saving")
+                    : t("unionForm.creating")
+                  : isEdit
+                    ? t("unionForm.saveChanges")
+                    : t("unionForm.createCamporee")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dashboard/role-distribution-chart-inner.tsx
+++ b/src/components/dashboard/role-distribution-chart-inner.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import { useTranslations } from "next-intl";
+import type { RoleDistributionEntry } from "./role-distribution-chart";
+
+const ROLE_LABEL_KEYS: Record<string, string> = {
+  "super-admin": "superAdmin",
+  admin: "admin",
+  "assistant-admin": "assistantAdmin",
+  coordinator: "coordinator",
+  pastor: "pastor",
+  user: "user",
+  director: "director",
+  "deputy-director": "deputyDirector",
+  secretary: "secretary",
+  treasurer: "treasurer",
+  counselor: "counselor",
+  instructor: "instructor",
+  member: "member",
+  sin_rol: "noRole",
+};
+
+const ROLE_COLORS: Record<string, string> = {
+  "super-admin": "var(--destructive)",
+  admin: "var(--primary)",
+  "assistant-admin": "color-mix(in oklch, var(--primary) 70%, transparent)",
+  coordinator: "var(--info)",
+  pastor: "var(--warning)",
+  user: "var(--success)",
+  director: "var(--chart-1)",
+  "deputy-director": "var(--chart-2)",
+  secretary: "var(--chart-3)",
+  treasurer: "var(--chart-4)",
+  counselor: "var(--chart-5)",
+  instructor: "color-mix(in oklch, var(--chart-1) 60%, var(--chart-3) 40%)",
+  member: "color-mix(in oklch, var(--muted-foreground) 80%, transparent)",
+  sin_rol: "color-mix(in oklch, var(--muted-foreground) 50%, transparent)",
+};
+
+const DEFAULT_COLOR = "color-mix(in oklch, var(--muted-foreground) 40%, transparent)";
+
+function roleColor(role: string): string {
+  return ROLE_COLORS[role] ?? DEFAULT_COLOR;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: RoleDistributionEntry }>;
+  roleLabel: (role: string) => string;
+  userCount: (count: number, percentage: string) => string;
+}
+
+function CustomTooltip({ active, payload, roleLabel, userCount }: CustomTooltipProps) {
+  if (!active || !payload?.length) return null;
+  const entry = payload[0].payload;
+  return (
+    <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
+      <p className="font-medium">{roleLabel(entry.role)}</p>
+      <p className="text-muted-foreground">
+        {userCount(entry.count, entry.percentage.toFixed(1))}
+      </p>
+    </div>
+  );
+}
+
+interface RoleDistributionChartInnerProps {
+  data: RoleDistributionEntry[];
+  sampleSize: number;
+}
+
+export function RoleDistributionChartInner({ data, sampleSize }: RoleDistributionChartInnerProps) {
+  const t = useTranslations("dashboardHub");
+
+  function roleLabel(role: string): string {
+    const key = ROLE_LABEL_KEYS[role];
+    if (key) {
+      return t(`roleLabels.${key}` as Parameters<typeof t>[0]);
+    }
+    return role.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  function userCount(count: number, percentage: string): string {
+    return t("roleChart.userCount", { count, percentage });
+  }
+
+  if (data.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        {t("roleChart.noRolesFound")}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <ResponsiveContainer width="100%" height={160}>
+        <BarChart data={data} layout="vertical" margin={{ top: 0, right: 8, left: 0, bottom: 0 }}>
+          <XAxis type="number" hide />
+          <YAxis
+            type="category"
+            dataKey="role"
+            tickFormatter={roleLabel}
+            width={80}
+            tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+            tickLine={false}
+            axisLine={false}
+          />
+          <Tooltip
+            content={
+              <CustomTooltip
+                roleLabel={roleLabel}
+                userCount={userCount}
+              />
+            }
+            cursor={{ fill: "color-mix(in oklch, var(--muted) 40%, transparent)" }}
+          />
+          <Bar dataKey="count" radius={[0, 4, 4, 0]} maxBarSize={18}>
+            {data.map((entry) => (
+              <Cell key={entry.role} fill={roleColor(entry.role)} />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+
+      <p className="text-[11px] text-muted-foreground">
+        {t("roleChart.basedOn", { count: sampleSize })}
+      </p>
+    </div>
+  );
+}

--- a/src/components/dashboard/role-distribution-chart.tsx
+++ b/src/components/dashboard/role-distribution-chart.tsx
@@ -1,15 +1,7 @@
 "use client";
 
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Cell,
-} from "recharts";
-import { useTranslations } from "next-intl";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
 
 export type RoleDistributionEntry = {
   role: string;
@@ -17,65 +9,16 @@ export type RoleDistributionEntry = {
   percentage: number;
 };
 
-const ROLE_LABEL_KEYS: Record<string, string> = {
-  "super-admin": "superAdmin",
-  admin: "admin",
-  "assistant-admin": "assistantAdmin",
-  coordinator: "coordinator",
-  pastor: "pastor",
-  user: "user",
-  director: "director",
-  "deputy-director": "deputyDirector",
-  secretary: "secretary",
-  treasurer: "treasurer",
-  counselor: "counselor",
-  instructor: "instructor",
-  member: "member",
-  sin_rol: "noRole",
-};
-
-const ROLE_COLORS: Record<string, string> = {
-  "super-admin": "var(--destructive)",
-  admin: "var(--primary)",
-  "assistant-admin": "color-mix(in oklch, var(--primary) 70%, transparent)",
-  coordinator: "var(--info)",
-  pastor: "var(--warning)",
-  user: "var(--success)",
-  director: "var(--chart-1)",
-  "deputy-director": "var(--chart-2)",
-  secretary: "var(--chart-3)",
-  treasurer: "var(--chart-4)",
-  counselor: "var(--chart-5)",
-  instructor: "color-mix(in oklch, var(--chart-1) 60%, var(--chart-3) 40%)",
-  member: "color-mix(in oklch, var(--muted-foreground) 80%, transparent)",
-  sin_rol: "color-mix(in oklch, var(--muted-foreground) 50%, transparent)",
-};
-
-const DEFAULT_COLOR = "color-mix(in oklch, var(--muted-foreground) 40%, transparent)";
-
-function roleColor(role: string): string {
-  return ROLE_COLORS[role] ?? DEFAULT_COLOR;
-}
-
-interface CustomTooltipProps {
-  active?: boolean;
-  payload?: Array<{ payload: RoleDistributionEntry }>;
-  roleLabel: (role: string) => string;
-  userCount: (count: number, percentage: string) => string;
-}
-
-function CustomTooltip({ active, payload, roleLabel, userCount }: CustomTooltipProps) {
-  if (!active || !payload?.length) return null;
-  const entry = payload[0].payload;
-  return (
-    <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
-      <p className="font-medium">{roleLabel(entry.role)}</p>
-      <p className="text-muted-foreground">
-        {userCount(entry.count, entry.percentage.toFixed(1))}
-      </p>
-    </div>
-  );
-}
+const RoleDistributionChartInner = dynamic(
+  () =>
+    import("./role-distribution-chart-inner").then(
+      (m) => m.RoleDistributionChartInner
+    ),
+  {
+    ssr: false,
+    loading: () => <Skeleton className="h-[160px] w-full rounded-md" />,
+  }
+);
 
 interface RoleDistributionChartProps {
   data: RoleDistributionEntry[];
@@ -83,62 +26,5 @@ interface RoleDistributionChartProps {
 }
 
 export function RoleDistributionChart({ data, sampleSize }: RoleDistributionChartProps) {
-  const t = useTranslations("dashboardHub");
-
-  function roleLabel(role: string): string {
-    const key = ROLE_LABEL_KEYS[role];
-    if (key) {
-      return t(`roleLabels.${key}` as Parameters<typeof t>[0]);
-    }
-    return role.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
-  }
-
-  function userCount(count: number, percentage: string): string {
-    return t("roleChart.userCount", { count, percentage });
-  }
-
-  if (data.length === 0) {
-    return (
-      <p className="text-sm text-muted-foreground">
-        {t("roleChart.noRolesFound")}
-      </p>
-    );
-  }
-
-  return (
-    <div className="space-y-3">
-      <ResponsiveContainer width="100%" height={160}>
-        <BarChart data={data} layout="vertical" margin={{ top: 0, right: 8, left: 0, bottom: 0 }}>
-          <XAxis type="number" hide />
-          <YAxis
-            type="category"
-            dataKey="role"
-            tickFormatter={roleLabel}
-            width={80}
-            tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
-            tickLine={false}
-            axisLine={false}
-          />
-          <Tooltip
-            content={
-              <CustomTooltip
-                roleLabel={roleLabel}
-                userCount={userCount}
-              />
-            }
-            cursor={{ fill: "color-mix(in oklch, var(--muted) 40%, transparent)" }}
-          />
-          <Bar dataKey="count" radius={[0, 4, 4, 0]} maxBarSize={18}>
-            {data.map((entry) => (
-              <Cell key={entry.role} fill={roleColor(entry.role)} />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
-
-      <p className="text-[11px] text-muted-foreground">
-        {t("roleChart.basedOn", { count: sampleSize })}
-      </p>
-    </div>
-  );
+  return <RoleDistributionChartInner data={data} sampleSize={sampleSize} />;
 }

--- a/src/components/investiture/config-form-dialog.test.tsx
+++ b/src/components/investiture/config-form-dialog.test.tsx
@@ -1,0 +1,470 @@
+/**
+ * Integration tests for ConfigFormDialog (investiture configuration).
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form + Zod. On open it calls:
+ *   - `listLocalFields()` from `@/lib/api/geography`
+ *   - `listEcclesiasticalYears()` from `@/lib/api/catalogs`
+ * On submit (create) it calls `createInvestitureConfig` from
+ * `@/lib/api/investiture` (which internally uses `apiRequestFromClient`).
+ * On submit (edit) it calls `updateInvestitureConfig`.
+ *
+ * We mock all three modules entirely — no MSW exercised.
+ *
+ * Create mode: local_field_id and ecclesiastical_year_id selects are shown.
+ * Edit mode:   only date fields are editable; select fields are hidden.
+ *
+ * Translations are used for validation messages (from useTranslations("investiture")).
+ * Hardcoded strings are used for title/button text (no i18n key).
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { InvestitureConfig } from "@/lib/api/investiture";
+import type { LocalField } from "@/lib/api/geography";
+import type { EcclesiasticalYear } from "@/lib/api/catalogs";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateConfig = vi.fn<(...args: any[]) => Promise<unknown>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdateConfig = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/investiture", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/investiture")>();
+  return {
+    ...original,
+    createInvestitureConfig: (...args: unknown[]) => mockCreateConfig(...args),
+    updateInvestitureConfig: (...args: unknown[]) => mockUpdateConfig(...args),
+  };
+});
+
+const mockListLocalFields = vi.fn<() => Promise<LocalField[]>>();
+vi.mock("@/lib/api/geography", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/geography")>();
+  return {
+    ...original,
+    listLocalFields: () => mockListLocalFields(),
+  };
+});
+
+const mockListEcclesiasticalYears = vi.fn<() => Promise<EcclesiasticalYear[]>>();
+vi.mock("@/lib/api/catalogs", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/catalogs")>();
+  return {
+    ...original,
+    listEcclesiasticalYears: () => mockListEcclesiasticalYears(),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { ConfigFormDialog } from "@/components/investiture/config-form-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_LOCAL_FIELDS: LocalField[] = [
+  { local_field_id: 1, name: "Campo Norte", union_id: 1 },
+  { local_field_id: 2, name: "Campo Sur", union_id: 1 },
+];
+
+const STUB_YEARS: EcclesiasticalYear[] = [
+  {
+    ecclesiastical_year_id: 10,
+    name: "2025",
+    start_date: "2025-01-01",
+    end_date: "2025-12-31",
+    active: true,
+  },
+  {
+    ecclesiastical_year_id: 11,
+    name: "2026",
+    start_date: "2026-01-01",
+    end_date: "2026-12-31",
+    active: false,
+  },
+];
+
+const STUB_CONFIG: InvestitureConfig = {
+  investiture_config_id: 50,
+  local_field_id: 1,
+  ecclesiastical_year_id: 10,
+  submission_deadline: "2026-08-01T00:00:00.000Z",
+  investiture_date: "2026-09-15T00:00:00.000Z",
+  active: true,
+};
+
+const STUB_CREATED_CONFIG: InvestitureConfig = {
+  ...STUB_CONFIG,
+  investiture_config_id: 99,
+};
+
+const inv = messages.investiture;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  config?: InvestitureConfig | null;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, config = null } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <ConfigFormDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        config={config}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ConfigFormDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListLocalFields.mockResolvedValue(STUB_LOCAL_FIELDS);
+    mockListEcclesiasticalYears.mockResolvedValue(STUB_YEARS);
+    mockCreateConfig.mockResolvedValue(STUB_CREATED_CONFIG);
+    mockUpdateConfig.mockResolvedValue(STUB_CONFIG);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Create mode — rendering and catalog load ───────────────────────────
+
+  it("renders create mode title and loads catalog selects on open", async () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /Nueva configuración/i }),
+    ).toBeInTheDocument();
+
+    // Date inputs are rendered (query by name attr — shadcn FormControl uses dynamic IDs)
+    expect(document.querySelector('input[name="submission_deadline"]')).toBeInTheDocument();
+    expect(document.querySelector('input[name="investiture_date"]')).toBeInTheDocument();
+
+    // Wait for catalogs to load and verify API was called
+    await waitFor(() => {
+      expect(mockListLocalFields).toHaveBeenCalledOnce();
+      expect(mockListEcclesiasticalYears).toHaveBeenCalledOnce();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /Crear configuración/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Edit mode — rendering ──────────────────────────────────────────────
+
+  it("renders edit mode title without catalog selects, only date fields", async () => {
+    renderDialog({ config: STUB_CONFIG });
+
+    expect(
+      screen.getByRole("heading", { name: /Editar configuración/i }),
+    ).toBeInTheDocument();
+
+    // In edit mode, Radix catalog selects are not rendered — no native <select> elements
+    expect(document.querySelectorAll("select").length).toBe(0);
+
+    // Date inputs are shown and pre-filled (query by name attr)
+    const deadlineInput = document.querySelector('input[name="submission_deadline"]') as HTMLInputElement | null;
+    const dateInput = document.querySelector('input[name="investiture_date"]') as HTMLInputElement | null;
+
+    expect(deadlineInput).not.toBeNull();
+    expect(dateInput).not.toBeNull();
+
+    // Pre-fill: submission_deadline = "2026-08-01T00:00:00.000Z" → "2026-08-01"
+    expect(deadlineInput?.value).toBe("2026-08-01");
+    expect(dateInput?.value).toBe("2026-09-15");
+
+    expect(
+      screen.getByRole("button", { name: /Guardar cambios/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 3. Validation — empty date fields on create ───────────────────────────
+
+  it("shows validation errors when date fields are empty on submit", async () => {
+    renderDialog();
+
+    // Wait for catalogs to load
+    await waitFor(() => expect(mockListLocalFields).toHaveBeenCalled());
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(inv.validation.submission_deadline_required),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(inv.validation.investiture_date_required),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockCreateConfig).not.toHaveBeenCalled();
+  });
+
+  // ── 4. Happy path — create config ────────────────────────────────────────
+
+  it("calls createInvestitureConfig with correct payload and shows success toast", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    // Wait for catalogs to load
+    await waitFor(() => expect(mockListLocalFields).toHaveBeenCalled());
+
+    // Radix renders hidden native <select> elements (no name attr here).
+    // In create mode: allNativeSelects[0] = local_field, allNativeSelects[1] = ecclesiastical_year.
+    const allNativeSelects = document.querySelectorAll("select");
+    const localFieldNative = allNativeSelects[0] as HTMLSelectElement | undefined;
+    const yearNative = allNativeSelects[1] as HTMLSelectElement | undefined;
+
+    if (localFieldNative) {
+      await act(async () => {
+        fireEvent.change(localFieldNative, { target: { value: "1" } });
+      });
+    }
+
+    if (yearNative) {
+      await act(async () => {
+        fireEvent.change(yearNative, { target: { value: "10" } });
+      });
+    }
+
+    // Fill date fields by name attr (shadcn FormControl generates dynamic IDs)
+    const deadlineInput = document.querySelector('input[name="submission_deadline"]') as HTMLInputElement | null;
+    const dateInput = document.querySelector('input[name="investiture_date"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (deadlineInput) fireEvent.change(deadlineInput, { target: { value: "2026-08-01" } });
+      if (dateInput) fireEvent.change(dateInput, { target: { value: "2026-09-15" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreateConfig).toHaveBeenCalledOnce();
+    });
+
+    const [payload] = mockCreateConfig.mock.calls[0] as [
+      {
+        local_field_id: number;
+        ecclesiastical_year_id: number;
+        submission_deadline: string;
+        investiture_date: string;
+      },
+    ];
+    expect(payload.submission_deadline).toBe("2026-08-01");
+    expect(payload.investiture_date).toBe("2026-09-15");
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(inv.toasts.config_created);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 5. Happy path — edit config ───────────────────────────────────────────
+
+  it("calls updateInvestitureConfig (not create) in edit mode and shows update toast", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ config: STUB_CONFIG });
+
+    const deadlineInput = document.querySelector('input[name="submission_deadline"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (deadlineInput) fireEvent.change(deadlineInput, { target: { value: "2026-07-15" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockUpdateConfig).toHaveBeenCalledOnce();
+    });
+
+    expect(mockCreateConfig).not.toHaveBeenCalled();
+
+    const [configId, payload] = mockUpdateConfig.mock.calls[0] as [
+      number,
+      { submission_deadline: string; investiture_date: string },
+    ];
+    expect(configId).toBe(50);
+    expect(payload.submission_deadline).toBe("2026-07-15");
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(inv.toasts.config_updated);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 6. Cancel closes dialog without API call ──────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call API when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /Cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateConfig).not.toHaveBeenCalled();
+    expect(mockUpdateConfig).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Submit button disabled while in flight (edit mode) ─────────────────
+
+  it("disables submit button while submission is in flight", async () => {
+    let resolveUpdate!: () => void;
+    mockUpdateConfig.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveUpdate = () => res(STUB_CONFIG);
+      }),
+    );
+
+    renderDialog({ config: STUB_CONFIG });
+
+    // Pre-fill dates to ensure form validates
+    const deadlineInput = document.querySelector('input[name="submission_deadline"]') as HTMLInputElement | null;
+    const dateInput = document.querySelector('input[name="investiture_date"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (deadlineInput) fireEvent.change(deadlineInput, { target: { value: "2026-08-01" } });
+      if (dateInput) fireEvent.change(dateInput, { target: { value: "2026-09-15" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      // Button should be disabled while in flight
+      const submitBtn = screen.getByRole("button", { name: /Guardar cambios/i });
+      expect(submitBtn).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveUpdate();
+    });
+  });
+
+  // ── 8. Catalog load failure — shows error toast ───────────────────────────
+
+  it("shows catalogs_load_failed toast when catalog APIs reject", async () => {
+    mockListLocalFields.mockRejectedValue(new Error("Network error"));
+    mockListEcclesiasticalYears.mockRejectedValue(new Error("Network error"));
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(inv.toasts.catalogs_load_failed);
+    });
+  });
+
+  // ── 9. API error — error message from thrown Error ────────────────────────
+
+  it("shows error toast with server message when updateInvestitureConfig throws", async () => {
+    mockUpdateConfig.mockRejectedValue(new Error("Config conflict"));
+
+    renderDialog({ config: STUB_CONFIG });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Config conflict");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 10. API error — fallback translated error ─────────────────────────────
+
+  it("shows fallback translated error when createInvestitureConfig throws non-Error", async () => {
+    mockCreateConfig.mockRejectedValue("unexpected");
+
+    renderDialog();
+
+    // Wait for catalogs
+    await waitFor(() => expect(mockListLocalFields).toHaveBeenCalled());
+
+    // Fill selects positionally (no name attr on Radix selects)
+    const allNativeSelects = document.querySelectorAll("select");
+    const localFieldNative = allNativeSelects[0] as HTMLSelectElement | undefined;
+    const yearNative = allNativeSelects[1] as HTMLSelectElement | undefined;
+
+    if (localFieldNative) {
+      await act(async () => {
+        fireEvent.change(localFieldNative, { target: { value: "1" } });
+      });
+    }
+    if (yearNative) {
+      await act(async () => {
+        fireEvent.change(yearNative, { target: { value: "10" } });
+      });
+    }
+
+    const deadlineInput = document.querySelector('input[name="submission_deadline"]') as HTMLInputElement | null;
+    const dateInput = document.querySelector('input[name="investiture_date"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (deadlineInput) fireEvent.change(deadlineInput, { target: { value: "2026-08-01" } });
+      if (dateInput) fireEvent.change(dateInput, { target: { value: "2026-09-15" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(inv.errors.config_create);
+    });
+  });
+});

--- a/src/components/investiture/config-form-dialog.tsx
+++ b/src/components/investiture/config-form-dialog.tsx
@@ -18,7 +18,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -26,6 +25,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import {
   createInvestitureConfig,
   updateInvestitureConfig,
@@ -87,14 +94,7 @@ export function ConfigFormDialog({
 
   const formSchema = useMemo(() => buildFormSchema(t), [t]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       local_field_id: undefined,
@@ -122,7 +122,7 @@ export function ConfigFormDialog({
   // Reset form when dialog opens or config changes
   useEffect(() => {
     if (open) {
-      reset({
+      form.reset({
         local_field_id: config?.local_field_id ?? undefined,
         ecclesiastical_year_id: config?.ecclesiastical_year_id ?? undefined,
         submission_deadline: config?.submission_deadline
@@ -135,9 +135,6 @@ export function ConfigFormDialog({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, config]);
-
-  const selectedLocalFieldId = watch("local_field_id");
-  const selectedYearId = watch("ecclesiastical_year_id");
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -188,137 +185,153 @@ export function ConfigFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-          {/* Campo Local — solo al crear */}
-          {!isEdit && (
-            <div className="space-y-1.5">
-              <Label htmlFor="cfg-local_field_id">
-                Campo Local <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-              </Label>
-              <Select
-                value={selectedLocalFieldId?.toString() ?? ""}
-                onValueChange={(v) => setValue("local_field_id", Number(v))}
-                disabled={loadingCatalogs}
-              >
-                <SelectTrigger id="cfg-local_field_id" aria-required="true">
-                  <SelectValue
-                    placeholder={
-                      loadingCatalogs ? "Cargando campos..." : "Seleccioná un campo local"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {localFields.map((lf) => (
-                    <SelectItem
-                      key={lf.local_field_id}
-                      value={lf.local_field_id.toString()}
-                    >
-                      {lf.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {errors.local_field_id && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.local_field_id.message}
-                </p>
-              )}
-            </div>
-          )}
-
-          {/* Año Eclesiástico — solo al crear */}
-          {!isEdit && (
-            <div className="space-y-1.5">
-              <Label htmlFor="cfg-ecclesiastical_year_id">
-                Año Eclesiástico <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-              </Label>
-              <Select
-                value={selectedYearId?.toString() ?? ""}
-                onValueChange={(v) => setValue("ecclesiastical_year_id", Number(v))}
-                disabled={loadingCatalogs}
-              >
-                <SelectTrigger id="cfg-ecclesiastical_year_id" aria-required="true">
-                  <SelectValue
-                    placeholder={
-                      loadingCatalogs ? "Cargando años..." : "Seleccioná un año"
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {years.map((year) => (
-                    <SelectItem
-                      key={year.ecclesiastical_year_id}
-                      value={year.ecclesiastical_year_id.toString()}
-                    >
-                      {year.name}
-                      {year.active && (
-                        <span className="ml-1.5 text-xs text-muted-foreground">
-                          (activo)
-                        </span>
-                      )}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {errors.ecclesiastical_year_id && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.ecclesiastical_year_id.message}
-                </p>
-              )}
-            </div>
-          )}
-
-          {/* Fecha límite de envío */}
-          <div className="space-y-1.5">
-            <Label htmlFor="submission_deadline">
-              Límite de Envío <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-            </Label>
-            <Input
-              id="submission_deadline"
-              type="date"
-              {...register("submission_deadline")}
-              aria-required="true"
-            />
-            {errors.submission_deadline && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.submission_deadline.message}
-              </p>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {/* Campo Local — solo al crear */}
+            {!isEdit && (
+              <FormField
+                control={form.control}
+                name="local_field_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Campo Local <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Select
+                        value={field.value?.toString() ?? ""}
+                        onValueChange={(v) => field.onChange(Number(v))}
+                        disabled={loadingCatalogs}
+                      >
+                        <SelectTrigger aria-required="true">
+                          <SelectValue
+                            placeholder={
+                              loadingCatalogs ? "Cargando campos..." : "Seleccioná un campo local"
+                            }
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {localFields.map((lf) => (
+                            <SelectItem
+                              key={lf.local_field_id}
+                              value={lf.local_field_id.toString()}
+                            >
+                              {lf.name}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             )}
-          </div>
 
-          {/* Fecha de investidura */}
-          <div className="space-y-1.5">
-            <Label htmlFor="investiture_date">
-              Fecha de Investidura <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-            </Label>
-            <Input
-              id="investiture_date"
-              type="date"
-              {...register("investiture_date")}
-              aria-required="true"
-            />
-            {errors.investiture_date && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.investiture_date.message}
-              </p>
+            {/* Año Eclesiástico — solo al crear */}
+            {!isEdit && (
+              <FormField
+                control={form.control}
+                name="ecclesiastical_year_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Año Eclesiástico <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Select
+                        value={field.value?.toString() ?? ""}
+                        onValueChange={(v) => field.onChange(Number(v))}
+                        disabled={loadingCatalogs}
+                      >
+                        <SelectTrigger aria-required="true">
+                          <SelectValue
+                            placeholder={
+                              loadingCatalogs ? "Cargando años..." : "Seleccioná un año"
+                            }
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {years.map((year) => (
+                            <SelectItem
+                              key={year.ecclesiastical_year_id}
+                              value={year.ecclesiastical_year_id.toString()}
+                            >
+                              {year.name}
+                              {year.active && (
+                                <span className="ml-1.5 text-xs text-muted-foreground">
+                                  (activo)
+                                </span>
+                              )}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             )}
-          </div>
 
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              Cancelar
-            </Button>
-            <Button type="submit" disabled={isSubmitting || loadingCatalogs}>
-              {isSubmitting && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
-              {isEdit ? "Guardar cambios" : "Crear configuración"}
-            </Button>
-          </DialogFooter>
-        </form>
+            {/* Fecha límite de envío */}
+            <FormField
+              control={form.control}
+              name="submission_deadline"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Límite de Envío <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="date"
+                      aria-required="true"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Fecha de investidura */}
+            <FormField
+              control={form.control}
+              name="investiture_date"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    Fecha de Investidura <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      type="date"
+                      aria-required="true"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                Cancelar
+              </Button>
+              <Button type="submit" disabled={isSubmitting || loadingCatalogs}>
+                {isSubmitting && <Loader2 className="size-4 animate-spin" aria-hidden="true" />}
+                {isEdit ? "Guardar cambios" : "Crear configuración"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/sla/sla-pipeline-chart-inner.tsx
+++ b/src/components/sla/sla-pipeline-chart-inner.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
+import type { InvestiturePipelineItem } from "@/lib/api/analytics";
+
+interface SlaPipelineChartInnerProps {
+  pipeline: InvestiturePipelineItem[];
+}
+
+// Map each status to a semantic chart color token
+const STATUS_COLORS: Record<string, string> = {
+  IN_PROGRESS: "hsl(var(--chart-1, 220 70% 50%))",
+  SUBMITTED_FOR_VALIDATION: "hsl(var(--chart-2, 160 60% 45%))",
+  CLUB_APPROVED: "hsl(var(--chart-3, 30 80% 55%))",
+  COORDINATOR_APPROVED: "hsl(var(--chart-4, 280 65% 60%))",
+  FIELD_APPROVED: "hsl(var(--chart-5, 340 75% 55%))",
+  APPROVED: "hsl(var(--primary))",
+  REJECTED: "hsl(var(--destructive))",
+};
+
+function statusColor(status: string): string {
+  return STATUS_COLORS[status] ?? "hsl(var(--muted-foreground))";
+}
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: Array<{ payload: InvestiturePipelineItem }>;
+}
+
+function CustomTooltip({ active, payload }: TooltipProps) {
+  const t = useTranslations("sla.pipeline");
+  if (!active || !payload?.length) return null;
+  const entry = payload[0].payload;
+  return (
+    <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
+      <p className="font-medium">{entry.label}</p>
+      <p className="text-muted-foreground">
+        {entry.count.toLocaleString("es-MX")} {t("tooltip_enrollments", { count: entry.count })}
+      </p>
+    </div>
+  );
+}
+
+export function SlaPipelineChartInner({ pipeline }: SlaPipelineChartInnerProps) {
+  const t = useTranslations("sla.pipeline");
+  const visiblePipeline = pipeline.filter((p) => p.count > 0 || p.status !== "FIELD_APPROVED");
+
+  if (visiblePipeline.every((p) => p.count === 0)) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t("title")}</CardTitle>
+          <CardDescription>{t("description_distribution")}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={220}>
+          <BarChart
+            data={visiblePipeline}
+            layout="vertical"
+            margin={{ top: 0, right: 12, left: 0, bottom: 0 }}
+          >
+            <XAxis type="number" hide />
+            <YAxis
+              type="category"
+              dataKey="label"
+              width={145}
+              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <Tooltip content={<CustomTooltip />} cursor={{ fill: "hsl(var(--muted) / 0.4)" }} />
+            <Bar dataKey="count" radius={[0, 4, 4, 0]} maxBarSize={20}>
+              {visiblePipeline.map((entry) => (
+                <Cell key={entry.status} fill={statusColor(entry.status)} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/sla/sla-pipeline-chart.tsx
+++ b/src/components/sla/sla-pipeline-chart.tsx
@@ -1,105 +1,37 @@
 "use client";
 
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Cell,
-} from "recharts";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { useTranslations } from "next-intl";
+import dynamic from "next/dynamic";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { InvestiturePipelineItem } from "@/lib/api/analytics";
 
-interface SlaPipelineChartProps {
+export interface SlaPipelineChartProps {
   pipeline: InvestiturePipelineItem[];
 }
 
-// Map each status to a semantic chart color token
-const STATUS_COLORS: Record<string, string> = {
-  IN_PROGRESS: "hsl(var(--chart-1, 220 70% 50%))",
-  SUBMITTED_FOR_VALIDATION: "hsl(var(--chart-2, 160 60% 45%))",
-  CLUB_APPROVED: "hsl(var(--chart-3, 30 80% 55%))",
-  COORDINATOR_APPROVED: "hsl(var(--chart-4, 280 65% 60%))",
-  FIELD_APPROVED: "hsl(var(--chart-5, 340 75% 55%))",
-  APPROVED: "hsl(var(--primary))",
-  REJECTED: "hsl(var(--destructive))",
-};
-
-function statusColor(status: string): string {
-  return STATUS_COLORS[status] ?? "hsl(var(--muted-foreground))";
-}
-
-interface TooltipProps {
-  active?: boolean;
-  payload?: Array<{ payload: InvestiturePipelineItem }>;
-}
-
-function CustomTooltip({ active, payload }: TooltipProps) {
-  const t = useTranslations("sla.pipeline");
-  if (!active || !payload?.length) return null;
-  const entry = payload[0].payload;
-  return (
-    <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
-      <p className="font-medium">{entry.label}</p>
-      <p className="text-muted-foreground">
-        {entry.count.toLocaleString("es-MX")} {t("tooltip_enrollments", { count: entry.count })}
-      </p>
-    </div>
-  );
-}
-
-export function SlaPipelineChart({ pipeline }: SlaPipelineChartProps) {
-  const t = useTranslations("sla.pipeline");
-  const visiblePipeline = pipeline.filter((p) => p.count > 0 || p.status !== "FIELD_APPROVED");
-
-  if (visiblePipeline.every((p) => p.count === 0)) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">{t("title")}</CardTitle>
-          <CardDescription>{t("description_distribution")}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">{t("empty")}</p>
-        </CardContent>
-      </Card>
-    );
-  }
-
+function SlaPipelineChartSkeleton() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">{t("title")}</CardTitle>
-        <CardDescription>{t("description")}</CardDescription>
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3 w-56 mt-1" />
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={220}>
-          <BarChart
-            data={visiblePipeline}
-            layout="vertical"
-            margin={{ top: 0, right: 12, left: 0, bottom: 0 }}
-          >
-            <XAxis type="number" hide />
-            <YAxis
-              type="category"
-              dataKey="label"
-              width={145}
-              tick={{ fontSize: 11, fill: "hsl(var(--muted-foreground))" }}
-              tickLine={false}
-              axisLine={false}
-            />
-            <Tooltip content={<CustomTooltip />} cursor={{ fill: "hsl(var(--muted) / 0.4)" }} />
-            <Bar dataKey="count" radius={[0, 4, 4, 0]} maxBarSize={20}>
-              {visiblePipeline.map((entry) => (
-                <Cell key={entry.status} fill={statusColor(entry.status)} />
-              ))}
-            </Bar>
-          </BarChart>
-        </ResponsiveContainer>
+        <Skeleton className="h-[220px] w-full rounded-md" />
       </CardContent>
     </Card>
   );
+}
+
+const SlaPipelineChartInner = dynamic(
+  () =>
+    import("./sla-pipeline-chart-inner").then((m) => m.SlaPipelineChartInner),
+  {
+    ssr: false,
+    loading: () => <SlaPipelineChartSkeleton />,
+  }
+);
+
+export function SlaPipelineChart({ pipeline }: SlaPipelineChartProps) {
+  return <SlaPipelineChartInner pipeline={pipeline} />;
 }

--- a/src/components/sla/sla-throughput-chart-inner.tsx
+++ b/src/components/sla/sla-throughput-chart-inner.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useTranslations } from "next-intl";
+import type { ThroughputWeek } from "@/lib/api/analytics";
+
+interface SlaThroughputChartInnerProps {
+  throughput: ThroughputWeek[];
+}
+
+interface TooltipProps {
+  active?: boolean;
+  payload?: Array<{ name: string; value: number; color: string }>;
+  label?: string;
+}
+
+function CustomTooltip({ active, payload, label }: TooltipProps) {
+  const t = useTranslations("sla.throughput");
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
+      <p className="mb-1 font-medium text-xs text-muted-foreground">{label}</p>
+      {payload.map((entry) => (
+        <p key={entry.name} style={{ color: entry.color }} className="text-sm">
+          {entry.name === "approved" ? t("legend_approved") : t("legend_rejected")}: {entry.value}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+export function SlaThroughputChartInner({ throughput }: SlaThroughputChartInnerProps) {
+  const t = useTranslations("sla.throughput");
+
+  if (throughput.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t("title")}</CardTitle>
+          <CardDescription>{t("description")}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">{t("empty")}</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={220}>
+          <LineChart
+            data={throughput}
+            margin={{ top: 4, right: 12, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
+            <XAxis
+              dataKey="week"
+              tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+              tickLine={false}
+              axisLine={false}
+            />
+            <YAxis
+              allowDecimals={false}
+              tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
+              tickLine={false}
+              axisLine={false}
+              width={28}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend
+              iconSize={10}
+              formatter={(value) => (
+                <span className="text-xs text-muted-foreground">
+                  {value === "approved" ? t("legend_approved") : t("legend_rejected")}
+                </span>
+              )}
+            />
+            <Line
+              type="monotone"
+              dataKey="approved"
+              stroke="hsl(var(--chart-2, 160 60% 45%))"
+              strokeWidth={2}
+              dot={{ r: 3, fill: "hsl(var(--chart-2, 160 60% 45%))" }}
+              activeDot={{ r: 5 }}
+            />
+            <Line
+              type="monotone"
+              dataKey="rejected"
+              stroke="hsl(var(--destructive))"
+              strokeWidth={2}
+              dot={{ r: 3, fill: "hsl(var(--destructive))" }}
+              activeDot={{ r: 5 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/sla/sla-throughput-chart.tsx
+++ b/src/components/sla/sla-throughput-chart.tsx
@@ -1,115 +1,39 @@
 "use client";
 
-import {
-  LineChart,
-  Line,
-  XAxis,
-  YAxis,
-  Tooltip,
-  Legend,
-  ResponsiveContainer,
-  CartesianGrid,
-} from "recharts";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { useTranslations } from "next-intl";
+import dynamic from "next/dynamic";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { ThroughputWeek } from "@/lib/api/analytics";
 
-interface SlaThroughputChartProps {
+export interface SlaThroughputChartProps {
   throughput: ThroughputWeek[];
 }
 
-interface TooltipProps {
-  active?: boolean;
-  payload?: Array<{ name: string; value: number; color: string }>;
-  label?: string;
-}
-
-function CustomTooltip({ active, payload, label }: TooltipProps) {
-  const t = useTranslations("sla.throughput");
-  if (!active || !payload?.length) return null;
-  return (
-    <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
-      <p className="mb-1 font-medium text-xs text-muted-foreground">{label}</p>
-      {payload.map((entry) => (
-        <p key={entry.name} style={{ color: entry.color }} className="text-sm">
-          {entry.name === "approved" ? t("legend_approved") : t("legend_rejected")}: {entry.value}
-        </p>
-      ))}
-    </div>
-  );
-}
-
-export function SlaThroughputChart({ throughput }: SlaThroughputChartProps) {
-  const t = useTranslations("sla.throughput");
-
-  if (throughput.length === 0) {
-    return (
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">{t("title")}</CardTitle>
-          <CardDescription>{t("description")}</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-muted-foreground">{t("empty")}</p>
-        </CardContent>
-      </Card>
-    );
-  }
-
+function SlaThroughputChartSkeleton() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-base">{t("title")}</CardTitle>
-        <CardDescription>{t("description")}</CardDescription>
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3 w-56 mt-1" />
       </CardHeader>
       <CardContent>
-        <ResponsiveContainer width="100%" height={220}>
-          <LineChart
-            data={throughput}
-            margin={{ top: 4, right: 12, left: 0, bottom: 0 }}
-          >
-            <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
-            <XAxis
-              dataKey="week"
-              tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
-              tickLine={false}
-              axisLine={false}
-            />
-            <YAxis
-              allowDecimals={false}
-              tick={{ fontSize: 10, fill: "hsl(var(--muted-foreground))" }}
-              tickLine={false}
-              axisLine={false}
-              width={28}
-            />
-            <Tooltip content={<CustomTooltip />} />
-            <Legend
-              iconSize={10}
-              formatter={(value) => (
-                <span className="text-xs text-muted-foreground">
-                  {value === "approved" ? t("legend_approved") : t("legend_rejected")}
-                </span>
-              )}
-            />
-            <Line
-              type="monotone"
-              dataKey="approved"
-              stroke="hsl(var(--chart-2, 160 60% 45%))"
-              strokeWidth={2}
-              dot={{ r: 3, fill: "hsl(var(--chart-2, 160 60% 45%))" }}
-              activeDot={{ r: 5 }}
-            />
-            <Line
-              type="monotone"
-              dataKey="rejected"
-              stroke="hsl(var(--destructive))"
-              strokeWidth={2}
-              dot={{ r: 3, fill: "hsl(var(--destructive))" }}
-              activeDot={{ r: 5 }}
-            />
-          </LineChart>
-        </ResponsiveContainer>
+        <Skeleton className="h-[220px] w-full rounded-md" />
       </CardContent>
     </Card>
   );
+}
+
+const SlaThroughputChartInner = dynamic(
+  () =>
+    import("./sla-throughput-chart-inner").then(
+      (m) => m.SlaThroughputChartInner
+    ),
+  {
+    ssr: false,
+    loading: () => <SlaThroughputChartSkeleton />,
+  }
+);
+
+export function SlaThroughputChart({ throughput }: SlaThroughputChartProps) {
+  return <SlaThroughputChartInner throughput={throughput} />;
 }


### PR DESCRIPTION
## Summary

Single-PR consolidation of 3 disjoint workstreams (Session 21):

### A — Perf round 4: recharts dynamic imports
- `RoleDistributionChart`, `SlaPipelineChart`, `SlaThroughputChart` split into wrapper + `*-inner.tsx`.
- Wrappers use `next/dynamic({ ssr: false })` with skeleton placeholders.
- Defers ~98KB gzip recharts cost off `/dashboard` and `/dashboard/sla` initial bundles.

### B — Analyze script fix
- `pnpm analyze` rewritten to `next experimental-analyze -o` (Turbopack-native, Next 16+).
- `@next/bundle-analyzer` removed (incompatible with Turbopack — generated no HTML).
- `analyze:server` script removed.
- `PERF-BASELINE.md` instructions updated.

### C — shadcn Form primitive r3 (4 rhf forms)
- `camporees/payment-dialog`
- `camporees/union-camporee-form-dialog`
- `camporees/register-member-dialog`
- `investiture/config-form-dialog`

Each migrated from bare `Input`/`Label`/manual error `<p>` to `FormField` + `FormLabel` + `FormControl` + `FormMessage`. `aria-invalid` auto-wired. Net `-221` LOC across the 4 dialogs.

### D — MSW dialog tests r3 (+28 tests, 344 → 372)
- `payment-dialog.test.tsx` — 9 tests
- `register-member-dialog.test.tsx` — 9 tests
- `config-form-dialog.test.tsx` — 10 tests

Stable query pattern: `input[name="..."]` for RHF fields (survives shadcn FormControl `React.useId` override) + role/regex matching for buttons and `FormMessage` assertions.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test --run` — 372/372 pass (24 → 27 files)
- [x] `pnpm lint` — 10 errors / 42 warnings, all pre-existing baseline, zero regressions in touched files
- [ ] CI Vitest unit tests green
- [ ] CI TypeScript typecheck green
- [ ] Vercel preview deploy green

## Stats

- 17 files: 11 modified, 6 created
- Test count journey: 41 (audit) → 316 (Sesión 19) → 344 (Sesión 20) → **372 (Sesión 21)** = 9.1x growth