### PR TITLE
chore: perf r7 finances+insurance (~206KB gz) + Form r6 + MSW r6 + CI build gate

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+      - preproduction
+      - development
+
+jobs:
+  build:
+    name: Next.js production build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:3000

--- a/PERF-BASELINE.md
+++ b/PERF-BASELINE.md
@@ -358,14 +358,79 @@ and investiture routes. On `/dashboard/clubs/[id]` it was still fully eager.
 
 ---
 
+## 10. Round 7 (2026-05-10) — finances and insurance dialog defers + CI build gate
+
+**Branch:** `perf/admin-r7-routes` (off `origin/development`)
+**Worktree:** `.claude/worktrees/agent-perf-r7-2026-05-10`
+
+### Routes targeted
+
+| Route | Baseline gz | Rank | Why targeted |
+|---|---|---|---|
+| `/dashboard/finances` | ~237 KB gz | #8 | `FinancesDashboard` eagerly imports `TransactionFormDialog` (zod + zodResolver) |
+| `/dashboard/insurance` | ~237 KB gz | #10 | `InsuranceView` eagerly imports `InsuranceFormDialog` (zod + zodResolver) |
+
+Both routes are Client Component trees — `ssr: false` is valid for all deferred dialogs.
+
+### Components deferred
+
+| Parent file | Component deferred | Zod? | Gate |
+|---|---|---|---|
+| `src/components/finances/finances-dashboard.tsx` | `TransactionFormDialog` | YES | "Nueva transacción" button click |
+| `src/components/finances/finances-dashboard.tsx` | `DeleteTransactionDialog` | no | Delete row action |
+| `src/components/insurance/insurance-view.tsx` | `InsuranceFormDialog` | YES | Edit/create member action |
+| `src/components/insurance/insurance-view.tsx` | `DeleteInsuranceDialog` | no | Delete row action |
+
+### Pattern applied
+
+`dynamic<Props>(import, { ssr: false, loading: () => null })` in each Client Component
+parent. Props interfaces exported from each dialog file (`InsuranceFormDialogProps`,
+`DeleteInsuranceDialogProps`, `TransactionFormDialogProps`, `DeleteTransactionDialogProps`)
+for correct `dynamic<Props>()` generic typing. Dialogs start closed — `loading: () => null`
+produces no visual flash.
+
+### Estimated gz savings
+
+| Route | Removed from initial chunk | Estimated gz saved |
+|---|---|---|
+| `/dashboard/finances` | `TransactionFormDialog` zod/zodResolver bundle | ~103 KB |
+| `/dashboard/insurance` | `InsuranceFormDialog` zod/zodResolver bundle | ~103 KB |
+| Both routes | `DeleteTransactionDialog` + `DeleteInsuranceDialog` (smaller) | ~5–10 KB each |
+
+Total estimated: **~103 KB gz per route** on first paint (same zod v4 + i18n locale
+chunk isolated in R5 on camporees/evidence-review/investiture routes).
+
+### CI build gate added
+
+**New file:** `.github/workflows/build.yml`
+
+Runs `pnpm build` on every PR targeting `main`, `preproduction`, or `development`.
+This catches the critical class of bug fixed in R6 (commit `cb94d33`): `ssr: false`
+inside a Server Component passes typecheck and Vitest but fails Vercel build. The new
+workflow catches it at PR time, before merge.
+
+Env vars used: `NEXT_PUBLIC_API_URL=http://localhost:3000` (dummy; only needed to resolve
+the CSP origin in `next.config.ts`). Sentry DSN is hardcoded as fallback in
+`sentry.server.config.ts` — no extra secret needed for build to complete.
+
+### Verification
+
+- `pnpm typecheck`: PASS
+- `pnpm test --run`: 432/432 PASS
+- `pnpm lint`: unchanged from baseline
+
+---
+
 ## 8. Next actions (handoff)
 
 - ~~Replace `pnpm analyze` script with `next experimental-analyze`~~ DONE.
 - ~~Recharts dynamic imports (#1 in §5)~~ DONE (R4).
 - ~~zod form-dialog deferred imports (#2 in §5)~~ DONE (R5).
-- **Remaining items from §5 (#3–#5)**:
-  - Investigate `/dashboard/clubs/[id]` (18-chunk heavyweight route).
-  - Audit `/dashboard/annual-folders/templates` remaining eagerly-imported helpers.
-  - Evaluate replacing/deferring `cmdk` on `/dashboard/clubs/[id]`.
+- ~~`/dashboard/clubs/[id]` tab-gated panels~~ DONE (R6).
+- ~~`/dashboard/finances` + `/dashboard/insurance` dialog defers~~ DONE (R7).
+- **Remaining items**:
+  - Audit `/dashboard/annual-folders/templates` remaining eagerly-imported helpers (inner components of the template editor).
+  - Evaluate replacing/deferring `cmdk` on any route still carrying it.
+  - Regenerate per-route baseline numbers post-R7 to confirm gz savings.
 - After the next perf wave, regenerate this baseline and commit a diff so we
   can see savings by route.

--- a/src/components/annual-folders/evaluate-section-dialog.test.tsx
+++ b/src/components/annual-folders/evaluate-section-dialog.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * Integration tests for EvaluateSectionDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog uses controlled inputs (no React Hook Form). Inline validation
+ * via handlePointsChange. On open, useEffect syncs earnedPoints from
+ * currentPoints prop and notes from currentNotes prop.
+ *
+ * Submit calls `evaluateSection(folderId, sectionId, { earned_points, notes })`.
+ * Submit button is disabled until pointsError === null and input is non-empty.
+ *
+ * `evaluateSection` is mocked at module boundary.
+ * ApiError is imported from `@/lib/api/client` and tested against instanceof check.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockEvaluateSection = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/annual-folders", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/lib/api/annual-folders")>();
+  return {
+    ...original,
+    evaluateSection: (...args: unknown[]) => mockEvaluateSection(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { EvaluateSectionDialog } from "@/components/annual-folders/evaluate-section-dialog";
+import { ApiError } from "@/lib/api/client";
+
+// ---------------------------------------------------------------------------
+// Constants / helpers
+// ---------------------------------------------------------------------------
+
+const t = messages.annual_folders;
+
+const DEFAULT_PROPS = {
+  folderId: "folder-abc",
+  sectionId: "section-xyz",
+  sectionName: "Actividades al aire libre",
+  maxPoints: 50,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  currentPoints?: number | null;
+  currentNotes?: string | null;
+  maxPoints?: number;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    currentPoints = null,
+    currentNotes = null,
+    maxPoints = DEFAULT_PROPS.maxPoints,
+  } = opts;
+
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <EvaluateSectionDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        folderId={DEFAULT_PROPS.folderId}
+        sectionId={DEFAULT_PROPS.sectionId}
+        sectionName={DEFAULT_PROPS.sectionName}
+        maxPoints={maxPoints}
+        currentPoints={currentPoints}
+        currentNotes={currentNotes}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+function getPointsInput() {
+  return document.getElementById("earned-points") as HTMLInputElement;
+}
+
+function getNotesTextarea() {
+  return document.getElementById("eval-notes") as HTMLTextAreaElement;
+}
+
+function getSubmitButton() {
+  return screen.getByRole("button", { name: /guardar evaluación/i });
+}
+
+function getCancelButton() {
+  return screen.getByRole("button", { name: /cancelar/i });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EvaluateSectionDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEvaluateSection.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title, section name, and form controls ────────────────────
+
+  it("renders dialog title, section name, inputs and buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /evaluar sección/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(DEFAULT_PROPS.sectionName),
+    ).toBeInTheDocument();
+    expect(getPointsInput()).toBeInTheDocument();
+    expect(getNotesTextarea()).toBeInTheDocument();
+    expect(getSubmitButton()).toBeInTheDocument();
+    expect(getCancelButton()).toBeInTheDocument();
+  });
+
+  // ── 2. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /evaluar sección/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. useEffect syncs form from currentPoints/currentNotes props ────────
+
+  it("pre-fills points input and notes textarea from currentPoints/currentNotes props", () => {
+    renderDialog({ currentPoints: 30, currentNotes: "Muy bien hecho" });
+
+    expect(getPointsInput().value).toBe("30");
+    expect(getNotesTextarea().value).toBe("Muy bien hecho");
+  });
+
+  // ── 4. Submit disabled when input is empty ───────────────────────────────
+
+  it("keeps submit button disabled when points input is empty", () => {
+    renderDialog({ currentPoints: null });
+
+    // No input yet — earnedPoints === "" so isValid = false
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  // ── 5. Inline validation — shows error below maxPoints ───────────────────
+
+  it("shows error message when entered points exceed maxPoints", async () => {
+    const user = userEvent.setup();
+    renderDialog({ maxPoints: 50 });
+
+    await user.type(getPointsInput(), "99");
+
+    expect(
+      screen.getByText(/no puede superar el máximo de 50 puntos/i),
+    ).toBeInTheDocument();
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  // ── 6. Inline validation — negative value error ──────────────────────────
+
+  it("shows error message for negative points", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(getPointsInput(), "-1");
+
+    expect(screen.getByText(/no puede ser menor a 0/i)).toBeInTheDocument();
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  // ── 7. Inline validation — non-integer value error ───────────────────────
+
+  it("shows error message for non-integer points value", () => {
+    renderDialog();
+
+    fireEvent.change(getPointsInput(), { target: { value: "10.5" } });
+
+    expect(screen.getByText(/debe ser un número entero/i)).toBeInTheDocument();
+    expect(getSubmitButton()).toBeDisabled();
+  });
+
+  // ── 8. Happy path — calls evaluateSection with correct args ──────────────
+
+  it("calls evaluateSection with folderId, sectionId and earned_points on valid submit", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    fireEvent.change(getPointsInput(), { target: { value: "40" } });
+
+    await act(async () => {
+      fireEvent.submit(getPointsInput().closest("form")!);
+    });
+
+    await waitFor(() => {
+      expect(mockEvaluateSection).toHaveBeenCalledWith(
+        DEFAULT_PROPS.folderId,
+        DEFAULT_PROPS.sectionId,
+        { earned_points: 40, notes: undefined },
+      );
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.section_evaluated);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 9. Happy path — notes are sent when filled ───────────────────────────
+
+  it("passes trimmed notes when the textarea is filled", async () => {
+    renderDialog({ currentPoints: 25, currentNotes: "  good work  " });
+
+    // currentNotes synced to textarea value; re-open to trigger useEffect
+    // The textarea value is set directly from prop
+    fireEvent.change(getNotesTextarea(), { target: { value: "great work" } });
+    fireEvent.change(getPointsInput(), { target: { value: "25" } });
+
+    await act(async () => {
+      fireEvent.submit(getPointsInput().closest("form")!);
+    });
+
+    await waitFor(() => {
+      expect(mockEvaluateSection).toHaveBeenCalledWith(
+        DEFAULT_PROPS.folderId,
+        DEFAULT_PROPS.sectionId,
+        { earned_points: 25, notes: "great work" },
+      );
+    });
+  });
+
+  // ── 10. API error — ApiError message shown in toast ──────────────────────
+
+  it("shows ApiError message in error toast when evaluateSection throws ApiError", async () => {
+    const apiErr = new ApiError("Evaluation window closed", 422, null);
+    mockEvaluateSection.mockRejectedValue(apiErr);
+
+    renderDialog();
+    fireEvent.change(getPointsInput(), { target: { value: "20" } });
+
+    await act(async () => {
+      fireEvent.submit(getPointsInput().closest("form")!);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Evaluation window closed");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 11. API error — i18n fallback for generic errors ────────────────────
+
+  it("shows i18n fallback error when evaluateSection throws a non-ApiError", async () => {
+    mockEvaluateSection.mockRejectedValue(new Error("network failure"));
+
+    renderDialog();
+    fireEvent.change(getPointsInput(), { target: { value: "15" } });
+
+    await act(async () => {
+      fireEvent.submit(getPointsInput().closest("form")!);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.save_evaluation_failed);
+    });
+  });
+
+  // ── 12. In-flight state — buttons disabled while submitting ──────────────
+
+  it("disables cancel and submit buttons while submission is in flight", async () => {
+    let resolveEval!: () => void;
+    mockEvaluateSection.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveEval = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+    fireEvent.change(getPointsInput(), { target: { value: "30" } });
+
+    await act(async () => {
+      fireEvent.submit(getPointsInput().closest("form")!);
+    });
+
+    // While submitting, the button label changes to "Guardando..."
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /guardando/i }),
+      ).toBeDisabled();
+      expect(getCancelButton()).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveEval();
+    });
+  });
+
+  // ── 13. Cancel does not call API ─────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call evaluateSection on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(getCancelButton());
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockEvaluateSection).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/camporees/camporee-approval-dialog.tsx
+++ b/src/components/camporees/camporee-approval-dialog.tsx
@@ -15,8 +15,15 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import { ApiError } from "@/lib/api/client";
 
@@ -113,49 +120,49 @@ export function CamporeeApprovalDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          {isReject && (
-            <div className="space-y-2">
-              <Label htmlFor="rejection_reason">Motivo de rechazo</Label>
-              <Textarea
-                id="rejection_reason"
-                placeholder="Describe el motivo del rechazo (opcional)..."
-                rows={3}
-                {...form.register("rejection_reason")}
-                disabled={isPending}
-                aria-describedby={
-                  form.formState.errors.rejection_reason
-                    ? "rejection-reason-error"
-                    : undefined
-                }
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {isReject && (
+              <FormField
+                control={form.control}
+                name="rejection_reason"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Motivo de rechazo</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        placeholder="Describe el motivo del rechazo (opcional)..."
+                        rows={3}
+                        disabled={isPending}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-              {form.formState.errors.rejection_reason && (
-                <p id="rejection-reason-error" className="text-xs text-destructive">
-                  {form.formState.errors.rejection_reason.message}
-                </p>
-              )}
-            </div>
-          )}
+            )}
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleClose(false)}
-              disabled={isPending}
-            >
-              Cancelar
-            </Button>
-            <Button
-              type="submit"
-              variant={isReject ? "destructive" : "default"}
-              disabled={isPending}
-            >
-              {isPending && <Loader2 className="size-4 animate-spin" />}
-              {isReject ? "Rechazar" : "Aprobar"}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isPending}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                variant={isReject ? "destructive" : "default"}
+                disabled={isPending}
+              >
+                {isPending && <Loader2 className="size-4 animate-spin" />}
+                {isReject ? "Rechazar" : "Aprobar"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/camporees/camporee-form-dialog.tsx
+++ b/src/components/camporees/camporee-form-dialog.tsx
@@ -16,9 +16,16 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import { createCamporee, updateCamporee } from "@/lib/api/camporees";
 import type { Camporee } from "@/lib/api/camporees";
@@ -78,14 +85,7 @@ export function CamporeeFormDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const schema = useMemo(() => buildSchema(tVal), [tVal]);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       name: "",
@@ -101,14 +101,10 @@ export function CamporeeFormDialog({
     },
   });
 
-  const includesAdventurers = watch("includes_adventurers");
-  const includesPathfinders = watch("includes_pathfinders");
-  const includesMasterGuides = watch("includes_master_guides");
-
   useEffect(() => {
     if (open) {
       if (camporee) {
-        reset({
+        form.reset({
           name: camporee.name,
           description: camporee.description ?? "",
           start_date: toDateInput(camporee.start_date),
@@ -121,7 +117,7 @@ export function CamporeeFormDialog({
           includes_master_guides: camporee.includes_master_guides ?? false,
         });
       } else {
-        reset({
+        form.reset({
           name: "",
           description: "",
           start_date: "",
@@ -135,7 +131,7 @@ export function CamporeeFormDialog({
         });
       }
     }
-  }, [open, camporee, reset]);
+  }, [open, camporee, form]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -195,169 +191,236 @@ export function CamporeeFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-          {/* Nombre */}
-          <div className="space-y-1.5">
-            <Label htmlFor="name">{t("form.labelName")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-            <Input
-              id="name"
-              {...register("name")}
-              placeholder={t("form.placeholderName")}
-              aria-required="true"
-            />
-            {errors.name && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
-            )}
-          </div>
-
-          {/* Descripción */}
-          <div className="space-y-1.5">
-            <Label htmlFor="description">{t("form.labelDescription")}</Label>
-            <Textarea
-              id="description"
-              {...register("description")}
-              placeholder={t("form.placeholderDescription")}
-              rows={3}
-            />
-          </div>
-
-          {/* Fechas */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="start_date">{t("form.labelStartDate")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-              <Input id="start_date" type="date" {...register("start_date")} aria-required="true" />
-              {errors.start_date && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.start_date.message}
-                </p>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {/* Nombre */}
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("form.labelName")}{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder={t("form.placeholderName")}
+                      aria-required="true"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-            <div className="space-y-1.5">
-              <Label htmlFor="end_date">{t("form.labelEndDate")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-              <Input id="end_date" type="date" {...register("end_date")} aria-required="true" />
-              {errors.end_date && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.end_date.message}
-                </p>
+            />
+
+            {/* Descripción */}
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("form.labelDescription")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      {...field}
+                      placeholder={t("form.placeholderDescription")}
+                      rows={3}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
+            />
+
+            {/* Fechas */}
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="start_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("form.labelStartDate")}{" "}
+                      <span aria-hidden="true" className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input {...field} type="date" aria-required="true" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="end_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("form.labelEndDate")}{" "}
+                      <span aria-hidden="true" className="text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Input {...field} type="date" aria-required="true" />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
             </div>
-          </div>
 
-          {/* Lugar */}
-          <div className="space-y-1.5">
-            <Label htmlFor="local_camporee_place">{t("form.labelPlace")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-            <Input
-              id="local_camporee_place"
-              {...register("local_camporee_place")}
-              placeholder={t("form.placeholderPlace")}
-              aria-required="true"
+            {/* Lugar */}
+            <FormField
+              control={form.control}
+              name="local_camporee_place"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("form.labelPlace")}{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder={t("form.placeholderPlace")}
+                      aria-required="true"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.local_camporee_place && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.local_camporee_place.message}
-              </p>
-            )}
-          </div>
 
-          {/* Campo local */}
-          <div className="space-y-1.5">
-            <Label htmlFor="local_field_id">{t("form.labelLocalFieldId")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-            <Input
-              id="local_field_id"
-              type="number"
-              min={1}
-              {...register("local_field_id")}
-              placeholder="1"
-              aria-required="true"
+            {/* Campo local */}
+            <FormField
+              control={form.control}
+              name="local_field_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("form.labelLocalFieldId")}{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="number"
+                      min={1}
+                      placeholder="1"
+                      aria-required="true"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.local_field_id && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.local_field_id.message}
-              </p>
-            )}
-          </div>
 
-          {/* Costo de inscripción */}
-          <div className="space-y-1.5">
-            <Label htmlFor="registration_cost">{t("form.labelRegistrationCost")}</Label>
-            <Input
-              id="registration_cost"
-              type="number"
-              min={0}
-              step="0.01"
-              {...register("registration_cost")}
-              placeholder="0.00"
+            {/* Costo de inscripción */}
+            <FormField
+              control={form.control}
+              name="registration_cost"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("form.labelRegistrationCost")}</FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="number"
+                      min={0}
+                      step="0.01"
+                      placeholder="0.00"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {errors.registration_cost && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.registration_cost.message}
-              </p>
-            )}
-          </div>
 
-          {/* Tipos de club */}
-          <div className="space-y-2">
-            <Label>{t("form.labelIncludes")}</Label>
-            <div className="space-y-2 rounded-md border border-border p-3">
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="includes_adventurers"
-                  checked={includesAdventurers}
-                  onCheckedChange={(checked) =>
-                    setValue("includes_adventurers", checked === true)
-                  }
+            {/* Tipos de club */}
+            <div className="space-y-2">
+              <FormLabel className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">
+                {t("form.labelIncludes")}
+              </FormLabel>
+              <div className="space-y-2 rounded-md border border-border p-3">
+                <FormField
+                  control={form.control}
+                  name="includes_adventurers"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center gap-2 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          id="includes_adventurers"
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                      <FormLabel htmlFor="includes_adventurers" className="font-normal cursor-pointer">
+                        {t("form.adventurers")}
+                      </FormLabel>
+                    </FormItem>
+                  )}
                 />
-                <Label htmlFor="includes_adventurers" className="font-normal cursor-pointer">
-                  {t("form.adventurers")}
-                </Label>
-              </div>
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="includes_pathfinders"
-                  checked={includesPathfinders}
-                  onCheckedChange={(checked) =>
-                    setValue("includes_pathfinders", checked === true)
-                  }
+                <FormField
+                  control={form.control}
+                  name="includes_pathfinders"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center gap-2 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          id="includes_pathfinders"
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                      <FormLabel htmlFor="includes_pathfinders" className="font-normal cursor-pointer">
+                        {t("form.pathfinders")}
+                      </FormLabel>
+                    </FormItem>
+                  )}
                 />
-                <Label htmlFor="includes_pathfinders" className="font-normal cursor-pointer">
-                  {t("form.pathfinders")}
-                </Label>
-              </div>
-              <div className="flex items-center gap-2">
-                <Checkbox
-                  id="includes_master_guides"
-                  checked={includesMasterGuides}
-                  onCheckedChange={(checked) =>
-                    setValue("includes_master_guides", checked === true)
-                  }
+                <FormField
+                  control={form.control}
+                  name="includes_master_guides"
+                  render={({ field }) => (
+                    <FormItem className="flex items-center gap-2 space-y-0">
+                      <FormControl>
+                        <Checkbox
+                          id="includes_master_guides"
+                          checked={field.value}
+                          onCheckedChange={field.onChange}
+                        />
+                      </FormControl>
+                      <FormLabel htmlFor="includes_master_guides" className="font-normal cursor-pointer">
+                        {t("form.masterGuides")}
+                      </FormLabel>
+                    </FormItem>
+                  )}
                 />
-                <Label htmlFor="includes_master_guides" className="font-normal cursor-pointer">
-                  {t("form.masterGuides")}
-                </Label>
               </div>
             </div>
-          </div>
 
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              {t("form.cancel")}
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? isEdit
-                  ? t("form.saving")
-                  : t("form.creating")
-                : isEdit
-                  ? t("form.saveChanges")
-                  : t("form.createCamporee")}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                {t("form.cancel")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? isEdit
+                    ? t("form.saving")
+                    : t("form.creating")
+                  : isEdit
+                    ? t("form.saveChanges")
+                    : t("form.createCamporee")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/camporees/delete-camporee-dialog.test.tsx
+++ b/src/components/camporees/delete-camporee-dialog.test.tsx
@@ -1,0 +1,321 @@
+/**
+ * Integration tests for DeleteCamporeeDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar.
+ * On confirm: calls `deleteCamporee(id)`, shows success toast, closes
+ * the dialog, and either redirects via router.push(redirectTo) or calls
+ * onSuccess() + router.refresh().
+ *
+ * `deleteCamporee` is mocked at module boundary (no fetch exercised).
+ * `useRouter` from next/navigation is mocked.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { Camporee } from "@/lib/api/camporees";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix AlertDialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+const mockPush = vi.fn();
+const mockRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, refresh: mockRefresh }),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteCamporee = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/camporees", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/camporees")>();
+  return {
+    ...original,
+    deleteCamporee: (...args: unknown[]) => mockDeleteCamporee(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteCamporeeDialog } from "@/components/camporees/delete-camporee-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_CAMPOREE: Camporee = {
+  camporee_id: 5,
+  name: "Camporee Regional 2026",
+  start_date: "2026-08-01",
+  end_date: "2026-08-05",
+};
+
+const STUB_CAMPOREE_LEGACY_ID: Camporee = {
+  id: 99,
+  name: "Camporee Legado",
+  start_date: "2026-09-01",
+  end_date: "2026-09-03",
+};
+
+const t = messages.camporees;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  camporee?: Camporee | null;
+  redirectTo?: string;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, camporee = STUB_CAMPOREE, redirectTo, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteCamporeeDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        camporee={camporee}
+        redirectTo={redirectTo}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteCamporeeDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteCamporee.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and action buttons ──────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /eliminar camporee/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows camporee name in description ────────────────────────────────
+
+  it("shows the camporee name in the description", () => {
+    renderDialog({ camporee: STUB_CAMPOREE });
+
+    expect(screen.getByText(/Camporee Regional 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/Esta acción desactivará el camporee/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /eliminar camporee/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null camporee — early return, no API call ─────────────────────────
+
+  it("does not call deleteCamporee when camporee is null", async () => {
+    renderDialog({ camporee: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteCamporee).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls deleteCamporee with camporee_id ───────────────
+
+  it("calls deleteCamporee with camporee_id and closes dialog + calls onSuccess + refresh", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ camporee: STUB_CAMPOREE });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteCamporee).toHaveBeenCalledWith(5);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.camporee_deleted);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(mockRefresh).toHaveBeenCalledOnce();
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  // ── 6. Legacy id field — uses camporee.id when camporee_id is absent ────
+
+  it("calls deleteCamporee with id when camporee_id is absent", async () => {
+    renderDialog({ camporee: STUB_CAMPOREE_LEGACY_ID });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteCamporee).toHaveBeenCalledWith(99);
+    });
+  });
+
+  // ── 7. redirectTo — calls router.push instead of onSuccess + refresh ────
+
+  it("calls router.push(redirectTo) and does NOT call onSuccess when redirectTo is set", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({
+      camporee: STUB_CAMPOREE,
+      redirectTo: "/dashboard/camporees",
+    });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/dashboard/camporees");
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(mockRefresh).not.toHaveBeenCalled();
+  });
+
+  // ── 8. Cancel button closes without API call ─────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteCamporee on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteCamporee).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error — shows error toast from message ───────────────────────
+
+  it("shows error toast from API error message when deleteCamporee throws Error", async () => {
+    mockDeleteCamporee.mockRejectedValue(new Error("Server failure"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Server failure");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 10. API error — falls back to i18n message for non-Error throws ──────
+
+  it("shows i18n fallback error toast when deleteCamporee throws a non-Error", async () => {
+    mockDeleteCamporee.mockRejectedValue("plain string error");
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.delete_camporee);
+    });
+  });
+
+  // ── 11. In-flight state — buttons disabled while deleting ────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteCamporee.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+});

--- a/src/components/camporees/enroll-club-dialog.tsx
+++ b/src/components/camporees/enroll-club-dialog.tsx
@@ -16,7 +16,15 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { useTranslations } from "next-intl";
 import { enrollClub } from "@/lib/api/camporees";
 
@@ -51,12 +59,7 @@ export function EnrollClubDialog({
   const t = useTranslations("camporees");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
       club_section_id: undefined,
@@ -65,7 +68,7 @@ export function EnrollClubDialog({
 
   function handleOpenChange(nextOpen: boolean) {
     if (!nextOpen) {
-      reset();
+      form.reset();
     }
     onOpenChange(nextOpen);
   }
@@ -96,42 +99,50 @@ export function EnrollClubDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-          {/* Club section ID */}
-          <div className="space-y-1.5">
-            <Label htmlFor="club_section_id">{t("enrollDialog.labelSectionId")} <span aria-hidden="true" className="text-destructive">*</span></Label>
-            <Input
-              id="club_section_id"
-              type="number"
-              min={1}
-              {...register("club_section_id")}
-              placeholder={t("enrollDialog.placeholderSectionId")}
-              aria-required="true"
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {/* Club section ID */}
+            <FormField
+              control={form.control}
+              name="club_section_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("enrollDialog.labelSectionId")}{" "}
+                    <span aria-hidden="true" className="text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      type="number"
+                      min={1}
+                      placeholder={t("enrollDialog.placeholderSectionId")}
+                      aria-required="true"
+                    />
+                  </FormControl>
+                  <FormMessage role="alert" aria-live="polite" />
+                  <FormDescription>
+                    {t("enrollDialog.helpSectionId")}
+                  </FormDescription>
+                </FormItem>
+              )}
             />
-            {errors.club_section_id && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.club_section_id.message}
-              </p>
-            )}
-            <p className="text-xs text-muted-foreground">
-              {t("enrollDialog.helpSectionId")}
-            </p>
-          </div>
 
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              {t("enrollDialog.cancel")}
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting ? t("enrollDialog.enrolling") : t("enrollDialog.enroll")}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                {t("enrollDialog.cancel")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? t("enrollDialog.enrolling") : t("enrollDialog.enroll")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/evidence-review/evidence-approve-dialog.test.tsx
+++ b/src/components/evidence-review/evidence-approve-dialog.test.tsx
@@ -1,0 +1,371 @@
+/**
+ * Integration tests for EvidenceApproveDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog (not AlertDialog). Controlled textarea for optional comments.
+ * On approve: calls `approveEvidence(type, id, comments)`.
+ * On close while not submitting: clears comments + calls onOpenChange.
+ * If isSubmitting, handleClose is a no-op (user cannot close).
+ *
+ * `approveEvidence` is mocked at module boundary.
+ * ApiError from `@/lib/api/client` is used for the error instanceof check.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { EvidenceType } from "@/lib/api/evidence-review";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockApproveEvidence = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/evidence-review", async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import("@/lib/api/evidence-review")>();
+  return {
+    ...original,
+    approveEvidence: (...args: unknown[]) => mockApproveEvidence(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { EvidenceApproveDialog } from "@/components/evidence-review/evidence-approve-dialog";
+import { ApiError } from "@/lib/api/client";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const t = messages.evidence_review;
+
+const DEFAULT_PROPS = {
+  type: "folder" as EvidenceType,
+  id: 42,
+  memberName: "Ana García",
+  sectionName: "Actividades al aire libre",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  type?: EvidenceType;
+  id?: number;
+  memberName?: string;
+  sectionName?: string;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    type = DEFAULT_PROPS.type,
+    id = DEFAULT_PROPS.id,
+    memberName = DEFAULT_PROPS.memberName,
+    sectionName = DEFAULT_PROPS.sectionName,
+  } = opts;
+
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <EvidenceApproveDialog
+        open={open}
+        type={type}
+        id={id}
+        memberName={memberName}
+        sectionName={sectionName}
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess };
+}
+
+function getCommentsTextarea() {
+  return document.getElementById("approve-comments") as HTMLTextAreaElement;
+}
+
+function getApproveButton() {
+  return screen.getByRole("button", { name: /aprobar/i });
+}
+
+function getCancelButton() {
+  return screen.getByRole("button", { name: /cancelar/i });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EvidenceApproveDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApproveEvidence.mockResolvedValue({
+      id: DEFAULT_PROPS.id,
+      type: DEFAULT_PROPS.type,
+      status: "VALIDATED",
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title, description and action buttons ─────────────────────
+
+  it("renders dialog title, member name, section name and action buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /aprobar evidencia/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_PROPS.memberName)).toBeInTheDocument();
+    expect(screen.getByText(DEFAULT_PROPS.sectionName)).toBeInTheDocument();
+    expect(getCommentsTextarea()).toBeInTheDocument();
+    expect(getApproveButton()).toBeInTheDocument();
+    expect(getCancelButton()).toBeInTheDocument();
+  });
+
+  // ── 2. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /aprobar evidencia/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Renders description with correct member and section names ─────────
+
+  it("renders description mentioning memberName and sectionName", () => {
+    renderDialog({
+      memberName: "Carlos Pérez",
+      sectionName: "Honor de Natación",
+    });
+
+    expect(screen.getByText("Carlos Pérez")).toBeInTheDocument();
+    expect(screen.getByText("Honor de Natación")).toBeInTheDocument();
+  });
+
+  // ── 4. Happy path — no comments — calls approveEvidence with undefined ───
+
+  it("calls approveEvidence(type, id, undefined) when comments textarea is empty", async () => {
+    const { onSuccess } = renderDialog();
+
+    await act(async () => {
+      fireEvent.click(getApproveButton());
+    });
+
+    await waitFor(() => {
+      expect(mockApproveEvidence).toHaveBeenCalledWith(
+        DEFAULT_PROPS.type,
+        DEFAULT_PROPS.id,
+        undefined,
+      );
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.evidence_approved);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 5. Happy path — with comments — passes trimmed string ───────────────
+
+  it("calls approveEvidence with trimmed comments when textarea is filled", async () => {
+    renderDialog();
+
+    fireEvent.change(getCommentsTextarea(), {
+      target: { value: "  Excelente trabajo  " },
+    });
+
+    await act(async () => {
+      fireEvent.click(getApproveButton());
+    });
+
+    await waitFor(() => {
+      expect(mockApproveEvidence).toHaveBeenCalledWith(
+        DEFAULT_PROPS.type,
+        DEFAULT_PROPS.id,
+        "Excelente trabajo",
+      );
+    });
+  });
+
+  // ── 6. Happy path — passes correct type for different EvidenceTypes ──────
+
+  it("calls approveEvidence with type='class' when type prop is 'class'", async () => {
+    renderDialog({ type: "class", id: 77 });
+
+    await act(async () => {
+      fireEvent.click(getApproveButton());
+    });
+
+    await waitFor(() => {
+      expect(mockApproveEvidence).toHaveBeenCalledWith("class", 77, undefined);
+    });
+  });
+
+  // ── 7. Cancel closes dialog and clears comments ──────────────────────────
+
+  it("calls onOpenChange(false) and clears comments on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.type(getCommentsTextarea(), "some text");
+    expect(getCommentsTextarea().value).toBe("some text");
+
+    await user.click(getCancelButton());
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockApproveEvidence).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — ApiError message shown in toast ───────────────────────
+
+  it("shows ApiError message in toast when approveEvidence throws ApiError", async () => {
+    const apiErr = new ApiError("Evidence already approved", 409, null);
+    mockApproveEvidence.mockRejectedValue(apiErr);
+
+    const { onSuccess } = renderDialog();
+
+    await act(async () => {
+      fireEvent.click(getApproveButton());
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Evidence already approved");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error — i18n fallback for generic errors ──────────────────────
+
+  it("shows i18n fallback error toast for non-ApiError throws", async () => {
+    mockApproveEvidence.mockRejectedValue(new Error("network timeout"));
+
+    renderDialog();
+
+    await act(async () => {
+      fireEvent.click(getApproveButton());
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.approve);
+    });
+  });
+
+  // ── 10. In-flight — buttons disabled and Approve button shows spinner ────
+
+  it("disables both buttons while approval is in flight", async () => {
+    let resolveApprove!: () => void;
+    mockApproveEvidence.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveApprove = () => res({ id: 42, type: "folder", status: "VALIDATED" });
+      }),
+    );
+
+    renderDialog();
+
+    await act(async () => {
+      fireEvent.click(getApproveButton());
+    });
+
+    await waitFor(() => {
+      expect(getApproveButton()).toBeDisabled();
+      expect(getCancelButton()).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveApprove();
+    });
+  });
+
+  // ── 11. Char counter updates as user types ────────────────────────────────
+
+  it("updates char counter as user types in comments textarea", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    expect(screen.getByText(/0\/500 caracteres/i)).toBeInTheDocument();
+
+    await user.type(getCommentsTextarea(), "hola");
+
+    expect(screen.getByText(/4\/500 caracteres/i)).toBeInTheDocument();
+  });
+
+  // ── 12. Cannot close while submitting ────────────────────────────────────
+
+  it("does not call onOpenChange while submitting when cancel is attempted", async () => {
+    let resolveApprove!: () => void;
+    mockApproveEvidence.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveApprove = () => res({ id: 42, type: "folder", status: "VALIDATED" });
+      }),
+    );
+
+    const { onOpenChange } = renderDialog();
+
+    await act(async () => {
+      fireEvent.click(getApproveButton());
+    });
+
+    // While in-flight, Cancel is disabled — click has no effect via the
+    // disabled button (browser blocks it). onOpenChange should NOT be called.
+    await waitFor(() => {
+      expect(getCancelButton()).toBeDisabled();
+    });
+
+    fireEvent.click(getCancelButton());
+    expect(onOpenChange).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveApprove();
+    });
+  });
+});

--- a/src/components/finances/delete-transaction-dialog.tsx
+++ b/src/components/finances/delete-transaction-dialog.tsx
@@ -17,7 +17,7 @@ import { useTranslations } from "next-intl";
 import { deleteFinance, type Finance } from "@/lib/api/finances";
 import { useFormatCurrency } from "@/lib/format-locale";
 
-interface DeleteTransactionDialogProps {
+export interface DeleteTransactionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   finance: Finance | null;

--- a/src/components/finances/finances-dashboard.tsx
+++ b/src/components/finances/finances-dashboard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import dynamic from "next/dynamic";
 import { Plus, RefreshCw, Filter } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
@@ -18,8 +19,6 @@ import {
   TransactionsTable,
   TransactionsTableSkeleton,
 } from "@/components/finances/transactions-table";
-import { TransactionFormDialog } from "@/components/finances/transaction-form-dialog";
-import { DeleteTransactionDialog } from "@/components/finances/delete-transaction-dialog";
 import {
   listFinances,
   getFinanceSummary,
@@ -29,8 +28,27 @@ import {
   type PaginatedFinances,
 } from "@/lib/api/finances";
 import type { SortDirection } from "@/components/shared/sortable-header";
-import type { ClubSection } from "@/components/finances/transaction-form-dialog";
+import type { TransactionFormDialogProps, ClubSection } from "@/components/finances/transaction-form-dialog";
+import type { DeleteTransactionDialogProps } from "@/components/finances/delete-transaction-dialog";
 import { useTranslations } from "next-intl";
+
+// ─── Deferred dialogs (dialog-gated — zod bundle only loaded on first open) ───
+
+const TransactionFormDialog = dynamic<TransactionFormDialogProps>(
+  () =>
+    import("@/components/finances/transaction-form-dialog").then((m) => ({
+      default: m.TransactionFormDialog,
+    })),
+  { ssr: false, loading: () => null },
+);
+
+const DeleteTransactionDialog = dynamic<DeleteTransactionDialogProps>(
+  () =>
+    import("@/components/finances/delete-transaction-dialog").then((m) => ({
+      default: m.DeleteTransactionDialog,
+    })),
+  { ssr: false, loading: () => null },
+);
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 

--- a/src/components/finances/transaction-form-dialog.tsx
+++ b/src/components/finances/transaction-form-dialog.tsx
@@ -97,7 +97,7 @@ export type ClubSection = {
   club_type?: { name?: string } | null;
 };
 
-interface TransactionFormDialogProps {
+export interface TransactionFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   clubId: number;

--- a/src/components/insurance/delete-insurance-dialog.tsx
+++ b/src/components/insurance/delete-insurance-dialog.tsx
@@ -26,7 +26,7 @@ function memberFullName(member: MemberInsurance | null): string {
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface DeleteInsuranceDialogProps {
+export interface DeleteInsuranceDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   member: MemberInsurance | null;

--- a/src/components/insurance/insurance-form-dialog.tsx
+++ b/src/components/insurance/insurance-form-dialog.tsx
@@ -72,7 +72,7 @@ function memberFullName(member: MemberInsurance): string {
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface InsuranceFormDialogProps {
+export interface InsuranceFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   member: MemberInsurance | null;

--- a/src/components/insurance/insurance-view.tsx
+++ b/src/components/insurance/insurance-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { Plus, RefreshCw } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -12,10 +13,28 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { InsuranceTable } from "@/components/insurance/insurance-table";
-import { InsuranceFormDialog } from "@/components/insurance/insurance-form-dialog";
-import { DeleteInsuranceDialog } from "@/components/insurance/delete-insurance-dialog";
 import { apiRequestFromClient, ApiError } from "@/lib/api/client";
 import type { MemberInsurance } from "@/lib/api/insurance";
+import type { InsuranceFormDialogProps } from "@/components/insurance/insurance-form-dialog";
+import type { DeleteInsuranceDialogProps } from "@/components/insurance/delete-insurance-dialog";
+
+// ─── Deferred dialogs (dialog-gated — zod bundle only loaded on first open) ───
+
+const InsuranceFormDialog = dynamic<InsuranceFormDialogProps>(
+  () =>
+    import("@/components/insurance/insurance-form-dialog").then((m) => ({
+      default: m.InsuranceFormDialog,
+    })),
+  { ssr: false, loading: () => null },
+);
+
+const DeleteInsuranceDialog = dynamic<DeleteInsuranceDialogProps>(
+  () =>
+    import("@/components/insurance/delete-insurance-dialog").then((m) => ({
+      default: m.DeleteInsuranceDialog,
+    })),
+  { ssr: false, loading: () => null },
+);
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Single-PR consolidation of 3 disjoint workstreams + CI safety net (Session 24). Zero cross-agent conflict — fully orthogonal scopes.

### A — Perf round 7: defer 4 dialogs on 2 routes (~206 KB gz)
- `/dashboard/finances`: `TransactionFormDialog` + `DeleteTransactionDialog` dynamic-imported
- `/dashboard/insurance`: `InsuranceFormDialog` + `DeleteInsuranceDialog` dynamic-imported
- Both parents are Client Components — `ssr: false` safe.
- Drops ~103 KB gz zod v4 + i18n locale chunk off both routes (same R5 chunk).
- PERF-BASELINE.md round 7 section added.

### B — shadcn Form primitive r6 (3 camporee dialogs, atomic refactor + test ownership)
- `camporees/camporee-form-dialog` — Checkbox via `field.value`/`onChange`, removed `watch()` variables
- `camporees/camporee-approval-dialog` — single optional Textarea in reject mode
- `camporees/enroll-club-dialog` — `FormMessage` with `role="alert" aria-live="polite"` preserved for `getByRole("alert")` queries

Single agent owned both `.tsx` refactor AND test verification — all 30 pre-existing dialog tests stayed green on first run after migration. **Zero test fixes needed.** New pattern that fully eliminates the Sesión 21 B↔C conflict (17 broken tests at combine).

### C — MSW dialog tests r6 (+36 tests, 432 → 468)
- `camporees/delete-camporee-dialog.test.tsx` — 11 tests (AlertDialog flow + router)
- `annual-folders/evaluate-section-dialog.test.tsx` — 13 tests (Dialog + ApiError instanceof + in-flight label `/guardando/i`)
- `evidence-review/evidence-approve-dialog.test.tsx` — 12 tests (textarea char counter + cannot-close-while-submitting)

### D — CI build gate (`.github/workflows/build.yml`)
New workflow runs `pnpm build` on every PR to `main`/`preproduction`/`development`. **Catches the bug class fixed in commit cb94d33 (#128) BEFORE merge** — `ssr: false` in Server Components passes typecheck + Vitest but breaks Vercel build. This was a post-merge surprise in PR #128; this workflow makes it a pre-merge block.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `pnpm test --run` — 468/468 pass (33 → 36 files)
- [x] `pnpm lint` — 10 errors / 42 warnings, baseline preserved
- [x] Manual verification: `head -3` of both `finances-dashboard.tsx` and `insurance-view.tsx` confirms `"use client"` — `ssr: false` safe.
- [ ] CI Vitest green
- [ ] CI Typecheck green
- [ ] **CI Build green (NEW gate)**
- [ ] Vercel preview green

## Stats

- 13 files: 9 modified, 4 created (1 workflow + 3 test files)
- Test count journey: 41 (audit) → 316 → 344 → 372 → 402 → 432 → **468 (Sesión 24)** = **11.4x growth**