### PR TITLE
chore: cascade development → preproduction (post #135 #136 #137)

### DIFF
--- a/PERF-BASELINE.md
+++ b/PERF-BASELINE.md
@@ -421,6 +421,74 @@ the CSP origin in `next.config.ts`). Sentry DSN is hardcoded as fallback in
 
 ---
 
+## 11. Round 8 mega (2026-05-11) — investiture, config, templates, validation dialog defers
+
+**Branch:** `perf/admin-r8-mega` (off `origin/development`, includes #131 + #133)
+**Worktree:** `.claude/worktrees/agent-perf-mega-2026-05-11`
+
+### Strategy
+
+Three zod-heavy dialog pairs and one react-query dialog deferred across four routes.
+All parent files confirmed as Client Components (`"use client"` present) before applying
+`ssr: false`. Props interfaces exported from each dialog file for correct `dynamic<Props>()`
+generic typing. Pattern: `dynamic<Props>(import, { ssr: false, loading: () => null })`.
+
+### Routes addressed
+
+| Route | Components deferred | Zod? | Gate |
+|---|---|---|---|
+| `/dashboard/investiture` | `ValidateDialog`, `InvestidoDialog` | YES (both) | Row action buttons |
+| `/dashboard/investiture/config` | `ConfigFormDialog`, `DeleteConfigDialog` | YES (form), no (delete) | Toolbar buttons |
+| `/dashboard/annual-folders/templates` | `SectionFormDialog` | YES | "Add section" button inside detail view |
+| `/dashboard/validation` | `ValidationHistoryDialog` | no (react-query only) | History row button |
+
+### Files modified
+
+| File | Change |
+|---|---|
+| `src/components/investiture/validate-dialog.tsx` | Export `ValidateDialogProps` |
+| `src/components/investiture/investido-dialog.tsx` | Export `InvestidoDialogProps` |
+| `src/components/investiture/config-form-dialog.tsx` | Export `ConfigFormDialogProps` |
+| `src/components/investiture/delete-config-dialog.tsx` | Export `DeleteConfigDialogProps` |
+| `src/components/annual-folders/section-form-dialog.tsx` | Export `SectionFormDialogProps` |
+| `src/components/validation/validation-history-dialog.tsx` | Export `ValidationHistoryDialogProps` |
+| `src/components/investiture/pending-table.tsx` | Dynamic import `ValidateDialog` + `InvestidoDialog` |
+| `src/components/investiture/config-client-page.tsx` | Dynamic import `ConfigFormDialog` + `DeleteConfigDialog` |
+| `src/components/annual-folders/templates-client-page.tsx` | Dynamic import `SectionFormDialog` |
+| `src/components/validation/validation-table.tsx` | Dynamic import `ValidationHistoryDialog` |
+
+### Deliberately out of scope (Agent B conflict avoidance)
+
+- `src/components/membership/membership-reject-dialog.tsx` — Agent B's scope
+- `src/components/validation/validation-review-dialog.tsx` — Agent B's scope
+- `src/components/requests/request-review-dialog.tsx` — Agent B's scope
+- `src/components/annual-folders/template-form-dialog.tsx` — Agent B's scope
+
+`ValidationReviewDialog` in `validation-table.tsx` remains eagerly imported to avoid
+conflict. `ValidationHistoryDialog` was safely deferred (no overlap with Agent B).
+
+### Estimated gz savings
+
+| Route | Removed from initial chunk | Estimated gz saved |
+|---|---|---|
+| `/dashboard/investiture` | `ValidateDialog` + `InvestidoDialog` zod/zodResolver bundles | ~50–70 KB |
+| `/dashboard/investiture/config` | `ConfigFormDialog` zod/zodResolver bundle | ~50 KB |
+| `/dashboard/annual-folders/templates` | `SectionFormDialog` zod/zodResolver bundle | ~20–30 KB |
+| `/dashboard/validation` | `ValidationHistoryDialog` (react-query only, smaller) | ~8–15 KB |
+| **Total estimated** | | **~128–165 KB gz** across 4 routes |
+
+The dominant savings come from the zod v4 + i18n locale chunk (~103 KB gz) being removed
+from the initial load on 3 of the 4 routes — same chunk pattern isolated in R5 and applied
+in R6+R7 on other routes.
+
+### Verification
+
+- `pnpm typecheck`: PASS
+- `pnpm test --run`: 468/468 PASS
+- `pnpm lint`: 10 err / 42 warn (unchanged from baseline — all pre-existing)
+
+---
+
 ## 8. Next actions (handoff)
 
 - ~~Replace `pnpm analyze` script with `next experimental-analyze`~~ DONE.

--- a/src/app/(dashboard)/dashboard/annual-folders/page.tsx
+++ b/src/app/(dashboard)/dashboard/annual-folders/page.tsx
@@ -81,7 +81,7 @@ export default async function AnnualFoldersPage({
       {/* Search / selector — always visible */}
       <FolderByEnrollmentView
         currentEnrollmentId={enrollmentId}
-        currentFolderId={folder?.folder_id ?? null}
+        currentFolderId={folder?.annual_folder_id ?? null}
       />
 
       {/* Error state */}

--- a/src/app/(dashboard)/dashboard/evidence-review/page.tsx
+++ b/src/app/(dashboard)/dashboard/evidence-review/page.tsx
@@ -31,7 +31,7 @@ export default async function EvidenceReviewPage() {
   }
 
   const pendingCount = items.filter((item) =>
-    item.type === "honor" ? item.status === "in_progress" : item.status === "pendiente",
+    ["SUBMITTED", "PENDING_REVIEW"].includes(item.status),
   ).length;
 
   return (

--- a/src/components/activities/delete-activity-dialog.test.tsx
+++ b/src/components/activities/delete-activity-dialog.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * Integration tests for DeleteActivityDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar.
+ * On confirm: calls `deleteActivity(activity_id)`, shows success toast,
+ * calls onSuccess() and closes the dialog.
+ *
+ * `deleteActivity` is mocked at module boundary (no fetch exercised).
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { Activity } from "@/lib/api/activities";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix AlertDialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteActivity = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/activities", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/activities")>();
+  return {
+    ...original,
+    deleteActivity: (...args: unknown[]) => mockDeleteActivity(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteActivityDialog } from "@/components/activities/delete-activity-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_ACTIVITY: Activity = {
+  activity_id: 42,
+  name: "Acampada Primavera 2026",
+  club_id: 1,
+  club_type_id: 2,
+  club_section_id: 3,
+  lat: 0,
+  long: 0,
+  activity_place: "Parque Central",
+  activity_type_id: 1,
+  active: true,
+};
+
+const t = messages.activities;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  activity?: Activity | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, activity = STUB_ACTIVITY, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteActivityDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        activity={activity}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteActivityDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteActivity.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /¿eliminar actividad\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows activity name in description ────────────────────────────────
+
+  it("shows the activity name in the description", () => {
+    renderDialog({ activity: STUB_ACTIVITY });
+
+    expect(screen.getByText(/Acampada Primavera 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/desactivará la actividad/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /¿eliminar actividad\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null activity — early return, no API call ─────────────────────────
+
+  it("does not call deleteActivity when activity is null", async () => {
+    renderDialog({ activity: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteActivity).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls deleteActivity with activity_id ────────────────
+
+  it("calls deleteActivity with activity_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ activity: STUB_ACTIVITY });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteActivity).toHaveBeenCalledWith(42);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.deleted);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteActivity on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteActivity).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error message when deleteActivity throws", async () => {
+    mockDeleteActivity.mockRejectedValue(new Error("Connection timeout"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Connection timeout");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deleteActivity throws a non-Error", async () => {
+    mockDeleteActivity.mockRejectedValue("plain string error");
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.delete_failed);
+    });
+  });
+
+  // ── 9. In-flight state — buttons disabled while deleting ─────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteActivity.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+
+  // ── 10. onSuccess is NOT called on error ─────────────────────────────────
+
+  it("does NOT call onSuccess when deleteActivity fails", async () => {
+    mockDeleteActivity.mockRejectedValue(new Error("Server error"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/annual-folders/evaluation-client-page.tsx
+++ b/src/components/annual-folders/evaluation-client-page.tsx
@@ -69,7 +69,6 @@ function formatDateTime(dateString: string | null | undefined): string {
 interface EvalSectionRowProps {
   section: FolderSectionWithEvidences;
   evaluation: SectionEvaluation | undefined;
-  folderId: string;
   onEvaluate: (section: FolderSectionWithEvidences) => void;
   onReopen: (section: FolderSectionWithEvidences) => void;
 }
@@ -77,7 +76,6 @@ interface EvalSectionRowProps {
 function EvalSectionRow({
   section,
   evaluation,
-  folderId: _folderId,
   onEvaluate,
   onReopen,
 }: EvalSectionRowProps) {
@@ -239,21 +237,21 @@ function FolderSummaryCard({
           <div className="flex flex-wrap items-center gap-2">
             <FolderStatusBadge status={folder.status} />
             <span className="text-sm font-semibold">
-              Carpeta #{folder.folder_id}
+              Carpeta #{folder.annual_folder_id}
             </span>
           </div>
 
           <div className="grid gap-0.5 text-xs text-muted-foreground">
             <span>
               <span className="font-medium text-foreground">Inscripción:</span>{" "}
-              #{folder.enrollment_id}
+              #{folder.club_enrollment_id}
               {folder.enrollment?.club_name
                 ? ` — ${folder.enrollment.club_name}`
                 : ""}
             </span>
             <span>
               <span className="font-medium text-foreground">Plantilla:</span>{" "}
-              {folder.template?.name ?? `#${folder.template_id}`}
+              {folder.template?.name ?? `#${folder.folder_template_id}`}
             </span>
             {folder.submitted_at && (
               <span>
@@ -398,7 +396,7 @@ export function EvaluationClientPage() {
     if (!folder) return;
     setIsRefreshing(true);
     try {
-      await loadFolder(folder.folder_id);
+      await loadFolder(folder.annual_folder_id);
     } catch (err) {
       const message =
         err instanceof ApiError
@@ -428,7 +426,7 @@ export function EvaluationClientPage() {
     if (!folder || !reopeningSection) return;
     setIsReopening(true);
     try {
-      await reopenSection(folder.folder_id, reopeningSection.section_id);
+      await reopenSection(folder.annual_folder_id, reopeningSection.section_id);
       toast.success(t("toasts.section_reopened"));
       setReopenOpen(false);
       setReopeningSection(null);
@@ -525,7 +523,7 @@ export function EvaluationClientPage() {
               title="Ver carpeta completa con evidencias"
             >
               <a
-                href={`/dashboard/annual-folders?folder=${folder.folder_id}`}
+                href={`/dashboard/annual-folders?folder=${folder.annual_folder_id}`}
                 target="_blank"
                 rel="noopener noreferrer"
               >
@@ -549,7 +547,6 @@ export function EvaluationClientPage() {
                   key={section.section_id}
                   section={section}
                   evaluation={getEvaluationForSection(section)}
-                  folderId={folder.folder_id}
                   onEvaluate={handleEvaluate}
                   onReopen={handleReopen}
                 />
@@ -564,7 +561,7 @@ export function EvaluationClientPage() {
         <EvaluateSectionDialog
           open={evaluateOpen}
           onOpenChange={setEvaluateOpen}
-          folderId={folder.folder_id}
+          folderId={folder.annual_folder_id}
           sectionId={evaluatingSection.section_id}
           sectionName={evaluatingSection.name}
           maxPoints={evaluatingSection.max_points ?? 0}

--- a/src/components/annual-folders/folder-client-page.tsx
+++ b/src/components/annual-folders/folder-client-page.tsx
@@ -214,7 +214,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
   const refreshFolder = useCallback(async () => {
     setIsRefreshing(true);
     try {
-      const updated = await getFolder(folder.folder_id);
+      const updated = await getFolder(folder.annual_folder_id);
       setFolder(updated);
     } catch (err) {
       const message =
@@ -225,7 +225,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
     } finally {
       setIsRefreshing(false);
     }
-  }, [folder.folder_id]);
+  }, [folder.annual_folder_id]);
 
   // ─── Upload handlers ─────────────────────────────────────────────────────
 
@@ -266,7 +266,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
   async function confirmSubmit() {
     setIsActioning(true);
     try {
-      const updated = await submitFolder(folder.folder_id);
+      const updated = await submitFolder(folder.annual_folder_id);
       setFolder(updated);
       toast.success(t("toasts.folder_submitted"));
       setSubmitOpen(false);
@@ -284,7 +284,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
   async function confirmClose() {
     setIsActioning(true);
     try {
-      const updated = await closeFolder(folder.folder_id);
+      const updated = await closeFolder(folder.annual_folder_id);
       setFolder(updated);
       toast.success(t("toasts.folder_closed"));
       setCloseOpen(false);
@@ -433,7 +433,7 @@ export function FolderClientPage({ initialFolder }: FolderClientPageProps) {
         <EvidenceUploadDialog
           open={uploadOpen}
           onOpenChange={setUploadOpen}
-          folderId={folder.folder_id}
+          folderId={folder.annual_folder_id}
           sectionId={uploadSection.section_id}
           sectionName={uploadSection.name}
           onSuccess={refreshFolder}

--- a/src/components/annual-folders/section-form-dialog.tsx
+++ b/src/components/annual-folders/section-form-dialog.tsx
@@ -63,7 +63,7 @@ type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface SectionFormDialogProps {
+export interface SectionFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   templateId: string;

--- a/src/components/annual-folders/template-form-dialog.tsx
+++ b/src/components/annual-folders/template-form-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
-import { useForm, Controller } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import type { SubmitHandler } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -17,7 +17,6 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
@@ -26,6 +25,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { createTemplate, updateTemplate } from "@/lib/api/annual-folders";
 import type { FolderTemplate } from "@/lib/api/annual-folders";
 import type { ClubType, EcclesiasticalYear } from "@/lib/api/catalogs";
@@ -138,24 +145,13 @@ export function TemplateFormDialog({
     owner_local_field_id: template?.owner_local_field_id ?? null,
   };
 
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-    control,
-    formState: { errors },
-  } = useForm<FormValues>({
+  const form = useForm<FormValues>({
     resolver: zodResolver(schema as z.ZodType<FormValues, FormValues>),
     defaultValues,
   });
 
-  const clubTypeValue = watch("club_type_id");
-  const yearValue = watch("ecclesiastical_year_id");
-  const ownerTier = watch("owner_tier");
-  const ownerUnionId = watch("owner_union_id");
-  const ownerLocalFieldId = watch("owner_local_field_id");
+  // ownerTier drives conditional rendering — single watch is justified
+  const ownerTier = form.watch("owner_tier");
 
   // Load owner catalogs when dialog opens
   useEffect(() => {
@@ -173,7 +169,7 @@ export function TemplateFormDialog({
   // Reset form when dialog opens or template changes
   useEffect(() => {
     if (open) {
-      reset({
+      form.reset({
         name: template?.name ?? "",
         club_type_id: template?.club_type_id ?? (clubTypes[0]?.club_type_id ?? 0),
         ecclesiastical_year_id:
@@ -190,7 +186,7 @@ export function TemplateFormDialog({
         owner_local_field_id: template?.owner_local_field_id ?? null,
       });
     }
-  }, [open, template, clubTypes, ecclesiasticalYears, reset]);
+  }, [open, template, clubTypes, ecclesiasticalYears, form]);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     setIsSubmitting(true);
@@ -242,292 +238,322 @@ export function TemplateFormDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-          {/* Nombre */}
-          <div className="space-y-1.5">
-            <Label htmlFor="template-name">
-              {t("templateDialog.fieldName")}{" "}
-              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-            </Label>
-            <Input
-              id="template-name"
-              {...register("name")}
-              placeholder={t("templateDialog.fieldNamePlaceholder")}
-              aria-required="true"
-            />
-            {errors.name && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">{errors.name.message}</p>
-            )}
-          </div>
-
-          {/* Tipo de club */}
-          <div className="space-y-1.5">
-            <Label htmlFor="template-club-type">
-              {t("templateDialog.fieldClubType")}{" "}
-              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-            </Label>
-            <Select
-              value={String(clubTypeValue)}
-              onValueChange={(val) => setValue("club_type_id", Number(val))}
-            >
-              <SelectTrigger id="template-club-type" aria-required="true">
-                <SelectValue placeholder={t("templateDialog.fieldClubTypePlaceholder")} />
-              </SelectTrigger>
-              <SelectContent>
-                {clubTypes.length > 0 ? (
-                  clubTypes.map((ct) => (
-                    <SelectItem
-                      key={ct.club_type_id}
-                      value={String(ct.club_type_id)}
-                    >
-                      {ct.name}
-                    </SelectItem>
-                  ))
-                ) : (
-                  <SelectItem value="0" disabled>
-                    {t("templateDialog.fieldClubTypeNone")}
-                  </SelectItem>
-                )}
-              </SelectContent>
-            </Select>
-            {errors.club_type_id && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.club_type_id.message}
-              </p>
-            )}
-          </div>
-
-          {/* Año eclesiástico */}
-          <div className="space-y-1.5">
-            <Label htmlFor="template-ecclesiastical-year">
-              {t("templateDialog.fieldYear")}{" "}
-              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-            </Label>
-            <Select
-              value={String(yearValue)}
-              onValueChange={(val) =>
-                setValue("ecclesiastical_year_id", Number(val))
-              }
-            >
-              <SelectTrigger id="template-ecclesiastical-year" aria-required="true">
-                <SelectValue placeholder={t("templateDialog.fieldYearPlaceholder")} />
-              </SelectTrigger>
-              <SelectContent>
-                {ecclesiasticalYears.length > 0 ? (
-                  ecclesiasticalYears.map((year) => (
-                    <SelectItem
-                      key={year.ecclesiastical_year_id}
-                      value={String(year.ecclesiastical_year_id)}
-                    >
-                      {year.name}
-                      {year.active && (
-                        <span className="ml-1.5 text-xs text-muted-foreground">
-                          {t("templateDialog.fieldYearActive")}
-                        </span>
-                      )}
-                    </SelectItem>
-                  ))
-                ) : (
-                  <SelectItem value="0" disabled>
-                    {t("templateDialog.fieldYearNone")}
-                  </SelectItem>
-                )}
-              </SelectContent>
-            </Select>
-            {errors.ecclesiastical_year_id && (
-              <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                {errors.ecclesiastical_year_id.message}
-              </p>
-            )}
-          </div>
-
-          {/* Owner tier — radio group */}
-          <div className="space-y-2">
-            <Label>
-              {t("templateDialog.fieldOwner")}{" "}
-              <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-            </Label>
-            <Controller
-              name="owner_tier"
-              control={control}
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            {/* Nombre */}
+            <FormField
+              control={form.control}
+              name="name"
               render={({ field }) => (
-                <RadioGroup
-                  value={field.value}
-                  onValueChange={(val) => {
-                    field.onChange(val);
-                    // Clear the other tier selection to avoid stale values
-                    if (val === "union") {
-                      setValue("owner_local_field_id", null);
-                    } else {
-                      setValue("owner_union_id", null);
-                    }
-                  }}
-                  className="flex gap-6"
-                >
-                  <div className="flex items-center gap-2">
-                    <RadioGroupItem value="union" id="owner-tier-union" />
-                    <Label htmlFor="owner-tier-union" className="cursor-pointer font-normal">
-                      {t("templateDialog.fieldOwnerTierUnion")}
-                    </Label>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <RadioGroupItem value="local_field" id="owner-tier-local-field" />
-                    <Label htmlFor="owner-tier-local-field" className="cursor-pointer font-normal">
-                      {t("templateDialog.fieldOwnerTierLocalField")}
-                    </Label>
-                  </div>
-                </RadioGroup>
+                <FormItem>
+                  <FormLabel>
+                    {t("templateDialog.fieldName")}{" "}
+                    <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Input
+                      {...field}
+                      placeholder={t("templateDialog.fieldNamePlaceholder")}
+                      aria-required="true"
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
             />
-          </div>
 
-          {/* Conditional owner select */}
-          {ownerTier === "union" ? (
-            <div className="space-y-1.5">
-              <Label htmlFor="template-owner-union">
-                {t("templateDialog.fieldUnion")}{" "}
-                <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-              </Label>
-              <Select
-                disabled={loadingOwnerCatalogs}
-                value={ownerUnionId ? String(ownerUnionId) : ""}
-                onValueChange={(val) =>
-                  setValue("owner_union_id", Number(val), { shouldValidate: true })
-                }
-              >
-                <SelectTrigger id="template-owner-union" aria-required="true">
-                  <SelectValue
-                    placeholder={
-                      loadingOwnerCatalogs
-                        ? t("templateDialog.fieldLoading")
-                        : t("templateDialog.fieldUnionPlaceholder")
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {unions.length > 0 ? (
-                    unions.map((u) => (
-                      <SelectItem key={u.union_id} value={String(u.union_id)}>
-                        {u.name}
-                      </SelectItem>
-                    ))
-                  ) : (
-                    <SelectItem value="0" disabled>
-                      {loadingOwnerCatalogs
-                        ? t("templateDialog.fieldLoading")
-                        : t("templateDialog.fieldUnionNone")}
-                    </SelectItem>
-                  )}
-                </SelectContent>
-              </Select>
-              {errors.owner_union_id && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.owner_union_id.message}
-                </p>
+            {/* Tipo de club */}
+            <FormField
+              control={form.control}
+              name="club_type_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("templateDialog.fieldClubType")}{" "}
+                    <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Select
+                      value={String(field.value)}
+                      onValueChange={(val) => field.onChange(Number(val))}
+                    >
+                      <SelectTrigger id="template-club-type" aria-required="true">
+                        <SelectValue placeholder={t("templateDialog.fieldClubTypePlaceholder")} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {clubTypes.length > 0 ? (
+                          clubTypes.map((ct) => (
+                            <SelectItem
+                              key={ct.club_type_id}
+                              value={String(ct.club_type_id)}
+                            >
+                              {ct.name}
+                            </SelectItem>
+                          ))
+                        ) : (
+                          <SelectItem value="0" disabled>
+                            {t("templateDialog.fieldClubTypeNone")}
+                          </SelectItem>
+                        )}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
               )}
-            </div>
-          ) : (
-            <div className="space-y-1.5">
-              <Label htmlFor="template-owner-local-field">
-                {t("templateDialog.fieldLocalField")}{" "}
-                <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
-              </Label>
-              <Select
-                disabled={loadingOwnerCatalogs}
-                value={ownerLocalFieldId ? String(ownerLocalFieldId) : ""}
-                onValueChange={(val) =>
-                  setValue("owner_local_field_id", Number(val), { shouldValidate: true })
-                }
-              >
-                <SelectTrigger id="template-owner-local-field" aria-required="true">
-                  <SelectValue
-                    placeholder={
-                      loadingOwnerCatalogs
-                        ? t("templateDialog.fieldLoading")
-                        : t("templateDialog.fieldLocalFieldPlaceholder")
-                    }
-                  />
-                </SelectTrigger>
-                <SelectContent>
-                  {localFields.length > 0 ? (
-                    localFields.map((lf) => (
-                      <SelectItem
-                        key={lf.local_field_id}
-                        value={String(lf.local_field_id)}
+            />
+
+            {/* Año eclesiástico */}
+            <FormField
+              control={form.control}
+              name="ecclesiastical_year_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("templateDialog.fieldYear")}{" "}
+                    <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <Select
+                      value={String(field.value)}
+                      onValueChange={(val) => field.onChange(Number(val))}
+                    >
+                      <SelectTrigger id="template-ecclesiastical-year" aria-required="true">
+                        <SelectValue placeholder={t("templateDialog.fieldYearPlaceholder")} />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {ecclesiasticalYears.length > 0 ? (
+                          ecclesiasticalYears.map((year) => (
+                            <SelectItem
+                              key={year.ecclesiastical_year_id}
+                              value={String(year.ecclesiastical_year_id)}
+                            >
+                              {year.name}
+                              {year.active && (
+                                <span className="ml-1.5 text-xs text-muted-foreground">
+                                  {t("templateDialog.fieldYearActive")}
+                                </span>
+                              )}
+                            </SelectItem>
+                          ))
+                        ) : (
+                          <SelectItem value="0" disabled>
+                            {t("templateDialog.fieldYearNone")}
+                          </SelectItem>
+                        )}
+                      </SelectContent>
+                    </Select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Owner tier — radio group */}
+            <FormField
+              control={form.control}
+              name="owner_tier"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {t("templateDialog.fieldOwner")}{" "}
+                    <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                  </FormLabel>
+                  <FormControl>
+                    <RadioGroup
+                      value={field.value}
+                      onValueChange={(val) => {
+                        field.onChange(val);
+                        // Clear the other tier selection to avoid stale values
+                        if (val === "union") {
+                          form.setValue("owner_local_field_id", null);
+                        } else {
+                          form.setValue("owner_union_id", null);
+                        }
+                      }}
+                      className="flex gap-6"
+                    >
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem value="union" id="owner-tier-union" />
+                        <FormLabel htmlFor="owner-tier-union" className="cursor-pointer font-normal">
+                          {t("templateDialog.fieldOwnerTierUnion")}
+                        </FormLabel>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <RadioGroupItem value="local_field" id="owner-tier-local-field" />
+                        <FormLabel htmlFor="owner-tier-local-field" className="cursor-pointer font-normal">
+                          {t("templateDialog.fieldOwnerTierLocalField")}
+                        </FormLabel>
+                      </div>
+                    </RadioGroup>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {/* Conditional owner select */}
+            {ownerTier === "union" ? (
+              <FormField
+                control={form.control}
+                name="owner_union_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("templateDialog.fieldUnion")}{" "}
+                      <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Select
+                        disabled={loadingOwnerCatalogs}
+                        value={field.value ? String(field.value) : ""}
+                        onValueChange={(val) =>
+                          field.onChange(Number(val))
+                        }
                       >
-                        {lf.name}
-                      </SelectItem>
-                    ))
-                  ) : (
-                    <SelectItem value="0" disabled>
-                      {loadingOwnerCatalogs
-                        ? t("templateDialog.fieldLoading")
-                        : t("templateDialog.fieldLocalFieldNone")}
-                    </SelectItem>
-                  )}
-                </SelectContent>
-              </Select>
-              {errors.owner_local_field_id && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.owner_local_field_id.message}
-                </p>
-              )}
-            </div>
-          )}
-
-          {/* Puntos mínimos / Fecha de cierre */}
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1.5">
-              <Label htmlFor="template-minimum-points">{t("templateDialog.fieldMinPoints")}</Label>
-              <Input
-                id="template-minimum-points"
-                type="number"
-                min={0}
-                {...register("minimum_points")}
-                placeholder="0"
+                        <SelectTrigger id="template-owner-union" aria-required="true">
+                          <SelectValue
+                            placeholder={
+                              loadingOwnerCatalogs
+                                ? t("templateDialog.fieldLoading")
+                                : t("templateDialog.fieldUnionPlaceholder")
+                            }
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {unions.length > 0 ? (
+                            unions.map((u) => (
+                              <SelectItem key={u.union_id} value={String(u.union_id)}>
+                                {u.name}
+                              </SelectItem>
+                            ))
+                          ) : (
+                            <SelectItem value="0" disabled>
+                              {loadingOwnerCatalogs
+                                ? t("templateDialog.fieldLoading")
+                                : t("templateDialog.fieldUnionNone")}
+                            </SelectItem>
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-              {errors.minimum_points && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.minimum_points.message}
-                </p>
-              )}
-            </div>
-
-            <div className="space-y-1.5">
-              <Label htmlFor="template-closing-date">{t("templateDialog.fieldClosingDate")}</Label>
-              <Input
-                id="template-closing-date"
-                type="datetime-local"
-                {...register("closing_date")}
+            ) : (
+              <FormField
+                control={form.control}
+                name="owner_local_field_id"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      {t("templateDialog.fieldLocalField")}{" "}
+                      <span aria-hidden="true" className="ml-0.5 text-destructive">*</span>
+                    </FormLabel>
+                    <FormControl>
+                      <Select
+                        disabled={loadingOwnerCatalogs}
+                        value={field.value ? String(field.value) : ""}
+                        onValueChange={(val) =>
+                          field.onChange(Number(val))
+                        }
+                      >
+                        <SelectTrigger id="template-owner-local-field" aria-required="true">
+                          <SelectValue
+                            placeholder={
+                              loadingOwnerCatalogs
+                                ? t("templateDialog.fieldLoading")
+                                : t("templateDialog.fieldLocalFieldPlaceholder")
+                            }
+                          />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {localFields.length > 0 ? (
+                            localFields.map((lf) => (
+                              <SelectItem
+                                key={lf.local_field_id}
+                                value={String(lf.local_field_id)}
+                              >
+                                {lf.name}
+                              </SelectItem>
+                            ))
+                          ) : (
+                            <SelectItem value="0" disabled>
+                              {loadingOwnerCatalogs
+                                ? t("templateDialog.fieldLoading")
+                                : t("templateDialog.fieldLocalFieldNone")}
+                            </SelectItem>
+                          )}
+                        </SelectContent>
+                      </Select>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
-              {errors.closing_date && (
-                <p className="text-xs text-destructive" role="alert" aria-live="polite">
-                  {errors.closing_date.message}
-                </p>
-              )}
-            </div>
-          </div>
+            )}
 
-          <DialogFooter className="pt-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={isSubmitting}
-            >
-              {t("templateDialog.cancel")}
-            </Button>
-            <Button type="submit" disabled={isSubmitting}>
-              {isSubmitting
-                ? isEdit
-                  ? t("templateDialog.submittingEdit")
-                  : t("templateDialog.submittingCreate")
-                : isEdit
-                ? t("templateDialog.submitEdit")
-                : t("templateDialog.submitCreate")}
-            </Button>
-          </DialogFooter>
-        </form>
+            {/* Puntos mínimos / Fecha de cierre */}
+            <div className="grid grid-cols-2 gap-3">
+              <FormField
+                control={form.control}
+                name="minimum_points"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("templateDialog.fieldMinPoints")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="number"
+                        min={0}
+                        placeholder="0"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={form.control}
+                name="closing_date"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("templateDialog.fieldClosingDate")}</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="datetime-local"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <DialogFooter className="pt-2">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => onOpenChange(false)}
+                disabled={isSubmitting}
+              >
+                {t("templateDialog.cancel")}
+              </Button>
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting
+                  ? isEdit
+                    ? t("templateDialog.submittingEdit")
+                    : t("templateDialog.submittingCreate")
+                  : isEdit
+                  ? t("templateDialog.submitEdit")
+                  : t("templateDialog.submitCreate")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/annual-folders/templates-client-page.tsx
+++ b/src/components/annual-folders/templates-client-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useRef } from "react";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import {
@@ -50,7 +51,12 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { TemplateFormDialog } from "@/components/annual-folders/template-form-dialog";
-import { SectionFormDialog } from "@/components/annual-folders/section-form-dialog";
+import type { SectionFormDialogProps } from "@/components/annual-folders/section-form-dialog";
+
+const SectionFormDialog = dynamic<SectionFormDialogProps>(
+  () => import("@/components/annual-folders/section-form-dialog").then((m) => ({ default: m.SectionFormDialog })),
+  { ssr: false, loading: () => null },
+);
 import {
   getTemplate,
   deleteTemplateSection,

--- a/src/components/camporees/delete-union-camporee-dialog.test.tsx
+++ b/src/components/camporees/delete-union-camporee-dialog.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * Integration tests for DeleteUnionCamporeeDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar.
+ * On confirm: resolves ID from union_camporee_id ?? id ?? 0, calls
+ * `deleteUnionCamporee(id)`, shows success toast, closes the dialog
+ * and calls optional onSuccess().
+ *
+ * `deleteUnionCamporee` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { UnionCamporee } from "@/lib/api/camporees";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteUnionCamporee = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/camporees", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/camporees")>();
+  return {
+    ...original,
+    deleteUnionCamporee: (...args: unknown[]) => mockDeleteUnionCamporee(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteUnionCamporeeDialog } from "@/components/camporees/delete-union-camporee-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_UNION_CAMPOREE: UnionCamporee = {
+  union_camporee_id: 7,
+  name: "Gran Camporee de Unión 2026",
+  start_date: "2026-07-01",
+  end_date: "2026-07-05",
+};
+
+const STUB_UNION_CAMPOREE_LEGACY: UnionCamporee = {
+  id: 15,
+  name: "Camporee Unión Legado",
+  start_date: "2026-09-10",
+  end_date: "2026-09-12",
+};
+
+const t = messages.camporees;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  camporee?: UnionCamporee | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, camporee = STUB_UNION_CAMPOREE, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteUnionCamporeeDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        camporee={camporee}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteUnionCamporeeDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteUnionCamporee.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /eliminar camporee de unión/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows camporee name in description ────────────────────────────────
+
+  it("shows the camporee name in the description", () => {
+    renderDialog({ camporee: STUB_UNION_CAMPOREE });
+
+    expect(screen.getByText(/Gran Camporee de Unión 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/desactivará el camporee/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /eliminar camporee de unión/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null camporee — early return, no API call ─────────────────────────
+
+  it("does not call deleteUnionCamporee when camporee is null", async () => {
+    renderDialog({ camporee: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteUnionCamporee).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — uses union_camporee_id ───────────────────────────────
+
+  it("calls deleteUnionCamporee with union_camporee_id, shows toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ camporee: STUB_UNION_CAMPOREE });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteUnionCamporee).toHaveBeenCalledWith(7);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.union_camporee_deleted);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 6. Legacy id field — uses camporee.id when union_camporee_id absent ──
+
+  it("calls deleteUnionCamporee with id when union_camporee_id is absent", async () => {
+    renderDialog({ camporee: STUB_UNION_CAMPOREE_LEGACY });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteUnionCamporee).toHaveBeenCalledWith(15);
+    });
+  });
+
+  // ── 7. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteUnionCamporee on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteUnionCamporee).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deleteUnionCamporee throws", async () => {
+    mockDeleteUnionCamporee.mockRejectedValue(new Error("Network failure"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Network failure");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deleteUnionCamporee throws a non-Error", async () => {
+    mockDeleteUnionCamporee.mockRejectedValue({ code: 500 });
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.delete_camporee);
+    });
+  });
+
+  // ── 10. In-flight state — buttons disabled while deleting ─────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteUnionCamporee.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+});

--- a/src/components/evidence-review/evidence-history-dialog.test.tsx
+++ b/src/components/evidence-review/evidence-history-dialog.test.tsx
@@ -116,7 +116,7 @@ interface RenderOpts {
 function renderDialog(opts: RenderOpts = {}) {
   const {
     open = true,
-    type = "folder",
+    type = "class",
     id = 42,
     memberName = "Juan Pérez",
   } = opts;

--- a/src/components/evidence-review/evidence-review-client-page.tsx
+++ b/src/components/evidence-review/evidence-review-client-page.tsx
@@ -21,8 +21,7 @@ type TabKey = EvidenceType | "all";
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function isPending(item: EvidenceItem): boolean {
-  if (item.type === "honor") return item.status === "in_progress";
-  return item.status === "pendiente";
+  return ["SUBMITTED", "PENDING_REVIEW"].includes(item.status);
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -41,7 +40,6 @@ export function EvidenceReviewClientPage({
   // TABS defined inside component so labels go through t()
   const TABS: { key: TabKey; label: string }[] = [
     { key: "all",    label: t("tab_all") },
-    { key: "folder", label: t("tab_folders") },
     { key: "class",  label: t("tab_classes") },
     { key: "honor",  label: t("tab_honors") },
   ];

--- a/src/components/evidence-review/evidence-review-table.tsx
+++ b/src/components/evidence-review/evidence-review-table.tsx
@@ -53,9 +53,8 @@ const EvidenceBulkActionBar = dynamic<EvidenceBulkActionBarProps>(
 import { useFormatDate } from "@/lib/format-locale";
 
 function isPending(status: string, type: EvidenceType): boolean {
-  if (status === "SUBMITTED") return true;
-  if (type === "honor") return status === "in_progress";
-  return status === "pendiente";
+  void type;
+  return ["SUBMITTED", "PENDING_REVIEW"].includes(status);
 }
 
 // ─── Dialog state ─────────────────────────────────────────────────────────────

--- a/src/components/evidence-review/evidence-status-badge.tsx
+++ b/src/components/evidence-review/evidence-status-badge.tsx
@@ -7,8 +7,8 @@ import type { EvidenceType } from "@/lib/api/evidence-review";
 type IntentConfig = { labelKey: string; intent: StatusIntent };
 
 // Backend enum evidence_validation_enum: PENDING | SUBMITTED | VALIDATED | REJECTED
-// Applies to folders_section_records.status AND class_section_progress.status
-const folderClassIntentMap: Record<string, IntentConfig> = {
+// Applies to class_section_progress.status
+const classIntentMap: Record<string, IntentConfig> = {
   PENDING:   { labelKey: "no_submit",  intent: "neutral" },
   SUBMITTED: { labelKey: "submitted",  intent: "info" },
   VALIDATED: { labelKey: "validated",  intent: "success" },
@@ -23,9 +23,8 @@ const honorIntentMap: Record<string, IntentConfig> = {
   SUBMITTED:   { labelKey: "submitted",  intent: "info" },
   VALIDATED:   { labelKey: "validated",  intent: "success" },
   REJECTED:    { labelKey: "rejected",   intent: "destructive" },
-  in_progress: { labelKey: "submitted",  intent: "info" },
-  validated:   { labelKey: "validated",  intent: "success" },
-  rejected:    { labelKey: "rejected",   intent: "destructive" },
+  PENDING_REVIEW: { labelKey: "submitted",  intent: "info" },
+
 };
 
 interface EvidenceStatusBadgeProps {
@@ -36,7 +35,7 @@ interface EvidenceStatusBadgeProps {
 
 export function EvidenceStatusBadge({ status, type, className }: EvidenceStatusBadgeProps) {
   const t = useTranslations("evidence_review.statusBadge");
-  const configMap = type === "honor" ? honorIntentMap : folderClassIntentMap;
+  const configMap = type === "honor" ? honorIntentMap : classIntentMap;
   const config = configMap[status];
   const label = config ? t(config.labelKey as "no_submit" | "submitted" | "validated" | "rejected") : status;
   const intent: StatusIntent = config?.intent ?? "neutral";

--- a/src/components/evidence-review/evidence-type-badge.tsx
+++ b/src/components/evidence-review/evidence-type-badge.tsx
@@ -5,7 +5,6 @@ import { StatusBadge, type StatusIntent } from "@/components/ui/status-badge";
 import type { EvidenceType } from "@/lib/api/evidence-review";
 
 const typeIntentMap: Record<EvidenceType, StatusIntent> = {
-  folder: "primary",
   class: "neutral",
   honor: "success",
 };

--- a/src/components/folders/folder-delete-dialog.test.tsx
+++ b/src/components/folders/folder-delete-dialog.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * Integration tests for FolderDeleteDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar carpeta.
+ * On confirm: calls `deleteFolder(folder_id)`, shows success toast,
+ * closes the dialog and calls onSuccess().
+ *
+ * Error handling: uses `ApiError instanceof` check for the error message.
+ * Non-ApiError falls back to hardcoded string (not i18n).
+ *
+ * `deleteFolder` is mocked at module boundary. ApiError is imported from
+ * the real client module (not mocked).
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { FolderTemplate } from "@/lib/api/folders";
+import { ApiError } from "@/lib/api/client";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteFolder = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/folders", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/folders")>();
+  return {
+    ...original,
+    deleteFolder: (...args: unknown[]) => mockDeleteFolder(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { FolderDeleteDialog } from "@/components/folders/folder-delete-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_FOLDER: FolderTemplate = {
+  folder_id: "11",
+  name: "Carpeta de Conquistas 2026",
+  description: "Evidencias del año",
+  active: true,
+  club_type_ids: [],
+  created_at: null,
+  updated_at: null,
+  modules: [],
+};
+
+const t = messages.folders;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  folder?: FolderTemplate | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, folder = STUB_FOLDER, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <FolderDeleteDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        folder={folder}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("FolderDeleteDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteFolder.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /eliminar carpeta de evidencias/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar carpeta/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows folder name in description ─────────────────────────────────
+
+  it("shows the folder name in the description", () => {
+    renderDialog({ folder: STUB_FOLDER });
+
+    expect(screen.getByText(/Carpeta de Conquistas 2026/)).toBeInTheDocument();
+    expect(screen.getByText(/eliminará permanentemente/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /eliminar carpeta de evidencias/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null folder — early return, no API call ───────────────────────────
+
+  it("does not call deleteFolder when folder is null", async () => {
+    renderDialog({ folder: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteFolder).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls deleteFolder with folder_id ────────────────────
+
+  it("calls deleteFolder with folder_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ folder: STUB_FOLDER });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteFolder).toHaveBeenCalledWith("11");
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.deleted);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  // ── 6. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteFolder on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteFolder).not.toHaveBeenCalled();
+  });
+
+  // ── 7. ApiError instanceof — uses err.message directly ───────────────────
+
+  it("shows ApiError.message in error toast when deleteFolder throws ApiError", async () => {
+    mockDeleteFolder.mockRejectedValue(
+      new ApiError("La carpeta tiene módulos activos", 409, null),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("La carpeta tiene módulos activos");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. Non-ApiError falls back to hardcoded message ─────────────────────
+
+  it("shows hardcoded fallback message when deleteFolder throws a non-ApiError", async () => {
+    mockDeleteFolder.mockRejectedValue(new Error("Generic network error"));
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("No se pudo eliminar la carpeta");
+    });
+  });
+
+  // ── 9. In-flight state — buttons disabled while deleting ─────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteFolder.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+
+  // ── 10. onSuccess is NOT called on error ─────────────────────────────────
+
+  it("does NOT call onSuccess when deleteFolder fails", async () => {
+    mockDeleteFolder.mockRejectedValue(new ApiError("Forbidden", 403, null));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar carpeta/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/honors/requirement-edit-dialog.test.tsx
+++ b/src/components/honors/requirement-edit-dialog.test.tsx
@@ -1,0 +1,364 @@
+/**
+ * Integration tests for RequirementEditDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog (not AlertDialog). Form with: displayLabel (max 10 chars),
+ * requirementText (required textarea), referenceText (collapsible),
+ * isChoiceGroup toggle (shows choiceMin input when on), requiresEvidence
+ * toggle, and needsReview toggle (only in edit mode).
+ *
+ * Uses TanStack Query `useMutation` + `useQueryClient`. Needs QueryClientProvider.
+ * Supports two modes: "create" and "edit".
+ *
+ * `createRequirement` and `updateRequirement` are mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import messages from "../../../messages/es.json";
+import type { RequirementNode } from "@/lib/api/honors";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills (Radix Dialog uses ResizeObserver + scrollIntoView)
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockCreateRequirement = vi.fn<(...args: any[]) => Promise<unknown>>();
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUpdateRequirement = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/honors", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/honors")>();
+  return {
+    ...original,
+    createRequirement: (...args: unknown[]) => mockCreateRequirement(...args),
+    updateRequirement: (...args: unknown[]) => mockUpdateRequirement(...args),
+  };
+});
+
+import { RequirementEditDialog } from "@/components/honors/requirement-edit-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_REQUIREMENT: RequirementNode = {
+  requirement_id: 77,
+  honor_id: 10,
+  parent_id: null,
+  requirement_number: 3,
+  display_label: "3",
+  requirement_text: "Conocer los principios básicos",
+  reference_text: "Manual pág. 45",
+  has_sub_items: false,
+  is_choice_group: false,
+  choice_min: null,
+  requires_evidence: false,
+  needs_review: false,
+  active: true,
+  created_at: "2026-01-01T00:00:00Z",
+  modified_at: "2026-01-01T00:00:00Z",
+  children: [],
+};
+
+const HONOR_ID = 10;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+type DialogMode = "create" | "edit";
+
+interface RenderOpts {
+  open?: boolean;
+  mode?: DialogMode;
+  requirement?: RequirementNode | null;
+  nextNumber?: number;
+  parentId?: number | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    mode = "create",
+    requirement = null,
+    nextNumber = 1,
+    parentId = null,
+    onSuccess,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <NextIntlClientProvider locale="es" messages={messages}>
+        <RequirementEditDialog
+          open={open}
+          onOpenChange={onOpenChange}
+          mode={mode}
+          honorId={HONOR_ID}
+          nextNumber={nextNumber}
+          parentId={parentId}
+          requirement={requirement}
+          onSuccess={successCb}
+        />
+      </NextIntlClientProvider>
+    </QueryClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb, queryClient };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("RequirementEditDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateRequirement.mockResolvedValue({ requirement_id: 100 });
+    mockUpdateRequirement.mockResolvedValue({ requirement_id: 77 });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Create mode renders correct title ─────────────────────────────────
+
+  it("renders 'Agregar requisito' title in create mode", () => {
+    renderDialog({ mode: "create" });
+
+    expect(
+      screen.getByRole("heading", { name: /agregar requisito/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Edit mode renders correct title ──────────────────────────────────
+
+  it("renders 'Editar requisito' title in edit mode", () => {
+    renderDialog({ mode: "edit", requirement: STUB_REQUIREMENT });
+
+    expect(
+      screen.getByRole("heading", { name: /editar requisito/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 3. Sub-requirement create mode title ────────────────────────────────
+
+  it("renders 'Agregar sub-requisito' title when parentId is set in create mode", () => {
+    renderDialog({ mode: "create", parentId: 5 });
+
+    expect(
+      screen.getByRole("heading", { name: /agregar sub-requisito/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 4. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /agregar requisito/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 5. Edit mode pre-fills form fields ───────────────────────────────────
+
+  it("pre-fills form fields from requirement in edit mode", () => {
+    renderDialog({ mode: "edit", requirement: STUB_REQUIREMENT });
+
+    const displayLabelInput = document.querySelector<HTMLInputElement>("#displayLabel");
+    expect(displayLabelInput?.value).toBe("3");
+
+    const requirementTextArea = document.querySelector<HTMLTextAreaElement>("#requirementText");
+    expect(requirementTextArea?.value).toBe("Conocer los principios básicos");
+  });
+
+  // ── 6. Validation — empty requirementText shows error ────────────────────
+
+  it("shows validation error when requirementText is empty on submit", async () => {
+    renderDialog({ mode: "create" });
+
+    // Submit the form directly — avoids ambiguity with the "Agregar referencia" button
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/texto del requisito es obligatorio/i),
+      ).toBeInTheDocument();
+    });
+
+    expect(mockCreateRequirement).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Happy path create — calls createRequirement ───────────────────────
+
+  it("calls createRequirement and closes on valid create submission", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ mode: "create", nextNumber: 5 });
+
+    const textArea = document.querySelector<HTMLTextAreaElement>("#requirementText");
+    await act(async () => {
+      fireEvent.change(textArea!, { target: { value: "Nuevo requisito de prueba" } });
+    });
+
+    // Submit via form — avoids ambiguity between "Agregar" submit and "Agregar referencia" button
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(mockCreateRequirement).toHaveBeenCalledWith(
+        HONOR_ID,
+        expect.objectContaining({
+          requirementText: "Nuevo requisito de prueba",
+          requirementNumber: 5,
+        }),
+      );
+    });
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 8. Happy path edit — calls updateRequirement ─────────────────────────
+
+  it("calls updateRequirement and closes on valid edit submission", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({
+      mode: "edit",
+      requirement: STUB_REQUIREMENT,
+    });
+
+    const textArea = document.querySelector<HTMLTextAreaElement>("#requirementText");
+    await act(async () => {
+      fireEvent.change(textArea!, { target: { value: "Requisito actualizado" } });
+    });
+
+    const submitBtn = screen.getByRole("button", { name: /guardar cambios/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateRequirement).toHaveBeenCalledWith(
+        77,
+        expect.objectContaining({
+          requirementText: "Requisito actualizado",
+        }),
+      );
+    });
+
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 9. Cancel closes dialog without API call ─────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call API on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog({ mode: "create" });
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockCreateRequirement).not.toHaveBeenCalled();
+  });
+
+  // ── 10. isChoiceGroup toggle shows/hides choiceMin input ─────────────────
+
+  it("shows choiceMin input when isChoiceGroup is toggled on", async () => {
+    renderDialog({ mode: "create" });
+
+    expect(screen.queryByLabelText(/mínimo de opciones/i)).not.toBeInTheDocument();
+
+    const choiceGroupSwitch = document.querySelector<HTMLButtonElement>("#isChoiceGroup");
+    await act(async () => {
+      fireEvent.click(choiceGroupSwitch!);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/mínimo de opciones/i)).toBeInTheDocument();
+    });
+  });
+
+  // ── 11. needsReview toggle only visible in edit mode ─────────────────────
+
+  it("shows needsReview toggle only in edit mode", () => {
+    const { unmount } = renderDialog({ mode: "edit", requirement: STUB_REQUIREMENT });
+    expect(screen.getByLabelText(/pendiente de revisión/i)).toBeInTheDocument();
+    unmount();
+
+    renderDialog({ mode: "create" });
+    expect(screen.queryByLabelText(/pendiente de revisión/i)).not.toBeInTheDocument();
+  });
+
+  // ── 12. In-flight — submit button shows Guardando... ─────────────────────
+
+  it("shows 'Guardando...' label while mutation is in flight", async () => {
+    let resolveCreate!: () => void;
+    mockCreateRequirement.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveCreate = () => res({ requirement_id: 100 });
+      }),
+    );
+
+    renderDialog({ mode: "create" });
+
+    const textArea = document.querySelector<HTMLTextAreaElement>("#requirementText");
+    await act(async () => {
+      fireEvent.change(textArea!, { target: { value: "Texto de prueba" } });
+    });
+
+    // Submit via form to avoid ambiguity with "Agregar referencia bibliográfica" button
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /guardando/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveCreate();
+    });
+  });
+});

--- a/src/components/insurance/delete-insurance-dialog.test.tsx
+++ b/src/components/insurance/delete-insurance-dialog.test.tsx
@@ -1,0 +1,321 @@
+/**
+ * Integration tests for DeleteInsuranceDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Desactivar.
+ * Action: deactivateInsurance(member.insurance.insurance_id).
+ * Guards: exits early if insurance_id is undefined.
+ * Member name is derived from name + paternal_last_name + maternal_last_name.
+ *
+ * `deactivateInsurance` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { MemberInsurance } from "@/lib/api/insurance";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeactivateInsurance = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/insurance", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/insurance")>();
+  return {
+    ...original,
+    deactivateInsurance: (...args: unknown[]) => mockDeactivateInsurance(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteInsuranceDialog } from "@/components/insurance/delete-insurance-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_MEMBER: MemberInsurance = {
+  user_id: "user-abc-123",
+  name: "Ana",
+  paternal_last_name: "García",
+  maternal_last_name: "López",
+  user_image: null,
+  insurance: {
+    insurance_id: 55,
+    insurance_type: "GENERAL_ACTIVITIES",
+    policy_number: "POL-2026-001",
+    provider: "Aseguradora XYZ",
+    start_date: "2026-01-01",
+    end_date: "2026-12-31",
+    coverage_amount: 10000,
+    active: true,
+    evidence_file_url: null,
+    evidence_file_name: null,
+    created_at: null,
+    modified_at: null,
+    created_by_name: null,
+    modified_by_name: null,
+  },
+};
+
+const STUB_MEMBER_NO_INSURANCE: MemberInsurance = {
+  user_id: "user-xyz-456",
+  name: "Luis",
+  paternal_last_name: "Martínez",
+  maternal_last_name: null,
+  user_image: null,
+  insurance: null,
+};
+
+const t = messages.insurance;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  member?: MemberInsurance | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, member = STUB_MEMBER, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteInsuranceDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        member={member}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteInsuranceDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeactivateInsurance.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /¿desactivar seguro\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /desactivar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows full member name in description ─────────────────────────────
+
+  it("shows full member name (name + paternal + maternal) in description", () => {
+    renderDialog({ member: STUB_MEMBER });
+
+    expect(screen.getByText(/Ana García López/)).toBeInTheDocument();
+    expect(screen.getByText(/El registro se conservará/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /¿desactivar seguro\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. No insurance_id — early return, no API call ───────────────────────
+
+  it("does not call deactivateInsurance when member has no insurance", async () => {
+    renderDialog({ member: STUB_MEMBER_NO_INSURANCE });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeactivateInsurance).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Null member — early return, no API call ───────────────────────────
+
+  it("does not call deactivateInsurance when member is null", async () => {
+    renderDialog({ member: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeactivateInsurance).not.toHaveBeenCalled();
+  });
+
+  // ── 6. Happy path — calls deactivateInsurance with insurance_id ──────────
+
+  it("calls deactivateInsurance with insurance_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ member: STUB_MEMBER });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeactivateInsurance).toHaveBeenCalledWith(55);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.deactivated);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 7. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deactivateInsurance on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeactivateInsurance).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deactivateInsurance throws", async () => {
+    mockDeactivateInsurance.mockRejectedValue(new Error("Insurance not found"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Insurance not found");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deactivateInsurance throws a non-Error", async () => {
+    mockDeactivateInsurance.mockRejectedValue({ status: 500 });
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.deactivate_failed);
+    });
+  });
+
+  // ── 10. In-flight state — buttons disabled while deactivating ─────────────
+
+  it("disables both buttons while deactivation is in flight", async () => {
+    let resolveDeactivate!: () => void;
+    mockDeactivateInsurance.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDeactivate = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /desactivando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDeactivate();
+    });
+  });
+
+  // ── 11. Member name fallback — only name when no last names ──────────────
+
+  it("shows just the name when paternal and maternal last names are absent", () => {
+    const memberNameOnly: MemberInsurance = {
+      ...STUB_MEMBER_NO_INSURANCE,
+      name: "Carlos",
+      paternal_last_name: null,
+      maternal_last_name: null,
+      insurance: { ...STUB_MEMBER.insurance! },
+    };
+
+    renderDialog({ member: memberNameOnly });
+
+    // Description contains the name
+    expect(screen.getByText(/Carlos/)).toBeInTheDocument();
+  });
+});

--- a/src/components/inventory/delete-inventory-dialog.test.tsx
+++ b/src/components/inventory/delete-inventory-dialog.test.tsx
@@ -1,0 +1,286 @@
+/**
+ * Integration tests for DeleteInventoryDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar.
+ * On confirm: calls `deleteInventoryItem(item.inventory_id)`, shows
+ * success toast, calls onSuccess() and closes the dialog.
+ *
+ * `deleteInventoryItem` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { InventoryItem } from "@/lib/api/inventory";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteInventoryItem = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/inventory", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/inventory")>();
+  return {
+    ...original,
+    deleteInventoryItem: (...args: unknown[]) => mockDeleteInventoryItem(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteInventoryDialog } from "@/components/inventory/delete-inventory-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_ITEM: InventoryItem = {
+  inventory_id: 33,
+  name: "Tienda de campaña grande",
+  description: "Tienda 6 personas",
+  inventory_category_id: 1,
+  club_id: 10,
+  amount: 2,
+  active: true,
+};
+
+const t = messages.inventory;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  item?: InventoryItem | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, item = STUB_ITEM, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteInventoryDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        item={item}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteInventoryDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteInventoryItem.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /¿eliminar ítem\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows item name in description ───────────────────────────────────
+
+  it("shows the item name in the description", () => {
+    renderDialog({ item: STUB_ITEM });
+
+    expect(screen.getByText(/Tienda de campaña grande/)).toBeInTheDocument();
+    expect(screen.getByText(/desactivará el ítem del inventario/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /¿eliminar ítem\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null item — early return, no API call ─────────────────────────────
+
+  it("does not call deleteInventoryItem when item is null", async () => {
+    renderDialog({ item: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteInventoryItem).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls deleteInventoryItem with inventory_id ──────────
+
+  it("calls deleteInventoryItem with inventory_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ item: STUB_ITEM });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteInventoryItem).toHaveBeenCalledWith(33);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.item_deleted);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteInventoryItem on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteInventoryItem).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deleteInventoryItem throws", async () => {
+    mockDeleteInventoryItem.mockRejectedValue(new Error("Item not found"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Item not found");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deleteInventoryItem throws a non-Error", async () => {
+    mockDeleteInventoryItem.mockRejectedValue({ code: "ECONNRESET" });
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.delete_failed);
+    });
+  });
+
+  // ── 9. In-flight state — buttons disabled while deleting ─────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolveDelete!: () => void;
+    mockDeleteInventoryItem.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDelete = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDelete();
+    });
+  });
+
+  // ── 10. onSuccess NOT called on error ────────────────────────────────────
+
+  it("does NOT call onSuccess when deleteInventoryItem fails", async () => {
+    mockDeleteInventoryItem.mockRejectedValue(new Error("Server error"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/investiture/config-client-page.tsx
+++ b/src/components/investiture/config-client-page.tsx
@@ -1,15 +1,26 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { toast } from "sonner";
 import { Plus, RefreshCw } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
 import { ConfigTable } from "@/components/investiture/config-table";
-import { ConfigFormDialog } from "@/components/investiture/config-form-dialog";
-import { DeleteConfigDialog } from "@/components/investiture/delete-config-dialog";
 import { getInvestitureConfigs, type InvestitureConfig } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
+import type { ConfigFormDialogProps } from "@/components/investiture/config-form-dialog";
+import type { DeleteConfigDialogProps } from "@/components/investiture/delete-config-dialog";
+
+const ConfigFormDialog = dynamic<ConfigFormDialogProps>(
+  () => import("@/components/investiture/config-form-dialog").then((m) => ({ default: m.ConfigFormDialog })),
+  { ssr: false, loading: () => null },
+);
+
+const DeleteConfigDialog = dynamic<DeleteConfigDialogProps>(
+  () => import("@/components/investiture/delete-config-dialog").then((m) => ({ default: m.DeleteConfigDialog })),
+  { ssr: false, loading: () => null },
+);
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 

--- a/src/components/investiture/config-form-dialog.tsx
+++ b/src/components/investiture/config-form-dialog.tsx
@@ -69,7 +69,7 @@ type FormValues = {
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface ConfigFormDialogProps {
+export interface ConfigFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** If provided, dialog is in edit mode */

--- a/src/components/investiture/delete-config-dialog.test.tsx
+++ b/src/components/investiture/delete-config-dialog.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * Integration tests for DeleteConfigDialog (Investiture).
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Desactivar.
+ * On confirm: calls `deleteInvestitureConfig(config.investiture_config_id)`,
+ * shows success toast, calls onSuccess() and closes the dialog.
+ *
+ * The description conditionally shows config details (localFieldName + yearName)
+ * when config is provided, or a generic message when config is null.
+ *
+ * `deleteInvestitureConfig` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { InvestitureConfig } from "@/lib/api/investiture";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteInvestitureConfig = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/investiture", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/investiture")>();
+  return {
+    ...original,
+    deleteInvestitureConfig: (...args: unknown[]) => mockDeleteInvestitureConfig(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteConfigDialog } from "@/components/investiture/delete-config-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_CONFIG: InvestitureConfig = {
+  investiture_config_id: 9,
+  local_field_id: 3,
+  ecclesiastical_year_id: 2026,
+  submission_deadline: "2026-11-01",
+  investiture_date: "2026-11-30",
+  active: true,
+  local_fields: { name: "Campo Local Sur" },
+  ecclesiastical_years: {
+    ecclesiastical_year_id: 2026,
+    name: "Año 2026",
+  },
+};
+
+const STUB_CONFIG_NO_RELATIONS: InvestitureConfig = {
+  investiture_config_id: 12,
+  local_field_id: 5,
+  ecclesiastical_year_id: 2027,
+  submission_deadline: "2027-10-01",
+  investiture_date: "2027-10-31",
+  active: true,
+  local_fields: null,
+  ecclesiastical_years: null,
+};
+
+const t = messages.investiture;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  config?: InvestitureConfig | null;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, config = STUB_CONFIG, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteConfigDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        config={config}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteConfigDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteInvestitureConfig.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /¿desactivar configuración\?/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /desactivar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows local field and year names in description ───────────────────
+
+  it("shows local field name and year name in description when config is provided", () => {
+    renderDialog({ config: STUB_CONFIG });
+
+    expect(screen.getByText(/Campo Local Sur/)).toBeInTheDocument();
+    expect(screen.getByText(/Año 2026/)).toBeInTheDocument();
+  });
+
+  // ── 3. Fallback names when relations are absent ──────────────────────────
+
+  it("shows fallback field/year labels when local_fields and ecclesiastical_years are null", () => {
+    renderDialog({ config: STUB_CONFIG_NO_RELATIONS });
+
+    expect(screen.getByText(/Campo #5/)).toBeInTheDocument();
+    expect(screen.getByText(/Año #2027/)).toBeInTheDocument();
+  });
+
+  // ── 4. Null config — shows generic description ───────────────────────────
+
+  it("shows generic description when config is null", () => {
+    renderDialog({ config: null });
+
+    expect(
+      screen.getByText(/desactivará la configuración/i),
+    ).toBeInTheDocument();
+  });
+
+  // ── 5. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /¿desactivar configuración\?/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 6. Null config — early return, no API call ───────────────────────────
+
+  it("does not call deleteInvestitureConfig when config is null", async () => {
+    renderDialog({ config: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteInvestitureConfig).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Happy path — calls deleteInvestitureConfig with config id ─────────
+
+  it("calls deleteInvestitureConfig with investiture_config_id, shows toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ config: STUB_CONFIG });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteInvestitureConfig).toHaveBeenCalledWith(9);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.config_deactivated);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 8. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteInvestitureConfig on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteInvestitureConfig).not.toHaveBeenCalled();
+  });
+
+  // ── 9. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deleteInvestitureConfig throws", async () => {
+    mockDeleteInvestitureConfig.mockRejectedValue(new Error("Config conflict"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Config conflict");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 10. API error — falls back to i18n message for non-Error throws ──────
+
+  it("shows i18n fallback error toast when deleteInvestitureConfig throws a non-Error", async () => {
+    mockDeleteInvestitureConfig.mockRejectedValue("plain string error");
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.config_deactivate);
+    });
+  });
+
+  // ── 11. In-flight state — Desactivar button disabled ─────────────────────
+
+  it("disables both buttons while deactivation is in flight", async () => {
+    let resolveDeactivate!: () => void;
+    mockDeleteInvestitureConfig.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDeactivate = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      // The Desactivar button gets a Loader2 spinner prepended — stays accessible by name
+      expect(screen.getByRole("button", { name: /desactivar/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDeactivate();
+    });
+  });
+});

--- a/src/components/investiture/delete-config-dialog.tsx
+++ b/src/components/investiture/delete-config-dialog.tsx
@@ -18,7 +18,7 @@ import { deleteInvestitureConfig, type InvestitureConfig } from "@/lib/api/inves
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface DeleteConfigDialogProps {
+export interface DeleteConfigDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   config: InvestitureConfig | null;

--- a/src/components/investiture/investido-dialog.tsx
+++ b/src/components/investiture/investido-dialog.tsx
@@ -37,7 +37,7 @@ type FormValues = z.infer<typeof schema>;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface InvestidoDialogProps {
+export interface InvestidoDialogProps {
   open: boolean;
   enrollmentId: number;
   memberName: string;

--- a/src/components/investiture/pending-table.tsx
+++ b/src/components/investiture/pending-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
 import { CheckCircle2, XCircle, Award, History, ClipboardList } from "lucide-react";
@@ -24,9 +25,19 @@ import {
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { EmptyState } from "@/components/shared/empty-state";
 import { InvestitureStatusBadge } from "@/components/investiture/investiture-status-badge";
-import { ValidateDialog } from "@/components/investiture/validate-dialog";
-import { InvestidoDialog } from "@/components/investiture/investido-dialog";
 import { HistoryTimeline } from "@/components/investiture/history-timeline";
+import type { ValidateDialogProps } from "@/components/investiture/validate-dialog";
+import type { InvestidoDialogProps } from "@/components/investiture/investido-dialog";
+
+const ValidateDialog = dynamic<ValidateDialogProps>(
+  () => import("@/components/investiture/validate-dialog").then((m) => ({ default: m.ValidateDialog })),
+  { ssr: false, loading: () => null },
+);
+
+const InvestidoDialog = dynamic<InvestidoDialogProps>(
+  () => import("@/components/investiture/investido-dialog").then((m) => ({ default: m.InvestidoDialog })),
+  { ssr: false, loading: () => null },
+);
 import {
   getInvestitureHistory,
   type PendingEnrollment,

--- a/src/components/investiture/validate-dialog.tsx
+++ b/src/components/investiture/validate-dialog.tsx
@@ -45,7 +45,7 @@ type RejectFormValues = z.infer<ReturnType<typeof buildRejectSchema>>;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface ValidateDialogProps {
+export interface ValidateDialogProps {
   open: boolean;
   enrollmentId: number;
   memberName: string;

--- a/src/components/membership/membership-reject-dialog.tsx
+++ b/src/components/membership/membership-reject-dialog.tsx
@@ -16,8 +16,15 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { ApiError } from "@/lib/api/client";
 import {
   rejectMembershipRequest,
@@ -112,33 +119,43 @@ export function MembershipRejectDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="reject-reason">{t("dialogs.reject.reason_label")}</Label>
-            <Textarea
-              id="reject-reason"
-              placeholder={t("dialogs.reject.reason_placeholder")}
-              rows={3}
-              {...form.register("reason")}
-              disabled={isPending}
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="reason"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>{t("dialogs.reject.reason_label")}</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={t("dialogs.reject.reason_placeholder")}
+                      rows={3}
+                      {...field}
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-          </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleClose(false)}
-              disabled={isPending}
-            >
-              {t("dialogs.reject.cancel")}
-            </Button>
-            <Button type="submit" variant="destructive" disabled={isPending}>
-              {isPending && <Loader2 className="size-4 animate-spin" />}
-              {isPending ? t("dialogs.reject.confirming") : t("dialogs.reject.confirm")}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isPending}
+              >
+                {t("dialogs.reject.cancel")}
+              </Button>
+              <Button type="submit" variant="destructive" disabled={isPending}>
+                {isPending && <Loader2 className="size-4 animate-spin" />}
+                {isPending ? t("dialogs.reject.confirming") : t("dialogs.reject.confirm")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/requests/request-review-dialog.tsx
+++ b/src/components/requests/request-review-dialog.tsx
@@ -16,8 +16,15 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import { ApiError } from "@/lib/api/client";
 import type { ReviewAction, ReviewRequestPayload } from "@/lib/api/requests";
 
@@ -113,51 +120,53 @@ export function RequestReviewDialog({
           <DialogDescription>{description}</DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="comment">
-              {isApprove ? "Comentarios (opcional)" : "Motivo de rechazo *"}
-            </Label>
-            <Textarea
-              id="comment"
-              placeholder={
-                isApprove
-                  ? "Añade un comentario opcional..."
-                  : "Describe el motivo del rechazo..."
-              }
-              rows={3}
-              {...form.register("comment")}
-              disabled={isPending}
-              aria-describedby={
-                form.formState.errors.comment ? "comment-error" : undefined
-              }
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="comment"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {isApprove ? "Comentarios (opcional)" : "Motivo de rechazo *"}
+                  </FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={
+                        isApprove
+                          ? "Añade un comentario opcional..."
+                          : "Describe el motivo del rechazo..."
+                      }
+                      rows={3}
+                      {...field}
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {form.formState.errors.comment && (
-              <p id="comment-error" className="text-xs text-destructive">
-                {form.formState.errors.comment.message}
-              </p>
-            )}
-          </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleClose(false)}
-              disabled={isPending}
-            >
-              Cancelar
-            </Button>
-            <Button
-              type="submit"
-              variant={isApprove ? "default" : "destructive"}
-              disabled={isPending}
-            >
-              {isPending && <Loader2 className="size-4 animate-spin" />}
-              {isApprove ? "Aprobar" : "Rechazar"}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isPending}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                variant={isApprove ? "default" : "destructive"}
+                disabled={isPending}
+              >
+                {isPending && <Loader2 className="size-4 animate-spin" />}
+                {isApprove ? "Aprobar" : "Rechazar"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/units/add-member-dialog.test.tsx
+++ b/src/components/units/add-member-dialog.test.tsx
@@ -1,0 +1,399 @@
+/**
+ * Integration tests for AddMemberDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog (not AlertDialog). Form with a MemberCombobox (controlled) and
+ * submit/cancel buttons.
+ *
+ * MemberCombobox is a Popover+Command widget with its own TanStack Query
+ * fetch — mocked at module boundary to a simple select input to isolate
+ * dialog-level behavior from combobox internals.
+ *
+ * Validation: requires userId to be non-empty (inline error, no toast).
+ * Happy path: addUnitMember(clubId, unitId, userId), success toast, resets
+ * userId, calls onSuccess(), closes dialog.
+ *
+ * `addUnitMember` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { UnitMember } from "@/lib/api/units";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// Mock MemberCombobox — render a simple <select> so we can control userId
+// without dealing with Radix Popover/Command internals in jsdom.
+vi.mock("@/components/units/member-combobox", () => ({
+  MemberCombobox: ({
+    value,
+    onChange,
+    disabled,
+  }: {
+    clubId: number;
+    value: string;
+    onChange: (id: string) => void;
+    disabled?: boolean;
+    placeholder?: string;
+    excludeUserIds?: string[];
+  }) => (
+    <select
+      data-testid="member-combobox"
+      value={value}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.value)}
+    >
+      <option value="">-- Seleccionar --</option>
+      <option value="user-001">María Pérez</option>
+      <option value="user-002">Carlos Ruiz</option>
+    </select>
+  ),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockAddUnitMember = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/units", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/units")>();
+  return {
+    ...original,
+    addUnitMember: (...args: unknown[]) => mockAddUnitMember(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { AddMemberDialog } from "@/components/units/add-member-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const ACTIVE_MEMBER: UnitMember = {
+  unit_member_id: 1,
+  user_id: "user-001",
+  active: true,
+};
+
+const t = messages.units_admin;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  clubId?: number;
+  unitId?: number;
+  unitName?: string;
+  existingMembers?: UnitMember[];
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    clubId = 5,
+    unitId = 21,
+    unitName = "Unidad Águilas",
+    existingMembers = [],
+    onSuccess,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <AddMemberDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        clubId={clubId}
+        unitId={unitId}
+        unitName={unitName}
+        existingMembers={existingMembers}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// Helper: select a member from the mocked combobox
+async function selectMember(userId: string) {
+  const combobox = screen.getByTestId("member-combobox");
+  await act(async () => {
+    fireEvent.change(combobox, { target: { value: userId } });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AddMemberDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAddUnitMember.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and unit name in description ─────────────────────────
+
+  it("renders title, unit name in description, and cancel/submit buttons when open", () => {
+    renderDialog({ unitName: "Unidad Águilas" });
+
+    expect(
+      screen.getByRole("heading", { name: /agregar miembro/i }),
+    ).toBeInTheDocument();
+    // Unit name appears in the description text
+    const unitNameEls = screen.getAllByText(/Unidad Águilas/);
+    expect(unitNameEls.length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /agregar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /agregar miembro/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Submit button disabled when no userId selected ────────────────────
+
+  it("disables submit button when no member is selected", () => {
+    renderDialog();
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  // ── 4. Validation — shows inline error when submitting with empty userId ──
+
+  it("shows inline error when form is submitted with no userId via keyboard", async () => {
+    renderDialog();
+
+    // Force submit with empty userId (bypass disabled by triggering the form directly)
+    const form = document.querySelector("form")!;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/selecciona un miembro para agregar/i)).toBeInTheDocument();
+    });
+
+    expect(mockAddUnitMember).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls addUnitMember with correct args ────────────────
+
+  it("calls addUnitMember with clubId, unitId, userId on valid submit", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ clubId: 5, unitId: 21 });
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockAddUnitMember).toHaveBeenCalledWith(5, 21, "user-002");
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.member_added);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel calls onOpenChange(false) and clears state ─────────────────
+
+  it("calls onOpenChange(false) and does NOT call addUnitMember on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockAddUnitMember).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error — shows error toast from Error instance ─────────────────
+
+  it("shows error toast from Error.message when addUnitMember throws", async () => {
+    mockAddUnitMember.mockRejectedValue(new Error("Member already in unit"));
+
+    const { onSuccess } = renderDialog();
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Member already in unit");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when addUnitMember throws a non-Error", async () => {
+    mockAddUnitMember.mockRejectedValue({ status: 500 });
+
+    renderDialog();
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.add_member_failed);
+    });
+  });
+
+  // ── 9. In-flight — buttons disabled while submitting ─────────────────────
+
+  it("disables buttons while submission is in flight", async () => {
+    let resolveAdd!: () => void;
+    mockAddUnitMember.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveAdd = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /agregando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveAdd();
+    });
+  });
+
+  // ── 10. Closing via cancel resets userId state ────────────────────────────
+
+  it("resets selected member when dialog is closed via cancel", async () => {
+    const { onOpenChange, rerender } = renderDialog({ open: true });
+
+    await selectMember("user-002");
+
+    // Cancel closes dialog
+    const cancelBtn = screen.getByRole("button", { name: /cancelar/i });
+    await act(async () => {
+      fireEvent.click(cancelBtn);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    // Re-open — userId should be reset (empty combobox)
+    rerender(
+      <NextIntlClientProvider locale="es" messages={messages}>
+        <AddMemberDialog
+          open={true}
+          onOpenChange={onOpenChange}
+          clubId={5}
+          unitId={21}
+          unitName="Unidad Águilas"
+          existingMembers={[]}
+          onSuccess={vi.fn()}
+        />
+      </NextIntlClientProvider>,
+    );
+
+    const combobox = screen.getByTestId("member-combobox") as HTMLSelectElement;
+    expect(combobox.value).toBe("");
+  });
+
+  // ── 11. existingMembers — excludedIds forwarded as prop ──────────────────
+
+  it("renders with existingMembers prop without error", () => {
+    // Verifies that existingMembers are accepted; the mock combobox receives excludeUserIds
+    renderDialog({ existingMembers: [ACTIVE_MEMBER] });
+
+    expect(screen.getByRole("heading", { name: /agregar miembro/i })).toBeInTheDocument();
+  });
+
+  // ── 12. onSuccess NOT called on API error ────────────────────────────────
+
+  it("does NOT call onSuccess when addUnitMember fails", async () => {
+    mockAddUnitMember.mockRejectedValue(new Error("Server error"));
+
+    const { onSuccess } = renderDialog();
+
+    await selectMember("user-002");
+
+    const submitBtn = screen.getByRole("button", { name: /agregar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/units/delete-unit-dialog.test.tsx
+++ b/src/components/units/delete-unit-dialog.test.tsx
@@ -1,0 +1,287 @@
+/**
+ * Integration tests for DeleteUnitDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Desactivar.
+ * On confirm: calls `deleteUnit(clubId, unit.unit_id)`, shows success toast,
+ * calls onSuccess() and closes the dialog.
+ *
+ * Component uses AlertDialogMedia (custom shadcn extension) with AlertTriangle icon.
+ *
+ * `deleteUnit` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { Unit } from "@/lib/api/units";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockDeleteUnit = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/units", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/units")>();
+  return {
+    ...original,
+    deleteUnit: (...args: unknown[]) => mockDeleteUnit(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { DeleteUnitDialog } from "@/components/units/delete-unit-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const STUB_UNIT: Unit = {
+  unit_id: 21,
+  name: "Unidad Águilas",
+  active: true,
+  club_type_id: 2,
+};
+
+const STUB_CLUB_ID = 5;
+
+const t = messages.units_admin;
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  unit?: Unit | null;
+  clubId?: number;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, unit = STUB_UNIT, clubId = STUB_CLUB_ID, onSuccess } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <DeleteUnitDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        clubId={clubId}
+        unit={unit}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DeleteUnitDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDeleteUnit.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title and buttons ─────────────────────────────────────────
+
+  it("renders title, cancel and confirm buttons when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /desactivar unidad/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /desactivar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Shows unit name in description ───────────────────────────────────
+
+  it("shows the unit name in the description", () => {
+    renderDialog({ unit: STUB_UNIT });
+
+    expect(screen.getByText(/Unidad Águilas/)).toBeInTheDocument();
+    expect(screen.getByText(/La unidad y sus miembros/i)).toBeInTheDocument();
+  });
+
+  // ── 3. Dialog not in DOM when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /desactivar unidad/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Null unit — early return, no API call ─────────────────────────────
+
+  it("does not call deleteUnit when unit is null", async () => {
+    renderDialog({ unit: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(mockDeleteUnit).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls deleteUnit with clubId and unit_id ────────────
+
+  it("calls deleteUnit with clubId and unit_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onSuccess } = renderDialog({ unit: STUB_UNIT, clubId: STUB_CLUB_ID });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteUnit).toHaveBeenCalledWith(STUB_CLUB_ID, 21);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.unit_deactivated);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel does not call API ──────────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call deleteUnit on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockDeleteUnit).not.toHaveBeenCalled();
+  });
+
+  // ── 7. API error — shows error message from Error instance ───────────────
+
+  it("shows error toast from Error.message when deleteUnit throws", async () => {
+    mockDeleteUnit.mockRejectedValue(new Error("Unit has active members"));
+
+    const { onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Unit has active members");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. API error — falls back to i18n message for non-Error throws ───────
+
+  it("shows i18n fallback error toast when deleteUnit throws a non-Error", async () => {
+    mockDeleteUnit.mockRejectedValue("plain string error");
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.deactivate_unit_failed);
+    });
+  });
+
+  // ── 9. In-flight state — buttons disabled while deactivating ─────────────
+
+  it("disables both buttons while deactivation is in flight", async () => {
+    let resolveDeactivate!: () => void;
+    mockDeleteUnit.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolveDeactivate = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /desactivando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolveDeactivate();
+    });
+  });
+
+  // ── 10. Different clubId is passed to API ────────────────────────────────
+
+  it("passes the provided clubId correctly to deleteUnit", async () => {
+    const { onOpenChange } = renderDialog({ clubId: 99 });
+
+    const confirmBtn = screen.getByRole("button", { name: /desactivar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockDeleteUnit).toHaveBeenCalledWith(99, 21);
+    });
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/validation/validation-history-dialog.tsx
+++ b/src/components/validation/validation-history-dialog.tsx
@@ -41,7 +41,7 @@ const actionVisual: Record<
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface ValidationHistoryDialogProps {
+export interface ValidationHistoryDialogProps {
   open: boolean;
   entityType: ValidationEntityType;
   entityId: number | string;

--- a/src/components/validation/validation-review-dialog.tsx
+++ b/src/components/validation/validation-review-dialog.tsx
@@ -16,8 +16,15 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
 import {
   reviewValidation,
   type ValidationAction,
@@ -127,51 +134,53 @@ export function ValidationReviewDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="comment">
-              {isApprove ? "Comentarios (opcional)" : "Motivo de rechazo *"}
-            </Label>
-            <Textarea
-              id="comment"
-              placeholder={
-                isApprove
-                  ? "Añade un comentario opcional..."
-                  : "Describe el motivo del rechazo..."
-              }
-              rows={3}
-              {...form.register("comment")}
-              disabled={isPending}
-              aria-describedby={
-                form.formState.errors.comment ? "comment-error" : undefined
-              }
+        <Form {...form}>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="comment"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>
+                    {isApprove ? "Comentarios (opcional)" : "Motivo de rechazo *"}
+                  </FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder={
+                        isApprove
+                          ? "Añade un comentario opcional..."
+                          : "Describe el motivo del rechazo..."
+                      }
+                      rows={3}
+                      {...field}
+                      disabled={isPending}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
             />
-            {form.formState.errors.comment && (
-              <p id="comment-error" className="text-xs text-destructive">
-                {form.formState.errors.comment.message}
-              </p>
-            )}
-          </div>
 
-          <DialogFooter>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => handleClose(false)}
-              disabled={isPending}
-            >
-              Cancelar
-            </Button>
-            <Button
-              type="submit"
-              variant={isApprove ? "default" : "destructive"}
-              disabled={isPending}
-            >
-              {isPending && <Loader2 className="size-4 animate-spin" />}
-              {isApprove ? "Aprobar" : "Rechazar"}
-            </Button>
-          </DialogFooter>
-        </form>
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isPending}
+              >
+                Cancelar
+              </Button>
+              <Button
+                type="submit"
+                variant={isApprove ? "default" : "destructive"}
+                disabled={isPending}
+              >
+                {isPending && <Loader2 className="size-4 animate-spin" />}
+                {isApprove ? "Aprobar" : "Rechazar"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/validation/validation-table.tsx
+++ b/src/components/validation/validation-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { CheckCircle2, XCircle, History, ClipboardList } from "lucide-react";
@@ -17,7 +18,12 @@ import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip
 import { EmptyState } from "@/components/shared/empty-state";
 import { ValidationStatusBadge } from "@/components/validation/validation-status-badge";
 import { ValidationReviewDialog } from "@/components/validation/validation-review-dialog";
-import { ValidationHistoryDialog } from "@/components/validation/validation-history-dialog";
+import type { ValidationHistoryDialogProps } from "@/components/validation/validation-history-dialog";
+
+const ValidationHistoryDialog = dynamic<ValidationHistoryDialogProps>(
+  () => import("@/components/validation/validation-history-dialog").then((m) => ({ default: m.ValidationHistoryDialog })),
+  { ssr: false, loading: () => null },
+);
 import type {
   PendingValidation,
   ValidationAction,

--- a/src/lib/api/annual-folders.ts
+++ b/src/lib/api/annual-folders.ts
@@ -85,7 +85,7 @@ export type FolderTemplate = {
 
 export type FolderEvidence = {
   evidence_id: string;
-  folder_id: string;
+  annual_folder_id: string;
   section_id: string;
   file_url: string;
   file_name: string | null;
@@ -116,9 +116,9 @@ export type SectionEvaluationEntry = {
 };
 
 export type AnnualFolder = {
-  folder_id: string;
-  enrollment_id: string;
-  template_id: string;
+  annual_folder_id: string;
+  club_enrollment_id: string;
+  folder_template_id: string;
   status: FolderStatus;
   submitted_at: string | null;
   closed_at: string | null;
@@ -136,6 +136,33 @@ export type AnnualFolder = {
   // Enrollment info (available when fetched via evaluation endpoint)
   enrollment?: { enrollment_id: string; club_name?: string | null } | null;
 };
+
+type AnnualFolderWire = AnnualFolder & {
+  folder_id?: string;
+  enrollment_id?: string;
+  template_id?: string;
+};
+
+function normalizeAnnualFolder(folder: AnnualFolderWire): AnnualFolder {
+  return {
+    ...folder,
+    annual_folder_id: folder.annual_folder_id ?? folder.folder_id ?? "",
+    club_enrollment_id:
+      folder.club_enrollment_id ?? folder.enrollment_id ?? "",
+    folder_template_id:
+      folder.folder_template_id ?? folder.template_id ?? "",
+    sections: folder.sections?.map((section) => ({
+      ...section,
+      evidences: section.evidences.map((evidence) => ({
+        ...evidence,
+        annual_folder_id:
+          evidence.annual_folder_id ??
+          (evidence as FolderEvidence & { folder_id?: string }).folder_id ??
+          "",
+      })),
+    })),
+  };
+}
 
 // ─── Payloads ─────────────────────────────────────────────────────────────────
 
@@ -178,15 +205,16 @@ export async function getTemplate(templateId: string): Promise<FolderTemplate> {
 }
 
 /**
- * GET /api/v1/annual-folders/enrollment/:enrollmentId
+ * GET /api/v1/annual-folders/by-enrollment/:enrollmentId
  * Returns the annual folder for the given enrollment.
  */
 export async function getFolderByEnrollment(
   enrollmentId: string,
 ): Promise<AnnualFolder> {
-  return apiRequest<AnnualFolder>(
-    `/annual-folders/enrollment/${enrollmentId}`,
+  const folder = await apiRequest<AnnualFolderWire>(
+    `/annual-folders/by-enrollment/${enrollmentId}`,
   );
+  return normalizeAnnualFolder(folder);
 }
 
 /**
@@ -194,7 +222,10 @@ export async function getFolderByEnrollment(
  * Returns the folder with all section evidences.
  */
 export async function getFolder(folderId: string): Promise<AnnualFolder> {
-  return apiRequest<AnnualFolder>(`/annual-folders/${folderId}`);
+  const folder = await apiRequest<AnnualFolderWire>(
+    `/annual-folders/${folderId}`,
+  );
+  return normalizeAnnualFolder(folder);
 }
 
 // ─── Client-side (mutations) ──────────────────────────────────────────────────
@@ -268,7 +299,7 @@ export async function deleteTemplateSection(
 }
 
 /**
- * POST /api/v1/annual-folders/:folderId/evidences
+ * POST /api/v1/annual-folders/:folderId/sections/:sectionId/evidences
  * Uploads a file evidence for a section. Sends multipart/form-data.
  */
 export async function uploadEvidence(
@@ -279,11 +310,10 @@ export async function uploadEvidence(
 ): Promise<FolderEvidence> {
   const formData = new FormData();
   formData.append("file", file);
-  formData.append("section_id", sectionId);
   if (description) formData.append("description", description);
 
   return apiRequestFromClient<FolderEvidence>(
-    `/annual-folders/${folderId}/evidences`,
+    `/annual-folders/${folderId}/sections/${sectionId}/evidences`,
     { method: "POST", body: formData },
   );
 }

--- a/src/lib/api/evidence-review.ts
+++ b/src/lib/api/evidence-review.ts
@@ -2,7 +2,7 @@ import { apiRequest, apiRequestFromClient } from "@/lib/api/client";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-export type EvidenceType = "folder" | "class" | "honor";
+export type EvidenceType = "class" | "honor";
 
 export type EvidenceStatus =
   | "PENDING"


### PR DESCRIPTION
## Summary

Cascade `development → preproduction` following merge of the mega-batch covering 3 logical sesiones in parallel:

- **#135** refactor: shadcn Form primitive r7 mega — 4 rhf dialogs atomic (membership-reject, validation-review, request-review, template-form). 30+ pre-existing tests stayed green automatically.
- **#136** chore: perf r8 mega — 6 dialogs deferred across 4 routes (~128-165 KB gz). Routes: /dashboard/investiture, /dashboard/investiture/config, /dashboard/annual-folders/templates, /dashboard/validation.
- **#137** test: MSW dialog suite r7 mega — 9 new test files / +96 tests. Total **564 / 45 files (13.8x audit baseline)**.

## Test plan

- [x] CI green on `development` (#135, #136, #137)
- [ ] CI Vitest green on this PR
- [ ] CI Typecheck green on this PR
- [ ] CI Build green on this PR (gate active since #131)
- [ ] Vercel preview green on this PR