### PR TITLE
chore: cascade development → preproduction (post #125)

### DIFF
--- a/PERF-BASELINE.md
+++ b/PERF-BASELINE.md
@@ -227,10 +227,71 @@ or brotli (smaller). These numbers are upper-bound for HTTP transfer.
 
 ---
 
-## 7. Next actions (handoff)
+## 7. Round 5 (2026-05-10) — zod form-dialog deferred imports
+
+**Branch:** `perf/admin-r5-dynamic` (off `origin/development`)
+**Tool:** `pnpm analyze` → `next experimental-analyze -o` → `.next/diagnostics/analyze/data/`
+**Method:** parsed `analyze.data` (binary Turbopack format) via Python to extract
+`compressed_size` per `(output_file, source)` pair across all routes.
+
+### New finding: 103 KB zod/i18n chunk on form-heavy routes
+
+`0atc2p9c7en0i.js` (**103 KB compressed**) appears on `/dashboard/camporees`,
+`/dashboard/evidence-review`, `/dashboard/investiture/pipeline`, and other form-heavy
+routes. Sources: `zod.mjs` + all 50+ `zod@4` i18n locale files
+(`es.js`, `fr.js`, `zh-TW.js`, etc.) + `@hookform/resolvers/zod` internals.
+Root cause: form dialog components import `zodResolver` at the module level,
+pulling the entire zod v4 locale bundle into the initial page chunk.
+
+| Route | Chunk saved (compressed) |
+|---|---|
+| `/dashboard/camporees` | ~103 KB |
+| `/dashboard/evidence-review` | ~103 KB |
+| `/dashboard/investiture/pipeline` | ~103 KB |
+
+### Components deferred
+
+| File | Dynamic-imported component(s) | Why safe to defer |
+|---|---|---|
+| `src/components/camporees/camporees-view.tsx` | `CamporeeFormDialog` | Only opened via "Nueva campaña" button click |
+| `src/components/evidence-review/evidence-review-table.tsx` | `EvidenceRejectDialog`, `EvidenceBulkActionBar` | Reject dialog requires row action; bulk bar appears after row selection |
+| `src/components/investiture/pipeline-table.tsx` | `PipelineRejectDialog`, `BulkActionBar` | Both require user interaction to mount |
+
+### Pattern applied
+
+Direct `next/dynamic({ ssr: false, loading: () => null })` on each dialog
+component in its parent client component — no wrapper+inner split needed since
+these are already conditionally rendered. Props interfaces exported from each
+dialog file for correct generic typing of `dynamic<Props>()`.
+
+### Other findings from R5 analyze run
+
+- **`react-day-picker`** (4.6 MB disk): completely tree-shaken. `calendar.tsx` is
+  defined but imported nowhere in the app — zero bundle impact.
+- **`recharts`** (`02jltdgb8b9kl.js`, 150 KB compressed): correctly isolated in its
+  own lazy chunk, confirming R4 work holds.
+- **Largest initial client chunks** (non-framework): `lucide-react` 16.9 KB, 
+  `next-intl` client runtime 13.2 KB, `floating-ui` 11.3 KB — all structural,
+  cannot be deferred without major refactor.
+- **`axios`** (`0kkorn5o_nsv3.js`, 21.9 KB): present on ~50 routes via `src/lib/api/client.ts`.
+  Used for all browser-side API calls. Cannot be deferred.
+
+### Verification
+
+- `pnpm typecheck`: PASS
+- `pnpm test --run`: 372/372 PASS
+- `pnpm lint`: 10 err / 42 warn (unchanged from baseline)
+
+---
+
+## 8. Next actions (handoff)
 
 - ~~Replace `pnpm analyze` script with `next experimental-analyze`~~ DONE.
-- ~~Recharts dynamic imports (#1 in §5)~~ DONE.
-- File remaining follow-up items from §5 (#2–#5) as separate perf PRs.
+- ~~Recharts dynamic imports (#1 in §5)~~ DONE (R4).
+- ~~zod form-dialog deferred imports (#2 in §5)~~ DONE (R5).
+- **Remaining items from §5 (#3–#5)**:
+  - Investigate `/dashboard/clubs/[id]` (18-chunk heavyweight route).
+  - Audit `/dashboard/annual-folders/templates` remaining eagerly-imported helpers.
+  - Evaluate replacing/deferring `cmdk` on `/dashboard/clubs/[id]`.
 - After the next perf wave, regenerate this baseline and commit a diff so we
   can see savings by route.

--- a/src/components/camporees/camporee-approval-dialog.test.tsx
+++ b/src/components/camporees/camporee-approval-dialog.test.tsx
@@ -1,0 +1,343 @@
+/**
+ * Integration tests for CamporeeApprovalDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form + Zod (static rejectSchema).
+ * It calls the `onConfirm` prop (a Promise<void>) provided by the parent.
+ * No direct HTTP calls — the parent owns the API call.
+ *
+ * Two modes (controlled by `mode` prop):
+ *   - "approve": shows no textarea, calls onConfirm with no args
+ *   - "reject":  shows optional rejection_reason textarea,
+ *                calls onConfirm(rejectionReason)
+ *
+ * Validation: rejection_reason.max(500) — only fire if >500 chars.
+ *
+ * Renders are wrapped in `NextIntlClientProvider` with real `messages/es.json`.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import { ApiError } from "@/lib/api/client";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import {
+  CamporeeApprovalDialog,
+  type ApprovalDialogMode,
+} from "@/components/camporees/camporee-approval-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ENTITY_LABEL = "Club";
+const ENTITY_NAME = "Club Los Pinos";
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  mode?: ApprovalDialogMode;
+  entityLabel?: string;
+  entityName?: string;
+  onConfirm?: () => Promise<void>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    mode = "approve",
+    entityLabel = ENTITY_LABEL,
+    entityName = ENTITY_NAME,
+    onConfirm = vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <CamporeeApprovalDialog
+        open={open}
+        mode={mode}
+        entityLabel={entityLabel}
+        entityName={entityName}
+        onOpenChange={onOpenChange}
+        onConfirm={onConfirm}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess, onConfirm };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CamporeeApprovalDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Approve mode — rendering ───────────────────────────────────────────
+
+  it("renders approve mode title, entity name in description, and action buttons", () => {
+    renderDialog({ mode: "approve" });
+
+    // Title contains "Aprobar" and entity label
+    expect(
+      screen.getByRole("heading", { name: /Aprobar/i }),
+    ).toBeInTheDocument();
+
+    // Description contains entity name
+    expect(screen.getByText(new RegExp(ENTITY_NAME, "i"))).toBeInTheDocument();
+
+    // No textarea in approve mode
+    expect(document.querySelector("textarea")).not.toBeInTheDocument();
+
+    // Buttons
+    expect(screen.getByRole("button", { name: /Aprobar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Cancelar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Reject mode — rendering ────────────────────────────────────────────
+
+  it("renders reject mode title and shows rejection_reason textarea", () => {
+    renderDialog({ mode: "reject" });
+
+    expect(
+      screen.getByRole("heading", { name: /Rechazar/i }),
+    ).toBeInTheDocument();
+
+    // Textarea for rejection_reason is rendered in reject mode
+    expect(document.querySelector("textarea")).toBeInTheDocument();
+    expect(screen.getByText(/Motivo de rechazo/i)).toBeInTheDocument();
+
+    expect(screen.getByRole("button", { name: /Rechazar/i })).toBeInTheDocument();
+  });
+
+  // ── 3. Approve — calls onConfirm with no reason and shows success toast ───
+
+  it("calls onConfirm() with no args in approve mode and shows success toast", async () => {
+    const mockOnConfirm = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const { onOpenChange, onSuccess } = renderDialog({
+      mode: "approve",
+      onConfirm: mockOnConfirm,
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockOnConfirm).toHaveBeenCalledOnce();
+    });
+
+    // onConfirm called with undefined (no rejection reason in approve mode)
+    expect(mockOnConfirm).toHaveBeenCalledWith(undefined);
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      expect.stringContaining(ENTITY_NAME),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 4. Reject — calls onConfirm with reason when provided ────────────────
+
+  it("calls onConfirm(reason) in reject mode when rejection reason is entered", async () => {
+    const mockOnConfirm = vi.fn<(reason?: string) => Promise<void>>().mockResolvedValue(undefined);
+    const { onOpenChange, onSuccess } = renderDialog({
+      mode: "reject",
+      onConfirm: mockOnConfirm,
+    });
+
+    // Type a rejection reason
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+    await act(async () => {
+      if (textarea) fireEvent.change(textarea, { target: { value: "Documentación incompleta" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockOnConfirm).toHaveBeenCalledOnce();
+    });
+
+    expect(mockOnConfirm).toHaveBeenCalledWith("Documentación incompleta");
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      expect.stringContaining(ENTITY_NAME),
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 5. Reject — calls onConfirm with empty string when no reason ──────────
+
+  it("calls onConfirm with empty string when rejection reason is omitted", async () => {
+    const mockOnConfirm = vi.fn<(reason?: string) => Promise<void>>().mockResolvedValue(undefined);
+    renderDialog({ mode: "reject", onConfirm: mockOnConfirm });
+
+    // Submit without filling the textarea
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockOnConfirm).toHaveBeenCalledOnce();
+    });
+
+    // rejection_reason is optional — empty string is valid
+    const calledWith = mockOnConfirm.mock.calls[0]![0];
+    expect(typeof calledWith === "string" || calledWith === undefined).toBe(true);
+  });
+
+  // ── 6. Cancel closes dialog without calling onConfirm ─────────────────────
+
+  it("calls onOpenChange(false) and does NOT call onConfirm when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const mockOnConfirm = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    const { onOpenChange } = renderDialog({ onConfirm: mockOnConfirm });
+
+    await user.click(screen.getByRole("button", { name: /Cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Submit button disabled while in flight ─────────────────────────────
+
+  it("disables submit button while onConfirm is pending", async () => {
+    let resolveConfirm!: () => void;
+    const mockOnConfirm = vi.fn<() => Promise<void>>().mockReturnValue(
+      new Promise<void>((res) => {
+        resolveConfirm = res;
+      }),
+    );
+
+    renderDialog({ mode: "approve", onConfirm: mockOnConfirm });
+
+    await submitForm();
+
+    await waitFor(() => {
+      // The submit button is disabled while pending (contains Loader2 + label)
+      const submitBtn = screen.getByRole("button", { name: /Aprobar/i });
+      expect(submitBtn).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveConfirm();
+    });
+  });
+
+  // ── 8. ApiError — shows error message from ApiError instance ─────────────
+
+  it("shows toast.error with ApiError message when onConfirm throws ApiError", async () => {
+    const mockOnConfirm = vi.fn<() => Promise<void>>().mockRejectedValue(
+      new ApiError("Permiso insuficiente", 403, null),
+    );
+
+    renderDialog({ mode: "approve", onConfirm: mockOnConfirm });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Permiso insuficiente");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 9. Generic error — shows unexpected error fallback ────────────────────
+
+  it("shows unexpected error toast when onConfirm throws non-ApiError", async () => {
+    const mockOnConfirm = vi.fn<() => Promise<void>>().mockRejectedValue(
+      new Error("Network failure"),
+    );
+
+    renderDialog({ mode: "reject", onConfirm: mockOnConfirm });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(messages.camporees.errors.unexpected);
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 10. Validation — rejection_reason exceeds 500 chars ──────────────────
+
+  it("shows validation error when rejection_reason exceeds 500 characters", async () => {
+    const mockOnConfirm = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+    renderDialog({ mode: "reject", onConfirm: mockOnConfirm });
+
+    // Build a string of 501 characters
+    const longText = "a".repeat(501);
+    const textarea = document.querySelector("textarea") as HTMLTextAreaElement | null;
+    await act(async () => {
+      if (textarea) fireEvent.change(textarea, { target: { value: longText } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/500/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockOnConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/camporees/camporee-form-dialog.test.tsx
+++ b/src/components/camporees/camporee-form-dialog.test.tsx
@@ -1,0 +1,418 @@
+/**
+ * Integration tests for CamporeeFormDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form + Zod (schema built inside component via
+ * buildSchema factory). It calls `createCamporee` or `updateCamporee` from
+ * `@/lib/api/camporees` (HTTP). We mock the module entirely — MSW is active
+ * per vitest.setup but is not exercised here (no fetch path).
+ *
+ * Two modes:
+ *   - Create: empty form, submit calls createCamporee
+ *   - Edit:   pre-filled from camporee prop, submit calls updateCamporee
+ *
+ * Checkboxes are Radix Checkbox components (not native) — toggled via
+ * fireEvent.click on the rendered button element.
+ *
+ * Renders are wrapped in `NextIntlClientProvider` with the real `messages/es.json`.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { Camporee } from "@/lib/api/camporees";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateCamporee = vi.fn<(...args: any[]) => Promise<unknown>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdateCamporee = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/camporees", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/camporees")>();
+  return {
+    ...original,
+    createCamporee: (...args: unknown[]) => mockCreateCamporee(...args),
+    updateCamporee: (...args: unknown[]) => mockUpdateCamporee(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { CamporeeFormDialog } from "@/components/camporees/camporee-form-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_CAMPOREE: Camporee = {
+  camporee_id: 7,
+  name: "Camporee Primavera",
+  description: "Descripción de prueba",
+  start_date: "2026-05-10T00:00:00.000Z",
+  end_date: "2026-05-15T00:00:00.000Z",
+  local_camporee_place: "Parque Nacional",
+  local_field_id: 3,
+  registration_cost: 250,
+  includes_adventurers: true,
+  includes_pathfinders: true,
+  includes_master_guides: false,
+};
+
+const t = messages.camporees;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  camporee?: Camporee | null;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, camporee = null } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <CamporeeFormDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        camporee={camporee}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// Fill all required fields with valid values (create mode)
+async function fillRequiredFields() {
+  await act(async () => {
+    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement | null;
+    if (nameInput) fireEvent.change(nameInput, { target: { value: "Camporee Test" } });
+
+    const startInput = document.querySelector('input[name="start_date"]') as HTMLInputElement | null;
+    if (startInput) fireEvent.change(startInput, { target: { value: "2026-07-01" } });
+
+    const endInput = document.querySelector('input[name="end_date"]') as HTMLInputElement | null;
+    if (endInput) fireEvent.change(endInput, { target: { value: "2026-07-05" } });
+
+    const placeInput = document.querySelector('input[name="local_camporee_place"]') as HTMLInputElement | null;
+    if (placeInput) fireEvent.change(placeInput, { target: { value: "Lugar de prueba" } });
+
+    const fieldIdInput = document.querySelector('input[name="local_field_id"]') as HTMLInputElement | null;
+    if (fieldIdInput) fireEvent.change(fieldIdInput, { target: { value: "2" } });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("CamporeeFormDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateCamporee.mockResolvedValue({ ok: true });
+    mockUpdateCamporee.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Create mode — rendering ────────────────────────────────────────────
+
+  it("renders create mode title, required inputs, checkboxes, and buttons", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: t.form.titleCreate }),
+    ).toBeInTheDocument();
+
+    // Required text inputs (query by name attr — RHF spreads name via {...register()})
+    expect(document.querySelector('input[name="name"]')).toBeInTheDocument();
+    expect(document.querySelector('input[name="start_date"]')).toBeInTheDocument();
+    expect(document.querySelector('input[name="end_date"]')).toBeInTheDocument();
+    expect(document.querySelector('input[name="local_camporee_place"]')).toBeInTheDocument();
+    expect(document.querySelector('input[name="local_field_id"]')).toBeInTheDocument();
+    expect(document.querySelector('input[name="registration_cost"]')).toBeInTheDocument();
+
+    // Club type checkboxes by label text
+    expect(screen.getByText(t.form.adventurers)).toBeInTheDocument();
+    expect(screen.getByText(t.form.pathfinders)).toBeInTheDocument();
+    expect(screen.getByText(t.form.masterGuides)).toBeInTheDocument();
+
+    // Buttons
+    expect(
+      screen.getByRole("button", { name: t.form.createCamporee }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: t.form.cancel }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Edit mode — pre-fills form with camporee data ──────────────────────
+
+  it("renders edit mode title and pre-fills inputs from camporee prop", () => {
+    renderDialog({ camporee: STUB_CAMPOREE });
+
+    expect(
+      screen.getByRole("heading", { name: t.form.titleEdit }),
+    ).toBeInTheDocument();
+
+    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement | null;
+    expect(nameInput?.value).toBe("Camporee Primavera");
+
+    // ISO date is sliced to "YYYY-MM-DD"
+    const startInput = document.querySelector('input[name="start_date"]') as HTMLInputElement | null;
+    expect(startInput?.value).toBe("2026-05-10");
+
+    const endInput = document.querySelector('input[name="end_date"]') as HTMLInputElement | null;
+    expect(endInput?.value).toBe("2026-05-15");
+
+    const placeInput = document.querySelector('input[name="local_camporee_place"]') as HTMLInputElement | null;
+    expect(placeInput?.value).toBe("Parque Nacional");
+
+    expect(
+      screen.getByRole("button", { name: t.form.saveChanges }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 3. Validation — required fields empty ────────────────────────────────
+
+  it("shows validation errors when required fields are empty on submit", async () => {
+    renderDialog();
+
+    await submitForm();
+
+    await waitFor(() => {
+      // Zod error messages rendered as role="alert" paragraphs
+      expect(
+        screen.getByText(new RegExp(messages.camporees.validation.name_required, "i")),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(new RegExp(messages.camporees.validation.start_date_required, "i")),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(new RegExp(messages.camporees.validation.end_date_required, "i")),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockCreateCamporee).not.toHaveBeenCalled();
+  });
+
+  // ── 4. Validation — end date before start date ───────────────────────────
+
+  it("shows end_date_after_start error when end_date precedes start_date", async () => {
+    renderDialog();
+
+    await act(async () => {
+      const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement | null;
+      if (nameInput) fireEvent.change(nameInput, { target: { value: "Test" } });
+
+      const startInput = document.querySelector('input[name="start_date"]') as HTMLInputElement | null;
+      if (startInput) fireEvent.change(startInput, { target: { value: "2026-07-10" } });
+
+      // end before start
+      const endInput = document.querySelector('input[name="end_date"]') as HTMLInputElement | null;
+      if (endInput) fireEvent.change(endInput, { target: { value: "2026-07-05" } });
+
+      const placeInput = document.querySelector('input[name="local_camporee_place"]') as HTMLInputElement | null;
+      if (placeInput) fireEvent.change(placeInput, { target: { value: "Lugar" } });
+
+      const fieldIdInput = document.querySelector('input[name="local_field_id"]') as HTMLInputElement | null;
+      if (fieldIdInput) fireEvent.change(fieldIdInput, { target: { value: "1" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(new RegExp(messages.camporees.validation.end_date_after_start_full, "i")),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockCreateCamporee).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — create camporee ──────────────────────────────────────
+
+  it("calls createCamporee with correct payload and shows success toast", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    await fillRequiredFields();
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreateCamporee).toHaveBeenCalledOnce();
+    });
+
+    const [payload] = mockCreateCamporee.mock.calls[0] as [
+      {
+        name: string;
+        start_date: string;
+        end_date: string;
+        local_camporee_place: string;
+        local_field_id: number;
+      },
+    ];
+    expect(payload.name).toBe("Camporee Test");
+    expect(payload.start_date).toBe("2026-07-01");
+    expect(payload.end_date).toBe("2026-07-05");
+    expect(payload.local_camporee_place).toBe("Lugar de prueba");
+    expect(payload.local_field_id).toBe(2);
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.camporee_created);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 6. Happy path — edit camporee ────────────────────────────────────────
+
+  it("calls updateCamporee (not create) in edit mode and shows update toast", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ camporee: STUB_CAMPOREE });
+
+    // Change name field
+    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement | null;
+    await act(async () => {
+      if (nameInput) fireEvent.change(nameInput, { target: { value: "Nuevo Nombre" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockUpdateCamporee).toHaveBeenCalledOnce();
+    });
+
+    expect(mockCreateCamporee).not.toHaveBeenCalled();
+
+    const [camporeeId, payload] = mockUpdateCamporee.mock.calls[0] as [
+      number,
+      { name: string },
+    ];
+    expect(camporeeId).toBe(7);
+    expect(payload.name).toBe("Nuevo Nombre");
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.camporee_updated);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 7. Cancel closes dialog without API call ──────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call API when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: t.form.cancel }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateCamporee).not.toHaveBeenCalled();
+    expect(mockUpdateCamporee).not.toHaveBeenCalled();
+  });
+
+  // ── 8. Submit button disabled while in flight ─────────────────────────────
+
+  it("disables submit button while submission is in flight (edit mode)", async () => {
+    let resolveUpdate!: () => void;
+    mockUpdateCamporee.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveUpdate = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog({ camporee: STUB_CAMPOREE });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: new RegExp(t.form.saving, "i") }),
+      ).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveUpdate();
+    });
+  });
+
+  // ── 9. API error — shows server error message ─────────────────────────────
+
+  it("shows error toast with server message when createCamporee throws", async () => {
+    mockCreateCamporee.mockRejectedValue(new Error("Name already taken"));
+
+    renderDialog();
+
+    await fillRequiredFields();
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Name already taken");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 10. API error — fallback translated message ───────────────────────────
+
+  it("shows fallback translated error when createCamporee throws non-Error", async () => {
+    mockCreateCamporee.mockRejectedValue("unexpected string");
+
+    renderDialog();
+
+    await fillRequiredFields();
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.save_camporee);
+    });
+  });
+});

--- a/src/components/camporees/camporee-form-dialog.tsx
+++ b/src/components/camporees/camporee-form-dialog.tsx
@@ -49,7 +49,7 @@ type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
-interface CamporeeFormDialogProps {
+export interface CamporeeFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   camporee?: Camporee | null;

--- a/src/components/camporees/camporees-view.tsx
+++ b/src/components/camporees/camporees-view.tsx
@@ -13,9 +13,20 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import dynamic from "next/dynamic";
 import { EmptyState } from "@/components/shared/empty-state";
-import { CamporeeFormDialog } from "@/components/camporees/camporee-form-dialog";
 import { DeleteCamporeeDialog } from "@/components/camporees/delete-camporee-dialog";
+import type { CamporeeFormDialogProps } from "@/components/camporees/camporee-form-dialog";
+
+// Deferred: CamporeeFormDialog imports zodResolver + zod (~103 KB compressed).
+// The dialog is only opened by an explicit user action, never at first paint.
+const CamporeeFormDialog = dynamic<CamporeeFormDialogProps>(
+  () =>
+    import("@/components/camporees/camporee-form-dialog").then(
+      (m) => m.CamporeeFormDialog
+    ),
+  { ssr: false, loading: () => null }
+);
 import { useTranslations } from "next-intl";
 import { listCamporees } from "@/lib/api/camporees";
 import type { Camporee } from "@/lib/api/camporees";

--- a/src/components/evidence-review/evidence-bulk-action-bar.tsx
+++ b/src/components/evidence-review/evidence-bulk-action-bar.tsx
@@ -60,7 +60,7 @@ type RejectFormValues = { reason: string };
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface EvidenceBulkActionBarProps {
+export interface EvidenceBulkActionBarProps {
   selectedIds: number[];
   selectedType: EvidenceType | null;
   onClearSelection: () => void;

--- a/src/components/evidence-review/evidence-history-dialog.test.tsx
+++ b/src/components/evidence-review/evidence-history-dialog.test.tsx
@@ -1,0 +1,312 @@
+/**
+ * Integration tests for EvidenceHistoryDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses `useQuery` from @tanstack/react-query to fetch evidence
+ * history via `getEvidenceHistory` from `@/lib/api/evidence-review`.
+ * We mock `getEvidenceHistory` at module level — no MSW handler needed
+ * (consistent with other test files in this suite that mock API modules).
+ *
+ * The component is display-only (no form, no RHF). Tests verify:
+ *   - Loading skeleton is shown while query is pending
+ *   - History entries are rendered with correct action labels/icons
+ *   - Empty state is shown when entries are []
+ *   - Error toast fires when getEvidenceHistory throws
+ *   - Fetch is NOT triggered when dialog is closed (enabled: open)
+ *
+ * Requires QueryClientProvider — a fresh client per test to avoid cache bleed.
+ *
+ * Renders are wrapped in `NextIntlClientProvider` with real `messages/es.json`.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import messages from "../../../messages/es.json";
+import type { EvidenceHistoryEntry, EvidenceType } from "@/lib/api/evidence-review";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetEvidenceHistory = vi.fn<(...args: any[]) => Promise<EvidenceHistoryEntry[]>>();
+
+vi.mock("@/lib/api/evidence-review", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/evidence-review")>();
+  return {
+    ...original,
+    getEvidenceHistory: (...args: unknown[]) => mockGetEvidenceHistory(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { EvidenceHistoryDialog } from "@/components/evidence-review/evidence-history-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const th = messages.evidence_review.history;
+
+const STUB_ENTRIES: EvidenceHistoryEntry[] = [
+  {
+    action: "SUBMITTED",
+    performed_by_name: "Ana López",
+    comment: null,
+    created_at: "2026-04-01T10:00:00.000Z",
+  },
+  {
+    action: "REJECTED",
+    performed_by_name: "Carlos Díaz",
+    comment: "Falta la firma del director",
+    created_at: "2026-04-05T14:30:00.000Z",
+  },
+  {
+    action: "APPROVED",
+    performed_by_name: null,
+    comment: null,
+    created_at: "2026-04-10T09:00:00.000Z",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  type?: EvidenceType;
+  id?: number;
+  memberName?: string;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    type = "folder",
+    id = 42,
+    memberName = "Juan Pérez",
+  } = opts;
+  const onOpenChange = vi.fn();
+
+  // Fresh QueryClient per test — prevents cache bleed between tests
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,       // no retries in tests
+        gcTime: 0,         // garbage-collect immediately after unmount
+      },
+    },
+  });
+
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <NextIntlClientProvider locale="es" messages={messages}>
+        <EvidenceHistoryDialog
+          open={open}
+          type={type}
+          id={id}
+          memberName={memberName}
+          onOpenChange={onOpenChange}
+        />
+      </NextIntlClientProvider>
+    </QueryClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, queryClient };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EvidenceHistoryDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Title and member name rendering ────────────────────────────────────
+
+  it("renders dialog title and memberName as description", async () => {
+    mockGetEvidenceHistory.mockResolvedValue([]);
+
+    renderDialog({ memberName: "Juan Pérez" });
+
+    expect(
+      screen.getByRole("heading", { name: th.title }),
+    ).toBeInTheDocument();
+
+    expect(screen.getByText("Juan Pérez")).toBeInTheDocument();
+  });
+
+  // ── 2. Loading skeleton while query is in flight ──────────────────────────
+
+  it("shows loading skeleton while getEvidenceHistory is pending", async () => {
+    // Never resolves during the check
+    let resolve!: (v: EvidenceHistoryEntry[]) => void;
+    mockGetEvidenceHistory.mockReturnValue(
+      new Promise<EvidenceHistoryEntry[]>((res) => {
+        resolve = res;
+      }),
+    );
+
+    renderDialog();
+
+    // The skeleton renders div.animate-pulse elements while loading
+    const skeletons = document.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+
+    // Resolve to allow cleanup
+    resolve([]);
+  });
+
+  // ── 3. Empty state — no history entries ───────────────────────────────────
+
+  it("renders empty state text when history entries are empty", async () => {
+    mockGetEvidenceHistory.mockResolvedValue([]);
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(th.empty)).toBeInTheDocument();
+    });
+
+    expect(mockGetEvidenceHistory).toHaveBeenCalledOnce();
+  });
+
+  // ── 4. Renders history entries with correct action labels ─────────────────
+
+  it("renders all history entries with translated action labels", async () => {
+    mockGetEvidenceHistory.mockResolvedValue(STUB_ENTRIES);
+
+    renderDialog();
+
+    await waitFor(() => {
+      // Three entries should appear
+      expect(screen.getByText(th.action_submitted)).toBeInTheDocument();
+      expect(screen.getByText(th.action_rejected)).toBeInTheDocument();
+      expect(screen.getByText(th.action_approved)).toBeInTheDocument();
+    });
+
+    // Performed-by names
+    expect(screen.getByText(/Ana López/)).toBeInTheDocument();
+    expect(screen.getByText(/Carlos Díaz/)).toBeInTheDocument();
+  });
+
+  // ── 5. Renders comment when present ──────────────────────────────────────
+
+  it("renders comment text when an entry has a comment", async () => {
+    mockGetEvidenceHistory.mockResolvedValue(STUB_ENTRIES);
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Falta la firma del director")).toBeInTheDocument();
+    });
+  });
+
+  // ── 6. System fallback for null performed_by_name ────────────────────────
+
+  it("shows 'Sistema' when performed_by_name is null", async () => {
+    mockGetEvidenceHistory.mockResolvedValue(STUB_ENTRIES);
+
+    renderDialog();
+
+    await waitFor(() => {
+      // STUB_ENTRIES[2].performed_by_name is null → should fall back to "Sistema"
+      expect(screen.getByText(new RegExp(th.system, "i"))).toBeInTheDocument();
+    });
+  });
+
+  // ── 7. getEvidenceHistory is called with correct type and id ─────────────
+
+  it("calls getEvidenceHistory with type='class' and id=99 when open", async () => {
+    mockGetEvidenceHistory.mockResolvedValue([]);
+
+    renderDialog({ type: "class", id: 99 });
+
+    await waitFor(() => {
+      expect(mockGetEvidenceHistory).toHaveBeenCalledWith("class", 99);
+    });
+  });
+
+  // ── 8. Fetch NOT triggered when dialog is closed ──────────────────────────
+
+  it("does NOT call getEvidenceHistory when open=false", () => {
+    mockGetEvidenceHistory.mockResolvedValue([]);
+
+    renderDialog({ open: false });
+
+    // useQuery is disabled when open=false — the function must NOT be called
+    expect(mockGetEvidenceHistory).not.toHaveBeenCalled();
+  });
+
+  // ── 9. Error path — ApiError message is shown directly ──────────────────
+
+  it("shows ApiError message directly when getEvidenceHistory throws ApiError", async () => {
+    // The queryFn checks `error instanceof ApiError` — uses error.message
+    // We import ApiError to construct a proper instance.
+    const { ApiError } = await import("@/lib/api/client");
+    mockGetEvidenceHistory.mockRejectedValue(
+      new ApiError("Historial no disponible", 503, null),
+    );
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Historial no disponible");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 10. Error path — fallback error_load for plain Error or non-Error ─────
+
+  it("shows error_load toast when getEvidenceHistory throws a plain Error (non-ApiError)", async () => {
+    // Plain Error is NOT instanceof ApiError → falls back to t("error_load")
+    mockGetEvidenceHistory.mockRejectedValue(new Error("Network timeout"));
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(th.error_load);
+    });
+  });
+});

--- a/src/components/evidence-review/evidence-reject-dialog.tsx
+++ b/src/components/evidence-review/evidence-reject-dialog.tsx
@@ -16,8 +16,15 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { rejectEvidence, type EvidenceType } from "@/lib/api/evidence-review";
 import { ApiError } from "@/lib/api/client";
 
@@ -34,7 +41,7 @@ function buildRejectSchema(t: RejectTranslator) {
 
 type RejectFormValues = { reason: string };
 
-interface EvidenceRejectDialogProps {
+export interface EvidenceRejectDialogProps {
   open: boolean;
   type: EvidenceType;
   id: number;
@@ -99,41 +106,43 @@ export function EvidenceRejectDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="reject-reason">{t("rejectDialog.reasonLabel")}</Label>
-            <Textarea
-              id="reject-reason"
-              placeholder={t("rejectDialog.reasonPlaceholder")}
-              rows={4}
-              {...form.register("reason")}
-              disabled={isSubmitting}
-              aria-describedby={
-                form.formState.errors.reason ? "reject-reason-error" : undefined
-              }
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="reason"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("rejectDialog.reasonLabel")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("rejectDialog.reasonPlaceholder")}
+                      rows={4}
+                      {...field}
+                      disabled={isSubmitting}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {form.formState.errors.reason && (
-              <p id="reject-reason-error" className="text-xs text-destructive">
-                {form.formState.errors.reason.message}
-              </p>
-            )}
-          </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleClose(false)}
-              disabled={isSubmitting}
-            >
-              {t("rejectDialog.cancel")}
-            </Button>
-            <Button type="submit" variant="destructive" disabled={isSubmitting}>
-              {isSubmitting && <Loader2 className="size-4 animate-spin" />}
-              {t("rejectDialog.confirm")}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isSubmitting}
+              >
+                {t("rejectDialog.cancel")}
+              </Button>
+              <Button type="submit" variant="destructive" disabled={isSubmitting}>
+                {isSubmitting && <Loader2 className="size-4 animate-spin" />}
+                {t("rejectDialog.confirm")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/evidence-review/evidence-review-table.tsx
+++ b/src/components/evidence-review/evidence-review-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import {
   CheckCircle2,
@@ -25,11 +26,30 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { EvidenceStatusBadge } from "@/components/evidence-review/evidence-status-badge";
 import { EvidenceTypeBadge } from "@/components/evidence-review/evidence-type-badge";
 import { EvidenceApproveDialog } from "@/components/evidence-review/evidence-approve-dialog";
-import { EvidenceRejectDialog } from "@/components/evidence-review/evidence-reject-dialog";
 import { EvidenceDetailDialog } from "@/components/evidence-review/evidence-detail-dialog";
 import { EvidenceHistoryDialog } from "@/components/evidence-review/evidence-history-dialog";
-import { EvidenceBulkActionBar } from "@/components/evidence-review/evidence-bulk-action-bar";
+import type { EvidenceRejectDialogProps } from "@/components/evidence-review/evidence-reject-dialog";
+import type { EvidenceBulkActionBarProps } from "@/components/evidence-review/evidence-bulk-action-bar";
 import type { EvidenceItem, EvidenceType } from "@/lib/api/evidence-review";
+
+// Deferred: EvidenceRejectDialog and EvidenceBulkActionBar both import zodResolver + zod
+// (~103 KB compressed). Neither is needed at first paint — reject dialog requires a
+// row action click, bulk action bar requires selecting evidence rows.
+const EvidenceRejectDialog = dynamic<EvidenceRejectDialogProps>(
+  () =>
+    import("@/components/evidence-review/evidence-reject-dialog").then(
+      (m) => m.EvidenceRejectDialog
+    ),
+  { ssr: false, loading: () => null }
+);
+
+const EvidenceBulkActionBar = dynamic<EvidenceBulkActionBarProps>(
+  () =>
+    import("@/components/evidence-review/evidence-bulk-action-bar").then(
+      (m) => m.EvidenceBulkActionBar
+    ),
+  { ssr: false, loading: () => null }
+);
 import { useFormatDate } from "@/lib/format-locale";
 
 function isPending(status: string, type: EvidenceType): boolean {

--- a/src/components/investiture/bulk-action-bar.tsx
+++ b/src/components/investiture/bulk-action-bar.tsx
@@ -80,7 +80,7 @@ type RejectFormValues = { reason: string };
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface BulkActionBarProps {
+export interface BulkActionBarProps {
   /** IDs of currently selected enrollments */
   selectedIds: number[];
   /** Status of the currently selected enrollments (used to derive the bulk action) */

--- a/src/components/investiture/investido-dialog.tsx
+++ b/src/components/investiture/investido-dialog.tsx
@@ -16,8 +16,14 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+} from "@/components/ui/form";
 import { markAsInvestido } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
 
@@ -98,33 +104,42 @@ export function InvestidoDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="investido-comments">{t("investidoDialog.commentsLabel")}</Label>
-            <Textarea
-              id="investido-comments"
-              placeholder={t("investidoDialog.commentsPlaceholder")}
-              rows={3}
-              {...form.register("comments")}
-              disabled={isPending}
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="comments"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("investidoDialog.commentsLabel")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("investidoDialog.commentsPlaceholder")}
+                      rows={3}
+                      {...field}
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
             />
-          </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleClose(false)}
-              disabled={isPending}
-            >
-              {t("investidoDialog.cancel")}
-            </Button>
-            <Button type="submit" disabled={isPending}>
-              {isPending && <Loader2 className="size-4 animate-spin" />}
-              {t("investidoDialog.confirm")}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isPending}
+              >
+                {t("investidoDialog.cancel")}
+              </Button>
+              <Button type="submit" disabled={isPending}>
+                {isPending && <Loader2 className="size-4 animate-spin" />}
+                {t("investidoDialog.confirm")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/investiture/pipeline-reject-dialog.tsx
+++ b/src/components/investiture/pipeline-reject-dialog.tsx
@@ -16,8 +16,15 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { pipelineReject } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
 
@@ -33,7 +40,7 @@ type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface PipelineRejectDialogProps {
+export interface PipelineRejectDialogProps {
   open: boolean;
   enrollmentId: number;
   memberName: string;
@@ -97,41 +104,43 @@ export function PipelineRejectDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="reason">{t("pipelineRejectDialog.reasonLabel")}</Label>
-            <Textarea
-              id="reason"
-              placeholder={t("pipelineRejectDialog.reasonPlaceholder")}
-              rows={3}
-              {...form.register("reason")}
-              disabled={isPending}
-              aria-describedby={
-                form.formState.errors.reason ? "reason-error" : undefined
-              }
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="reason"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("pipelineRejectDialog.reasonLabel")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("pipelineRejectDialog.reasonPlaceholder")}
+                      rows={3}
+                      {...field}
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {form.formState.errors.reason && (
-              <p id="reason-error" className="text-xs text-destructive">
-                {form.formState.errors.reason.message}
-              </p>
-            )}
-          </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleClose(false)}
-              disabled={isPending}
-            >
-              {t("pipelineRejectDialog.cancel")}
-            </Button>
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Loader2 className="size-4 animate-spin" />}
-              {t("pipelineRejectDialog.confirm")}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isPending}
+              >
+                {t("pipelineRejectDialog.cancel")}
+              </Button>
+              <Button type="submit" variant="destructive" disabled={isPending}>
+                {isPending && <Loader2 className="size-4 animate-spin" />}
+                {t("pipelineRejectDialog.confirm")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/investiture/pipeline-table.tsx
+++ b/src/components/investiture/pipeline-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import {
@@ -24,9 +25,28 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { EmptyState } from "@/components/shared/empty-state";
 import { PipelineStatusBadge } from "@/components/investiture/pipeline-status-badge";
-import { PipelineRejectDialog } from "@/components/investiture/pipeline-reject-dialog";
 import { PipelineHistoryDialog } from "@/components/investiture/pipeline-history-dialog";
-import { BulkActionBar } from "@/components/investiture/bulk-action-bar";
+import type { PipelineRejectDialogProps } from "@/components/investiture/pipeline-reject-dialog";
+import type { BulkActionBarProps } from "@/components/investiture/bulk-action-bar";
+
+// Deferred: PipelineRejectDialog and BulkActionBar both import zodResolver + zod
+// (~103 KB compressed). Reject dialog requires a row action click;
+// BulkActionBar only appears after selecting pipeline rows.
+const PipelineRejectDialog = dynamic<PipelineRejectDialogProps>(
+  () =>
+    import("@/components/investiture/pipeline-reject-dialog").then(
+      (m) => m.PipelineRejectDialog
+    ),
+  { ssr: false, loading: () => null }
+);
+
+const BulkActionBar = dynamic<BulkActionBarProps>(
+  () =>
+    import("@/components/investiture/bulk-action-bar").then(
+      (m) => m.BulkActionBar
+    ),
+  { ssr: false, loading: () => null }
+);
 import {
   pipelineClubApprove,
   pipelineCoordinatorApprove,

--- a/src/components/investiture/validate-dialog.tsx
+++ b/src/components/investiture/validate-dialog.tsx
@@ -16,8 +16,15 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { validateEnrollment, type ValidateAction } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
 
@@ -119,51 +126,53 @@ export function ValidateDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="comments">
-              {isApprove ? "Comentarios (opcional)" : "Motivo de rechazo *"}
-            </Label>
-            <Textarea
-              id="comments"
-              placeholder={
-                isApprove
-                  ? "Añade un comentario opcional..."
-                  : "Describe el motivo del rechazo..."
-              }
-              rows={3}
-              {...form.register("comments")}
-              disabled={isPending}
-              aria-describedby={
-                form.formState.errors.comments ? "comments-error" : undefined
-              }
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="comments"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {isApprove ? "Comentarios (opcional)" : "Motivo de rechazo *"}
+                  </FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={
+                        isApprove
+                          ? "Añade un comentario opcional..."
+                          : "Describe el motivo del rechazo..."
+                      }
+                      rows={3}
+                      {...field}
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {form.formState.errors.comments && (
-              <p id="comments-error" className="text-xs text-destructive">
-                {form.formState.errors.comments.message}
-              </p>
-            )}
-          </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleClose(false)}
-              disabled={isPending}
-            >
-              Cancelar
-            </Button>
-            <Button
-              type="submit"
-              variant={isApprove ? "default" : "destructive"}
-              disabled={isPending}
-            >
-              {isPending && <Loader2 className="size-4 animate-spin" />}
-              {isApprove ? "Aprobar" : "Rechazar"}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isPending}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                variant={isApprove ? "default" : "destructive"}
+                disabled={isPending}
+              >
+                {isPending && <Loader2 className="size-4 animate-spin" />}
+                {isApprove ? "Aprobar" : "Rechazar"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

Cascade `development → preproduction` following merge of PR #125. Brings the Sesión 22 batch to preproduction:

- #125 perf r5 (5 dialogs dynamic-import, ~103 KB gz defer for zod v4 + locales on 3 routes) + Form r4 (4 rhf dialogs) + MSW r4 (+30 tests, 372 → 402)

## Test plan

- [x] CI green on `development` (#125)
- [ ] CI Vitest green on this PR
- [ ] CI Typecheck green on this PR
- [ ] Vercel preview green on this PR