### PR TITLE
feat(evidence-review): align annual folder flows

### DIFF
--- a/src/app/(dashboard)/dashboard/annual-folders/page.tsx
+++ b/src/app/(dashboard)/dashboard/annual-folders/page.tsx
@@ -81,7 +81,7 @@ export default async function AnnualFoldersPage({
       {/* Search / selector — always visible */}
       <FolderByEnrollmentView
         currentEnrollmentId={enrollmentId}
-        currentFolderId={folder?.folder_id ?? null}
+        currentFolderId={folder?.annual_folder_id ?? null}
       />
 
       {/* Error state */}

--- a/src/app/(dashboard)/dashboard/evidence-review/page.tsx
+++ b/src/app/(dashboard)/dashboard/evidence-review/page.tsx
@@ -31,7 +31,7 @@ export default async function EvidenceReviewPage() {
   }
 
   const pendingCount = items.filter((item) =>
-    item.type === "honor" ? item.status === "in_progress" : item.status === "pendiente",
+    ["SUBMITTED", "PENDING_REVIEW"].includes(item.status),
   ).length;
 
   return (

--- a/src/components/annual-folders/evaluation-client-page.tsx
+++ b/src/components/annual-folders/evaluation-client-page.tsx
@@ -69,7 +69,6 @@ function formatDateTime(dateString: string | null | undefined): string {
 interface EvalSectionRowProps {
   section: FolderSectionWithEvidences;
   evaluation: SectionEvaluation | undefined;
-  folderId: string;
   onEvaluate: (section: FolderSectionWithEvidences) => void;
   onReopen: (section: FolderSectionWithEvidences) => void;
 }
@@ -77,7 +76,6 @@ interface EvalSectionRowProps {
 function EvalSectionRow({
   section,
   evaluation,
-  folderId: _folderId,
   onEvaluate,
   onReopen,
 }: EvalSectionRowProps) {
@@ -239,21 +237,21 @@ function FolderSummaryCard({
           <div className="flex flex-wrap items-center gap-2">
             <FolderStatusBadge status={folder.status} />
             <span className="text-sm font-semibold">
-              Carpeta #{folder.folder_id}
+              Carpeta #{folder.annual_folder_id}
             </span>
           </div>
 
           <div className="grid gap-0.5 text-xs text-muted-foreground">
             <span>
               <span className="font-medium text-foreground">Inscripción:</span>{" "}
-              #{folder.enrollment_id}
+              #{folder.club_enrollment_id}
               {folder.enrollment?.club_name
                 ? ` — ${folder.enrollment.club_name}`
                 : ""}
             </span>
             <span>
               <span className="font-medium text-foreground">Plantilla:</span>{" "}
-              {folder.template?.name ?? `#${folder.template_id}`}
+              {folder.template?.name ?? `#${folder.folder_template_id}`}
             </span>
             {folder.submitted_at && (
               <span>
@@ -398,7 +396,7 @@ export function EvaluationClientPage() {
     if (!folder) return;
     setIsRefreshing(true);
     try {
-      await loadFolder(folder.folder_id);
+      await loadFolder(folder.annual_folder_id);
     } catch (err) {
       const message =
         err instanceof ApiError
@@ -428,7 +426,7 @@ export function EvaluationClientPage() {
     if (!folder || !reopeningSection) return;
     setIsReopening(true);
     try {
-      await reopenSection(folder.folder_id, reopeningSection.section_id);
+      await reopenSection(folder.annual_folder_id, reopeningSection.section_id);
       toast.success(t("toasts.section_reopened"));
       setReopenOpen(false);
       setReopeningSection(null);
@@ -525,7 +523,7 @@ export function EvaluationClientPage() {
               title="Ver carpeta completa con evidencias"
             >
               <a
-                href={`/dashboard/annual-folders?folder=${folder.folder_id}`}
+                href={`/dashboard/annual-folders?folder=${folder.annual_folder_id}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -549,7 +547,6 @@ export function EvaluationClientPage() {
                   key={section.section_id}
                   section={section}
                   evaluation={getEvaluationForSection(section)}
-                  folderId={folder.folder_id}
                   onEvaluate={handleEvaluate}
                   onReopen={handleReopen}
                 />
@@ -564,7 +561,7 @@ export function EvaluationClientPage() {
         <EvaluateSectionDialog
           open={evaluateOpen}
           onOpenChange={setEvaluateOpen}
-          folderId={folder.folder_id}
+          folderId={folder.annual_folder_id}
           sectionId={evaluatingSection.section_id}
           sectionName={evaluatingSection.name}
           maxPoints={evaluatingSection.max_points ?? 0}

--- a/src/components/annual-folders/folder-client-page.tsx
+++ b/src/components/annual-folders/folder-client-page.tsx
@@ -214,7 +214,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
   const refreshFolder = useCallback(async () => {
     setIsRefreshing(true);
     try {
-      const updated = await getFolder(folder.folder_id);
+      const updated = await getFolder(folder.annual_folder_id);
       setFolder(updated);
     } catch (err) {
       const message =
@@ -225,7 +225,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
     } finally {
       setIsRefreshing(false);
     }
-  }, [folder.folder_id]);
+  }, [folder.annual_folder_id]);
 
   // ─── Upload handlers ─────────────────────────────────────────────────────
 
@@ -266,7 +266,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
   async function confirmSubmit() {
     setIsActioning(true);
     try {
-      const updated = await submitFolder(folder.folder_id);
+      const updated = await submitFolder(folder.annual_folder_id);
       setFolder(updated);
       toast.success(t("toasts.folder_submitted"));
       setSubmitOpen(false);
@@ -284,7 +284,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
   async function confirmClose() {
     setIsActioning(true);
     try {
-      const updated = await closeFolder(folder.folder_id);
+      const updated = await closeFolder(folder.annual_folder_id);
       setFolder(updated);
       toast.success(t("toasts.folder_closed"));
       setCloseOpen(false);
@@ -433,7 +433,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
         <EvidenceUploadDialog
           open={uploadOpen}
           onOpenChange={setUploadOpen}
-          folderId={folder.folder_id}
+          folderId={folder.annual_folder_id}
           sectionId={uploadSection.section_id}
           sectionName={uploadSection.name}
           onSuccess={refreshFolder}

--- a/src/components/evidence-review/evidence-history-dialog.test.tsx
+++ b/src/components/evidence-review/evidence-history-dialog.test.tsx
@@ -116,7 +116,7 @@ interface RenderOpts {
 function renderDialog(opts: RenderOpts = {}) {
   const {
     open = true,
-    type = "folder",
+    type = "class",
     id = 42,
     memberName = "Juan Pérez",
   } = opts;

--- a/src/components/evidence-review/evidence-review-client-page.tsx
+++ b/src/components/evidence-review/evidence-review-client-page.tsx
@@ -21,8 +21,7 @@ type TabKey = EvidenceType | "all";
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function isPending(item: EvidenceItem): boolean {
-  if (item.type === "honor") return item.status === "in_progress";
-  return item.status === "pendiente";
+  return ["SUBMITTED", "PENDING_REVIEW"].includes(item.status);
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -41,7 +40,6 @@ export function EvidenceReviewClientPage({
   // TABS defined inside component so labels go through t()
   const TABS: { key: TabKey; label: string }[] = [
     { key: "all",    label: t("tab_all") },
-    { key: "folder", label: t("tab_folders") },
     { key: "class",  label: t("tab_classes") },
     { key: "honor",  label: t("tab_honors") },
   ];

--- a/src/components/evidence-review/evidence-review-table.tsx
+++ b/src/components/evidence-review/evidence-review-table.tsx
@@ -53,9 +53,8 @@ const EvidenceBulkActionBar = dynamic<EvidenceBulkActionBarProps>(
 import { useFormatDate } from "@/lib/format-locale";
 
 function isPending(status: string, type: EvidenceType): boolean {
-  if (status === "SUBMITTED") return true;
-  if (type === "honor") return status === "in_progress";
-  return status === "pendiente";
+  void type;
+  return ["SUBMITTED", "PENDING_REVIEW"].includes(status);
 }
 
 // ─── Dialog state ─────────────────────────────────────────────────────────────

--- a/src/components/evidence-review/evidence-status-badge.tsx
+++ b/src/components/evidence-review/evidence-status-badge.tsx
@@ -7,8 +7,8 @@ import type { EvidenceType } from "@/lib/api/evidence-review";
 type IntentConfig = { labelKey: string; intent: StatusIntent };
 
 // Backend enum evidence_validation_enum: PENDING | SUBMITTED | VALIDATED | REJECTED
-// Applies to folders_section_records.status AND class_section_progress.status
-const folderClassIntentMap: Record<string, IntentConfig> = {
+// Applies to class_section_progress.status
+const classIntentMap: Record<string, IntentConfig> = {
   PENDING:   { labelKey: "no_submit",  intent: "neutral" },
   SUBMITTED: { labelKey: "submitted",  intent: "info" },
   VALIDATED: { labelKey: "validated",  intent: "success" },
@@ -23,9 +23,8 @@ const honorIntentMap: Record<string, IntentConfig> = {
   SUBMITTED:   { labelKey: "submitted",  intent: "info" },
   VALIDATED:   { labelKey: "validated",  intent: "success" },
   REJECTED:    { labelKey: "rejected",   intent: "destructive" },
-  in_progress: { labelKey: "submitted",  intent: "info" },
-  validated:   { labelKey: "validated",  intent: "success" },
-  rejected:    { labelKey: "rejected",   intent: "destructive" },
+  PENDING_REVIEW: { labelKey: "submitted",  intent: "info" },
+
 };
 
 interface EvidenceStatusBadgeProps {
@@ -36,7 +35,7 @@ interface EvidenceStatusBadgeProps {
 
 export function EvidenceStatusBadge({ status, type, className }: EvidenceStatusBadgeProps) {
   const t = useTranslations("evidence_review.statusBadge");
-  const configMap = type === "honor" ? honorIntentMap : folderClassIntentMap;
+  const configMap = type === "honor" ? honorIntentMap : classIntentMap;
   const config = configMap[status];
   const label = config ? t(config.labelKey as "no_submit" | "submitted" | "validated" | "rejected") : status;
   const intent: StatusIntent = config?.intent ?? "neutral";

--- a/src/components/evidence-review/evidence-type-badge.tsx
+++ b/src/components/evidence-review/evidence-type-badge.tsx
@@ -5,7 +5,6 @@ import { StatusBadge, type StatusIntent } from "@/components/ui/status-badge";
 import type { EvidenceType } from "@/lib/api/evidence-review";
 
 const typeIntentMap: Record<EvidenceType, StatusIntent> = {
-  folder: "primary",
   class: "neutral",
   honor: "success",
 };

--- a/src/lib/api/annual-folders.ts
+++ b/src/lib/api/annual-folders.ts
@@ -85,7 +85,7 @@ export type FolderTemplate = {
 
 export type FolderEvidence = {
   evidence_id: string;
-  folder_id: string;
+  annual_folder_id: string;
   section_id: string;
   file_url: string;
   file_name: string | null;
@@ -116,9 +116,9 @@ export type SectionEvaluationEntry = {
 };
 
 export type AnnualFolder = {
-  folder_id: string;
-  enrollment_id: string;
-  template_id: string;
+  annual_folder_id: string;
+  club_enrollment_id: string;
+  folder_template_id: string;
   status: FolderStatus;
   submitted_at: string | null;
   closed_at: string | null;
@@ -136,6 +136,33 @@ export type AnnualFolder = {
   // Enrollment info (available when fetched via evaluation endpoint)
   enrollment?: { enrollment_id: string; club_name?: string | null } | null;
 };
+
+type AnnualFolderWire = AnnualFolder & {
+  folder_id?: string;
+  enrollment_id?: string;
+  template_id?: string;
+};
+
+function normalizeAnnualFolder(folder: AnnualFolderWire): AnnualFolder {
+  return {
+    ...folder,
+    annual_folder_id: folder.annual_folder_id ?? folder.folder_id ?? "",
+    club_enrollment_id:
+      folder.club_enrollment_id ?? folder.enrollment_id ?? "",
+    folder_template_id:
+      folder.folder_template_id ?? folder.template_id ?? "",
+    sections: folder.sections?.map((section) => ({
+      ...section,
+      evidences: section.evidences.map((evidence) => ({
+        ...evidence,
+        annual_folder_id:
+          evidence.annual_folder_id ??
+          (evidence as FolderEvidence & { folder_id?: string }).folder_id ??
+          "",
+      })),
+    })),
+  };
+}
 
 // ─── Payloads ─────────────────────────────────────────────────────────────────
 
@@ -178,15 +205,16 @@ export async function getTemplate(templateId: string): Promise<FolderTemplate> {
 }
 
 /**
- * GET /api/v1/annual-folders/enrollment/:enrollmentId
+ * GET /api/v1/annual-folders/by-enrollment/:enrollmentId
  * Returns the annual folder for the given enrollment.
  */
 export async function getFolderByEnrollment(
   enrollmentId: string,
 ): Promise<AnnualFolder> {
-  return apiRequest<AnnualFolder>(
-    `/annual-folders/enrollment/${enrollmentId}`,
+  const folder = await apiRequest<AnnualFolderWire>(
+    `/annual-folders/by-enrollment/${enrollmentId}`,
   );
+  return normalizeAnnualFolder(folder);
 }
 
 /**
@@ -194,7 +222,10 @@ export async function getFolderByEnrollment(
  * Returns the folder with all section evidences.
  */
 export async function getFolder(folderId: string): Promise<AnnualFolder> {
-  return apiRequest<AnnualFolder>(`/annual-folders/${folderId}`);
+  const folder = await apiRequest<AnnualFolderWire>(
+    `/annual-folders/${folderId}`,
+  );
+  return normalizeAnnualFolder(folder);
 }
 
 // ─── Client-side (mutations) ──────────────────────────────────────────────────
@@ -268,7 +299,7 @@ export async function deleteTemplateSection(
 }
 
 /**
- * POST /api/v1/annual-folders/:folderId/evidences
+ * POST /api/v1/annual-folders/:folderId/sections/:sectionId/evidences
  * Uploads a file evidence for a section. Sends multipart/form-data.
  */
 export async function uploadEvidence(
@@ -279,11 +310,10 @@ export async function uploadEvidence(
 ): Promise<FolderEvidence> {
   const formData = new FormData();
   formData.append("file", file);
-  formData.append("section_id", sectionId);
   if (description) formData.append("description", description);
 
   return apiRequestFromClient<FolderEvidence>(
-    `/annual-folders/${folderId}/evidences`,
+    `/annual-folders/${folderId}/sections/${sectionId}/evidences`,
     { method: "POST", body: formData },
   );
 }

--- a/src/lib/api/evidence-review.ts
+++ b/src/lib/api/evidence-review.ts
@@ -2,7 +2,7 @@ import { apiRequest, apiRequestFromClient } from "@/lib/api/client";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type EvidenceType = "folder" | "class" | "honor";
+export type EvidenceType = "class" | "honor";
 
 export type EvidenceStatus =
   | "PENDING"


### PR DESCRIPTION
## Summary
- Removes annual folders from the admin Evidence Review surface.
- Aligns annual folder API usage with canonical backend routes and IDs.
- Normalizes legacy annual folder response shapes for compatibility.

## Test Plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec eslint 'src/lib/api/evidence-review.ts' 'src/app/(dashboard)/dashboard/evidence-review/page.tsx' 'src/components/evidence-review/evidence-review-client-page.tsx' 'src/components/evidence-review/evidence-review-table.tsx' 'src/components/evidence-review/evidence-type-badge.tsx' 'src/components/evidence-review/evidence-status-badge.tsx' 'src/components/evidence-review/evidence-history-dialog.test.tsx' 'src/lib/api/annual-folders.ts' 'src/app/(dashboard)/dashboard/annual-folders/page.tsx' 'src/components/annual-folders/folder-client-page.tsx' 'src/components/annual-folders/evaluation-client-page.tsx'`
