### PR TITLE
chore: perf r9 — defer 10 dialog/tab components across camporees, system-config, scoring-categories (~135-210 KB gz)

### DIFF
--- a/PERF-BASELINE.md
+++ b/PERF-BASELINE.md
@@ -489,6 +489,79 @@ in R6+R7 on other routes.
 
 ---
 
+## 12. Round 9 (2026-05-11) — camporees, union-camporees, system-config, scoring-categories dialog defers
+
+**Branch:** `perf/admin-r9` (off `origin/development`, includes #128 + #131 + #135/136/137)
+**Worktree:** `.claude/worktrees/agent-perf-r9-2026-05-11`
+
+### Strategy
+
+Five caller Client Components targeted. All confirmed `"use client"` before applying `ssr: false`.
+Props interfaces exported from each dialog/tab file for correct `dynamic<Props>()` generic typing.
+Pattern: `dynamic<Props>(import, { ssr: false, loading: () => null })` for dialogs (closed by default),
+`loading: () => <Skeleton className="h-48 w-full" />` for tab subtrees that are visible after tab switch.
+
+### Routes addressed
+
+| Route | Components deferred | Zod? | Gate |
+|---|---|---|---|
+| `/dashboard/camporees/[id]` | `CamporeeMembersTab`, `CamporeeClubsTab`, `CamporeePaymentsTab` | YES (via RegisterMemberDialog, EnrollClubDialog, PaymentDialog) | Non-default tabs |
+| `/dashboard/camporees/[id]` | `CamporeeFormDialog`, `DeleteCamporeeDialog` | YES (form) | Edit/delete button click |
+| `/dashboard/camporees` (union) | `UnionCamporeeFormDialog`, `DeleteUnionCamporeeDialog` | YES (form) | Create/edit/delete button click |
+| `/dashboard/settings/system-config` | `SystemConfigEditDialog` | YES | Edit row action |
+| `/dashboard/settings/scoring-categories` (all levels) | `ScoringCategoryDialog`, `ScoringCategoryDeleteDialog` | no | Create/edit/delete button click |
+
+### Files modified
+
+**Props exports added (dialog/tab files):**
+
+| File | Export added |
+|---|---|
+| `src/components/camporees/enroll-club-dialog.tsx` | `EnrollClubDialogProps` |
+| `src/components/camporees/register-member-dialog.tsx` | `RegisterMemberDialogProps` |
+| `src/components/camporees/payment-dialog.tsx` | `PaymentDialogProps` |
+| `src/components/camporees/delete-camporee-dialog.tsx` | `DeleteCamporeeDialogProps` |
+| `src/components/camporees/union-camporee-form-dialog.tsx` | `UnionCamporeeFormDialogProps` |
+| `src/components/camporees/delete-union-camporee-dialog.tsx` | `DeleteUnionCamporeeDialogProps` |
+| `src/components/system-config/system-config-edit-dialog.tsx` | `SystemConfigEditDialogProps` |
+| `src/components/scoring-categories/scoring-category-dialog.tsx` | `ScoringCategoryDialogProps` |
+| `src/components/scoring-categories/scoring-category-delete-dialog.tsx` | `ScoringCategoryDeleteDialogProps` |
+| `src/components/camporees/camporee-members-tab.tsx` | `CamporeeMembersTabProps` |
+| `src/components/camporees/camporee-clubs-tab.tsx` | `CamporeeClubsTabProps` |
+| `src/components/camporees/camporee-payments-tab.tsx` | `CamporeePaymentsTabProps` |
+
+**Dynamic imports added (caller files):**
+
+| File | Components deferred |
+|---|---|
+| `src/components/camporees/camporee-detail-tabs.tsx` | `CamporeeMembersTab`, `CamporeeClubsTab`, `CamporeePaymentsTab` |
+| `src/components/camporees/camporee-detail-actions.tsx` | `CamporeeFormDialog`, `DeleteCamporeeDialog` |
+| `src/components/camporees/union-camporees-view.tsx` | `UnionCamporeeFormDialog`, `DeleteUnionCamporeeDialog` |
+| `src/components/system-config/system-config-client-page.tsx` | `SystemConfigEditDialog` |
+| `src/components/scoring-categories/scoring-categories-table.tsx` | `ScoringCategoryDialog`, `ScoringCategoryDeleteDialog` |
+
+### Estimated gz savings
+
+| Route | Removed from initial chunk | Estimated gz saved |
+|---|---|---|
+| `/dashboard/camporees/[id]` | `CamporeeMembersTab` + `RegisterMemberDialog` (zod) + `CamporeeClubsTab` + `EnrollClubDialog` (zod) + `CamporeePaymentsTab` + `PaymentDialog` (zod) + `CamporeeFormDialog` (zod) + `DeleteCamporeeDialog` | ~80–120 KB |
+| `/dashboard/camporees` (union page) | `UnionCamporeeFormDialog` (zod) + `DeleteUnionCamporeeDialog` | ~30–50 KB |
+| `/dashboard/settings/system-config` | `SystemConfigEditDialog` (zod) | ~20–30 KB |
+| `/dashboard/settings/scoring-categories` | `ScoringCategoryDialog` + `ScoringCategoryDeleteDialog` | ~5–10 KB |
+| **Total estimated** | | **~135–210 KB gz** across affected routes |
+
+The dominant savings on `/dashboard/camporees/[id]` (rank #2 at 245 KB gz) come from removing the zod v4 + i18n
+locale chunk (~103 KB gz pattern from R5) that was eagerly pulled in via three separate form dialogs on
+non-default tabs.
+
+### Verification
+
+- `pnpm typecheck`: PASS
+- `pnpm test --run`: 564/564 PASS (45 suites)
+- `pnpm lint`: 10 err / 41 warn (pre-existing, unchanged from baseline)
+
+---
+
 ## 8. Next actions (handoff)
 
 - ~~Replace `pnpm analyze` script with `next experimental-analyze`~~ DONE.

--- a/src/components/camporees/camporee-clubs-tab.tsx
+++ b/src/components/camporees/camporee-clubs-tab.tsx
@@ -8,7 +8,7 @@ import { EnrollClubDialog } from "@/components/camporees/enroll-club-dialog";
 import { getEnrolledClubs } from "@/lib/api/camporees";
 import type { CamporeeClub } from "@/lib/api/camporees";
 
-interface CamporeeClubsTabProps {
+export interface CamporeeClubsTabProps {
   camporeeId: number;
   initialClubs: CamporeeClub[];
   isUnionCamporee?: boolean;

--- a/src/components/camporees/camporee-detail-actions.tsx
+++ b/src/components/camporees/camporee-detail-actions.tsx
@@ -1,12 +1,29 @@
 "use client";
 
 import { useState } from "react";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { CamporeeFormDialog } from "@/components/camporees/camporee-form-dialog";
-import { DeleteCamporeeDialog } from "@/components/camporees/delete-camporee-dialog";
+import type { CamporeeFormDialogProps } from "@/components/camporees/camporee-form-dialog";
+import type { DeleteCamporeeDialogProps } from "@/components/camporees/delete-camporee-dialog";
 import type { Camporee } from "@/lib/api/camporees";
+
+const CamporeeFormDialog = dynamic<CamporeeFormDialogProps>(
+  () =>
+    import("@/components/camporees/camporee-form-dialog").then(
+      (m) => m.CamporeeFormDialog,
+    ),
+  { ssr: false, loading: () => null },
+);
+
+const DeleteCamporeeDialog = dynamic<DeleteCamporeeDialogProps>(
+  () =>
+    import("@/components/camporees/delete-camporee-dialog").then(
+      (m) => m.DeleteCamporeeDialog,
+    ),
+  { ssr: false, loading: () => null },
+);
 
 interface CamporeeDetailActionsProps {
   camporee: Camporee;

--- a/src/components/camporees/camporee-detail-tabs.tsx
+++ b/src/components/camporees/camporee-detail-tabs.tsx
@@ -1,14 +1,40 @@
 "use client";
 
 import { useState, useCallback, type ReactNode } from "react";
+import dynamic from "next/dynamic";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
-import { CamporeeMembersTab } from "@/components/camporees/camporee-members-tab";
-import { CamporeeClubsTab } from "@/components/camporees/camporee-clubs-tab";
-import { CamporeePaymentsTab } from "@/components/camporees/camporee-payments-tab";
 import { getCamporeePendingApprovals } from "@/lib/api/camporees";
+import type { CamporeeMembersTabProps } from "@/components/camporees/camporee-members-tab";
+import type { CamporeeClubsTabProps } from "@/components/camporees/camporee-clubs-tab";
+import type { CamporeePaymentsTabProps } from "@/components/camporees/camporee-payments-tab";
+
+const CamporeeMembersTab = dynamic<CamporeeMembersTabProps>(
+  () =>
+    import("@/components/camporees/camporee-members-tab").then(
+      (m) => m.CamporeeMembersTab,
+    ),
+  { ssr: false, loading: () => <Skeleton className="h-48 w-full" /> },
+);
+
+const CamporeeClubsTab = dynamic<CamporeeClubsTabProps>(
+  () =>
+    import("@/components/camporees/camporee-clubs-tab").then(
+      (m) => m.CamporeeClubsTab,
+    ),
+  { ssr: false, loading: () => <Skeleton className="h-48 w-full" /> },
+);
+
+const CamporeePaymentsTab = dynamic<CamporeePaymentsTabProps>(
+  () =>
+    import("@/components/camporees/camporee-payments-tab").then(
+      (m) => m.CamporeePaymentsTab,
+    ),
+  { ssr: false, loading: () => <Skeleton className="h-48 w-full" /> },
+);
 import type {
   CamporeeMember,
   CamporeeClub,

--- a/src/components/camporees/camporee-members-tab.tsx
+++ b/src/components/camporees/camporee-members-tab.tsx
@@ -11,7 +11,7 @@ import type { CamporeeMember, PaginationMeta } from "@/lib/api/camporees";
 const LOCAL_DEFAULT_LIMIT = 50;
 const UNION_DEFAULT_LIMIT = 100;
 
-interface CamporeeMembersTabProps {
+export interface CamporeeMembersTabProps {
   camporeeId: number;
   initialMembers: CamporeeMember[];
   initialMeta?: PaginationMeta;

--- a/src/components/camporees/camporee-payments-tab.tsx
+++ b/src/components/camporees/camporee-payments-tab.tsx
@@ -8,7 +8,7 @@ import { PaymentDialog } from "@/components/camporees/payment-dialog";
 import { getCamporeePayments } from "@/lib/api/camporees";
 import type { CamporeePayment, CamporeeMember } from "@/lib/api/camporees";
 
-interface CamporeePaymentsTabProps {
+export interface CamporeePaymentsTabProps {
   camporeeId: number;
   initialPayments: CamporeePayment[];
   members: CamporeeMember[];

--- a/src/components/camporees/delete-camporee-dialog.tsx
+++ b/src/components/camporees/delete-camporee-dialog.tsx
@@ -17,7 +17,7 @@ import { useTranslations } from "next-intl";
 import { deleteCamporee } from "@/lib/api/camporees";
 import type { Camporee } from "@/lib/api/camporees";
 
-interface DeleteCamporeeDialogProps {
+export interface DeleteCamporeeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   camporee: Camporee | null;

--- a/src/components/camporees/delete-union-camporee-dialog.tsx
+++ b/src/components/camporees/delete-union-camporee-dialog.tsx
@@ -16,7 +16,7 @@ import { useTranslations } from "next-intl";
 import { deleteUnionCamporee } from "@/lib/api/camporees";
 import type { UnionCamporee } from "@/lib/api/camporees";
 
-interface DeleteUnionCamporeeDialogProps {
+export interface DeleteUnionCamporeeDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   camporee: UnionCamporee | null;

--- a/src/components/camporees/enroll-club-dialog.tsx
+++ b/src/components/camporees/enroll-club-dialog.tsx
@@ -41,7 +41,7 @@ type FormValues = z.infer<typeof formSchema>;
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
-interface EnrollClubDialogProps {
+export interface EnrollClubDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   camporeeId: number;

--- a/src/components/camporees/payment-dialog.tsx
+++ b/src/components/camporees/payment-dialog.tsx
@@ -64,7 +64,7 @@ const PAYMENT_TYPE_LABELS: Record<PaymentType, string> = {
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
-interface PaymentDialogProps {
+export interface PaymentDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   camporeeId: number;

--- a/src/components/camporees/register-member-dialog.tsx
+++ b/src/components/camporees/register-member-dialog.tsx
@@ -48,7 +48,7 @@ type FormValues = z.infer<typeof formSchema>;
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
-interface RegisterMemberDialogProps {
+export interface RegisterMemberDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   camporeeId: number;

--- a/src/components/camporees/union-camporee-form-dialog.tsx
+++ b/src/components/camporees/union-camporee-form-dialog.tsx
@@ -64,7 +64,7 @@ type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
-interface UnionCamporeeFormDialogProps {
+export interface UnionCamporeeFormDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   camporee?: UnionCamporee | null;

--- a/src/components/camporees/union-camporees-view.tsx
+++ b/src/components/camporees/union-camporees-view.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { Plus, Pencil, Trash2, RefreshCw, Tent } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -13,12 +14,28 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { EmptyState } from "@/components/shared/empty-state";
-import { UnionCamporeeFormDialog } from "@/components/camporees/union-camporee-form-dialog";
-import { DeleteUnionCamporeeDialog } from "@/components/camporees/delete-union-camporee-dialog";
 import { useTranslations } from "next-intl";
 import { listUnionCamporees } from "@/lib/api/camporees";
 import type { UnionCamporee } from "@/lib/api/camporees";
 import type { Union } from "@/lib/api/geography";
+import type { UnionCamporeeFormDialogProps } from "@/components/camporees/union-camporee-form-dialog";
+import type { DeleteUnionCamporeeDialogProps } from "@/components/camporees/delete-union-camporee-dialog";
+
+const UnionCamporeeFormDialog = dynamic<UnionCamporeeFormDialogProps>(
+  () =>
+    import("@/components/camporees/union-camporee-form-dialog").then(
+      (m) => m.UnionCamporeeFormDialog,
+    ),
+  { ssr: false, loading: () => null },
+);
+
+const DeleteUnionCamporeeDialog = dynamic<DeleteUnionCamporeeDialogProps>(
+  () =>
+    import("@/components/camporees/delete-union-camporee-dialog").then(
+      (m) => m.DeleteUnionCamporeeDialog,
+    ),
+  { ssr: false, loading: () => null },
+);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/src/components/scoring-categories/scoring-categories-table.tsx
+++ b/src/components/scoring-categories/scoring-categories-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useCallback, useEffect, useMemo } from "react";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import { Plus, Pencil, Trash2, Tags, Loader2 } from "lucide-react";
 import { toast } from "sonner";
@@ -22,14 +23,30 @@ import {
   SortableHeader,
   type SortDirection,
 } from "@/components/shared/sortable-header";
-import { ScoringCategoryDialog } from "@/components/scoring-categories/scoring-category-dialog";
-import { ScoringCategoryDeleteDialog } from "@/components/scoring-categories/scoring-category-delete-dialog";
+import type { ScoringCategoryDialogProps } from "@/components/scoring-categories/scoring-category-dialog";
+import type { ScoringCategoryDeleteDialogProps } from "@/components/scoring-categories/scoring-category-delete-dialog";
 import type {
   ScoringCategory,
   CreateScoringCategoryPayload,
   UpdateScoringCategoryPayload,
   OriginLevel,
 } from "@/lib/api/scoring-categories";
+
+const ScoringCategoryDialog = dynamic<ScoringCategoryDialogProps>(
+  () =>
+    import("@/components/scoring-categories/scoring-category-dialog").then(
+      (m) => m.ScoringCategoryDialog,
+    ),
+  { ssr: false, loading: () => null },
+);
+
+const ScoringCategoryDeleteDialog = dynamic<ScoringCategoryDeleteDialogProps>(
+  () =>
+    import("@/components/scoring-categories/scoring-category-delete-dialog").then(
+      (m) => m.ScoringCategoryDeleteDialog,
+    ),
+  { ssr: false, loading: () => null },
+);
 
 // ─── Origin badge config ──────────────────────────────────────────────────────
 

--- a/src/components/scoring-categories/scoring-category-delete-dialog.tsx
+++ b/src/components/scoring-categories/scoring-category-delete-dialog.tsx
@@ -18,7 +18,7 @@ import type { ScoringCategory } from "@/lib/api/scoring-categories";
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface ScoringCategoryDeleteDialogProps {
+export interface ScoringCategoryDeleteDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   category: ScoringCategory | null;

--- a/src/components/scoring-categories/scoring-category-dialog.tsx
+++ b/src/components/scoring-categories/scoring-category-dialog.tsx
@@ -25,7 +25,7 @@ import type {
 
 // ─── Props ────────────────────────────────────────────────────────────────────
 
-interface ScoringCategoryDialogProps {
+export interface ScoringCategoryDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** Pass an existing category to edit; omit to create. */

--- a/src/components/system-config/system-config-client-page.tsx
+++ b/src/components/system-config/system-config-client-page.tsx
@@ -1,14 +1,23 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import dynamic from "next/dynamic";
 import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { SystemConfigTable } from "@/components/system-config/system-config-table";
-import { SystemConfigEditDialog } from "@/components/system-config/system-config-edit-dialog";
 import { getSystemConfigs, type SystemConfig } from "@/lib/api/system-config";
 import { ApiError } from "@/lib/api/client";
+import type { SystemConfigEditDialogProps } from "@/components/system-config/system-config-edit-dialog";
+
+const SystemConfigEditDialog = dynamic<SystemConfigEditDialogProps>(
+  () =>
+    import("@/components/system-config/system-config-edit-dialog").then(
+      (m) => m.SystemConfigEditDialog,
+    ),
+  { ssr: false, loading: () => null },
+);
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/src/components/system-config/system-config-edit-dialog.tsx
+++ b/src/components/system-config/system-config-edit-dialog.tsx
@@ -40,7 +40,7 @@ type FormValues = z.infer<ReturnType<typeof buildSchema>>;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface SystemConfigEditDialogProps {
+export interface SystemConfigEditDialogProps {
   open: boolean;
   config: SystemConfig | null;
   onOpenChange: (open: boolean) => void;


### PR DESCRIPTION
## Summary

- Deferred `CamporeeMembersTab`, `CamporeeClubsTab`, `CamporeePaymentsTab` in `camporee-detail-tabs.tsx` (tab-gated, each pulls zod-heavy dialogs)
- Deferred `CamporeeFormDialog` + `DeleteCamporeeDialog` in `camporee-detail-actions.tsx` (button click-gated)
- Deferred `UnionCamporeeFormDialog` + `DeleteUnionCamporeeDialog` in `union-camporees-view.tsx` (button click-gated)
- Deferred `SystemConfigEditDialog` in `system-config-client-page.tsx` (row action-gated)
- Deferred `ScoringCategoryDialog` + `ScoringCategoryDeleteDialog` in `scoring-categories-table.tsx` (button click-gated)

## Estimated gz savings

| Route | Estimated saved |
|---|---|
| `/dashboard/camporees/[id]` (rank #2, 245 KB gz) | ~80–120 KB |
| `/dashboard/camporees` (union page) | ~30–50 KB |
| `/dashboard/settings/system-config` | ~20–30 KB |
| `/dashboard/settings/scoring-categories` | ~5–10 KB |
| **Total** | **~135–210 KB gz** |

Primary gain: removes the zod v4 + i18n locale chunk (~103 KB gz) from the initial load of `/dashboard/camporees/[id]` — same pattern eliminated on 6 other routes in R5–R8.

## Pattern applied

- All callers are `"use client"` — `ssr: false` is safe
- Props interfaces exported from all 12 dialog/tab files for correct `dynamic<Props>()` typing
- Dialogs: `loading: () => null` (start closed, no visible flash)
- Tab subtrees: `loading: () => <Skeleton className="h-48 w-full" />` (visible after tab switch)

## Verification

- `pnpm typecheck`: PASS
- `pnpm test --run`: 564/564 PASS (45 suites)
- `pnpm lint`: 10 err / 41 warn (pre-existing, unchanged)
- All callers confirmed `"use client"` before applying `ssr: false` (no CI build gate risk)

## Files changed (18)

- 12 dialog/tab files: `export interface XxxProps` added
- 5 caller files: `next/dynamic` imports added
- `PERF-BASELINE.md`: Round 9 section added