### PR TITLE
test: MSW dialog suite r7 mega (9 new test files, +96 tests)

### DIFF
--- a/src/components/activities/delete-activity-dialog.test.tsx
+++ b/src/components/activities/delete-activity-dialog.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * Integration tests for DeleteActivityDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar.
+ * On confirm: calls `deleteActivity(activity_id)`, shows success toast,
+ * calls onSuccess() and closes the dialog.
+ *
+ * `deleteActivity` is mocked at module boundary (no fetch exercised).
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { Activity } from "@/lib/api/activities";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix AlertDialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteActivity = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/activities", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/activities")>();
+  return {
+    ...original,
+    deleteActivity: (...args: unknown[]) => mockDeleteActivity(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteActivityDialog } from "@/components/activities/delete-activity-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_ACTIVITY: Activity = {
+  activity_id: 42,
+  name: "Acampada Primavera 2026",
+  club_id: 1,
+  club_type_id: 2,
+  club_section_id: 3,
+  lat: 0,
+  long: 0,
+  activity_place: "Parque Central",
+  activity_type_id: 1,
+  active: true,
+};
+
+const t = messages.activities;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  activity?: Activity | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, activity = STUB_ACTIVITY, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteActivityDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        activity={activity}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteActivityDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteActivity.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /¿eliminar actividad\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows activity name in description ────────────────────────────────
+
+  it("shows the activity name in the description", () => {
+    renderDialog({ activity: STUB_ACTIVITY });
+
+    expect(screen.getByText(/Acampada Primavera 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/desactivará la actividad/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /¿eliminar actividad\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null activity — early return, no API call ─────────────────────────
+
+  it("does not call deleteActivity when activity is null", async () => {
+    renderDialog({ activity: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteActivity).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls deleteActivity with activity_id ────────────────
+
+  it("calls deleteActivity with activity_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ activity: STUB_ACTIVITY });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteActivity).toHaveBeenCalledWith(42);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.deleted);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteActivity on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteActivity).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error message when deleteActivity throws", async () => {
+    mockDeleteActivity.mockRejectedValue(new Error("Connection timeout"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Connection timeout");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deleteActivity throws a non-Error", async () => {
+    mockDeleteActivity.mockRejectedValue("plain string error");
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.delete_failed);
+    });
+  });
+
+  // ── 9. In-flight state — buttons disabled while deleting ─────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteActivity.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+
+  // ── 10. onSuccess is NOT called on error ─────────────────────────────────
+
+  it("does NOT call onSuccess when deleteActivity fails", async () => {
+    mockDeleteActivity.mockRejectedValue(new Error("Server error"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/camporees/delete-union-camporee-dialog.test.tsx
+++ b/src/components/camporees/delete-union-camporee-dialog.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * Integration tests for DeleteUnionCamporeeDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar.
+ * On confirm: resolves ID from union_camporee_id ?? id ?? 0, calls
+ * `deleteUnionCamporee(id)`, shows success toast, closes the dialog
+ * and calls optional onSuccess().
+ *
+ * `deleteUnionCamporee` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { UnionCamporee } from "@/lib/api/camporees";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteUnionCamporee = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/camporees", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/camporees")>();
+  return {
+    ...original,
+    deleteUnionCamporee: (...args: unknown[]) => mockDeleteUnionCamporee(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteUnionCamporeeDialog } from "@/components/camporees/delete-union-camporee-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_UNION_CAMPOREE: UnionCamporee = {
+  union_camporee_id: 7,
+  name: "Gran Camporee de Unión 2026",
+  start_date: "2026-07-01",
+  end_date: "2026-07-05",
+};
+
+const STUB_UNION_CAMPOREE_LEGACY: UnionCamporee = {
+  id: 15,
+  name: "Camporee Unión Legado",
+  start_date: "2026-09-10",
+  end_date: "2026-09-12",
+};
+
+const t = messages.camporees;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  camporee?: UnionCamporee | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, camporee = STUB_UNION_CAMPOREE, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteUnionCamporeeDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        camporee={camporee}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteUnionCamporeeDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteUnionCamporee.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /eliminar camporee de unión/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows camporee name in description ────────────────────────────────
+
+  it("shows the camporee name in the description", () => {
+    renderDialog({ camporee: STUB_UNION_CAMPOREE });
+
+    expect(screen.getByText(/Gran Camporee de Unión 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/desactivará el camporee/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /eliminar camporee de unión/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null camporee — early return, no API call ─────────────────────────
+
+  it("does not call deleteUnionCamporee when camporee is null", async () => {
+    renderDialog({ camporee: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteUnionCamporee).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — uses union_camporee_id ───────────────────────────────
+
+  it("calls deleteUnionCamporee with union_camporee_id, shows toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ camporee: STUB_UNION_CAMPOREE });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteUnionCamporee).toHaveBeenCalledWith(7);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.union_camporee_deleted);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 6. Legacy id field — uses camporee.id when union_camporee_id absent ──
+
+  it("calls deleteUnionCamporee with id when union_camporee_id is absent", async () => {
+    renderDialog({ camporee: STUB_UNION_CAMPOREE_LEGACY });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteUnionCamporee).toHaveBeenCalledWith(15);
+    });
+  });
+
+  // ── 7. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteUnionCamporee on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteUnionCamporee).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deleteUnionCamporee throws", async () => {
+    mockDeleteUnionCamporee.mockRejectedValue(new Error("Network failure"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Network failure");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deleteUnionCamporee throws a non-Error", async () => {
+    mockDeleteUnionCamporee.mockRejectedValue({ code: 500 });
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.delete_camporee);
+    });
+  });
+
+  // ── 10. In-flight state — buttons disabled while deleting ─────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteUnionCamporee.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+});

--- a/src/components/folders/folder-delete-dialog.test.tsx
+++ b/src/components/folders/folder-delete-dialog.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * Integration tests for FolderDeleteDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar carpeta.
+ * On confirm: calls `deleteFolder(folder_id)`, shows success toast,
+ * closes the dialog and calls onSuccess().
+ *
+ * Error handling: uses `ApiError instanceof` check for the error message.
+ * Non-ApiError falls back to hardcoded string (not i18n).
+ *
+ * `deleteFolder` is mocked at module boundary. ApiError is imported from
+ * the real client module (not mocked).
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { FolderTemplate } from "@/lib/api/folders";
+import { ApiError } from "@/lib/api/client";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteFolder = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/folders", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/folders")>();
+  return {
+    ...original,
+    deleteFolder: (...args: unknown[]) => mockDeleteFolder(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { FolderDeleteDialog } from "@/components/folders/folder-delete-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_FOLDER: FolderTemplate = {
+  folder_id: "11",
+  name: "Carpeta de Conquistas 2026",
+  description: "Evidencias del año",
+  active: true,
+  club_type_ids: [],
+  created_at: null,
+  updated_at: null,
+  modules: [],
+};
+
+const t = messages.folders;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  folder?: FolderTemplate | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, folder = STUB_FOLDER, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <FolderDeleteDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        folder={folder}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FolderDeleteDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteFolder.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /eliminar carpeta de evidencias/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar carpeta/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows folder name in description ─────────────────────────────────
+
+  it("shows the folder name in the description", () => {
+    renderDialog({ folder: STUB_FOLDER });
+
+    expect(screen.getByText(/Carpeta de Conquistas 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/eliminará permanentemente/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /eliminar carpeta de evidencias/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null folder — early return, no API call ───────────────────────────
+
+  it("does not call deleteFolder when folder is null", async () => {
+    renderDialog({ folder: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteFolder).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls deleteFolder with folder_id ────────────────────
+
+  it("calls deleteFolder with folder_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ folder: STUB_FOLDER });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteFolder).toHaveBeenCalledWith("11");
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.deleted);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 6. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteFolder on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteFolder).not.toHaveBeenCalled();
+  });
+
+  // ── 7. ApiError instanceof — uses err.message directly ───────────────────
+
+  it("shows ApiError.message in error toast when deleteFolder throws ApiError", async () => {
+    mockDeleteFolder.mockRejectedValue(
+      new ApiError("La carpeta tiene módulos activos", 409, null),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("La carpeta tiene módulos activos");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. Non-ApiError falls back to hardcoded message ─────────────────────
+
+  it("shows hardcoded fallback message when deleteFolder throws a non-ApiError", async () => {
+    mockDeleteFolder.mockRejectedValue(new Error("Generic network error"));
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("No se pudo eliminar la carpeta");
+    });
+  });
+
+  // ── 9. In-flight state — buttons disabled while deleting ─────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteFolder.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+
+  // ── 10. onSuccess is NOT called on error ─────────────────────────────────
+
+  it("does NOT call onSuccess when deleteFolder fails", async () => {
+    mockDeleteFolder.mockRejectedValue(new ApiError("Forbidden", 403, null));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/honors/requirement-edit-dialog.test.tsx
+++ b/src/components/honors/requirement-edit-dialog.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * Integration tests for RequirementEditDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog (not AlertDialog). Form with: displayLabel (max 10 chars),
+ * requirementText (required textarea), referenceText (collapsible),
+ * isChoiceGroup toggle (shows choiceMin input when on), requiresEvidence
+ * toggle, and needsReview toggle (only in edit mode).
+ *
+ * Uses TanStack Query `useMutation` + `useQueryClient`. Needs QueryClientProvider.
+ * Supports two modes: "create" and "edit".
+ *
+ * `createRequirement` and `updateRequirement` are mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import messages from "../../../messages/es.json";
+import type { RequirementNode } from "@/lib/api/honors";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateRequirement = vi.fn<(...args: any[]) => Promise<unknown>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdateRequirement = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/honors", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/honors")>();
+  return {
+    ...original,
+    createRequirement: (...args: unknown[]) => mockCreateRequirement(...args),
+    updateRequirement: (...args: unknown[]) => mockUpdateRequirement(...args),
+  };
+});
+
+import { RequirementEditDialog } from "@/components/honors/requirement-edit-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_REQUIREMENT: RequirementNode = {
+  requirement_id: 77,
+  honor_id: 10,
+  parent_id: null,
+  requirement_number: 3,
+  display_label: "3",
+  requirement_text: "Conocer los principios básicos",
+  reference_text: "Manual pág. 45",
+  has_sub_items: false,
+  is_choice_group: false,
+  choice_min: null,
+  requires_evidence: false,
+  needs_review: false,
+  active: true,
+  created_at: "2026-01-01T00:00:00Z",
+  modified_at: "2026-01-01T00:00:00Z",
+  children: [],
+};
+
+const HONOR_ID = 10;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+type DialogMode = "create" | "edit";
+
+interface RenderOpts {
+  open?: boolean;
+  mode?: DialogMode;
+  requirement?: RequirementNode | null;
+  nextNumber?: number;
+  parentId?: number | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    mode = "create",
+    requirement = null,
+    nextNumber = 1,
+    parentId = null,
+    onSuccess,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <NextIntlClientProvider locale="es" messages={messages}>
+        <RequirementEditDialog
+          open={open}
+          onOpenChange={onOpenChange}
+          mode={mode}
+          honorId={HONOR_ID}
+          nextNumber={nextNumber}
+          parentId={parentId}
+          requirement={requirement}
+          onSuccess={successCb}
+        />
+      </NextIntlClientProvider>
+    </QueryClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb, queryClient };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RequirementEditDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRequirement.mockResolvedValue({ requirement_id: 100 });
+    mockUpdateRequirement.mockResolvedValue({ requirement_id: 77 });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Create mode renders correct title ─────────────────────────────────
+
+  it("renders 'Agregar requisito' title in create mode", () => {
+    renderDialog({ mode: "create" });
+
+    expect(
+      screen.getByRole("heading", { name: /agregar requisito/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Edit mode renders correct title ──────────────────────────────────
+
+  it("renders 'Editar requisito' title in edit mode", () => {
+    renderDialog({ mode: "edit", requirement: STUB_REQUIREMENT });
+
+    expect(
+      screen.getByRole("heading", { name: /editar requisito/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 3. Sub-requirement create mode title ────────────────────────────────
+
+  it("renders 'Agregar sub-requisito' title when parentId is set in create mode", () => {
+    renderDialog({ mode: "create", parentId: 5 });
+
+    expect(
+      screen.getByRole("heading", { name: /agregar sub-requisito/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 4. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /agregar requisito/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 5. Edit mode pre-fills form fields ───────────────────────────────────
+
+  it("pre-fills form fields from requirement in edit mode", () => {
+    renderDialog({ mode: "edit", requirement: STUB_REQUIREMENT });
+
+    const displayLabelInput = document.querySelector<HTMLInputElement>("#displayLabel");
+    expect(displayLabelInput?.value).toBe("3");
+
+    const requirementTextArea = document.querySelector<HTMLTextAreaElement>("#requirementText");
+    expect(requirementTextArea?.value).toBe("Conocer los principios básicos");
+  });
+
+  // ── 6. Validation — empty requirementText shows error ────────────────────
+
+  it("shows validation error when requirementText is empty on submit", async () => {
+    renderDialog({ mode: "create" });
+
+    // Submit the form directly — avoids ambiguity with the "Agregar referencia" button
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/texto del requisito es obligatorio/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockCreateRequirement).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Happy path create — calls createRequirement ───────────────────────
+
+  it("calls createRequirement and closes on valid create submission", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ mode: "create", nextNumber: 5 });
+
+    const textArea = document.querySelector<HTMLTextAreaElement>("#requirementText");
+    await act(async () => {
+      fireEvent.change(textArea!, { target: { value: "Nuevo requisito de prueba" } });
+    });
+
+    // Submit via form — avoids ambiguity between "Agregar" submit and "Agregar referencia" button
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(mockCreateRequirement).toHaveBeenCalledWith(
+        HONOR_ID,
+        expect.objectContaining({
+          requirementText: "Nuevo requisito de prueba",
+          requirementNumber: 5,
+        }),
+      );
+    });
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 8. Happy path edit — calls updateRequirement ─────────────────────────
+
+  it("calls updateRequirement and closes on valid edit submission", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({
+      mode: "edit",
+      requirement: STUB_REQUIREMENT,
+    });
+
+    const textArea = document.querySelector<HTMLTextAreaElement>("#requirementText");
+    await act(async () => {
+      fireEvent.change(textArea!, { target: { value: "Requisito actualizado" } });
+    });
+
+    const submitBtn = screen.getByRole("button", { name: /guardar cambios/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateRequirement).toHaveBeenCalledWith(
+        77,
+        expect.objectContaining({
+          requirementText: "Requisito actualizado",
+        }),
+      );
+    });
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 9. Cancel closes dialog without API call ─────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call API on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog({ mode: "create" });
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateRequirement).not.toHaveBeenCalled();
+  });
+
+  // ── 10. isChoiceGroup toggle shows/hides choiceMin input ─────────────────
+
+  it("shows choiceMin input when isChoiceGroup is toggled on", async () => {
+    renderDialog({ mode: "create" });
+
+    expect(screen.queryByLabelText(/mínimo de opciones/i)).not.toBeInTheDocument();
+
+    const choiceGroupSwitch = document.querySelector<HTMLButtonElement>("#isChoiceGroup");
+    await act(async () => {
+      fireEvent.click(choiceGroupSwitch!);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/mínimo de opciones/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── 11. needsReview toggle only visible in edit mode ─────────────────────
+
+  it("shows needsReview toggle only in edit mode", () => {
+    const { unmount } = renderDialog({ mode: "edit", requirement: STUB_REQUIREMENT });
+    expect(screen.getByLabelText(/pendiente de revisión/i)).toBeInTheDocument();
+    unmount();
+
+    renderDialog({ mode: "create" });
+    expect(screen.queryByLabelText(/pendiente de revisión/i)).not.toBeInTheDocument();
+  });
+
+  // ── 12. In-flight — submit button shows Guardando... ─────────────────────
+
+  it("shows 'Guardando...' label while mutation is in flight", async () => {
+    let resolveCreate!: () => void;
+    mockCreateRequirement.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveCreate = () => res({ requirement_id: 100 });
+      }),
+    );
+
+    renderDialog({ mode: "create" });
+
+    const textArea = document.querySelector<HTMLTextAreaElement>("#requirementText");
+    await act(async () => {
+      fireEvent.change(textArea!, { target: { value: "Texto de prueba" } });
+    });
+
+    // Submit via form to avoid ambiguity with "Agregar referencia bibliográfica" button
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /guardando/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveCreate();
+    });
+  });
+});

--- a/src/components/insurance/delete-insurance-dialog.test.tsx
+++ b/src/components/insurance/delete-insurance-dialog.test.tsx
@@ -1,0 +1,321 @@
+/**
+ * Integration tests for DeleteInsuranceDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Desactivar.
+ * Action: deactivateInsurance(member.insurance.insurance_id).
+ * Guards: exits early if insurance_id is undefined.
+ * Member name is derived from name + paternal_last_name + maternal_last_name.
+ *
+ * `deactivateInsurance` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { MemberInsurance } from "@/lib/api/insurance";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeactivateInsurance = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/insurance", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/insurance")>();
+  return {
+    ...original,
+    deactivateInsurance: (...args: unknown[]) => mockDeactivateInsurance(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteInsuranceDialog } from "@/components/insurance/delete-insurance-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_MEMBER: MemberInsurance = {
+  user_id: "user-abc-123",
+  name: "Ana",
+  paternal_last_name: "García",
+  maternal_last_name: "López",
+  user_image: null,
+  insurance: {
+    insurance_id: 55,
+    insurance_type: "GENERAL_ACTIVITIES",
+    policy_number: "POL-2026-001",
+    provider: "Aseguradora XYZ",
+    start_date: "2026-01-01",
+    end_date: "2026-12-31",
+    coverage_amount: 10000,
+    active: true,
+    evidence_file_url: null,
+    evidence_file_name: null,
+    created_at: null,
+    modified_at: null,
+    created_by_name: null,
+    modified_by_name: null,
+  },
+};
+
+const STUB_MEMBER_NO_INSURANCE: MemberInsurance = {
+  user_id: "user-xyz-456",
+  name: "Luis",
+  paternal_last_name: "Martínez",
+  maternal_last_name: null,
+  user_image: null,
+  insurance: null,
+};
+
+const t = messages.insurance;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  member?: MemberInsurance | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, member = STUB_MEMBER, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteInsuranceDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        member={member}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteInsuranceDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeactivateInsurance.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /¿desactivar seguro\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /desactivar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows full member name in description ─────────────────────────────
+
+  it("shows full member name (name + paternal + maternal) in description", () => {
+    renderDialog({ member: STUB_MEMBER });
+
+    expect(screen.getByText(/Ana García López/)).toBeInTheDocument();
+    expect(screen.getByText(/El registro se conservará/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /¿desactivar seguro\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. No insurance_id — early return, no API call ───────────────────────
+
+  it("does not call deactivateInsurance when member has no insurance", async () => {
+    renderDialog({ member: STUB_MEMBER_NO_INSURANCE });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeactivateInsurance).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Null member — early return, no API call ───────────────────────────
+
+  it("does not call deactivateInsurance when member is null", async () => {
+    renderDialog({ member: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeactivateInsurance).not.toHaveBeenCalled();
+  });
+
+  // ── 6. Happy path — calls deactivateInsurance with insurance_id ──────────
+
+  it("calls deactivateInsurance with insurance_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ member: STUB_MEMBER });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeactivateInsurance).toHaveBeenCalledWith(55);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.deactivated);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 7. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deactivateInsurance on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeactivateInsurance).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deactivateInsurance throws", async () => {
+    mockDeactivateInsurance.mockRejectedValue(new Error("Insurance not found"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Insurance not found");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deactivateInsurance throws a non-Error", async () => {
+    mockDeactivateInsurance.mockRejectedValue({ status: 500 });
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.deactivate_failed);
+    });
+  });
+
+  // ── 10. In-flight state — buttons disabled while deactivating ─────────────
+
+  it("disables both buttons while deactivation is in flight", async () => {
+    let resolveDeactivate!: () => void;
+    mockDeactivateInsurance.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDeactivate = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /desactivando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDeactivate();
+    });
+  });
+
+  // ── 11. Member name fallback — only name when no last names ──────────────
+
+  it("shows just the name when paternal and maternal last names are absent", () => {
+    const memberNameOnly: MemberInsurance = {
+      ...STUB_MEMBER_NO_INSURANCE,
+      name: "Carlos",
+      paternal_last_name: null,
+      maternal_last_name: null,
+      insurance: { ...STUB_MEMBER.insurance! },
+    };
+
+    renderDialog({ member: memberNameOnly });
+
+    // Description contains the name
+    expect(screen.getByText(/Carlos/)).toBeInTheDocument();
+  });
+});

--- a/src/components/inventory/delete-inventory-dialog.test.tsx
+++ b/src/components/inventory/delete-inventory-dialog.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * Integration tests for DeleteInventoryDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar.
+ * On confirm: calls `deleteInventoryItem(item.inventory_id)`, shows
+ * success toast, calls onSuccess() and closes the dialog.
+ *
+ * `deleteInventoryItem` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { InventoryItem } from "@/lib/api/inventory";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteInventoryItem = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/inventory", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/inventory")>();
+  return {
+    ...original,
+    deleteInventoryItem: (...args: unknown[]) => mockDeleteInventoryItem(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteInventoryDialog } from "@/components/inventory/delete-inventory-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_ITEM: InventoryItem = {
+  inventory_id: 33,
+  name: "Tienda de campaña grande",
+  description: "Tienda 6 personas",
+  inventory_category_id: 1,
+  club_id: 10,
+  amount: 2,
+  active: true,
+};
+
+const t = messages.inventory;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  item?: InventoryItem | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, item = STUB_ITEM, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteInventoryDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        item={item}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteInventoryDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteInventoryItem.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /¿eliminar ítem\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows item name in description ───────────────────────────────────
+
+  it("shows the item name in the description", () => {
+    renderDialog({ item: STUB_ITEM });
+
+    expect(screen.getByText(/Tienda de campaña grande/)).toBeInTheDocument();
+    expect(screen.getByText(/desactivará el ítem del inventario/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /¿eliminar ítem\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null item — early return, no API call ─────────────────────────────
+
+  it("does not call deleteInventoryItem when item is null", async () => {
+    renderDialog({ item: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteInventoryItem).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls deleteInventoryItem with inventory_id ──────────
+
+  it("calls deleteInventoryItem with inventory_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ item: STUB_ITEM });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteInventoryItem).toHaveBeenCalledWith(33);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.item_deleted);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteInventoryItem on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteInventoryItem).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deleteInventoryItem throws", async () => {
+    mockDeleteInventoryItem.mockRejectedValue(new Error("Item not found"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Item not found");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deleteInventoryItem throws a non-Error", async () => {
+    mockDeleteInventoryItem.mockRejectedValue({ code: "ECONNRESET" });
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.delete_failed);
+    });
+  });
+
+  // ── 9. In-flight state — buttons disabled while deleting ─────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteInventoryItem.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+
+  // ── 10. onSuccess NOT called on error ────────────────────────────────────
+
+  it("does NOT call onSuccess when deleteInventoryItem fails", async () => {
+    mockDeleteInventoryItem.mockRejectedValue(new Error("Server error"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/investiture/delete-config-dialog.test.tsx
+++ b/src/components/investiture/delete-config-dialog.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * Integration tests for DeleteConfigDialog (Investiture).
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Desactivar.
+ * On confirm: calls `deleteInvestitureConfig(config.investiture_config_id)`,
+ * shows success toast, calls onSuccess() and closes the dialog.
+ *
+ * The description conditionally shows config details (localFieldName + yearName)
+ * when config is provided, or a generic message when config is null.
+ *
+ * `deleteInvestitureConfig` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { InvestitureConfig } from "@/lib/api/investiture";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteInvestitureConfig = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/investiture", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/investiture")>();
+  return {
+    ...original,
+    deleteInvestitureConfig: (...args: unknown[]) => mockDeleteInvestitureConfig(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteConfigDialog } from "@/components/investiture/delete-config-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_CONFIG: InvestitureConfig = {
+  investiture_config_id: 9,
+  local_field_id: 3,
+  ecclesiastical_year_id: 2026,
+  submission_deadline: "2026-11-01",
+  investiture_date: "2026-11-30",
+  active: true,
+  local_fields: { name: "Campo Local Sur" },
+  ecclesiastical_years: {
+    ecclesiastical_year_id: 2026,
+    name: "Año 2026",
+  },
+};
+
+const STUB_CONFIG_NO_RELATIONS: InvestitureConfig = {
+  investiture_config_id: 12,
+  local_field_id: 5,
+  ecclesiastical_year_id: 2027,
+  submission_deadline: "2027-10-01",
+  investiture_date: "2027-10-31",
+  active: true,
+  local_fields: null,
+  ecclesiastical_years: null,
+};
+
+const t = messages.investiture;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  config?: InvestitureConfig | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, config = STUB_CONFIG, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteConfigDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        config={config}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteConfigDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteInvestitureConfig.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /¿desactivar configuración\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /desactivar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows local field and year names in description ───────────────────
+
+  it("shows local field name and year name in description when config is provided", () => {
+    renderDialog({ config: STUB_CONFIG });
+
+    expect(screen.getByText(/Campo Local Sur/)).toBeInTheDocument();
+    expect(screen.getByText(/Año 2026/)).toBeInTheDocument();
+  });
+
+  // ── 3. Fallback names when relations are absent ──────────────────────────
+
+  it("shows fallback field/year labels when local_fields and ecclesiastical_years are null", () => {
+    renderDialog({ config: STUB_CONFIG_NO_RELATIONS });
+
+    expect(screen.getByText(/Campo #5/)).toBeInTheDocument();
+    expect(screen.getByText(/Año #2027/)).toBeInTheDocument();
+  });
+
+  // ── 4. Null config — shows generic description ───────────────────────────
+
+  it("shows generic description when config is null", () => {
+    renderDialog({ config: null });
+
+    expect(
+      screen.getByText(/desactivará la configuración/i),
+    ).toBeInTheDocument();
+  });
+
+  // ── 5. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /¿desactivar configuración\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 6. Null config — early return, no API call ───────────────────────────
+
+  it("does not call deleteInvestitureConfig when config is null", async () => {
+    renderDialog({ config: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteInvestitureConfig).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Happy path — calls deleteInvestitureConfig with config id ─────────
+
+  it("calls deleteInvestitureConfig with investiture_config_id, shows toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ config: STUB_CONFIG });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteInvestitureConfig).toHaveBeenCalledWith(9);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.config_deactivated);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 8. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteInvestitureConfig on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteInvestitureConfig).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deleteInvestitureConfig throws", async () => {
+    mockDeleteInvestitureConfig.mockRejectedValue(new Error("Config conflict"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Config conflict");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 10. API error — falls back to i18n message for non-Error throws ──────
+
+  it("shows i18n fallback error toast when deleteInvestitureConfig throws a non-Error", async () => {
+    mockDeleteInvestitureConfig.mockRejectedValue("plain string error");
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.config_deactivate);
+    });
+  });
+
+  // ── 11. In-flight state — Desactivar button disabled ─────────────────────
+
+  it("disables both buttons while deactivation is in flight", async () => {
+    let resolveDeactivate!: () => void;
+    mockDeleteInvestitureConfig.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDeactivate = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      // The Desactivar button gets a Loader2 spinner prepended — stays accessible by name
+      expect(screen.getByRole("button", { name: /desactivar/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDeactivate();
+    });
+  });
+});

--- a/src/components/units/add-member-dialog.test.tsx
+++ b/src/components/units/add-member-dialog.test.tsx
@@ -1,0 +1,399 @@
+/**
+ * Integration tests for AddMemberDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog (not AlertDialog). Form with a MemberCombobox (controlled) and
+ * submit/cancel buttons.
+ *
+ * MemberCombobox is a Popover+Command widget with its own TanStack Query
+ * fetch — mocked at module boundary to a simple select input to isolate
+ * dialog-level behavior from combobox internals.
+ *
+ * Validation: requires userId to be non-empty (inline error, no toast).
+ * Happy path: addUnitMember(clubId, unitId, userId), success toast, resets
+ * userId, calls onSuccess(), closes dialog.
+ *
+ * `addUnitMember` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { UnitMember } from "@/lib/api/units";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// Mock MemberCombobox — render a simple <select> so we can control userId
+// without dealing with Radix Popover/Command internals in jsdom.
+vi.mock("@/components/units/member-combobox", () => ({
+  MemberCombobox: ({
+    value,
+    onChange,
+    disabled,
+  }: {
+    clubId: number;
+    value: string;
+    onChange: (id: string) => void;
+    disabled?: boolean;
+    placeholder?: string;
+    excludeUserIds?: string[];
+  }) => (
+    <select
+      data-testid="member-combobox"
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">-- Seleccionar --</option>
+      <option value="user-001">María Pérez</option>
+      <option value="user-002">Carlos Ruiz</option>
+    </select>
+  ),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAddUnitMember = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/units", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/units")>();
+  return {
+    ...original,
+    addUnitMember: (...args: unknown[]) => mockAddUnitMember(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { AddMemberDialog } from "@/components/units/add-member-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ACTIVE_MEMBER: UnitMember = {
+  unit_member_id: 1,
+  user_id: "user-001",
+  active: true,
+};
+
+const t = messages.units_admin;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  clubId?: number;
+  unitId?: number;
+  unitName?: string;
+  existingMembers?: UnitMember[];
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    clubId = 5,
+    unitId = 21,
+    unitName = "Unidad Águilas",
+    existingMembers = [],
+    onSuccess,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <AddMemberDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        clubId={clubId}
+        unitId={unitId}
+        unitName={unitName}
+        existingMembers={existingMembers}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// Helper: select a member from the mocked combobox
+async function selectMember(userId: string) {
+  const combobox = screen.getByTestId("member-combobox");
+  await act(async () => {
+    fireEvent.change(combobox, { target: { value: userId } });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AddMemberDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAddUnitMember.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and unit name in description ─────────────────────────
+
+  it("renders title, unit name in description, and cancel/submit buttons when open", () => {
+    renderDialog({ unitName: "Unidad Águilas" });
+
+    expect(
+      screen.getByRole("heading", { name: /agregar miembro/i }),
+    ).toBeInTheDocument();
+    // Unit name appears in the description text
+    const unitNameEls = screen.getAllByText(/Unidad Águilas/);
+    expect(unitNameEls.length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /agregar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /agregar miembro/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Submit button disabled when no userId selected ────────────────────
+
+  it("disables submit button when no member is selected", () => {
+    renderDialog();
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  // ── 4. Validation — shows inline error when submitting with empty userId ──
+
+  it("shows inline error when form is submitted with no userId via keyboard", async () => {
+    renderDialog();
+
+    // Force submit with empty userId (bypass disabled by triggering the form directly)
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/selecciona un miembro para agregar/i)).toBeInTheDocument();
+    });
+
+    expect(mockAddUnitMember).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls addUnitMember with correct args ────────────────
+
+  it("calls addUnitMember with clubId, unitId, userId on valid submit", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ clubId: 5, unitId: 21 });
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockAddUnitMember).toHaveBeenCalledWith(5, 21, "user-002");
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.member_added);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel calls onOpenChange(false) and clears state ─────────────────
+
+  it("calls onOpenChange(false) and does NOT call addUnitMember on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockAddUnitMember).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error — shows error toast from Error instance ─────────────────
+
+  it("shows error toast from Error.message when addUnitMember throws", async () => {
+    mockAddUnitMember.mockRejectedValue(new Error("Member already in unit"));
+
+    const { onSuccess } = renderDialog();
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Member already in unit");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when addUnitMember throws a non-Error", async () => {
+    mockAddUnitMember.mockRejectedValue({ status: 500 });
+
+    renderDialog();
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.add_member_failed);
+    });
+  });
+
+  // ── 9. In-flight — buttons disabled while submitting ─────────────────────
+
+  it("disables buttons while submission is in flight", async () => {
+    let resolveAdd!: () => void;
+    mockAddUnitMember.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveAdd = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /agregando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveAdd();
+    });
+  });
+
+  // ── 10. Closing via cancel resets userId state ────────────────────────────
+
+  it("resets selected member when dialog is closed via cancel", async () => {
+    const { onOpenChange, rerender } = renderDialog({ open: true });
+
+    await selectMember("user-002");
+
+    // Cancel closes dialog
+    const cancelBtn = screen.getByRole("button", { name: /cancelar/i });
+    await act(async () => {
+      fireEvent.click(cancelBtn);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    // Re-open — userId should be reset (empty combobox)
+    rerender(
+      <NextIntlClientProvider locale="es" messages={messages}>
+        <AddMemberDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          clubId={5}
+          unitId={21}
+          unitName="Unidad Águilas"
+          existingMembers={[]}
+          onSuccess={vi.fn()}
+        />
+      </NextIntlClientProvider>,
+    );
+
+    const combobox = screen.getByTestId("member-combobox") as HTMLSelectElement;
+    expect(combobox.value).toBe("");
+  });
+
+  // ── 11. existingMembers — excludedIds forwarded as prop ──────────────────
+
+  it("renders with existingMembers prop without error", () => {
+    // Verifies that existingMembers are accepted; the mock combobox receives excludeUserIds
+    renderDialog({ existingMembers: [ACTIVE_MEMBER] });
+
+    expect(screen.getByRole("heading", { name: /agregar miembro/i })).toBeInTheDocument();
+  });
+
+  // ── 12. onSuccess NOT called on API error ────────────────────────────────
+
+  it("does NOT call onSuccess when addUnitMember fails", async () => {
+    mockAddUnitMember.mockRejectedValue(new Error("Server error"));
+
+    const { onSuccess } = renderDialog();
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/units/delete-unit-dialog.test.tsx
+++ b/src/components/units/delete-unit-dialog.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * Integration tests for DeleteUnitDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Desactivar.
+ * On confirm: calls `deleteUnit(clubId, unit.unit_id)`, shows success toast,
+ * calls onSuccess() and closes the dialog.
+ *
+ * Component uses AlertDialogMedia (custom shadcn extension) with AlertTriangle icon.
+ *
+ * `deleteUnit` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { Unit } from "@/lib/api/units";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteUnit = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/units", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/units")>();
+  return {
+    ...original,
+    deleteUnit: (...args: unknown[]) => mockDeleteUnit(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteUnitDialog } from "@/components/units/delete-unit-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_UNIT: Unit = {
+  unit_id: 21,
+  name: "Unidad Águilas",
+  active: true,
+  club_type_id: 2,
+};
+
+const STUB_CLUB_ID = 5;
+
+const t = messages.units_admin;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  unit?: Unit | null;
+  clubId?: number;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, unit = STUB_UNIT, clubId = STUB_CLUB_ID, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteUnitDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        clubId={clubId}
+        unit={unit}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteUnitDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteUnit.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /desactivar unidad/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /desactivar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows unit name in description ───────────────────────────────────
+
+  it("shows the unit name in the description", () => {
+    renderDialog({ unit: STUB_UNIT });
+
+    expect(screen.getByText(/Unidad Águilas/)).toBeInTheDocument();
+    expect(screen.getByText(/La unidad y sus miembros/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /desactivar unidad/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null unit — early return, no API call ─────────────────────────────
+
+  it("does not call deleteUnit when unit is null", async () => {
+    renderDialog({ unit: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteUnit).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls deleteUnit with clubId and unit_id ────────────
+
+  it("calls deleteUnit with clubId and unit_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ unit: STUB_UNIT, clubId: STUB_CLUB_ID });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteUnit).toHaveBeenCalledWith(STUB_CLUB_ID, 21);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.unit_deactivated);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteUnit on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteUnit).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deleteUnit throws", async () => {
+    mockDeleteUnit.mockRejectedValue(new Error("Unit has active members"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Unit has active members");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deleteUnit throws a non-Error", async () => {
+    mockDeleteUnit.mockRejectedValue("plain string error");
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.deactivate_unit_failed);
+    });
+  });
+
+  // ── 9. In-flight state — buttons disabled while deactivating ─────────────
+
+  it("disables both buttons while deactivation is in flight", async () => {
+    let resolveDeactivate!: () => void;
+    mockDeleteUnit.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDeactivate = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /desactivando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDeactivate();
+    });
+  });
+
+  // ── 10. Different clubId is passed to API ────────────────────────────────
+
+  it("passes the provided clubId correctly to deleteUnit", async () => {
+    const { onOpenChange } = renderDialog({ clubId: 99 });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteUnit).toHaveBeenCalledWith(99, 21);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});


### PR DESCRIPTION
## Summary

- 9 new integration test suites covering AlertDialog and Dialog components across activities, camporees, folders, insurance, inventory, investiture, honors, and units modules
- All tests use module-boundary mocks (no fetch exercised), per-file jsdom polyfills, and explicit cleanup (vitest globals:false)
- Baseline 468/36 → 564/45 (+96 tests, +9 files)

## Files added

| File | Tests | Notes |
|------|-------|-------|
| `activities/delete-activity-dialog.test.tsx` | 10 | AlertDialog, null guard, in-flight |
| `camporees/delete-union-camporee-dialog.test.tsx` | 10 | Legacy id fallback (union_camporee_id ?? id) |
| `folders/folder-delete-dialog.test.tsx` | 10 | ApiError instanceof check, hardcoded fallback |
| `insurance/delete-insurance-dialog.test.tsx` | 11 | insurance_id guard, full name derivation |
| `inventory/delete-inventory-dialog.test.tsx` | 10 | i18n fallback, null guard |
| `investiture/delete-config-dialog.test.tsx` | 11 | Null config generic desc, relation name fallbacks |
| `units/delete-unit-dialog.test.tsx` | 10 | clubId+unit_id args, AlertDialogMedia |
| `honors/requirement-edit-dialog.test.tsx` | 12 | TanStack mutation, create/edit modes, validation, in-flight |
| `units/add-member-dialog.test.tsx` | 12 | MemberCombobox mocked, submit guard, in-flight |

## Test plan

- [x] `pnpm typecheck` — clean (no errors)
- [x] `pnpm test --run` — 564/45 passed (0 failures)
- [x] `pnpm lint` — 0 errors in new test files (pre-existing warnings in unrelated files only)
- [x] All edge cases covered: null props, in-flight disabled state, error toast from Error instance, i18n fallback for non-Error throws, success path, cancel path