### PR TITLE
chore: perf r8 mega — defer 6 dialogs across 4 routes (~128-165 KB gz)

### DIFF
--- a/PERF-BASELINE.md
+++ b/PERF-BASELINE.md
@@ -421,6 +421,74 @@ the CSP origin in `next.config.ts`). Sentry DSN is hardcoded as fallback in
 
 ---
 
+## 11. Round 8 mega (2026-05-11) — investiture, config, templates, validation dialog defers
+
+**Branch:** `perf/admin-r8-mega` (off `origin/development`, includes #131 + #133)
+**Worktree:** `.claude/worktrees/agent-perf-mega-2026-05-11`
+
+### Strategy
+
+Three zod-heavy dialog pairs and one react-query dialog deferred across four routes.
+All parent files confirmed as Client Components (`"use client"` present) before applying
+`ssr: false`. Props interfaces exported from each dialog file for correct `dynamic<Props>()`
+generic typing. Pattern: `dynamic<Props>(import, { ssr: false, loading: () => null })`.
+
+### Routes addressed
+
+| Route | Components deferred | Zod? | Gate |
+|---|---|---|---|
+| `/dashboard/investiture` | `ValidateDialog`, `InvestidoDialog` | YES (both) | Row action buttons |
+| `/dashboard/investiture/config` | `ConfigFormDialog`, `DeleteConfigDialog` | YES (form), no (delete) | Toolbar buttons |
+| `/dashboard/annual-folders/templates` | `SectionFormDialog` | YES | "Add section" button inside detail view |
+| `/dashboard/validation` | `ValidationHistoryDialog` | no (react-query only) | History row button |
+
+### Files modified
+
+| File | Change |
+|---|---|
+| `src/components/investiture/validate-dialog.tsx` | Export `ValidateDialogProps` |
+| `src/components/investiture/investido-dialog.tsx` | Export `InvestidoDialogProps` |
+| `src/components/investiture/config-form-dialog.tsx` | Export `ConfigFormDialogProps` |
+| `src/components/investiture/delete-config-dialog.tsx` | Export `DeleteConfigDialogProps` |
+| `src/components/annual-folders/section-form-dialog.tsx` | Export `SectionFormDialogProps` |
+| `src/components/validation/validation-history-dialog.tsx` | Export `ValidationHistoryDialogProps` |
+| `src/components/investiture/pending-table.tsx` | Dynamic import `ValidateDialog` + `InvestidoDialog` |
+| `src/components/investiture/config-client-page.tsx` | Dynamic import `ConfigFormDialog` + `DeleteConfigDialog` |
+| `src/components/annual-folders/templates-client-page.tsx` | Dynamic import `SectionFormDialog` |
+| `src/components/validation/validation-table.tsx` | Dynamic import `ValidationHistoryDialog` |
+
+### Deliberately out of scope (Agent B conflict avoidance)
+
+- `src/components/membership/membership-reject-dialog.tsx` — Agent B's scope
+- `src/components/validation/validation-review-dialog.tsx` — Agent B's scope
+- `src/components/requests/request-review-dialog.tsx` — Agent B's scope
+- `src/components/annual-folders/template-form-dialog.tsx` — Agent B's scope
+
+`ValidationReviewDialog` in `validation-table.tsx` remains eagerly imported to avoid
+conflict. `ValidationHistoryDialog` was safely deferred (no overlap with Agent B).
+
+### Estimated gz savings
+
+| Route | Removed from initial chunk | Estimated gz saved |
+|---|---|---|
+| `/dashboard/investiture` | `ValidateDialog` + `InvestidoDialog` zod/zodResolver bundles | ~50–70 KB |
+| `/dashboard/investiture/config` | `ConfigFormDialog` zod/zodResolver bundle | ~50 KB |
+| `/dashboard/annual-folders/templates` | `SectionFormDialog` zod/zodResolver bundle | ~20–30 KB |
+| `/dashboard/validation` | `ValidationHistoryDialog` (react-query only, smaller) | ~8–15 KB |
+| **Total estimated** | | **~128–165 KB gz** across 4 routes |
+
+The dominant savings come from the zod v4 + i18n locale chunk (~103 KB gz) being removed
+from the initial load on 3 of the 4 routes — same chunk pattern isolated in R5 and applied
+in R6+R7 on other routes.
+
+### Verification
+
+- `pnpm typecheck`: PASS
+- `pnpm test --run`: 468/468 PASS
+- `pnpm lint`: 10 err / 42 warn (unchanged from baseline — all pre-existing)
+
+---
+
 ## 8. Next actions (handoff)
 
 - ~~Replace `pnpm analyze` script with `next experimental-analyze`~~ DONE.

--- a/src/components/annual-folders/section-form-dialog.tsx
+++ b/src/components/annual-folders/section-form-dialog.tsx
@@ -63,7 +63,7 @@ type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface SectionFormDialogProps {
+export interface SectionFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   templateId: string;

--- a/src/components/annual-folders/templates-client-page.tsx
+++ b/src/components/annual-folders/templates-client-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import {
@@ -50,7 +51,12 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { TemplateFormDialog } from "@/components/annual-folders/template-form-dialog";
-import { SectionFormDialog } from "@/components/annual-folders/section-form-dialog";
+import type { SectionFormDialogProps } from "@/components/annual-folders/section-form-dialog";
+
+const SectionFormDialog = dynamic<SectionFormDialogProps>(
+  () => import("@/components/annual-folders/section-form-dialog").then((m) => ({ default: m.SectionFormDialog })),
+  { ssr: false, loading: () => null },
+);
 import {
   getTemplate,
   deleteTemplateSection,

--- a/src/components/investiture/config-client-page.tsx
+++ b/src/components/investiture/config-client-page.tsx
@@ -1,15 +1,26 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { toast } from "sonner";
 import { Plus, RefreshCw } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { ConfigTable } from "@/components/investiture/config-table";
-import { ConfigFormDialog } from "@/components/investiture/config-form-dialog";
-import { DeleteConfigDialog } from "@/components/investiture/delete-config-dialog";
 import { getInvestitureConfigs, type InvestitureConfig } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
+import type { ConfigFormDialogProps } from "@/components/investiture/config-form-dialog";
+import type { DeleteConfigDialogProps } from "@/components/investiture/delete-config-dialog";
+
+const ConfigFormDialog = dynamic<ConfigFormDialogProps>(
+  () => import("@/components/investiture/config-form-dialog").then((m) => ({ default: m.ConfigFormDialog })),
+  { ssr: false, loading: () => null },
+);
+
+const DeleteConfigDialog = dynamic<DeleteConfigDialogProps>(
+  () => import("@/components/investiture/delete-config-dialog").then((m) => ({ default: m.DeleteConfigDialog })),
+  { ssr: false, loading: () => null },
+);
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/components/investiture/config-form-dialog.tsx
+++ b/src/components/investiture/config-form-dialog.tsx
@@ -69,7 +69,7 @@ type FormValues = {
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface ConfigFormDialogProps {
+export interface ConfigFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** If provided, dialog is in edit mode */

--- a/src/components/investiture/delete-config-dialog.tsx
+++ b/src/components/investiture/delete-config-dialog.tsx
@@ -18,7 +18,7 @@ import { deleteInvestitureConfig, type InvestitureConfig } from "@/lib/api/inves
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface DeleteConfigDialogProps {
+export interface DeleteConfigDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   config: InvestitureConfig | null;

--- a/src/components/investiture/investido-dialog.tsx
+++ b/src/components/investiture/investido-dialog.tsx
@@ -37,7 +37,7 @@ type FormValues = z.infer<typeof schema>;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface InvestidoDialogProps {
+export interface InvestidoDialogProps {
   open: boolean;
   enrollmentId: number;
   memberName: string;

--- a/src/components/investiture/pending-table.tsx
+++ b/src/components/investiture/pending-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { CheckCircle2, XCircle, Award, History, ClipboardList } from "lucide-react";
@@ -24,9 +25,19 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { EmptyState } from "@/components/shared/empty-state";
 import { InvestitureStatusBadge } from "@/components/investiture/investiture-status-badge";
-import { ValidateDialog } from "@/components/investiture/validate-dialog";
-import { InvestidoDialog } from "@/components/investiture/investido-dialog";
 import { HistoryTimeline } from "@/components/investiture/history-timeline";
+import type { ValidateDialogProps } from "@/components/investiture/validate-dialog";
+import type { InvestidoDialogProps } from "@/components/investiture/investido-dialog";
+
+const ValidateDialog = dynamic<ValidateDialogProps>(
+  () => import("@/components/investiture/validate-dialog").then((m) => ({ default: m.ValidateDialog })),
+  { ssr: false, loading: () => null },
+);
+
+const InvestidoDialog = dynamic<InvestidoDialogProps>(
+  () => import("@/components/investiture/investido-dialog").then((m) => ({ default: m.InvestidoDialog })),
+  { ssr: false, loading: () => null },
+);
 import {
   getInvestitureHistory,
   type PendingEnrollment,

--- a/src/components/investiture/validate-dialog.tsx
+++ b/src/components/investiture/validate-dialog.tsx
@@ -45,7 +45,7 @@ type RejectFormValues = z.infer<ReturnType<typeof buildRejectSchema>>;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface ValidateDialogProps {
+export interface ValidateDialogProps {
   open: boolean;
   enrollmentId: number;
   memberName: string;

--- a/src/components/validation/validation-history-dialog.tsx
+++ b/src/components/validation/validation-history-dialog.tsx
@@ -41,7 +41,7 @@ const actionVisual: Record<
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface ValidationHistoryDialogProps {
+export interface ValidationHistoryDialogProps {
   open: boolean;
   entityType: ValidationEntityType;
   entityId: number | string;

--- a/src/components/validation/validation-table.tsx
+++ b/src/components/validation/validation-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { CheckCircle2, XCircle, History, ClipboardList } from "lucide-react";
@@ -17,7 +18,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { EmptyState } from "@/components/shared/empty-state";
 import { ValidationStatusBadge } from "@/components/validation/validation-status-badge";
 import { ValidationReviewDialog } from "@/components/validation/validation-review-dialog";
-import { ValidationHistoryDialog } from "@/components/validation/validation-history-dialog";
+import type { ValidationHistoryDialogProps } from "@/components/validation/validation-history-dialog";
+
+const ValidationHistoryDialog = dynamic<ValidationHistoryDialogProps>(
+  () => import("@/components/validation/validation-history-dialog").then((m) => ({ default: m.ValidationHistoryDialog })),
+  { ssr: false, loading: () => null },
+);
 import type {
   PendingValidation,
   ValidationAction,


### PR DESCRIPTION
## Summary

- `/dashboard/investiture`: defer `ValidateDialog` + `InvestidoDialog` — both use zod/zodResolver, gated behind row action buttons
- `/dashboard/investiture/config`: defer `ConfigFormDialog` (zod) + `DeleteConfigDialog` — gated behind toolbar buttons
- `/dashboard/annual-folders/templates`: defer `SectionFormDialog` (zod) — gated behind "Add section" button inside the detail view
- `/dashboard/validation`: defer `ValidationHistoryDialog` (react-query, no zod) — gated behind the History row button

**All parent files confirmed as Client Components** (`"use client"` verified before applying `ssr: false`).

Props interfaces exported from each of the 6 dialog files for correct `dynamic<Props>()` generic typing.

Agent B's 4 out-of-scope dialogs (`membership-reject-dialog`, `validation-review-dialog`, `request-review-dialog`, `template-form-dialog`) deliberately untouched.

Estimated gz savings: **~128–165 KB gz** across 4 routes on first paint (3 routes remove the ~103 KB zod v4 + i18n locale chunk from initial load).

PERF-BASELINE.md updated with Round 8 section.

## Test plan

- [x] `pnpm typecheck` — PASS
- [x] `pnpm test --run` — 468/468 PASS
- [x] `pnpm lint` — 10 err / 42 warn (unchanged from baseline, all pre-existing)
- [x] All 4 parent files verified as `"use client"` before applying `ssr: false`
- [x] CI build gate (`.github/workflows/build.yml`) will catch any SSR violations at PR time