### PR TITLE
test: MSW dialog suite r10 — 9 new display/edit dialog tests (+104 tests)

### DIFF
--- a/src/components/annual-folders/evidence-upload-dialog.test.tsx
+++ b/src/components/annual-folders/evidence-upload-dialog.test.tsx
@@ -1,0 +1,358 @@
+/**
+ * Integration tests for EvidenceUploadDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog with file upload (drop zone + file input) and optional textarea.
+ * Action: uploadEvidence(folderId, sectionId, file, description?).
+ * Guards: exits early (toast error) if no file selected.
+ * Resets state (file + description) when dialog closes.
+ *
+ * `uploadEvidence` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockUploadEvidence = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/annual-folders", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/annual-folders")>();
+  return {
+    ...original,
+    uploadEvidence: (...args: unknown[]) => mockUploadEvidence(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { EvidenceUploadDialog } from "@/components/annual-folders/evidence-upload-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const t = messages.annual_folders;
+
+const STUB_FILE = new File(["content"], "foto.jpg", { type: "image/jpeg" });
+const FOLDER_ID = "folder-abc";
+const SECTION_ID = "section-123";
+const SECTION_NAME = "Actividades recreativas";
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  folderId?: string;
+  sectionId?: string;
+  sectionName?: string;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    folderId = FOLDER_ID,
+    sectionId = SECTION_ID,
+    sectionName = SECTION_NAME,
+    onSuccess,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <EvidenceUploadDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        folderId={folderId}
+        sectionId={sectionId}
+        sectionName={sectionName}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EvidenceUploadDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUploadEvidence.mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog title and section name ──────────────────────────────
+
+  it("renders dialog title and section name in description", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /subir evidencia/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(SECTION_NAME))).toBeInTheDocument();
+  });
+
+  // ── 2. Dialog not rendered when closed ────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /subir evidencia/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Shows drop zone and both buttons ──────────────────────────────────
+
+  it("renders drop zone, cancel and submit buttons", () => {
+    renderDialog();
+
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /subir evidencia/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/arrastra un archivo/i),
+    ).toBeInTheDocument();
+  });
+
+  // ── 4. Submit button disabled when no file selected ──────────────────────
+
+  it("disables the submit button when no file is selected", () => {
+    renderDialog();
+
+    const submitBtn = screen.getByRole("button", { name: /subir evidencia/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  // ── 5. Shows file name after selecting a file ────────────────────────────
+
+  it("shows selected file name and enables submit button after file selection", async () => {
+    renderDialog();
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(fileInput).toBeTruthy();
+
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [STUB_FILE] } });
+    });
+
+    expect(screen.getByText("foto.jpg")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /subir evidencia/i })).not.toBeDisabled();
+  });
+
+  // ── 6. Toast error when submitting without a file ─────────────────────────
+
+  it("shows file_required toast when form is submitted without a file", async () => {
+    renderDialog();
+
+    // Force submit via form event even though button is disabled
+    const form = document.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith(t.toasts.file_required);
+    expect(mockUploadEvidence).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Happy path — uploads file and calls onSuccess ─────────────────────
+
+  it("calls uploadEvidence with correct args, shows success toast and calls onSuccess", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [STUB_FILE] } });
+    });
+
+    // Add a description
+    const textarea = screen.getByPlaceholderText(/descripción breve/i);
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: "Mi descripción" } });
+    });
+
+    const submitBtn = screen.getByRole("button", { name: /subir evidencia/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockUploadEvidence).toHaveBeenCalledWith(
+        FOLDER_ID,
+        SECTION_ID,
+        STUB_FILE,
+        "Mi descripción",
+      );
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.evidence_uploaded);
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 8. Uploads without description (trims empty string → undefined) ───────
+
+  it("passes undefined for description when textarea is blank", async () => {
+    renderDialog();
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [STUB_FILE] } });
+    });
+
+    const submitBtn = screen.getByRole("button", { name: /subir evidencia/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockUploadEvidence).toHaveBeenCalledWith(
+        FOLDER_ID,
+        SECTION_ID,
+        STUB_FILE,
+        undefined,
+      );
+    });
+  });
+
+  // ── 9. Error path — shows error message from Error instance ──────────────
+
+  it("shows error toast with Error.message when uploadEvidence throws", async () => {
+    mockUploadEvidence.mockRejectedValue(new Error("Archivo demasiado grande"));
+
+    renderDialog();
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [STUB_FILE] } });
+    });
+
+    const submitBtn = screen.getByRole("button", { name: /subir evidencia/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Archivo demasiado grande");
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 10. Error path — fallback i18n message for non-Error throws ──────────
+
+  it("shows i18n fallback error toast when uploadEvidence throws a non-Error", async () => {
+    mockUploadEvidence.mockRejectedValue({ status: 500 });
+
+    renderDialog();
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [STUB_FILE] } });
+    });
+
+    const submitBtn = screen.getByRole("button", { name: /subir evidencia/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.upload_evidence_failed);
+    });
+  });
+
+  // ── 11. Cancel closes dialog without API call ─────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call uploadEvidence on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockUploadEvidence).not.toHaveBeenCalled();
+  });
+
+  // ── 12. In-flight state — buttons disabled while uploading ────────────────
+
+  it("disables buttons while upload is in flight", async () => {
+    let resolve!: () => void;
+    mockUploadEvidence.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolve = () => res({ ok: true });
+      }),
+    );
+
+    renderDialog();
+
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await act(async () => {
+      fireEvent.change(fileInput, { target: { files: [STUB_FILE] } });
+    });
+
+    const submitBtn = screen.getByRole("button", { name: /subir evidencia/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /subiendo/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolve();
+    });
+  });
+});

--- a/src/components/certifications/user-progress-dialog.test.tsx
+++ b/src/components/certifications/user-progress-dialog.test.tsx
@@ -1,0 +1,324 @@
+/**
+ * Integration tests for UserProgressDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Display dialog (no outer API fetch — data passed as prop).
+ * Each section toggle calls apiRequestFromClient via PATCH.
+ * `apiRequestFromClient` is mocked at module boundary.
+ *
+ * Key behaviors:
+ *   - Shows user info (name, email, progress %) in header
+ *   - Loads spinner when progressData is null
+ *   - Empty state when modules is []
+ *   - Renders module + section list; sections show strike-through when completed
+ *   - Toggle section calls PATCH with correct payload, shows success toast
+ *   - Toggle failure shows error toast
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockApiRequest = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/client", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/client")>();
+  return {
+    ...original,
+    apiRequestFromClient: (...args: unknown[]) => mockApiRequest(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { UserProgressDialog } from "@/components/certifications/user-progress-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const t = messages.certifications;
+
+const STUB_PROGRESS = {
+  user_id: "user-abc",
+  certification_id: 7,
+  enrolled_at: "2026-01-15T00:00:00.000Z",
+  completed_at: null,
+  progress_percent: 50,
+  user_name: "Ana García",
+  user_email: "ana@example.com",
+  modules: [
+    {
+      module_id: 1,
+      title: "Módulo Uno",
+      sections: [
+        {
+          section_id: 101,
+          title: "Sección A",
+          completed: true,
+          completed_at: "2026-02-01T00:00:00.000Z",
+          notes: null,
+        },
+        {
+          section_id: 102,
+          title: "Sección B",
+          completed: false,
+          completed_at: null,
+          notes: null,
+        },
+      ],
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+type ProgressData = typeof STUB_PROGRESS | null;
+
+interface RenderOpts {
+  open?: boolean;
+  progressData?: ProgressData;
+  onProgressUpdated?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    progressData = STUB_PROGRESS,
+    onProgressUpdated,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const updatedCb = onProgressUpdated ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <UserProgressDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        progressData={progressData}
+        onProgressUpdated={updatedCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onProgressUpdated: updatedCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("UserProgressDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApiRequest.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog title ────────────────────────────────────────────────
+
+  it("renders 'Progreso del usuario' heading when open", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /progreso del usuario/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Not rendered when closed ───────────────────────────────────────────
+
+  it("does not render when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /progreso del usuario/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Shows loading spinner when progressData is null ────────────────────
+
+  it("shows loading spinner when progressData is null", () => {
+    renderDialog({ progressData: null });
+
+    // Spinner is rendered via Loader2.animate-spin
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeTruthy();
+  });
+
+  // ── 4. Shows user info in header ──────────────────────────────────────────
+
+  it("shows user name, email and progress percent in the header", () => {
+    renderDialog();
+
+    expect(screen.getByText("Ana García")).toBeInTheDocument();
+    expect(screen.getByText(/ana@example.com/)).toBeInTheDocument();
+    expect(screen.getByText(/50%/)).toBeInTheDocument();
+  });
+
+  // ── 5. Empty state when modules array is empty ────────────────────────────
+
+  it("shows empty modules message when modules is []", () => {
+    renderDialog({
+      progressData: { ...STUB_PROGRESS, modules: [] },
+    });
+
+    expect(
+      screen.getByText(/no hay módulos de progreso/i),
+    ).toBeInTheDocument();
+  });
+
+  // ── 6. Renders module title and section list ──────────────────────────────
+
+  it("renders module title and section names", () => {
+    renderDialog();
+
+    expect(screen.getByText("Módulo Uno")).toBeInTheDocument();
+    expect(screen.getByText("Sección A")).toBeInTheDocument();
+    expect(screen.getByText("Sección B")).toBeInTheDocument();
+  });
+
+  // ── 7. Completed section shows progress badge ─────────────────────────────
+
+  it("shows module progress badge (1/2)", () => {
+    renderDialog();
+
+    expect(screen.getByText("1/2")).toBeInTheDocument();
+  });
+
+  // ── 8. Toggle section calls PATCH and shows success toast ────────────────
+
+  it("calls PATCH with correct payload and shows success toast when toggling a section", async () => {
+    renderDialog();
+
+    // Find the toggle button for section_id=102 (incomplete → complete)
+    const toggleBtns = screen.getAllByRole("button", {
+      name: /marcar como completada/i,
+    });
+
+    await act(async () => {
+      fireEvent.click(toggleBtns[0]);
+    });
+
+    await waitFor(() => {
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        expect.stringContaining("/certifications/users/user-abc/certifications/7/progress"),
+        expect.objectContaining({
+          method: "PATCH",
+          body: { section_id: 102, completed: true },
+        }),
+      );
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      expect.stringContaining("completada"),
+    );
+  });
+
+  // ── 9. Toggle completed section (mark as pending) shows correct toast ────
+
+  it("shows 'pendiente' toast when toggling a completed section", async () => {
+    renderDialog();
+
+    const markPendingBtn = screen.getByRole("button", {
+      name: /marcar como pendiente/i,
+    });
+
+    await act(async () => {
+      fireEvent.click(markPendingBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockApiRequest).toHaveBeenCalledWith(
+        expect.stringContaining("/progress"),
+        expect.objectContaining({
+          body: { section_id: 101, completed: false },
+        }),
+      );
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(
+      expect.stringContaining("pendiente"),
+    );
+  });
+
+  // ── 10. API error shows error toast ──────────────────────────────────────
+
+  it("shows error toast when PATCH fails", async () => {
+    mockApiRequest.mockRejectedValue(new Error("Server error"));
+
+    renderDialog();
+
+    const toggleBtns = screen.getAllByRole("button", {
+      name: /marcar como completada/i,
+    });
+
+    await act(async () => {
+      fireEvent.click(toggleBtns[0]);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.toasts.progress_update_failed);
+    });
+  });
+
+  // ── 11. onProgressUpdated is called after successful toggle ──────────────
+
+  it("calls onProgressUpdated after successful toggle", async () => {
+    const { onProgressUpdated } = renderDialog();
+
+    const toggleBtns = screen.getAllByRole("button", {
+      name: /marcar como completada/i,
+    });
+
+    await act(async () => {
+      fireEvent.click(toggleBtns[0]);
+    });
+
+    await waitFor(() => {
+      expect(onProgressUpdated).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/components/evidence-review/evidence-detail-dialog.test.tsx
+++ b/src/components/evidence-review/evidence-detail-dialog.test.tsx
@@ -1,0 +1,309 @@
+/**
+ * Integration tests for EvidenceDetailDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Display-only dialog that fetches evidence detail via getEvidenceDetail()
+ * on open (useEffect, not useQuery).
+ * Mocked at module boundary.
+ *
+ * Key behaviors:
+ *   - Shows loading spinner while fetch is in flight
+ *   - Renders member name, section name, file count badge after successful fetch
+ *   - Shows rejection reason panel when rejection_reason is present
+ *   - Error panel (not toast) on ApiError; ApiError.message used directly
+ *   - Fetch NOT triggered when open=false
+ *   - Resets state on close (detail + error cleared on next open)
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { EvidenceDetail, EvidenceType } from "@/lib/api/evidence-review";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetEvidenceDetail = vi.fn<(...args: any[]) => Promise<EvidenceDetail>>();
+
+vi.mock("@/lib/api/evidence-review", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/evidence-review")>();
+  return {
+    ...original,
+    getEvidenceDetail: (...args: unknown[]) => mockGetEvidenceDetail(...args),
+  };
+});
+
+vi.mock("@/lib/format-locale", () => ({
+  useFormatDateTime: () => (dateStr: string) => `formatted:${dateStr}`,
+}));
+
+// EvidenceStatusBadge and EvidenceTypeBadge — render as simple text nodes
+vi.mock("@/components/evidence-review/evidence-status-badge", () => ({
+  EvidenceStatusBadge: ({ status }: { status: string }) => <span data-testid="status-badge">{status}</span>,
+}));
+
+vi.mock("@/components/evidence-review/evidence-type-badge", () => ({
+  EvidenceTypeBadge: ({ type }: { type: string }) => <span data-testid="type-badge">{type}</span>,
+}));
+
+import { EvidenceDetailDialog } from "@/components/evidence-review/evidence-detail-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const t = messages.evidence_review;
+
+const STUB_DETAIL: EvidenceDetail = {
+  id: 42,
+  type: "class",
+  status: "pending",
+  member_name: "Carlos Ruiz",
+  member_id: "user-123",
+  section_name: "Clase de natación",
+  submitted_at: "2026-03-15T10:00:00.000Z",
+  validated_at: null,
+  validated_by_name: null,
+  rejection_reason: null,
+  file_count: 2,
+  files: [
+    {
+      evidence_file_id: 1,
+      file_url: "https://example.com/foto1.jpg",
+      file_name: "foto1.jpg",
+      file_type: "image/jpeg",
+      uploaded_at: "2026-03-15T10:00:00.000Z",
+    },
+    {
+      evidence_file_id: 2,
+      file_url: "https://example.com/doc.pdf",
+      file_name: "doc.pdf",
+      file_type: "application/pdf",
+      uploaded_at: "2026-03-15T10:05:00.000Z",
+    },
+  ],
+};
+
+const STUB_DETAIL_REJECTED: EvidenceDetail = {
+  ...STUB_DETAIL,
+  id: 99,
+  member_id: "user-456",
+  status: "rechazado",
+  rejection_reason: "Imagen borrosa, no se puede verificar",
+  validated_at: "2026-04-01T12:00:00.000Z",
+  validated_by_name: "Admin Pérez",
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  type?: EvidenceType;
+  id?: number;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const { open = true, type = "class", id = 42 } = opts;
+  const onOpenChange = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <EvidenceDetailDialog
+        open={open}
+        type={type}
+        id={id}
+        onOpenChange={onOpenChange}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EvidenceDetailDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEvidenceDetail.mockResolvedValue(STUB_DETAIL);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog title ────────────────────────────────────────────────
+
+  it("renders 'Detalle de evidencia' heading when open", async () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /detalle de evidencia/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Not rendered when closed ───────────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /detalle de evidencia/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Shows loading spinner while fetching ───────────────────────────────
+
+  it("shows loading spinner while getEvidenceDetail is pending", async () => {
+    let resolve!: (v: EvidenceDetail) => void;
+    mockGetEvidenceDetail.mockReturnValue(
+      new Promise<EvidenceDetail>((res) => {
+        resolve = res;
+      }),
+    );
+
+    renderDialog();
+
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeTruthy();
+
+    resolve(STUB_DETAIL);
+  });
+
+  // ── 4. Fetch not triggered when open=false ────────────────────────────────
+
+  it("does NOT call getEvidenceDetail when open=false", () => {
+    mockGetEvidenceDetail.mockResolvedValue(STUB_DETAIL);
+
+    renderDialog({ open: false });
+
+    expect(mockGetEvidenceDetail).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Calls getEvidenceDetail with correct type and id ───────────────────
+
+  it("calls getEvidenceDetail with type='honor' and id=77 when open", async () => {
+    renderDialog({ type: "honor", id: 77 });
+
+    await waitFor(() => {
+      expect(mockGetEvidenceDetail).toHaveBeenCalledWith("honor", 77);
+    });
+  });
+
+  // ── 6. Renders member and section names after fetch ───────────────────────
+
+  it("renders member name, section name after successful fetch", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Carlos Ruiz")).toBeInTheDocument();
+      expect(screen.getByText("Clase de natación")).toBeInTheDocument();
+    });
+  });
+
+  // ── 7. File count badge is shown ─────────────────────────────────────────
+
+  it("renders file count badge", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 archivos/)).toBeInTheDocument();
+    });
+  });
+
+  // ── 8. Rejection reason panel when status is rejected ────────────────────
+
+  it("shows rejection reason when status is rechazado", async () => {
+    mockGetEvidenceDetail.mockResolvedValue(STUB_DETAIL_REJECTED);
+
+    renderDialog({ id: 99 });
+
+    await waitFor(() => {
+      expect(screen.getByText(/motivo de rechazo/i)).toBeInTheDocument();
+      expect(
+        screen.getByText("Imagen borrosa, no se puede verificar"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── 9. No rejection panel when rejection_reason is null ──────────────────
+
+  it("does NOT show rejection panel when rejection_reason is null", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Carlos Ruiz")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText(/motivo de rechazo/i)).not.toBeInTheDocument();
+  });
+
+  // ── 10. ApiError message shown in error panel ─────────────────────────────
+
+  it("shows ApiError message in error panel when fetch throws ApiError", async () => {
+    const { ApiError } = await import("@/lib/api/client");
+    mockGetEvidenceDetail.mockRejectedValue(
+      new ApiError("Evidencia no encontrada", 404, null),
+    );
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Evidencia no encontrada")).toBeInTheDocument();
+    });
+  });
+
+  // ── 11. Fallback i18n error for non-ApiError ──────────────────────────────
+
+  it("shows i18n fallback error when fetch throws a plain error", async () => {
+    mockGetEvidenceDetail.mockRejectedValue(new Error("Network issue"));
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(t.errors.load_detail_failed)).toBeInTheDocument();
+    });
+  });
+
+  // ── 12. Type and status badges rendered ───────────────────────────────────
+
+  it("renders type and status badges after fetch", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("type-badge")).toBeInTheDocument();
+      expect(screen.getByTestId("status-badge")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/inventory/inventory-history-dialog.test.tsx
+++ b/src/components/inventory/inventory-history-dialog.test.tsx
@@ -1,0 +1,307 @@
+/**
+ * Integration tests for InventoryHistoryDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Display-only dialog that fetches history via getInventoryHistory()
+ * on open (useEffect, cancelled on unmount).
+ * `getInventoryHistory` is mocked at module boundary.
+ *
+ * Key behaviors:
+ *   - Shows loading text while fetch is in flight
+ *   - Empty state when entries array is []
+ *   - Renders CREATE / UPDATE / DELETE entries with translated action labels
+ *   - UPDATE entries show old → new value diff
+ *   - Error panel rendered when fetch fails
+ *   - Fetch NOT triggered when open=false or inventoryId is null
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { InventoryHistoryEntry } from "@/lib/api/inventory";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetInventoryHistory = vi.fn<(...args: any[]) => Promise<InventoryHistoryEntry[]>>();
+
+vi.mock("@/lib/api/inventory", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/inventory")>();
+  return {
+    ...original,
+    getInventoryHistory: (...args: unknown[]) => mockGetInventoryHistory(...args),
+  };
+});
+
+vi.mock("@/lib/format-locale", () => ({
+  useFormatDateTime: () => (dateStr: string) => `formatted:${dateStr}`,
+}));
+
+import { InventoryHistoryDialog } from "@/components/inventory/inventory-history-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const t = messages.inventory;
+
+const STUB_ENTRIES: InventoryHistoryEntry[] = [
+  {
+    history_id: 1,
+    inventory_id: 55,
+    action: "CREATE",
+    field_changed: null,
+    old_value: null,
+    new_value: null,
+    created_at: "2026-01-10T09:00:00.000Z",
+    performed_by: {
+      name: "María",
+      paternal_last_name: "López",
+    },
+  },
+  {
+    history_id: 2,
+    inventory_id: 55,
+    action: "UPDATE",
+    field_changed: "amount",
+    old_value: "5",
+    new_value: "10",
+    created_at: "2026-02-15T14:00:00.000Z",
+    performed_by: {
+      name: "Carlos",
+      paternal_last_name: "Ruiz",
+    },
+  },
+  {
+    history_id: 3,
+    inventory_id: 55,
+    action: "DELETE",
+    field_changed: null,
+    old_value: null,
+    new_value: null,
+    created_at: "2026-03-20T16:00:00.000Z",
+    performed_by: null,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  inventoryId?: number | null;
+  itemName?: string;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    inventoryId = 55,
+    itemName = "Guitarra acústica",
+  } = opts;
+  const onOpenChange = vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <InventoryHistoryDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        inventoryId={inventoryId}
+        itemName={itemName}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("InventoryHistoryDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetInventoryHistory.mockResolvedValue(STUB_ENTRIES);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog title and item name ─────────────────────────────────
+
+  it("renders dialog title and item name when open", async () => {
+    renderDialog();
+
+    expect(
+      screen.getByText(new RegExp(t.history.dialog_title, "i")),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Guitarra acústica/)).toBeInTheDocument();
+  });
+
+  // ── 2. Not rendered when closed ───────────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    mockGetInventoryHistory.mockResolvedValue([]);
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByText(new RegExp(t.history.dialog_title, "i")),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Shows loading text while fetching ─────────────────────────────────
+
+  it("shows loading text while getInventoryHistory is pending", async () => {
+    let resolve!: (v: InventoryHistoryEntry[]) => void;
+    mockGetInventoryHistory.mockReturnValue(
+      new Promise<InventoryHistoryEntry[]>((res) => {
+        resolve = res;
+      }),
+    );
+
+    renderDialog();
+
+    expect(screen.getByText(new RegExp(t.history.loading, "i"))).toBeInTheDocument();
+
+    resolve([]);
+  });
+
+  // ── 4. Fetch not triggered when open=false ────────────────────────────────
+
+  it("does NOT call getInventoryHistory when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(mockGetInventoryHistory).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Fetch not triggered when inventoryId is null ──────────────────────
+
+  it("does NOT call getInventoryHistory when inventoryId is null", () => {
+    renderDialog({ inventoryId: null });
+
+    expect(mockGetInventoryHistory).not.toHaveBeenCalled();
+  });
+
+  // ── 6. Calls getInventoryHistory with correct inventoryId ─────────────────
+
+  it("calls getInventoryHistory with the correct inventoryId", async () => {
+    renderDialog({ inventoryId: 42 });
+
+    await waitFor(() => {
+      expect(mockGetInventoryHistory).toHaveBeenCalledWith(42);
+    });
+  });
+
+  // ── 7. Empty state when entries is [] ────────────────────────────────────
+
+  it("renders empty state text when no history entries", async () => {
+    mockGetInventoryHistory.mockResolvedValue([]);
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(t.history.empty)).toBeInTheDocument();
+    });
+  });
+
+  // ── 8. Renders CREATE, UPDATE, DELETE action labels ──────────────────────
+
+  it("renders translated action labels for CREATE, UPDATE and DELETE entries", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(t.history.action_create)).toBeInTheDocument();
+      expect(screen.getByText(t.history.action_update)).toBeInTheDocument();
+      expect(screen.getByText(t.history.action_delete)).toBeInTheDocument();
+    });
+  });
+
+  // ── 9. UPDATE entry shows old and new values ──────────────────────────────
+
+  it("renders old → new value diff for UPDATE entries", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("5")).toBeInTheDocument();
+      expect(screen.getByText("10")).toBeInTheDocument();
+    });
+  });
+
+  // ── 10. Performer name shown ─────────────────────────────────────────────
+
+  it("renders performer names from history entries", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(/María López/)).toBeInTheDocument();
+      expect(screen.getByText(/Carlos Ruiz/)).toBeInTheDocument();
+    });
+  });
+
+  // ── 11. System label when performed_by is null ────────────────────────────
+
+  it("shows system label when performed_by is null", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(new RegExp(t.history.performed_by_system, "i")),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── 12. Error panel — shows Error.message when fetch throws ─────────────
+
+  it("renders error panel with Error.message when getInventoryHistory throws", async () => {
+    mockGetInventoryHistory.mockRejectedValue(new Error("DB error"));
+
+    renderDialog();
+
+    await waitFor(() => {
+      // Component shows err.message for Error instances
+      expect(screen.getByText("DB error")).toBeInTheDocument();
+    });
+  });
+
+  // ── 13. Error panel — i18n fallback for non-Error throws ─────────────────
+
+  it("renders i18n fallback error when getInventoryHistory throws a non-Error", async () => {
+    mockGetInventoryHistory.mockRejectedValue({ status: 503 });
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(t.errors.load_history_failed)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/investiture/pipeline-history-dialog.test.tsx
+++ b/src/components/investiture/pipeline-history-dialog.test.tsx
@@ -1,0 +1,315 @@
+/**
+ * Integration tests for PipelineHistoryDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Display-only dialog that fetches via getPipelineHistory() using
+ * TanStack Query (useQuery, enabled: open, staleTime: Infinity).
+ * Requires QueryClientProvider — fresh client per test to avoid cache bleed.
+ *
+ * `getPipelineHistory` is mocked at module boundary.
+ *
+ * Key behaviors:
+ *   - Loading skeleton while query is pending
+ *   - Empty state when entries is []
+ *   - Renders entries with translated action labels
+ *   - Performer name shown; system fallback when performer is null
+ *   - Rejection reason rendered when entry has reason
+ *   - Fetch NOT triggered when open=false
+ *   - Error toast fired when getPipelineHistory throws
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import messages from "../../../messages/es.json";
+import type { PipelineHistoryEntry } from "@/lib/api/investiture";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetPipelineHistory = vi.fn<(...args: any[]) => Promise<PipelineHistoryEntry[]>>();
+
+vi.mock("@/lib/api/investiture", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/investiture")>();
+  return {
+    ...original,
+    getPipelineHistory: (...args: unknown[]) => mockGetPipelineHistory(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+vi.mock("@/lib/format-locale", () => ({
+  useFormatDateTime: () => (dateStr: string) => `formatted:${dateStr}`,
+}));
+
+import { PipelineHistoryDialog } from "@/components/investiture/pipeline-history-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const t = messages.investiture.historyDialog;
+
+const STUB_ENTRIES: PipelineHistoryEntry[] = [
+  {
+    history_id: 1,
+    enrollment_id: 10,
+    action: "SUBMITTED",
+    performed_by: "user-001",
+    performer: { user_id: "u1", first_name: "Ana", last_name: "López" },
+    reason: null,
+    created_at: "2026-01-10T09:00:00.000Z",
+  },
+  {
+    history_id: 2,
+    enrollment_id: 10,
+    action: "CLUB_APPROVED",
+    performed_by: "user-002",
+    performer: { user_id: "u2", first_name: "Juan", last_name: "Pérez" },
+    reason: null,
+    created_at: "2026-02-15T14:00:00.000Z",
+  },
+  {
+    history_id: 3,
+    enrollment_id: 10,
+    action: "REJECTED",
+    performed_by: null,
+    performer: null,
+    reason: "Documentación incompleta",
+    created_at: "2026-03-20T16:00:00.000Z",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  enrollmentId?: number;
+  memberName?: string;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    enrollmentId = 10,
+    memberName = "Pedro Martínez",
+  } = opts;
+  const onOpenChange = vi.fn();
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <NextIntlClientProvider locale="es" messages={messages}>
+        <PipelineHistoryDialog
+          open={open}
+          enrollmentId={enrollmentId}
+          memberName={memberName}
+          onOpenChange={onOpenChange}
+        />
+      </NextIntlClientProvider>
+    </QueryClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, queryClient };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PipelineHistoryDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPipelineHistory.mockResolvedValue(STUB_ENTRIES);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog title and member name ────────────────────────────────
+
+  it("renders dialog title and memberName as description", async () => {
+    mockGetPipelineHistory.mockResolvedValue([]);
+
+    renderDialog({ memberName: "Pedro Martínez" });
+
+    expect(
+      screen.getByRole("heading", { name: new RegExp(t.title, "i") }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Pedro Martínez")).toBeInTheDocument();
+  });
+
+  // ── 2. Not rendered when closed ───────────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: new RegExp(t.title, "i") }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Shows loading skeleton while query is pending ─────────────────────
+
+  it("shows loading skeleton while getPipelineHistory is pending", async () => {
+    let resolve!: (v: PipelineHistoryEntry[]) => void;
+    mockGetPipelineHistory.mockReturnValue(
+      new Promise<PipelineHistoryEntry[]>((res) => {
+        resolve = res;
+      }),
+    );
+
+    renderDialog();
+
+    const skeletons = document.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+
+    resolve([]);
+  });
+
+  // ── 4. Fetch not triggered when open=false ────────────────────────────────
+
+  it("does NOT call getPipelineHistory when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(mockGetPipelineHistory).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Empty state when entries is [] ────────────────────────────────────
+
+  it("renders empty state text when no history entries", async () => {
+    mockGetPipelineHistory.mockResolvedValue([]);
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(t.emptyHistory)).toBeInTheDocument();
+    });
+  });
+
+  // ── 6. Renders SUBMITTED and CLUB_APPROVED action labels ─────────────────
+
+  it("renders translated action labels for SUBMITTED and CLUB_APPROVED", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(t.actionSubmitted)).toBeInTheDocument();
+      expect(screen.getByText(t.actionClubApproved)).toBeInTheDocument();
+    });
+  });
+
+  // ── 7. Renders REJECTED action label ─────────────────────────────────────
+
+  it("renders REJECTED action label", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(t.actionRejected)).toBeInTheDocument();
+    });
+  });
+
+  // ── 8. Performer names shown ─────────────────────────────────────────────
+
+  it("renders performer names from entries", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ana López/)).toBeInTheDocument();
+      expect(screen.getByText(/Juan Pérez/)).toBeInTheDocument();
+    });
+  });
+
+  // ── 9. System fallback when performer is null ─────────────────────────────
+
+  it("shows system label when performer is null", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(new RegExp(t.system, "i")),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── 10. Rejection reason rendered when entry has reason ──────────────────
+
+  it("renders rejection reason when entry has a reason", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText("Documentación incompleta")).toBeInTheDocument();
+    });
+  });
+
+  // ── 11. Error toast when getPipelineHistory throws ApiError ──────────────
+
+  it("shows ApiError message toast when getPipelineHistory throws ApiError", async () => {
+    const { ApiError } = await import("@/lib/api/client");
+    mockGetPipelineHistory.mockRejectedValue(
+      new ApiError("Pipeline no encontrado", 404, null),
+    );
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Pipeline no encontrado");
+    });
+  });
+
+  // ── 12. Error toast with fallback message for non-ApiError ───────────────
+
+  it("shows i18n fallback error toast for plain Error throws", async () => {
+    mockGetPipelineHistory.mockRejectedValue(new Error("Network timeout"));
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errorLoad);
+    });
+  });
+});

--- a/src/components/member-of-month/evaluate-dialog.test.tsx
+++ b/src/components/member-of-month/evaluate-dialog.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * Integration tests for EvaluateMemberOfMonthDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog with two Radix Select inputs (month + year) and submit/cancel buttons.
+ * Action: evaluateMemberOfMonth(clubId, sectionId, { month, year }).
+ * Defaults to previous month/year on open; resets to defaults on close.
+ *
+ * Radix Select rendered via jsdom — use document.querySelectorAll("select")
+ * with fireEvent.change to drive value changes.
+ *
+ * `evaluateMemberOfMonth` is mocked at module boundary.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockEvaluate = vi.fn<(...args: any[]) => Promise<unknown>>();
+
+vi.mock("@/lib/api/member-of-month", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/member-of-month")>();
+  return {
+    ...original,
+    evaluateMemberOfMonth: (...args: unknown[]) => mockEvaluate(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { EvaluateMemberOfMonthDialog } from "@/components/member-of-month/evaluate-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const t = messages.member_of_month;
+
+const CLUB_ID = 3;
+const SECTION_ID = 7;
+const SECTION_NAME = "Tropa Estrellas";
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  clubId?: number;
+  sectionId?: number;
+  sectionName?: string;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    clubId = CLUB_ID,
+    sectionId = SECTION_ID,
+    sectionName = SECTION_NAME,
+    onSuccess,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <EvaluateMemberOfMonthDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        clubId={clubId}
+        sectionId={sectionId}
+        sectionName={sectionName}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("EvaluateMemberOfMonthDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEvaluate.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog title and section name ───────────────────────────────
+
+  it("renders dialog title and section name in description", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /evaluar miembro del mes/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(new RegExp(SECTION_NAME))).toBeInTheDocument();
+  });
+
+  // ── 2. Not rendered when closed ───────────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /evaluar miembro del mes/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Shows month and year selects and action buttons ────────────────────
+
+  it("renders month select, year select, cancel and submit buttons", () => {
+    renderDialog();
+
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /evaluar/i })).toBeInTheDocument();
+    // There should be a month trigger and year trigger (Radix Select renders as role=combobox)
+    const comboboxes = screen.getAllByRole("combobox");
+    expect(comboboxes.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ── 4. Happy path — calls evaluateMemberOfMonth with correct args ─────────
+
+  it("calls evaluateMemberOfMonth with clubId, sectionId and selected period", async () => {
+    const { onOpenChange, onSuccess } = renderDialog();
+
+    // Trigger select changes using native selects rendered by Radix in jsdom
+    const selects = document.querySelectorAll("select");
+    // First select is month, second is year
+    if (selects[0]) {
+      fireEvent.change(selects[0], { target: { value: "4" } });
+    }
+    if (selects[1]) {
+      fireEvent.change(selects[1], { target: { value: "2025" } });
+    }
+
+    const submitBtn = screen.getByRole("button", { name: /evaluar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        CLUB_ID,
+        SECTION_ID,
+        expect.objectContaining({ month: expect.any(Number), year: expect.any(Number) }),
+      );
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledOnce();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 5. API error — shows Error.message ───────────────────────────────────
+
+  it("shows error toast with Error.message when evaluateMemberOfMonth throws", async () => {
+    mockEvaluate.mockRejectedValue(new Error("Ya existe una evaluación para ese período"));
+
+    renderDialog();
+
+    const submitBtn = screen.getByRole("button", { name: /evaluar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Ya existe una evaluación para ese período",
+      );
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 6. API error — i18n fallback for non-Error throws ────────────────────
+
+  it("shows i18n fallback error toast when evaluateMemberOfMonth throws non-Error", async () => {
+    mockEvaluate.mockRejectedValue({ status: 500 });
+
+    renderDialog();
+
+    const submitBtn = screen.getByRole("button", { name: /evaluar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.evaluation_failed);
+    });
+  });
+
+  // ── 7. Cancel closes dialog without API call ─────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call evaluateMemberOfMonth on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(mockEvaluate).not.toHaveBeenCalled();
+  });
+
+  // ── 8. In-flight state — buttons disabled while evaluating ────────────────
+
+  it("disables both buttons while evaluation is in flight", async () => {
+    let resolve!: () => void;
+    mockEvaluate.mockReturnValue(
+      new Promise<unknown>((res) => {
+        resolve = () => res({});
+      }),
+    );
+
+    renderDialog();
+
+    const submitBtn = screen.getByRole("button", { name: /evaluar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /evaluando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolve();
+    });
+  });
+
+  // ── 9. onSuccess NOT called on error ─────────────────────────────────────
+
+  it("does NOT call onSuccess when evaluateMemberOfMonth throws", async () => {
+    mockEvaluate.mockRejectedValue(new Error("Server error"));
+
+    const { onSuccess } = renderDialog();
+
+    const submitBtn = screen.getByRole("button", { name: /evaluar/i });
+    await act(async () => {
+      fireEvent.click(submitBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalled();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 10. Shows sectionName in bold in description ──────────────────────────
+
+  it("shows section name in the dialog description", () => {
+    renderDialog({ sectionName: "Campamento Norte" });
+
+    expect(screen.getByText(/Campamento Norte/)).toBeInTheDocument();
+  });
+});

--- a/src/components/scoring-categories/scoring-category-delete-dialog.test.tsx
+++ b/src/components/scoring-categories/scoring-category-delete-dialog.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * Integration tests for ScoringCategoryDeleteDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * AlertDialog (no React Hook Form). Two buttons: Cancelar / Eliminar.
+ * Action: onDelete(category.scoring_category_id) — async function prop.
+ * Guards: exits early if category is null.
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { ScoringCategory } from "@/lib/api/scoring-categories";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { ScoringCategoryDeleteDialog } from "@/components/scoring-categories/scoring-category-delete-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const t = messages.scoring_categories;
+
+const STUB_CATEGORY: ScoringCategory = {
+  scoring_category_id: 11,
+  name: "Puntualidad",
+  max_points: 10,
+  active: true,
+  origin_level: "LOCAL_FIELD",
+  origin_id: 1,
+  origin_badge: "Campo Local",
+  readonly: false,
+  translations: [],
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  category?: ScoringCategory | null;
+  onDelete?: ReturnType<typeof vi.fn>;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    category = STUB_CATEGORY,
+    onDelete,
+    onSuccess,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const deleteCb = onDelete ?? vi.fn<(id: number) => Promise<void>>().mockResolvedValue(undefined);
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <ScoringCategoryDeleteDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        category={category}
+        onDelete={deleteCb}
+        onSuccess={successCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onDelete: deleteCb, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ScoringCategoryDeleteDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders title, category name and buttons ───────────────────────────
+
+  it("renders title, category name in description, cancel and confirm buttons", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /eliminar categoría/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Puntualidad/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /cancelar/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /eliminar/i })).toBeInTheDocument();
+  });
+
+  // ── 2. Not rendered when closed ───────────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /eliminar categoría/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Category name shown in description ─────────────────────────────────
+
+  it("shows the category name in bold in the description", () => {
+    renderDialog({ category: { ...STUB_CATEGORY, name: "Asistencia" } });
+
+    expect(screen.getByText(/Asistencia/)).toBeInTheDocument();
+  });
+
+  // ── 4. Category null — early return, no API call ──────────────────────────
+
+  it("does not call onDelete when category is null", async () => {
+    const { onDelete } = renderDialog({ category: null });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Happy path — calls onDelete with id, shows success toast ───────────
+
+  it("calls onDelete with scoring_category_id, shows success toast, calls onSuccess and closes", async () => {
+    const { onOpenChange, onDelete, onSuccess } = renderDialog();
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith(11);
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.deleted);
+    expect(onSuccess).toHaveBeenCalledWith(11);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 6. Cancel does not call onDelete ─────────────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call onDelete on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange, onDelete } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  // ── 7. Error path — Error.message shown in toast ──────────────────────────
+
+  it("shows Error.message in toast when onDelete throws", async () => {
+    const failingDelete = vi.fn<(id: number) => Promise<void>>().mockRejectedValue(
+      new Error("Categoría en uso, no se puede eliminar"),
+    );
+    const { onSuccess } = renderDialog({ onDelete: failingDelete });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(
+        "Categoría en uso, no se puede eliminar",
+      );
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 8. Error path — i18n fallback for non-Error throws ───────────────────
+
+  it("shows i18n fallback error toast when onDelete throws a non-Error", async () => {
+    const failingDelete = vi.fn<(id: number) => Promise<void>>().mockRejectedValue({ code: 500 });
+    renderDialog({ onDelete: failingDelete });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.delete_failed);
+    });
+  });
+
+  // ── 9. In-flight state — buttons disabled while deleting ─────────────────
+
+  it("disables both buttons while deletion is in flight", async () => {
+    let resolve!: () => void;
+    const slowDelete = vi.fn<(id: number) => Promise<void>>().mockReturnValue(
+      new Promise<void>((res) => {
+        resolve = res;
+      }),
+    );
+
+    renderDialog({ onDelete: slowDelete });
+
+    const confirmBtn = screen.getByRole("button", { name: /eliminar/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /eliminando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolve();
+    });
+  });
+
+  // ── 10. Description includes historical records note ─────────────────────
+
+  it("shows note about historical records being preserved", () => {
+    renderDialog();
+
+    expect(
+      screen.getByText(/registros históricos se conservarán/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/scoring-categories/scoring-category-dialog.test.tsx
+++ b/src/components/scoring-categories/scoring-category-dialog.test.tsx
@@ -1,0 +1,353 @@
+/**
+ * Integration tests for ScoringCategoryDialog (create + edit modes).
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Dialog with controlled form (name, maxPoints) + TranslationsTabsField.
+ * TranslationsTabsField is mocked at module boundary (just renders esContent).
+ * Action: onSave(payload, id?) — async function prop.
+ *
+ * Create mode: category prop is absent/null → title "Nueva categoría"
+ * Edit mode: category prop provided → title "Editar categoría", form pre-filled.
+ *
+ * Validation:
+ *   - name required (toast error)
+ *   - name > 100 chars (toast error)
+ *   - maxPoints < 1 (toast error)
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  cleanup,
+} from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import type { ScoringCategory } from "@/lib/api/scoring-categories";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// Mock TranslationsTabsField — just render esContent so we can test the
+// name input without dealing with Radix Tabs internals.
+vi.mock("@/components/forms/translations-tabs-field", () => ({
+  TranslationsTabsField: ({
+    esContent,
+  }: {
+    esContent: React.ReactNode;
+    translations: unknown[];
+    onTranslationsChange: (t: unknown[]) => void;
+    onDirtyChange?: (d: boolean) => void;
+    includeDescription?: boolean;
+    disabled?: boolean;
+  }) => <div data-testid="translations-tabs">{esContent}</div>,
+}));
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+import { ScoringCategoryDialog } from "@/components/scoring-categories/scoring-category-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const t = messages.scoring_categories;
+
+const STUB_CATEGORY: ScoringCategory = {
+  scoring_category_id: 5,
+  name: "Puntualidad",
+  max_points: 10,
+  active: true,
+  origin_level: "LOCAL_FIELD",
+  origin_id: 1,
+  origin_badge: "Campo Local",
+  readonly: false,
+  translations: [],
+};
+
+const SAVED_CATEGORY: ScoringCategory = {
+  ...STUB_CATEGORY,
+  scoring_category_id: 5,
+  name: "Puntualidad Updated",
+};
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  category?: ScoringCategory | null;
+  onSave?: ReturnType<typeof vi.fn>;
+  onSuccess?: ReturnType<typeof vi.fn>;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    category,
+    onSave,
+    onSuccess,
+  } = opts;
+  const onOpenChange = vi.fn();
+  const saveCb = onSave ?? vi.fn<(payload: unknown, id?: number) => Promise<ScoringCategory>>().mockResolvedValue(SAVED_CATEGORY);
+  const successCb = onSuccess ?? vi.fn();
+
+  const utils = render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <ScoringCategoryDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        category={category}
+        onSuccess={successCb}
+        onSave={saveCb}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, onSave: saveCb, onSuccess: successCb };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ScoringCategoryDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Create mode title ──────────────────────────────────────────────────
+
+  it("renders 'Nueva categoría' title when no category is provided", () => {
+    renderDialog();
+
+    expect(
+      screen.getByRole("heading", { name: /nueva categoría de puntuación/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 2. Edit mode title ────────────────────────────────────────────────────
+
+  it("renders 'Editar categoría' title when category is provided", () => {
+    renderDialog({ category: STUB_CATEGORY });
+
+    expect(
+      screen.getByRole("heading", { name: /editar categoría/i }),
+    ).toBeInTheDocument();
+  });
+
+  // ── 3. Not rendered when closed ───────────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: /categoría/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 4. Edit mode pre-fills form with category data ───────────────────────
+
+  it("pre-fills name and max_points inputs in edit mode", () => {
+    renderDialog({ category: STUB_CATEGORY });
+
+    const nameInput = document.querySelector('input[id="sc_name"]') as HTMLInputElement;
+    const pointsInput = document.querySelector('input[id="sc_max_points"]') as HTMLInputElement;
+
+    expect(nameInput?.value).toBe("Puntualidad");
+    expect(pointsInput?.value).toBe("10");
+  });
+
+  // ── 5. Validation — name required ─────────────────────────────────────────
+
+  it("shows name_required toast when name is empty and form is submitted", async () => {
+    renderDialog();
+
+    // Clear the name input and submit
+    const nameInput = document.querySelector('input[id="sc_name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "" } });
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith(t.validation.name_required);
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+  });
+
+  // ── 6. Validation — name too long ─────────────────────────────────────────
+
+  it("shows name_max toast when name exceeds 100 characters", async () => {
+    renderDialog();
+
+    const nameInput = document.querySelector('input[id="sc_name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "a".repeat(101) } });
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith(t.validation.name_max);
+  });
+
+  // ── 7. Validation — maxPoints < 1 ────────────────────────────────────────
+
+  it("shows points_invalid toast when max_points is 0", async () => {
+    renderDialog();
+
+    const pointsInput = document.querySelector('input[id="sc_max_points"]') as HTMLInputElement;
+    fireEvent.change(pointsInput, { target: { value: "0" } });
+
+    const nameInput = document.querySelector('input[id="sc_name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Nombre válido" } });
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith(t.validation.points_invalid);
+  });
+
+  // ── 8. Happy path create — calls onSave without id ───────────────────────
+
+  it("calls onSave with name, max_points but no id in create mode", async () => {
+    const { onOpenChange, onSave, onSuccess } = renderDialog();
+
+    const nameInput = document.querySelector('input[id="sc_name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Nueva cat" } });
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "Nueva cat" }),
+        undefined,
+      );
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalled();
+    expect(onSuccess).toHaveBeenCalledWith(SAVED_CATEGORY);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  // ── 9. Happy path edit — calls onSave with existing id ───────────────────
+
+  it("calls onSave with category id in edit mode", async () => {
+    const { onSave } = renderDialog({ category: STUB_CATEGORY });
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "Puntualidad" }),
+        5,
+      );
+    });
+  });
+
+  // ── 10. Error path — shows Error.message in toast ────────────────────────
+
+  it("shows Error.message in toast when onSave throws", async () => {
+    const failingSave = vi.fn<(payload: unknown, id?: number) => Promise<ScoringCategory>>().mockRejectedValue(
+      new Error("Categoría duplicada"),
+    );
+    renderDialog({ onSave: failingSave });
+
+    const nameInput = document.querySelector('input[id="sc_name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Duplicada" } });
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Categoría duplicada");
+    });
+  });
+
+  // ── 11. Cancel closes dialog without API call ─────────────────────────────
+
+  it("calls onOpenChange(false) and does NOT call onSave on cancel", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange, onSave } = renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /cancelar/i }));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  // ── 12. In-flight state — buttons disabled while saving ───────────────────
+
+  it("disables buttons while save is in flight", async () => {
+    let resolve!: (v: ScoringCategory) => void;
+    const slowSave = vi.fn<(payload: unknown, id?: number) => Promise<ScoringCategory>>().mockReturnValue(
+      new Promise<ScoringCategory>((res) => {
+        resolve = res;
+      }),
+    );
+    renderDialog({ onSave: slowSave });
+
+    const nameInput = document.querySelector('input[id="sc_name"]') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Lento" } });
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /guardando/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /cancelar/i })).toBeDisabled();
+    });
+
+    await act(async () => {
+      resolve(SAVED_CATEGORY);
+    });
+  });
+});

--- a/src/components/validation/validation-history-dialog.test.tsx
+++ b/src/components/validation/validation-history-dialog.test.tsx
@@ -1,0 +1,319 @@
+/**
+ * Integration tests for ValidationHistoryDialog.
+ *
+ * Architecture notes:
+ * ------------------------------------------------------------------
+ * Display-only dialog that fetches via getValidationHistory() using
+ * TanStack Query (useQuery, enabled: open, staleTime: Infinity).
+ * Requires QueryClientProvider — fresh client per test to avoid cache bleed.
+ *
+ * `getValidationHistory` is mocked at module boundary.
+ *
+ * Key behaviors:
+ *   - Loading skeleton while query is pending
+ *   - Empty state when entries is []
+ *   - Renders entries with APPROVED / REJECTED action labels
+ *   - Performer name shown; system fallback when performer is null
+ *   - Comment rendered when entry has comment
+ *   - Fetch NOT triggered when open=false
+ *   - Error toast fired when getValidationHistory throws
+ *
+ * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ */
+
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  cleanup,
+} from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import messages from "../../../messages/es.json";
+import type { ValidationHistoryEntry, ValidationEntityType } from "@/lib/api/validation";
+
+// ---------------------------------------------------------------------------
+// jsdom polyfills
+// ---------------------------------------------------------------------------
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+// ---------------------------------------------------------------------------
+// Module-level mocks
+// ---------------------------------------------------------------------------
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockGetValidationHistory = vi.fn<(...args: any[]) => Promise<ValidationHistoryEntry[]>>();
+
+vi.mock("@/lib/api/validation", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/validation")>();
+  return {
+    ...original,
+    getValidationHistory: (...args: unknown[]) => mockGetValidationHistory(...args),
+  };
+});
+
+const mockToastError = vi.fn();
+const mockToastSuccess = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    error: (msg: string) => mockToastError(msg),
+    success: (msg: string) => mockToastSuccess(msg),
+  },
+}));
+
+vi.mock("@/lib/format-locale", () => ({
+  useFormatDateTime: () => (dateStr: string) => `formatted:${dateStr}`,
+}));
+
+import { ValidationHistoryDialog } from "@/components/validation/validation-history-dialog";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const t = messages.validation_admin;
+
+const STUB_ENTRIES: ValidationHistoryEntry[] = [
+  {
+    history_id: 1,
+    action: "APPROVED",
+    performed_by: "user-001",
+    performer: { user_id: "u1", first_name: "Ana", last_name: "García" },
+    comment: null,
+    created_at: "2026-03-10T10:00:00.000Z",
+  },
+  {
+    history_id: 2,
+    action: "REJECTED",
+    performed_by: "user-002",
+    performer: { user_id: "u2", first_name: "Luis", last_name: "Martínez" },
+    comment: "Falta la firma del director de club",
+    created_at: "2026-03-15T14:00:00.000Z",
+  },
+  {
+    history_id: 3,
+    action: "APPROVED",
+    performed_by: null,
+    performer: null,
+    comment: null,
+    created_at: "2026-03-20T09:00:00.000Z",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Render helper
+// ---------------------------------------------------------------------------
+
+interface RenderOpts {
+  open?: boolean;
+  entityType?: ValidationEntityType;
+  entityId?: number | string;
+  title?: string;
+}
+
+function renderDialog(opts: RenderOpts = {}) {
+  const {
+    open = true,
+    entityType = "class",
+    entityId = 42,
+    title = "Juan Pérez — Salvavidas",
+  } = opts;
+  const onOpenChange = vi.fn();
+
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+
+  const utils = render(
+    <QueryClientProvider client={queryClient}>
+      <NextIntlClientProvider locale="es" messages={messages}>
+        <ValidationHistoryDialog
+          open={open}
+          entityType={entityType}
+          entityId={entityId}
+          title={title}
+          onOpenChange={onOpenChange}
+        />
+      </NextIntlClientProvider>
+    </QueryClientProvider>,
+  );
+
+  return { ...utils, onOpenChange, queryClient };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("ValidationHistoryDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetValidationHistory.mockResolvedValue(STUB_ENTRIES);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  // ── 1. Renders dialog title and entity title ───────────────────────────────
+
+  it("renders dialog title and entity title as description", async () => {
+    mockGetValidationHistory.mockResolvedValue([]);
+
+    renderDialog({ title: "Juan Pérez — Salvavidas" });
+
+    expect(
+      screen.getByRole("heading", { name: new RegExp(t.history.title, "i") }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Juan Pérez — Salvavidas")).toBeInTheDocument();
+  });
+
+  // ── 2. Not rendered when closed ───────────────────────────────────────────
+
+  it("does not render dialog content when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(
+      screen.queryByRole("heading", { name: new RegExp(t.history.title, "i") }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ── 3. Shows loading skeleton while query is pending ─────────────────────
+
+  it("shows loading skeleton while getValidationHistory is pending", async () => {
+    let resolve!: (v: ValidationHistoryEntry[]) => void;
+    mockGetValidationHistory.mockReturnValue(
+      new Promise<ValidationHistoryEntry[]>((res) => {
+        resolve = res;
+      }),
+    );
+
+    renderDialog();
+
+    const skeletons = document.querySelectorAll(".animate-pulse");
+    expect(skeletons.length).toBeGreaterThan(0);
+
+    resolve([]);
+  });
+
+  // ── 4. Fetch not triggered when open=false ────────────────────────────────
+
+  it("does NOT call getValidationHistory when open=false", () => {
+    renderDialog({ open: false });
+
+    expect(mockGetValidationHistory).not.toHaveBeenCalled();
+  });
+
+  // ── 5. Called with correct entityType and entityId ───────────────────────
+
+  it("calls getValidationHistory with correct entityType and entityId", async () => {
+    renderDialog({ entityType: "honor", entityId: 77 });
+
+    await waitFor(() => {
+      expect(mockGetValidationHistory).toHaveBeenCalledWith("honor", 77);
+    });
+  });
+
+  // ── 6. Empty state when entries is [] ────────────────────────────────────
+
+  it("renders empty state text when no history entries", async () => {
+    mockGetValidationHistory.mockResolvedValue([]);
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(t.history.empty)).toBeInTheDocument();
+    });
+  });
+
+  // ── 7. Renders APPROVED and REJECTED action labels ───────────────────────
+
+  it("renders translated APPROVED and REJECTED action labels", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      // "Aprobado" appears twice (entries 1 and 3), "Rechazado" once (entry 2)
+      const approved = screen.getAllByText(t.history.actions.APPROVED);
+      expect(approved.length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText(t.history.actions.REJECTED)).toBeInTheDocument();
+    });
+  });
+
+  // ── 8. Performer names shown ─────────────────────────────────────────────
+
+  it("renders performer names from history entries", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Ana García/)).toBeInTheDocument();
+      expect(screen.getByText(/Luis Martínez/)).toBeInTheDocument();
+    });
+  });
+
+  // ── 9. System fallback when performer is null ─────────────────────────────
+
+  it("shows system label when performer is null", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(new RegExp(t.history.performer.system, "i")),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── 10. Comment rendered when entry has one ───────────────────────────────
+
+  it("renders comment text when an entry has a comment", async () => {
+    renderDialog();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Falta la firma del director de club"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // ── 11. Error toast when getValidationHistory throws ApiError ────────────
+
+  it("shows ApiError message in error toast when getValidationHistory throws ApiError", async () => {
+    const { ApiError } = await import("@/lib/api/client");
+    mockGetValidationHistory.mockRejectedValue(
+      new ApiError("Historial no disponible", 503, null),
+    );
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith("Historial no disponible");
+    });
+  });
+
+  // ── 12. Fallback error toast for non-ApiError ─────────────────────────────
+
+  it("shows i18n fallback error toast for plain Error throws", async () => {
+    mockGetValidationHistory.mockRejectedValue(new Error("Network timeout"));
+
+    renderDialog();
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith(t.errors.loadHistory);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds 9 new integration test suites for previously untested dialog components across annual-folders, certifications, evidence-review, inventory, investiture, member-of-month, scoring-categories, and validation features
- 104 new tests bringing the total from 564 → 668 tests (45 → 54 test files)
- All tests use module-boundary mocks (vi.mock), fresh QueryClient per test to prevent cache bleed, and jsdom polyfills following the established patterns from r1–r9

## Test coverage per file

| File | Tests | Pattern |
|---|---|---|
| `evidence-upload-dialog.test.tsx` | 12 | useEffect + form submit |
| `user-progress-dialog.test.tsx` | 11 | apiRequestFromClient PATCH |
| `evidence-detail-dialog.test.tsx` | 12 | useEffect fetch + error panel |
| `inventory-history-dialog.test.tsx` | 13 | useEffect + cancelled promise |
| `pipeline-history-dialog.test.tsx` | 12 | useQuery + QueryClientProvider |
| `evaluate-dialog.test.tsx` | 10 | Radix Select + form submit |
| `scoring-category-delete-dialog.test.tsx` | 10 | AlertDialog + onDelete prop |
| `scoring-category-dialog.test.tsx` | 12 | Create/edit modes + TranslationsTabsField mock |
| `validation-history-dialog.test.tsx` | 12 | useQuery + QueryClientProvider |

## Test plan

- [x] `pnpm test --run` → 668/668 pass
- [x] `pnpm typecheck` → clean (strict mode, no implicit any)
- [x] `pnpm lint` → 0 errors from new files (pre-existing errors untouched)