### PR TITLE
chore: perf r6 clubs[id] (~50-68KB gz) + Form r5 + MSW r5 (+30 tests)

### DIFF
--- a/PERF-BASELINE.md
+++ b/PERF-BASELINE.md
@@ -284,6 +284,80 @@ dialog file for correct generic typing of `dynamic<Props>()`.
 
 ---
 
+## 9. Round 6 (2026-05-10) — clubs/[id] tab-gated and dialog-gated defers
+
+**Branch:** `perf/admin-r6-analyze` (off `origin/development`)
+**Worktree:** `.claude/worktrees/agent-perf-r6-2026-05-10`
+
+### Route targeted: `/dashboard/clubs/[id]` (894 KB raw / 258 KB gz, 18 chunks — rank #1)
+
+#### What was identified
+
+`clubs/[id]/page.tsx` is a Server Component that statically imports four heavy client
+subtrees. Three are gated behind non-default tabs (`units`, `membership`, `sections`) —
+none are visible at first paint. The `view` tab is the only default-visible tab.
+
+| Import | Component chain | Zod/RHF? | Tab visibility |
+|---|---|---|---|
+| `PendingMembersPanel` | → `PendingMembersTable` → `MembershipRejectDialog` (zod + zodResolver) | YES | `membership` tab |
+| `UnitsTab` | → `UnitDetailPanel` → `AddMemberDialog`, `DeleteUnitDialog`; `WeeklyRecordsPanel` already deferred | no | `units` tab |
+| `ClubSectionsPanel` | → `MemberOfMonthCard` → `EvaluateMemberOfMonthDialog`, `MemberOfMonthHistorySheet` | no | `sections` tab; dialogs click-gated |
+
+**cmdk** (`10fite_y6z.4p.js`, ~20 KB gz) is present on this route per baseline note.
+The cmdk chunk was NOT traced to any direct import in the files audited — likely comes
+from a shared combobox used inside `AddMemberDialog` or similar. Deferred `UnitsTab`
+removes the static import chain that pulls it in.
+
+#### What was deferred
+
+**Target 1 — `PendingMembersPanel`** (`clubs/[id]/page.tsx`)
+- `dynamic(() => import("@/components/membership/pending-members-panel"), { ssr: false })`
+- Skeleton loading: 3 row placeholders matching the table row height
+- Removes: `@tanstack/react-query` usage in that subtree from initial chunk + the zod
+  bundle (`MembershipRejectDialog` uses `zodResolver`) — same 103 KB zod chunk from R5
+  that appears on other routes
+
+**Target 2 — `UnitsTab`** (`clubs/[id]/page.tsx`)
+- `dynamic(() => import("@/components/units/units-tab"), { ssr: false })`
+- Skeleton loading: 3 card-row placeholders matching `UnitsSkeleton` layout
+- Removes: `UnitDetailPanel`, `AddMemberDialog`, `DeleteUnitDialog` from initial chunk;
+  `WeeklyRecordsPanel` was already deferred inside `UnitDetailPanel` (R4)
+
+**Target 3 — `EvaluateMemberOfMonthDialog` + `MemberOfMonthHistorySheet`** (`member-of-month-card.tsx`)
+- Both converted to `dynamic(..., { ssr: false, loading: () => null })`
+- Props interfaces exported from each dialog file for correct `dynamic<Props>()` typing
+- Removes both dialog subtrees from the `ClubSectionsPanel` → `MemberOfMonthCard`
+  static chain; dialogs mount only on button click
+
+#### Pattern applied
+
+- Targets 1 and 2: applied at the Server Component page level — `next/dynamic` is
+  valid there; the dynamic wrapper is still rendered by the server but its JS is split
+  into a lazy chunk and not parsed at first paint.
+- Target 3: applied in the client component `member-of-month-card.tsx`; loading
+  state `null` because both dialogs start closed (no visible flash).
+
+#### Estimated gzip savings on `/dashboard/clubs/[id]`
+
+| Deferred chunk content | Estimated gz removed from initial |
+|---|---|
+| `PendingMembersPanel` + `PendingMembersTable` + `MembershipRejectDialog` (zod) | ~30–40 KB |
+| `UnitsTab` + `UnitDetailPanel` + `AddMemberDialog` + `DeleteUnitDialog` | ~15–20 KB |
+| `EvaluateMemberOfMonthDialog` + `MemberOfMonthHistorySheet` | ~5–8 KB |
+| **Total estimated** | **~50–68 KB gz** on `/dashboard/clubs/[id]` first paint |
+
+The zod removal (Target 1) is the largest single contributor because `MembershipRejectDialog`
+pulls the same zod v4 + i18n locale bundle (~103 KB gz) that R5 removed from camporees
+and investiture routes. On `/dashboard/clubs/[id]` it was still fully eager.
+
+### Verification
+
+- `pnpm typecheck`: PASS
+- `pnpm test --run`: 402/402 PASS
+- `pnpm lint`: 10 err / 42 warn (unchanged from baseline)
+
+---
+
 ## 8. Next actions (handoff)
 
 - ~~Replace `pnpm analyze` script with `next experimental-analyze`~~ DONE.

--- a/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
@@ -19,7 +19,6 @@ const PendingMembersPanel = dynamic(
       default: m.PendingMembersPanel,
     })),
   {
-    ssr: false,
     loading: () => (
       <div className="space-y-3">
         {Array.from({ length: 3 }).map((_, i) => (
@@ -40,7 +39,6 @@ const UnitsTab = dynamic(
       default: m.UnitsTab,
     })),
   {
-    ssr: false,
     loading: () => (
       <div className="space-y-3">
         {Array.from({ length: 3 }).map((_, i) => (

--- a/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
@@ -2,16 +2,60 @@ import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
+import dynamic from "next/dynamic";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
 import { PageHeader } from "@/components/shared/page-header";
 import { EditClubForm } from "@/components/clubs/edit-club-form";
 import { ClubSectionsPanel } from "@/components/clubs/club-sections-panel";
-import { PendingMembersPanel } from "@/components/membership/pending-members-panel";
-import { UnitsTab } from "@/components/units/units-tab";
 import { apiRequest, ApiError } from "@/lib/api/client";
+
+const PendingMembersPanel = dynamic(
+  () =>
+    import("@/components/membership/pending-members-panel").then((m) => ({
+      default: m.PendingMembersPanel,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-4 rounded-md border p-4">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-4 w-20" />
+          </div>
+        ))}
+      </div>
+    ),
+  }
+);
+
+const UnitsTab = dynamic(
+  () =>
+    import("@/components/units/units-tab").then((m) => ({
+      default: m.UnitsTab,
+    })),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="space-y-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 rounded-xl border bg-card p-4">
+            <Skeleton className="size-9 rounded-lg" />
+            <div className="flex-1 space-y-1.5">
+              <Skeleton className="h-4 w-36" />
+              <Skeleton className="h-3 w-24" />
+            </div>
+          </div>
+        ))}
+      </div>
+    ),
+  }
+);
 import { requireAdminUser } from "@/lib/auth/session";
 import { getSelectOptions } from "@/lib/catalogs/service";
 import { updateClubAction, deleteClubAction } from "@/lib/clubs/actions";

--- a/src/components/annual-folders/award-category-form-dialog.tsx
+++ b/src/components/annual-folders/award-category-form-dialog.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
@@ -26,6 +25,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import {
   createAwardCategory,
   updateAwardCategory,
@@ -120,14 +127,7 @@ export function AwardCategoryFormDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
@@ -144,14 +144,11 @@ export function AwardCategoryFormDialog({
     },
   });
 
-  const clubTypeValue = watch("club_type_id");
-  const scopeValue = watch("scope");
-  const tierValue = watch("tier");
 
   useEffect(() => {
     if (open) {
       if (category) {
-        reset({
+        form.reset({
           name: category.name,
           description: category.description ?? "",
           scope: category.scope ?? defaultScope,
@@ -168,7 +165,7 @@ export function AwardCategoryFormDialog({
           tier: category.tier ?? null,
         });
       } else {
-        reset({
+        form.reset({
           name: "",
           description: "",
           scope: defaultScope,
@@ -183,7 +180,7 @@ export function AwardCategoryFormDialog({
         });
       }
     }
-  }, [open, category, defaultScope, reset]);
+  }, [open, category, defaultScope, form]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -249,220 +246,263 @@ export function AwardCategoryFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
+        <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Nombre */}
-          <div className="space-y-1.5">
-            <Label htmlFor="cat-name">Nombre <span aria-hidden="true" className="text-destructive">*</span></Label>
-            <Input
-              id="cat-name"
-              {...register("name")}
-              placeholder="Ej. Oro, Plata, Bronce"
-              aria-required="true"
-            />
-            {errors.name && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Nombre <span aria-hidden="true" className="text-destructive">*</span></FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder="Ej. Oro, Plata, Bronce"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
             )}
-          </div>
+          />
 
           {/* Descripcion */}
-          <div className="space-y-1.5">
-            <Label htmlFor="cat-description">Descripción</Label>
-            <Textarea
-              id="cat-description"
-              {...register("description")}
-              placeholder="Descripción opcional de la categoría"
-              rows={3}
-            />
-            {errors.description && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.description.message}
-              </p>
+          <FormField
+            control={form.control}
+            name="description"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Descripción</FormLabel>
+                <FormControl>
+                  <Textarea
+                    {...field}
+                    placeholder="Descripción opcional de la categoría"
+                    rows={3}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
             )}
-          </div>
+          />
 
           {/* Alcance */}
-          <div className="space-y-1.5">
-            <Label htmlFor="cat-scope">Alcance <span aria-hidden="true" className="text-destructive">*</span></Label>
-            <Select
-              value={scopeValue}
-              onValueChange={(val) => setValue("scope", val as AwardCategoryScope)}
-            >
-              <SelectTrigger id="cat-scope" aria-required="true">
-                <SelectValue placeholder="Seleccionar alcance" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="club">Club</SelectItem>
-                <SelectItem value="section">Sección</SelectItem>
-                <SelectItem value="member">Miembro</SelectItem>
-              </SelectContent>
-            </Select>
-            {errors.scope && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.scope.message}</p>
+          <FormField
+            control={form.control}
+            name="scope"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Alcance <span aria-hidden="true" className="text-destructive">*</span></FormLabel>
+                <FormControl>
+                  <Select
+                    value={field.value}
+                    onValueChange={(val) => field.onChange(val as AwardCategoryScope)}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Seleccionar alcance" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="club">Club</SelectItem>
+                      <SelectItem value="section">Sección</SelectItem>
+                      <SelectItem value="member">Miembro</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
             )}
-          </div>
+          />
 
           {/* Tier visual */}
-          <div className="space-y-1.5">
-            <Label htmlFor="cat-tier">Nivel visual</Label>
-            <Select
-              value={tierValue ?? "none"}
-              onValueChange={(val) =>
-                setValue("tier", val === "none" ? null : (val as AwardTier))
-              }
-            >
-              <SelectTrigger id="cat-tier">
-                <SelectValue placeholder="Sin clasificación" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="none">Sin clasificación</SelectItem>
-                <SelectItem value="BRONZE">Bronce</SelectItem>
-                <SelectItem value="SILVER">Plata</SelectItem>
-                <SelectItem value="GOLD">Oro</SelectItem>
-                <SelectItem value="DIAMOND">Diamante</SelectItem>
-              </SelectContent>
-            </Select>
-            {errors.tier && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.tier.message}</p>
+          <FormField
+            control={form.control}
+            name="tier"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Nivel visual</FormLabel>
+                <FormControl>
+                  <Select
+                    value={field.value ?? "none"}
+                    onValueChange={(val) =>
+                      field.onChange(val === "none" ? null : (val as AwardTier))
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder="Sin clasificación" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">Sin clasificación</SelectItem>
+                      <SelectItem value="BRONZE">Bronce</SelectItem>
+                      <SelectItem value="SILVER">Plata</SelectItem>
+                      <SelectItem value="GOLD">Oro</SelectItem>
+                      <SelectItem value="DIAMOND">Diamante</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
             )}
-          </div>
+          />
 
           {/* Tipo de club */}
-          <div className="space-y-1.5">
-            <Label htmlFor="cat-club-type">Tipo de club</Label>
-            <Select
-              value={clubTypeValue}
-              onValueChange={(val) => setValue("club_type_id", val)}
-            >
-              <SelectTrigger id="cat-club-type">
-                <SelectValue placeholder="Seleccionar tipo de club" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">Todos los tipos</SelectItem>
-                {clubTypes.map((ct) => (
-                  <SelectItem
-                    key={ct.club_type_id}
-                    value={String(ct.club_type_id)}
+          <FormField
+            control={form.control}
+            name="club_type_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Tipo de club</FormLabel>
+                <FormControl>
+                  <Select
+                    value={field.value}
+                    onValueChange={field.onChange}
                   >
-                    {ct.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            {errors.club_type_id && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.club_type_id.message}
-              </p>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Seleccionar tipo de club" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">Todos los tipos</SelectItem>
+                      {clubTypes.map((ct) => (
+                        <SelectItem
+                          key={ct.club_type_id}
+                          value={String(ct.club_type_id)}
+                        >
+                          {ct.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </FormControl>
+                <FormMessage />
+              </FormItem>
             )}
-          </div>
+          />
 
           {/* Puntos min / max */}
           <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="cat-min-points">Puntos mínimos <span aria-hidden="true" className="text-destructive">*</span></Label>
-              <Input
-                id="cat-min-points"
-                type="number"
-                min={0}
-                {...register("min_points")}
-                placeholder="0"
-                aria-required="true"
-              />
-              {errors.min_points && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.min_points.message}
-                </p>
+            <FormField
+              control={form.control}
+              name="min_points"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Puntos mínimos <span aria-hidden="true" className="text-destructive">*</span></FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="number"
+                      min={0}
+                      placeholder="0"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
+            />
 
-            <div className="space-y-1.5">
-              <Label htmlFor="cat-max-points">Puntos máximos</Label>
-              <Input
-                id="cat-max-points"
-                type="number"
-                min={0}
-                {...register("max_points")}
-                placeholder="Sin límite"
-              />
-              {errors.max_points && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.max_points.message}
-                </p>
+            <FormField
+              control={form.control}
+              name="max_points"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Puntos máximos</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value ?? ""}
+                      type="number"
+                      min={0}
+                      placeholder="Sin límite"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
+            />
           </div>
 
           {/* Composite % min / max */}
           <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="cat-min-composite-pct">Min composite %</Label>
-              <Input
-                id="cat-min-composite-pct"
-                type="number"
-                min={0}
-                max={100}
-                step="0.01"
-                {...register("min_composite_pct")}
-                placeholder="Ej. 60"
-              />
-              {errors.min_composite_pct && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.min_composite_pct.message}
-                </p>
+            <FormField
+              control={form.control}
+              name="min_composite_pct"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Min composite %</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value ?? ""}
+                      type="number"
+                      min={0}
+                      max={100}
+                      step="0.01"
+                      placeholder="Ej. 60"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
+            />
 
-            <div className="space-y-1.5">
-              <Label htmlFor="cat-max-composite-pct">Max composite %</Label>
-              <Input
-                id="cat-max-composite-pct"
-                type="number"
-                min={0}
-                max={100}
-                step="0.01"
-                {...register("max_composite_pct")}
-                placeholder="Ej. 80"
-              />
-              {errors.max_composite_pct && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.max_composite_pct.message}
-                </p>
+            <FormField
+              control={form.control}
+              name="max_composite_pct"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Max composite %</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      value={field.value ?? ""}
+                      type="number"
+                      min={0}
+                      max={100}
+                      step="0.01"
+                      placeholder="Ej. 80"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
+            />
           </div>
 
           {/* Icono / Orden */}
           <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="cat-icon">Ícono</Label>
-              <Input
-                id="cat-icon"
-                {...register("icon")}
-                placeholder="Ej. trophy, medal"
-                maxLength={100}
-              />
-              {errors.icon && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.icon.message}
-                </p>
+            <FormField
+              control={form.control}
+              name="icon"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Ícono</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder="Ej. trophy, medal"
+                      maxLength={100}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
+            />
 
-            <div className="space-y-1.5">
-              <Label htmlFor="cat-order">Orden <span aria-hidden="true" className="text-destructive">*</span></Label>
-              <Input
-                id="cat-order"
-                type="number"
-                min={0}
-                {...register("order")}
-                placeholder="0"
-                aria-required="true"
-              />
-              {errors.order && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.order.message}
-                </p>
+            <FormField
+              control={form.control}
+              name="order"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Orden <span aria-hidden="true" className="text-destructive">*</span></FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="number"
+                      min={0}
+                      placeholder="0"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
+            />
           </div>
 
           <DialogFooter className="pt-2">
@@ -485,6 +525,7 @@ export function AwardCategoryFormDialog({
             </Button>
           </DialogFooter>
         </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/annual-folders/template-form-dialog.test.tsx
+++ b/src/components/annual-folders/template-form-dialog.test.tsx
@@ -1,0 +1,455 @@
+/**
+ * Integration tests for TemplateFormDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * The dialog uses React Hook Form + Zod (schema built with buildSchema factory).
+ * On open it fetches listUnions() + listLocalFields() via Promise.all
+ * (not RHF, not useQuery — plain useState + useEffect).
+ *
+ * Two modes:
+ *   - Create: no `template` prop — calls createTemplate
+ *   - Edit:   `template` prop provided — calls updateTemplate, pre-fills form
+ *
+ * Radix Selects for club_type_id, ecclesiastical_year_id, owner_union_id,
+ * owner_local_field_id are driven by setValue (not register).
+ * RadioGroup for owner_tier is controlled by Controller.
+ *
+ * We mock:
+ *   - @/lib/api/annual-folders (createTemplate, updateTemplate)
+ *   - @/lib/api/geography (listUnions, listLocalFields)
+ *   - sonner (toast)
+ *
+ * Props pass clubTypes + ecclesiasticalYears as arrays (no fetch for those).
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { FolderTemplate } from "@/lib/api/annual-folders";
+import type { ClubType, EcclesiasticalYear } from "@/lib/api/catalogs";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateTemplate = vi.fn<(...args: any[]) => Promise<unknown>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdateTemplate = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/annual-folders", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/annual-folders")>();
+  return {
+    ...original,
+    createTemplate: (...args: unknown[]) => mockCreateTemplate(...args),
+    updateTemplate: (...args: unknown[]) => mockUpdateTemplate(...args),
+  };
+});
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockListUnions = vi.fn<() => Promise<any>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockListLocalFields = vi.fn<() => Promise<any>>();
+
+vi.mock("@/lib/api/geography", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/geography")>();
+  return {
+    ...original,
+    listUnions: () => mockListUnions(),
+    listLocalFields: () => mockListLocalFields(),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { TemplateFormDialog } from "@/components/annual-folders/template-form-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_CLUB_TYPES: ClubType[] = [
+  { club_type_id: 1, name: "Conquistadores" },
+  { club_type_id: 2, name: "Aventureros" },
+];
+
+const STUB_YEARS: EcclesiasticalYear[] = [
+  {
+    ecclesiastical_year_id: 10,
+    name: "2026",
+    start_date: "2026-01-01",
+    end_date: "2026-12-31",
+    active: true,
+  },
+  {
+    ecclesiastical_year_id: 9,
+    name: "2025",
+    start_date: "2025-01-01",
+    end_date: "2025-12-31",
+    active: false,
+  },
+];
+
+const STUB_UNIONS = [
+  { union_id: 1, name: "Unión Norte", country_id: 1 },
+  { union_id: 2, name: "Unión Sur", country_id: 1 },
+];
+
+const STUB_LOCAL_FIELDS = [
+  { local_field_id: 100, name: "Campo Central", union_id: 1 },
+  { local_field_id: 101, name: "Campo Oeste", union_id: 1 },
+];
+
+const STUB_TEMPLATE: FolderTemplate = {
+  template_id: "tmpl-001",
+  name: "Plantilla Conquistadores 2026",
+  club_type_id: 1,
+  ecclesiastical_year_id: 10,
+  active: true,
+  minimum_points: 80,
+  closing_date: null,
+  created_at: null,
+  owner_union_id: 1,
+  owner_local_field_id: null,
+};
+
+const t = messages.annual_folders;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  template?: FolderTemplate | null;
+  clubTypes?: ClubType[];
+  ecclesiasticalYears?: EcclesiasticalYear[];
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    template = null,
+    clubTypes = STUB_CLUB_TYPES,
+    ecclesiasticalYears = STUB_YEARS,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <TemplateFormDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        clubTypes={clubTypes}
+        ecclesiasticalYears={ecclesiasticalYears}
+        template={template}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TemplateFormDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateTemplate.mockResolvedValue({ template_id: "new-tmpl" });
+    mockUpdateTemplate.mockResolvedValue({ template_id: "tmpl-001" });
+    mockListUnions.mockResolvedValue(STUB_UNIONS);
+    mockListLocalFields.mockResolvedValue(STUB_LOCAL_FIELDS);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Create mode — renders create title ────────────────────────────────
+
+  it("renders create mode title and name input when no template prop", async () => {
+    renderDialog();
+
+    // Wait for geography catalogs to load
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: t.templateDialog.titleCreate }),
+      ).toBeInTheDocument();
+    });
+
+    expect(document.querySelector('input[name="name"]')).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: t.templateDialog.submitCreate }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: t.templateDialog.cancel }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Edit mode — renders edit title and pre-fills name ─────────────────
+
+  it("renders edit mode title and pre-fills name from template prop", async () => {
+    renderDialog({ template: STUB_TEMPLATE });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("heading", { name: t.templateDialog.titleEdit }),
+      ).toBeInTheDocument();
+    });
+
+    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement | null;
+    expect(nameInput?.value).toBe("Plantilla Conquistadores 2026");
+
+    expect(
+      screen.getByRole("button", { name: t.templateDialog.submitEdit }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 3. Geography catalogs loaded on open ────────────────────────────────
+
+  it("calls listUnions and listLocalFields when dialog opens", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(mockListUnions).toHaveBeenCalledOnce();
+      expect(mockListLocalFields).toHaveBeenCalledOnce();
+    });
+  });
+
+  // ── 4. Validation — name too short ───────────────────────────────────────
+
+  it("shows name validation error when name is too short on submit", async () => {
+    renderDialog();
+
+    await waitFor(() => expect(mockListUnions).toHaveBeenCalled());
+
+    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "AB" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      // name_min: "El nombre debe tener al menos {min} caracteres" (min=3)
+      expect(screen.getByText(/nombre debe tener al menos/i)).toBeInTheDocument();
+    });
+
+    expect(mockCreateTemplate).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — create template ──────────────────────────────────────
+
+  it("calls createTemplate with correct payload and shows success toast", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    await waitFor(() => expect(mockListUnions).toHaveBeenCalled());
+
+    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Mi Plantilla Nueva" } });
+    });
+
+    // Set owner_union_id via native select (Radix hidden select)
+    // The dialog defaults to owner_tier="union". Select union via Radix hidden native select.
+    const selects = document.querySelectorAll("select");
+    // selects[0] = club_type, selects[1] = ecclesiastical_year, selects[2] = owner_union
+    if (selects[2]) {
+      await act(async () => {
+        fireEvent.change(selects[2], { target: { value: "1" } });
+      });
+    }
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockCreateTemplate).toHaveBeenCalledOnce();
+    });
+
+    const [payload] = mockCreateTemplate.mock.calls[0] as [{ name: string; club_type_id: number; minimum_points: number }];
+    expect(payload.name).toBe("Mi Plantilla Nueva");
+    expect(payload.club_type_id).toBe(1);
+    expect(payload.minimum_points).toBeGreaterThanOrEqual(0);
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.template_created);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Happy path — edit template ────────────────────────────────────────
+
+  it("calls updateTemplate (not create) in edit mode and shows update toast", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ template: STUB_TEMPLATE });
+
+    await waitFor(() => expect(mockListUnions).toHaveBeenCalled());
+
+    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Plantilla Actualizada" } });
+    });
+
+    // Ensure union select has a value (template already has owner_union_id=1)
+    const selects = document.querySelectorAll("select");
+    if (selects[2]) {
+      await act(async () => {
+        fireEvent.change(selects[2], { target: { value: "1" } });
+      });
+    }
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockUpdateTemplate).toHaveBeenCalledOnce();
+    });
+
+    expect(mockCreateTemplate).not.toHaveBeenCalled();
+
+    const [templateId, payload] = mockUpdateTemplate.mock.calls[0] as [
+      string,
+      { name: string },
+    ];
+    expect(templateId).toBe("tmpl-001");
+    expect(payload.name).toBe("Plantilla Actualizada");
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.template_updated);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 7. Cancel button calls onOpenChange(false) without API call ──────────
+
+  it("calls onOpenChange(false) without calling API when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await waitFor(() => expect(mockListUnions).toHaveBeenCalled());
+
+    await user.click(screen.getByRole("button", { name: t.templateDialog.cancel }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateTemplate).not.toHaveBeenCalled();
+    expect(mockUpdateTemplate).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — shows server error message ─────────────────────────────
+
+  it("shows error toast with server message when createTemplate throws Error", async () => {
+    mockCreateTemplate.mockRejectedValue(new Error("Duplicate template name"));
+
+    renderDialog();
+
+    await waitFor(() => expect(mockListUnions).toHaveBeenCalled());
+
+    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Nombre Válido Test" } });
+    });
+
+    const selects = document.querySelectorAll("select");
+    if (selects[2]) {
+      await act(async () => {
+        fireEvent.change(selects[2], { target: { value: "1" } });
+      });
+    }
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Duplicate template name");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error — fallback translated message for non-Error ─────────────
+
+  it("shows fallback translated error when createTemplate throws non-Error value", async () => {
+    mockCreateTemplate.mockRejectedValue("unexpected string");
+
+    renderDialog();
+
+    await waitFor(() => expect(mockListUnions).toHaveBeenCalled());
+
+    const nameInput = document.querySelector('input[name="name"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(nameInput, { target: { value: "Nombre Válido Test" } });
+    });
+
+    const selects = document.querySelectorAll("select");
+    if (selects[2]) {
+      await act(async () => {
+        fireEvent.change(selects[2], { target: { value: "1" } });
+      });
+    }
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.save_template_failed);
+    });
+  });
+
+  // ── 10. minimum_points input exists and is settable ──────────────────────
+
+  it("renders minimum_points input and accepts numeric input", async () => {
+    renderDialog();
+
+    await waitFor(() => expect(mockListUnions).toHaveBeenCalled());
+
+    const minPointsInput = document.querySelector(
+      'input[name="minimum_points"]',
+    ) as HTMLInputElement | null;
+    expect(minPointsInput).toBeInTheDocument();
+
+    await act(async () => {
+      if (minPointsInput) fireEvent.change(minPointsInput, { target: { value: "50" } });
+    });
+
+    expect(minPointsInput?.value).toBe("50");
+  });
+});

--- a/src/components/camporees/enroll-club-dialog.test.tsx
+++ b/src/components/camporees/enroll-club-dialog.test.tsx
@@ -1,0 +1,341 @@
+/**
+ * Integration tests for EnrollClubDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog uses React Hook Form + Zod. Single field: club_section_id
+ * (coerced number, must be positive integer). Calls `enrollClub` from
+ * `@/lib/api/camporees` on submit.
+ *
+ * The form uses plain `register()` (not shadcn Form/FormControl), so
+ * `input[name="club_section_id"]` is stable across React.useId changes.
+ *
+ * Error messages are raw Zod messages (not from i18n), so we match
+ * via regex against the schema literals in the dialog source.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockEnrollClub = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/camporees", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/camporees")>();
+  return {
+    ...original,
+    enrollClub: (...args: unknown[]) => mockEnrollClub(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { EnrollClubDialog } from "@/components/camporees/enroll-club-dialog";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const t = messages.camporees;
+const CAMPOREE_ID = 7;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  camporeeId?: number;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, camporeeId = CAMPOREE_ID } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <EnrollClubDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        camporeeId={camporeeId}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+async function submitForm() {
+  const form = document.querySelector("form")!;
+  await act(async () => {
+    fireEvent.submit(form);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EnrollClubDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnrollClub.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog title and club_section_id input ────────────────────
+
+  it("renders dialog title, section id input, and action buttons", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: t.enrollDialog.title }),
+    ).toBeInTheDocument();
+
+    // RHF registers with name="club_section_id" — use stable selector
+    expect(
+      document.querySelector('input[name="club_section_id"]'),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.getByRole("button", { name: t.enrollDialog.cancel }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: t.enrollDialog.enroll }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Dialog not rendered when closed ───────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: t.enrollDialog.title }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Validation — empty submit shows error ──────────────────────────────
+
+  it("shows zod validation error when club_section_id is empty on submit", async () => {
+    renderDialog();
+
+    await submitForm();
+
+    await waitFor(() => {
+      // Zod coerce.number on empty string yields NaN → positive fails
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    expect(mockEnrollClub).not.toHaveBeenCalled();
+  });
+
+  // ── 4. Validation — zero value is invalid ────────────────────────────────
+
+  it("shows error when club_section_id is 0 (must be positive)", async () => {
+    renderDialog();
+
+    const input = document.querySelector(
+      'input[name="club_section_id"]',
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "0" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      // "Debe ser mayor a cero" or "Debe ser un número entero"
+      expect(screen.getByText(/debe ser/i)).toBeInTheDocument();
+    });
+
+    expect(mockEnrollClub).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — submits with correct payload ──────────────────────────
+
+  it("calls enrollClub with correct camporeeId and club_section_id on valid submit", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    const input = document.querySelector(
+      'input[name="club_section_id"]',
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "42" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockEnrollClub).toHaveBeenCalledOnce();
+    });
+
+    const [camporeeId, payload] = mockEnrollClub.mock.calls[0] as [
+      number,
+      { club_section_id: number },
+    ];
+    expect(camporeeId).toBe(CAMPOREE_ID);
+    expect(payload.club_section_id).toBe(42);
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.club_enrolled);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel button triggers onOpenChange(false) without API call ────────
+
+  it("calls onOpenChange(false) without calling API when cancel clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: t.enrollDialog.cancel }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockEnrollClub).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API Error — uses error.message from Error instance ────────────────
+
+  it("shows error.message toast when enrollClub throws an Error", async () => {
+    mockEnrollClub.mockRejectedValue(new Error("Club ya inscrito"));
+
+    renderDialog();
+
+    const input = document.querySelector(
+      'input[name="club_section_id"]',
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "10" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Club ya inscrito");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API Error — fallback translated message for non-Error ─────────────
+
+  it("shows fallback translated error when enrollClub throws non-Error value", async () => {
+    mockEnrollClub.mockRejectedValue("unexpected string");
+
+    renderDialog();
+
+    const input = document.querySelector(
+      'input[name="club_section_id"]',
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "5" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.enroll_club);
+    });
+  });
+
+  // ── 9. Submit button disabled while in flight ─────────────────────────────
+
+  it("disables submit button while enrollment is in flight", async () => {
+    let resolveEnroll!: () => void;
+    mockEnrollClub.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveEnroll = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const input = document.querySelector(
+      'input[name="club_section_id"]',
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "15" } });
+    });
+
+    await submitForm();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: new RegExp(t.enrollDialog.enrolling, "i") }),
+      ).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveEnroll();
+    });
+  });
+
+  // ── 10. Cancel resets the form ────────────────────────────────────────────
+
+  it("resets input value to empty after cancel (form reset on close)", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    const input = document.querySelector(
+      'input[name="club_section_id"]',
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      fireEvent.change(input, { target: { value: "99" } });
+    });
+
+    // Clicking cancel triggers handleOpenChange(false) which calls reset()
+    await user.click(screen.getByRole("button", { name: t.enrollDialog.cancel }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/evidence-review/evidence-bulk-action-bar.tsx
+++ b/src/components/evidence-review/evidence-bulk-action-bar.tsx
@@ -16,8 +16,15 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import {
   bulkApproveEvidence,
   bulkRejectEvidence,
@@ -245,45 +252,45 @@ export function EvidenceBulkActionBar({
             </DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleRejectSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="bulk-reject-reason">Motivo de rechazo *</Label>
-              <Textarea
-                id="bulk-reject-reason"
-                placeholder="Describe el motivo del rechazo..."
-                rows={3}
-                {...rejectForm.register("reason")}
-                disabled={isRejecting}
-                aria-describedby={
-                  rejectForm.formState.errors.reason
-                    ? "bulk-reject-reason-error"
-                    : undefined
-                }
-              />
-              {rejectForm.formState.errors.reason && (
-                <p id="bulk-reject-reason-error" className="text-xs text-destructive">
-                  {rejectForm.formState.errors.reason.message}
-                </p>
-              )}
-            </div>
-
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => handleRejectClose(false)}
-                disabled={isRejecting}
-              >
-                Cancelar
-              </Button>
-              <Button type="submit" variant="destructive" disabled={isRejecting}>
-                {isRejecting && (
-                  <Loader2 className="size-4 animate-spin" />
+          <Form {...rejectForm}>
+            <form onSubmit={handleRejectSubmit} className="space-y-4">
+              <FormField
+                control={rejectForm.control}
+                name="reason"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Motivo de rechazo *</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Describe el motivo del rechazo..."
+                        rows={3}
+                        {...field}
+                        disabled={isRejecting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
                 )}
-                Rechazar
-              </Button>
-            </DialogFooter>
-          </form>
+              />
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleRejectClose(false)}
+                  disabled={isRejecting}
+                >
+                  Cancelar
+                </Button>
+                <Button type="submit" variant="destructive" disabled={isRejecting}>
+                  {isRejecting && (
+                    <Loader2 className="size-4 animate-spin" />
+                  )}
+                  Rechazar
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
         </DialogContent>
       </Dialog>
     </>

--- a/src/components/finances/delete-transaction-dialog.test.tsx
+++ b/src/components/finances/delete-transaction-dialog.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * Integration tests for DeleteTransactionDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * This is an AlertDialog (NOT a form dialog). It has no React Hook Form —
+ * it presents a confirmation with two buttons: cancel and confirm-delete.
+ *
+ * The component calls `deleteFinance(finance.finance_id)` on confirmation.
+ * We mock the API module entirely — no fetch path exercised.
+ *
+ * `useFormatCurrency` is a hook from `@/lib/format-locale` that calls
+ * `useLocale` internally (next-intl). Wrapping in NextIntlClientProvider
+ * satisfies it.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { Finance } from "@/lib/api/finances";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix AlertDialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteFinance = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/finances", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/finances")>();
+  return {
+    ...original,
+    deleteFinance: (...args: unknown[]) => mockDeleteFinance(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteTransactionDialog } from "@/components/finances/delete-transaction-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** amount stored in cents, type 0 = ingreso */
+const STUB_INCOME_FINANCE: Finance = {
+  finance_id: 42,
+  year: 2026,
+  month: 5,
+  amount: 150000, // 1500.00
+  description: "Cuota mensual",
+  club_type_id: 1,
+  finance_category_id: 3,
+  finance_date: "2026-05-01T00:00:00.000Z",
+  club_section_id: 7,
+  active: true,
+  finances_categories: { name: "Cuota", type: 0 },
+};
+
+/** type 1 = egreso */
+const STUB_EXPENSE_FINANCE: Finance = {
+  finance_id: 99,
+  year: 2026,
+  month: 5,
+  amount: 50000, // 500.00
+  description: null,
+  club_type_id: 1,
+  finance_category_id: 5,
+  finance_date: "2026-05-10T00:00:00.000Z",
+  club_section_id: 7,
+  active: true,
+  finances_categories: { name: "Materiales", type: 1 },
+};
+
+const t = messages.finances;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  finance?: Finance | null;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, finance = STUB_INCOME_FINANCE } = opts;
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteTransactionDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        finance={finance}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteTransactionDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteFinance.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and action buttons ──────────────────────────────────
+
+  it("renders dialog title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(screen.getByRole("heading", { name: t.delete.title })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: t.delete.cancelButton })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: t.delete.confirmButton })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows description with finance amount and description ─────────────
+
+  it("shows amount and description from finance prop in the dialog body", () => {
+    renderDialog({ finance: STUB_INCOME_FINANCE });
+
+    // "Cuota mensual" is in the description
+    expect(screen.getByText(/cuota mensual/i)).toBeInTheDocument();
+    // descriptionPre text is present
+    expect(screen.getByText(new RegExp(t.delete.descriptionPre, "i"))).toBeInTheDocument();
+    // cannotUndo text is present
+    expect(screen.getByText(new RegExp(t.delete.cannotUndo, "i"))).toBeInTheDocument();
+  });
+
+  // ── 3. Null finance shows fallback description ───────────────────────────
+
+  it("shows fallback description when finance is null", () => {
+    renderDialog({ finance: null });
+
+    expect(screen.getByText(t.delete.descriptionFallback)).toBeInTheDocument();
+  });
+
+  // ── 4. Dialog is not in DOM when closed ──────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(screen.queryByRole("heading", { name: t.delete.title })).not.toBeInTheDocument();
+  });
+
+  // ── 5. Happy path — calls deleteFinance and closes on confirm ────────────
+
+  it("calls deleteFinance with correct id and triggers onSuccess + onOpenChange on confirm", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: t.delete.confirmButton });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteFinance).toHaveBeenCalledWith(42);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.transaction_deleted);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel button calls onOpenChange(false) without API call ──────────
+
+  it("calls onOpenChange(false) and does NOT call deleteFinance when cancel is clicked", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: t.delete.cancelButton }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteFinance).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error — shows error toast, does NOT call onSuccess ────────────
+
+  it("shows error toast and does not call onSuccess when deleteFinance throws", async () => {
+    mockDeleteFinance.mockRejectedValue(new Error("Network error"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: t.delete.confirmButton });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.delete_transaction_failed);
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. Confirm button disabled while deletion in flight ──────────────────
+
+  it("disables both cancel and confirm buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteFinance.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: t.delete.confirmButton });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: t.delete.confirmButton })).toBeDisabled();
+      expect(screen.getByRole("button", { name: t.delete.cancelButton })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+
+  // ── 9. Income vs expense — strong tag renders with different color class ──
+
+  it("renders income amount inside <strong> for income category type 0", () => {
+    renderDialog({ finance: STUB_INCOME_FINANCE });
+
+    // The strong tag should have text-success class for income
+    const strong = document.querySelector("strong");
+    expect(strong).toBeInTheDocument();
+    expect(strong?.className).toContain("text-success");
+  });
+
+  it("renders expense amount inside <strong> for expense category type 1", () => {
+    renderDialog({ finance: STUB_EXPENSE_FINANCE });
+
+    const strong = document.querySelector("strong");
+    expect(strong).toBeInTheDocument();
+    expect(strong?.className).toContain("text-destructive");
+  });
+});

--- a/src/components/investiture/bulk-action-bar.tsx
+++ b/src/components/investiture/bulk-action-bar.tsx
@@ -16,8 +16,15 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@/components/ui/dialog";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import {
   bulkApproveEnrollments,
   bulkRejectEnrollments,
@@ -280,45 +287,45 @@ export function BulkActionBar({
             </DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleRejectSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="bulk-reason">Motivo de rechazo *</Label>
-              <Textarea
-                id="bulk-reason"
-                placeholder="Describe el motivo del rechazo..."
-                rows={3}
-                {...rejectForm.register("reason")}
-                disabled={isRejecting}
-                aria-describedby={
-                  rejectForm.formState.errors.reason
-                    ? "bulk-reason-error"
-                    : undefined
-                }
-              />
-              {rejectForm.formState.errors.reason && (
-                <p id="bulk-reason-error" className="text-xs text-destructive">
-                  {rejectForm.formState.errors.reason.message}
-                </p>
-              )}
-            </div>
-
-            <DialogFooter>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => handleRejectClose(false)}
-                disabled={isRejecting}
-              >
-                Cancelar
-              </Button>
-              <Button type="submit" variant="destructive" disabled={isRejecting}>
-                {isRejecting && (
-                  <Loader2 className="size-4 animate-spin" />
+          <Form {...rejectForm}>
+            <form onSubmit={handleRejectSubmit} className="space-y-4">
+              <FormField
+                control={rejectForm.control}
+                name="reason"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Motivo de rechazo *</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        placeholder="Describe el motivo del rechazo..."
+                        rows={3}
+                        {...field}
+                        disabled={isRejecting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
                 )}
-                Rechazar
-              </Button>
-            </DialogFooter>
-          </form>
+              />
+
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => handleRejectClose(false)}
+                  disabled={isRejecting}
+                >
+                  Cancelar
+                </Button>
+                <Button type="submit" variant="destructive" disabled={isRejecting}>
+                  {isRejecting && (
+                    <Loader2 className="size-4 animate-spin" />
+                  )}
+                  Rechazar
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
         </DialogContent>
       </Dialog>
     </>

--- a/src/components/member-of-month/evaluate-dialog.tsx
+++ b/src/components/member-of-month/evaluate-dialog.tsx
@@ -40,7 +40,7 @@ function buildYearOptions(): number[] {
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface EvaluateMemberOfMonthDialogProps {
+export interface EvaluateMemberOfMonthDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   clubId: number;

--- a/src/components/member-of-month/history-sheet.tsx
+++ b/src/components/member-of-month/history-sheet.tsx
@@ -106,7 +106,7 @@ function HistorySkeleton() {
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface MemberOfMonthHistorySheetProps {
+export interface MemberOfMonthHistorySheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   clubId: number;

--- a/src/components/member-of-month/member-of-month-card.tsx
+++ b/src/components/member-of-month/member-of-month-card.tsx
@@ -4,15 +4,32 @@ import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { Trophy, Clock, Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import dynamic from "next/dynamic";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { EvaluateMemberOfMonthDialog } from "@/components/member-of-month/evaluate-dialog";
-import { MemberOfMonthHistorySheet } from "@/components/member-of-month/history-sheet";
 import { getMemberOfMonth } from "@/lib/api/member-of-month";
 import type { MemberOfMonthEntry } from "@/lib/api/member-of-month";
 import { MONTH_NAMES } from "@/lib/constants";
+import type { EvaluateMemberOfMonthDialogProps } from "@/components/member-of-month/evaluate-dialog";
+import type { MemberOfMonthHistorySheetProps } from "@/components/member-of-month/history-sheet";
+
+const EvaluateMemberOfMonthDialog = dynamic<EvaluateMemberOfMonthDialogProps>(
+  () =>
+    import("@/components/member-of-month/evaluate-dialog").then((m) => ({
+      default: m.EvaluateMemberOfMonthDialog,
+    })),
+  { ssr: false, loading: () => null }
+);
+
+const MemberOfMonthHistorySheet = dynamic<MemberOfMonthHistorySheetProps>(
+  () =>
+    import("@/components/member-of-month/history-sheet").then((m) => ({
+      default: m.MemberOfMonthHistorySheet,
+    })),
+  { ssr: false, loading: () => null }
+);
 
 // ─── Member avatar ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Single-PR consolidation of 3 disjoint workstreams (Session 23). Zero conflict between agents this round — fully orthogonal scopes.

### A — Perf round 6: defer tab-gated panels on /dashboard/clubs/[id] (~50-68 KB gz)
Top per-route bundle (894 KB raw / 258 KB gz) addressed. Three subtrees moved off first paint:
- `PendingMembersPanel` (membership tab) — drags zod v4 + locales via `MembershipRejectDialog` (same ~103 KB gz bundle deferred in R5 on other routes)
- `UnitsTab` (units tab) — `UnitDetailPanel` + `AddMemberDialog` + `DeleteUnitDialog`, breaks cmdk chain (~20 KB gz)
- `EvaluateMemberOfMonthDialog` + `MemberOfMonthHistorySheet` inside `MemberOfMonthCard` — dialogs closed on mount

Pattern: `next/dynamic({ ssr: false })` on Server Component (panels already `"use client"` with client-side fetch). Image audit found only 3 plain `<img>` tags, all inside dialogs/low-traffic pages — no migration warranted. PERF-BASELINE.md round 6 section added.

### B — shadcn Form primitive r5 (3 rhf components)
- `investiture/bulk-action-bar` (reject dialog form)
- `evidence-review/evidence-bulk-action-bar` (reject dialog form)
- `annual-folders/award-category-form-dialog` — most complex: 9 fields, removed 3 `watch()` variables now reading via `field.value`

### C — MSW dialog tests r5 (+30 tests, 402 → 432)
- `finances/delete-transaction-dialog.test.tsx` — 10 tests (AlertDialog flow)
- `camporees/enroll-club-dialog.test.tsx` — 10 tests (RHF + Zod positive integer)
- `annual-folders/template-form-dialog.test.tsx` — 10 tests (create/edit modes, geography catalog load via Promise.all)

## Scope notes

Agent B's initial scope (4 history/detail dialogs) was a false positive — `useFormatDateTime` matched the `useForm` rg pattern. Re-dispatched with 3 verified rhf components. Lesson: use `from "react-hook-form"` import check, not `useForm` token grep.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test --run` — 432/432 pass (30 → 33 files)
- [x] `pnpm lint` — 10 errors / 42 warnings, baseline preserved
- [ ] CI Vitest green
- [ ] CI Typecheck green
- [ ] Vercel preview green

## Stats

- 11 files: 8 modified, 3 created
- Test count journey: 41 (audit) → 316 (Sesión 19) → 344 (Sesión 20) → 372 (Sesión 21) → 402 (Sesión 22) → **432 (Sesión 23)** = **10.5x growth**