### PR TITLE
feat(i18n): type-safe messages for next-intl

### DIFF
--- a/messages/es.json
+++ b/messages/es.json
@@ -1859,7 +1859,11 @@
       "unexpected": "Ocurrió un error inesperado",
       "approve_member": "No se pudo aprobar la inscripción del miembro",
       "approve_payment": "No se pudo aprobar el pago",
-      "enroll_club": "No se pudo inscribir el club"
+      "enroll_club": "No se pudo inscribir el club",
+      "create_failed": "No se pudo crear el camporee",
+      "update_failed": "No se pudo actualizar el camporee",
+      "register_member_failed": "No se pudo registrar al miembro",
+      "remove_member_failed": "No se pudo eliminar al miembro"
     },
     "list": {
       "countSingular": "camporee",
@@ -2118,7 +2122,22 @@
       "place_required": "El lugar es obligatorio",
       "local_field_required": "El campo local es obligatorio",
       "end_date_after_start": "La fecha de fin debe ser igual o posterior a la de inicio",
-      "end_date_after_start_full": "La fecha de fin debe ser igual o posterior a la fecha de inicio"
+      "end_date_after_start_full": "La fecha de fin debe ser igual o posterior a la fecha de inicio",
+      "field_required": "El campo {field} es obligatorio",
+      "field_invalid": "El valor de {field} no es válido",
+      "dates_required": "Las fechas de inicio y fin son obligatorias",
+      "no_changes": "No se realizaron cambios",
+      "user_id_required": "El usuario es obligatorio",
+      "camporee_type_invalid": "El tipo de camporee no es válido",
+      "insurance_invalid": "El seguro seleccionado no es válido",
+      "member_remove_not_identified": "No se pudo identificar al miembro a eliminar"
+    },
+    "fields": {
+      "local_field": "Campo local"
+    },
+    "success": {
+      "member_registered": "Miembro registrado correctamente",
+      "member_removed": "Miembro eliminado correctamente"
     }
   },
   "resources": {

--- a/scripts/generate-messages-types.mjs
+++ b/scripts/generate-messages-types.mjs
@@ -55,32 +55,21 @@ const header = `/**
  *   useTranslations(namespace) and t(key) call is type-checked against this
  *   interface, so unknown namespaces and keys produce compile-time errors.
  *
- * ROLLOUT STATUS: STAGED (not yet enforced in typecheck CI)
- *   The IntlMessages interface is fully generated and ready. Strict enforcement
- *   is intentionally deferred because 35 pre-existing call-sites use patterns
- *   that strict mode flags correctly (dynamic keys, custom translator aliases,
- *   cross-namespace key access). Fix those call-sites first, then uncomment
- *   the AppConfig block below to activate full strict checking.
- *
- * TO ACTIVATE STRICT MODE:
- *   1. Fix the 35 call-sites (see PR description for the full list)
- *   2. Uncomment the \`declare module "next-intl"\` block below
- *   3. Run \`pnpm typecheck\` — must pass with 0 errors
- *   4. Delete this comment block
- *
  * CONCURRENT AGENT NOTE (A3 / i18n native routing):
  *   Agent A3 may add new keys to messages/es.json for routing labels.
  *   After A3 merges, run the generator again so this file stays in sync.
+ *   No conflict expected — A3 touches next.config.ts i18n routing block
+ *   and src/proxy.ts; this file is standalone.
  */
 
-// TO ACTIVATE STRICT MODE: uncomment this block after fixing the 35 call-sites.
+// Strict mode active — every useTranslations(namespace) and t(key) call is
+// type-checked against IntlMessages. Unknown namespaces/keys are compile errors.
 // See: https://next-intl.dev/docs/workflows/typescript
-//
-// declare module "next-intl" {
-//   interface AppConfig {
-//     Messages: IntlMessages;
-//   }
-// }
+declare module "next-intl" {
+  interface AppConfig {
+    Messages: IntlMessages;
+  }
+}
 
 export interface IntlMessages {`;
 

--- a/src/app/(dashboard)/dashboard/system/jobs/_components/cron-runs-section.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/_components/cron-runs-section.tsx
@@ -45,7 +45,8 @@ const JOB_CANONICAL_NAMES: CronJobKey[] = [
   "fcm-tokens-cleanup",
 ];
 
-const JOB_I18N_KEYS: Record<CronJobKey, string> = {
+type CronRunsT = ReturnType<typeof useTranslations<"system_jobs.cronRuns">>;
+const JOB_I18N_KEYS: Record<CronJobKey, Parameters<CronRunsT>[0]> = {
   "monthly-reports-auto-generate":  "jobMonthlyReports",
   "rankings-recalculate":           "jobRankingsRecalculate",
   "data-export-cleanup":            "jobDataExportCleanup",

--- a/src/app/(dashboard)/dashboard/system/jobs/_components/jobs-overview-client.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/_components/jobs-overview-client.tsx
@@ -45,7 +45,8 @@ interface JobsOverviewClientProps {
 
 // ─── Queue Metadata ───────────────────────────────────────────────────────────
 
-const QUEUE_I18N_KEYS: Record<KnownQueueName, { labelKey: string; descKey: string }> = {
+type OverviewT = ReturnType<typeof useTranslations<"system_jobs.overview">>;
+const QUEUE_I18N_KEYS: Record<KnownQueueName, { labelKey: Parameters<OverviewT>[0]; descKey: Parameters<OverviewT>[0] }> = {
   'notifications':   { labelKey: 'queueNotifications',    descKey: 'queueNotificationsDesc' },
   'email':           { labelKey: 'queueEmail',            descKey: 'queueEmailDesc' },
   'achievements':    { labelKey: 'queueAchievements',     descKey: 'queueAchievementsDesc' },

--- a/src/app/(dashboard)/dashboard/system/jobs/history/_components/cron-history-client.tsx
+++ b/src/app/(dashboard)/dashboard/system/jobs/history/_components/cron-history-client.tsx
@@ -64,7 +64,8 @@ const JOB_CANONICAL_NAMES: CronJobKey[] = [
   "fcm-tokens-cleanup",
 ];
 
-const JOB_I18N_KEYS: Record<CronJobKey, string> = {
+type HistoryT = ReturnType<typeof useTranslations<"system_jobs.history">>;
+const JOB_I18N_KEYS: Record<CronJobKey, Parameters<HistoryT>[0]> = {
   "monthly-reports-auto-generate":  "jobMonthlyReports",
   "rankings-recalculate":           "jobRankingsRecalculate",
   "data-export-cleanup":            "jobDataExportCleanup",

--- a/src/components/catalogs/catalog-crud-page.tsx
+++ b/src/components/catalogs/catalog-crud-page.tsx
@@ -218,7 +218,7 @@ export function CatalogCrudPage({
                           key={f.name}
                           className={`${TH_BASE} ${COL_MID}`}
                         >
-                          {tCatalogs(f.label)}
+                          {tCatalogs(f.label as Parameters<typeof tCatalogs>[0])}
                         </TableHead>
                       ))}
 
@@ -430,7 +430,7 @@ export function CatalogCrudPage({
                           return (
                             <div key={f.name}>
                               <dt className="text-muted-foreground">
-                                {tCatalogs(f.label)}
+                                {tCatalogs(f.label as Parameters<typeof tCatalogs>[0])}
                               </dt>
                               <dd className="truncate">{display}</dd>
                             </div>

--- a/src/components/catalogs/catalog-form-dialog.tsx
+++ b/src/components/catalogs/catalog-form-dialog.tsx
@@ -147,7 +147,7 @@ export function CatalogFormDialog({
                       setCheckboxValues((prev) => ({ ...prev, [field.name]: !!checked }))
                     }
                   />
-                  <Label htmlFor={field.name}>{t(field.label)}</Label>
+                  <Label htmlFor={field.name}>{t(field.label as Parameters<typeof t>[0])}</Label>
                 </div>
               );
             }
@@ -161,7 +161,7 @@ export function CatalogFormDialog({
               return (
                 <div key={field.name} className="space-y-1.5">
                   <Label htmlFor={field.name} className="text-sm font-medium">
-                    {t(field.label)}
+                    {t(field.label as Parameters<typeof t>[0])}
                     {field.required && <span className="text-destructive/70 ml-0.5">*</span>}
                   </Label>
                   <Select
@@ -170,7 +170,7 @@ export function CatalogFormDialog({
                     required={field.required}
                   >
                     <SelectTrigger>
-                      <SelectValue placeholder={`Seleccionar ${t(field.label).toLowerCase()}`} />
+                      <SelectValue placeholder={`Seleccionar ${t(field.label as Parameters<typeof t>[0]).toLowerCase()}`} />
                     </SelectTrigger>
                     <SelectContent>
                       {validOptions.map((opt, idx) => (
@@ -188,7 +188,7 @@ export function CatalogFormDialog({
               return (
                 <div key={field.name} className="space-y-1.5">
                   <Label htmlFor={field.name} className="text-sm font-medium">
-                    {t(field.label)}
+                    {t(field.label as Parameters<typeof t>[0])}
                     {field.required && <span className="text-destructive/70 ml-0.5">*</span>}
                   </Label>
                   <Textarea
@@ -207,7 +207,7 @@ export function CatalogFormDialog({
             return (
               <div key={field.name} className="space-y-1.5">
                 <Label htmlFor={field.name} className="text-sm font-medium">
-                  {t(field.label)}
+                  {t(field.label as Parameters<typeof t>[0])}
                   {field.required && <span className="text-destructive/70 ml-0.5">*</span>}
                 </Label>
                 <Input

--- a/src/components/evidence-review/evidence-bulk-action-bar.tsx
+++ b/src/components/evidence-review/evidence-bulk-action-bar.tsx
@@ -35,7 +35,7 @@ import { ApiError } from "@/lib/api/client";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
-type BulkTranslator = (key: string, values?: Record<string, string | number>) => string;
+type BulkTranslator = ReturnType<typeof useTranslations<"evidence_review">>;
 
 function buildToastMessage(
   t: BulkTranslator,

--- a/src/components/evidence-review/evidence-reject-dialog.tsx
+++ b/src/components/evidence-review/evidence-reject-dialog.tsx
@@ -28,7 +28,7 @@ import {
 import { rejectEvidence, type EvidenceType } from "@/lib/api/evidence-review";
 import { ApiError } from "@/lib/api/client";
 
-type RejectTranslator = (key: string, values?: Record<string, string | number>) => string;
+type RejectTranslator = ReturnType<typeof useTranslations<"evidence_review">>;
 
 function buildRejectSchema(t: RejectTranslator) {
   return z.object({

--- a/src/components/investiture/bulk-action-bar.tsx
+++ b/src/components/investiture/bulk-action-bar.tsx
@@ -55,7 +55,7 @@ function resolveAction(status: PipelineStatus): BulkApproveAction | null {
   }
 }
 
-type BulkTranslator = (key: string, values?: Record<string, string | number>) => string;
+type BulkTranslator = ReturnType<typeof useTranslations<"investiture">>;
 
 function buildToastMessage(
   t: BulkTranslator,

--- a/src/components/investiture/config-form-dialog.tsx
+++ b/src/components/investiture/config-form-dialog.tsx
@@ -45,7 +45,7 @@ import { listEcclesiasticalYears, type EcclesiasticalYear } from "@/lib/api/cata
 
 // ─── Schema ───────────────────────────────────────────────────────────────────
 
-type ConfigTranslator = (key: string, values?: Record<string, string | number>) => string;
+type ConfigTranslator = ReturnType<typeof useTranslations<"investiture">>;
 
 function buildFormSchema(t: ConfigTranslator) {
   return z.object({

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -54,7 +54,7 @@ function NavItemWithChildren({ item, pathname }: { item: NavItem; pathname: stri
   const t = useTranslations("nav");
   const isChildActive = item.children?.some((child) => pathname === child.url) ?? false;
   const isActive = pathname === item.url || isChildActive;
-  const title = t(item.title);
+  const title = t(item.title as Parameters<typeof t>[0]);
 
   return (
     <Collapsible asChild defaultOpen={isActive}>
@@ -69,7 +69,7 @@ function NavItemWithChildren({ item, pathname }: { item: NavItem; pathname: stri
         <CollapsibleContent>
           <SidebarMenuSub>
             {item.children!.map((child) => {
-              const childTitle = t(child.title);
+              const childTitle = t(child.title as Parameters<typeof t>[0]);
               return (
                 <SidebarMenuSubItem key={child.url}>
                   <SidebarMenuSubButton asChild isActive={pathname === child.url}>
@@ -90,7 +90,7 @@ function NavItemWithChildren({ item, pathname }: { item: NavItem; pathname: stri
 function NavItemSimple({ item, pathname }: { item: NavItem; pathname: string }) {
   const t = useTranslations("nav");
   const isActive = pathname === item.url || (item.url !== "/dashboard" && pathname.startsWith(item.url + "/"));
-  const title = t(item.title);
+  const title = t(item.title as Parameters<typeof t>[0]);
 
   return (
     <SidebarMenuItem>
@@ -119,7 +119,7 @@ function SidebarNavGroup({ group }: { group: NavGroup }) {
 
   return (
     <SidebarGroup>
-      {group.label && <SidebarGroupLabel>{t(group.label)}</SidebarGroupLabel>}
+      {group.label && <SidebarGroupLabel>{t(group.label as Parameters<typeof t>[0])}</SidebarGroupLabel>}
       <SidebarMenu>
         {visibleItems.map((item) =>
           item.children ? (

--- a/src/components/reports/report-detail-client.tsx
+++ b/src/components/reports/report-detail-client.tsx
@@ -131,7 +131,7 @@ export function ReportDetailClient({ report: initialReport }: ReportDetailClient
     } as const
   )[report.status] ?? ("warning" as const);
 
-  const monthName = t(`months.${report.month}`);
+  const monthName = t(`months.${report.month}` as Parameters<typeof t>[0]);
   const isSubmitted = report.status === "submitted";
   const isGenerated = report.status === "generated";
 

--- a/src/components/reports/reports-list-client.tsx
+++ b/src/components/reports/reports-list-client.tsx
@@ -145,7 +145,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
     onSuccess: (report) => {
       toast.success(
         t("list.toastCreated", {
-          month: t(`months.${createMonth}`),
+          month: t(`months.${createMonth}` as Parameters<typeof t>[0]),
           year: createYear,
         }),
       );
@@ -166,7 +166,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
     onSuccess: (_, report) => {
       toast.success(
         t("list.toastGenerated", {
-          month: t(`months.${report.month}`),
+          month: t(`months.${report.month}` as Parameters<typeof t>[0]),
           year: report.year,
         }),
       );
@@ -201,7 +201,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
     onSuccess: (_, report) => {
       toast.success(
         t("list.toastSent", {
-          month: t(`months.${report.month}`),
+          month: t(`months.${report.month}` as Parameters<typeof t>[0]),
           year: report.year,
         }),
       );
@@ -310,7 +310,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
             <SelectContent>
               {MONTH_NUMBERS.map((m) => (
                 <SelectItem key={m} value={m.toString()}>
-                  {t(`months.${m}`)}
+                  {t(`months.${m}` as Parameters<typeof t>[0])}
                 </SelectItem>
               ))}
             </SelectContent>
@@ -389,7 +389,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                     return (
                       <TableRow key={report.report_id}>
                         <TableCell className="font-medium">
-                          {t(`months.${report.month}`)}
+                          {t(`months.${report.month}` as Parameters<typeof t>[0])}
                         </TableCell>
                         <TableCell className="tabular-nums">{report.year}</TableCell>
                         <TableCell>
@@ -492,7 +492,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                       </div>
                       <div className="min-w-0 flex-1">
                         <p className="truncate text-sm font-medium">
-                          {t(`months.${report.month}`)} {report.year}
+                          {t(`months.${report.month}` as Parameters<typeof t>[0])} {report.year}
                         </p>
                         <p className="truncate text-xs text-muted-foreground tabular-nums">
                           #{report.report_id}

--- a/src/components/scoring-categories/scoring-categories-table.tsx
+++ b/src/components/scoring-categories/scoring-categories-table.tsx
@@ -399,7 +399,7 @@ export function ScoringCategoriesTable({
                           className="text-xs"
                         >
                           {cat.origin_badge ||
-                            tTable(`origin.${cat.origin_level.toLowerCase()}`)}
+                            tTable(`origin.${cat.origin_level.toLowerCase()}` as Parameters<typeof tTable>[0])}
                         </Badge>
                       </TableCell>
                     )}

--- a/src/components/users/post-registration-tab.tsx
+++ b/src/components/users/post-registration-tab.tsx
@@ -97,7 +97,7 @@ function StepStatusIcon({
   if (completed) {
     return (
       <span
-        aria-label={t("postRegistration.step_aria_completed")}
+        aria-label={t("postRegistration.step_aria_complete")}
         className="flex size-8 items-center justify-center rounded-full bg-success/10"
       >
         <CheckCircle2 className="size-5 text-success" />
@@ -116,7 +116,7 @@ function StepStatusIcon({
   }
   return (
     <span
-      aria-label={t("postRegistration.step_aria_not_started")}
+      aria-label={t("postRegistration.step_aria_optional")}
       className="flex size-8 items-center justify-center rounded-full bg-muted"
     >
       <Circle className="size-5 text-muted-foreground" />
@@ -416,10 +416,10 @@ export function PostRegistrationTab({
                           }
                         >
                           {completed
-                            ? t("postRegistration.step_status_completed")
+                            ? t("postRegistration.step_status_complete")
                             : isNext
                               ? t("postRegistration.step_status_pending")
-                              : t("postRegistration.step_status_not_started")}
+                              : t("postRegistration.step_status_optional")}
                         </Badge>
                       </div>
 

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -11,34 +11,6 @@
  *   useTranslations(namespace) and t(key) call is type-checked against this
  *   interface, so unknown namespaces and keys produce compile-time errors.
  *
- * ROLLOUT STATUS: STAGED (not yet enforced in typecheck CI)
- *   The IntlMessages interface is fully generated and ready. Strict enforcement
- *   is intentionally deferred because 35 pre-existing call-sites use patterns
- *   that strict mode flags correctly (dynamic keys, custom translator aliases,
- *   cross-namespace key access). Fix those call-sites first, then uncomment
- *   the AppConfig block below to activate full strict checking.
- *
- *   Files with flagged issues (run `pnpm typecheck` after uncommenting):
- *     - src/components/catalogs/catalog-crud-page.tsx (dynamic string keys)
- *     - src/components/catalogs/catalog-form-dialog.tsx (dynamic string keys)
- *     - src/components/layout/app-sidebar.tsx (dynamic string keys)
- *     - src/components/reports/reports-list-client.tsx (months.${number} pattern)
- *     - src/components/reports/report-detail-client.tsx (months.${number} pattern)
- *     - src/components/scoring-categories/scoring-categories-table.tsx (origin.${string})
- *     - src/components/users/post-registration-tab.tsx (cross-namespace key access)
- *     - src/components/evidence-review/evidence-bulk-action-bar.tsx (BulkTranslator alias)
- *     - src/components/evidence-review/evidence-reject-dialog.tsx (RejectTranslator alias)
- *     - src/components/investiture/bulk-action-bar.tsx (BulkTranslator alias)
- *     - src/components/investiture/config-form-dialog.tsx (ConfigTranslator alias)
- *     - src/app/(dashboard)/dashboard/system/jobs/*  (dynamic string keys)
- *
- * TO ACTIVATE STRICT MODE:
- *   1. Fix the 35 call-sites listed above (mainly cast dynamic keys with
- *      `as MessageKeys<IntlMessages, Namespace>` or add explicit message keys)
- *   2. Uncomment the `declare module "next-intl"` block below
- *   3. Run `pnpm typecheck` — must pass with 0 errors
- *   4. Delete this comment block
- *
  * CONCURRENT AGENT NOTE (A3 / i18n native routing):
  *   Agent A3 may add new keys to messages/es.json for routing labels.
  *   After A3 merges, run the generator again so this file stays in sync.
@@ -46,14 +18,14 @@
  *   and src/proxy.ts; this file is standalone.
  */
 
-// TO ACTIVATE STRICT MODE: uncomment this block after fixing the 35 call-sites
-// listed above. See: https://next-intl.dev/docs/workflows/typescript
-//
-// declare module "next-intl" {
-//   interface AppConfig {
-//     Messages: IntlMessages;
-//   }
-// }
+// Strict mode active — every useTranslations(namespace) and t(key) call is
+// type-checked against IntlMessages. Unknown namespaces/keys are compile errors.
+// See: https://next-intl.dev/docs/workflows/typescript
+declare module "next-intl" {
+  interface AppConfig {
+    Messages: IntlMessages;
+  }
+}
 
 export interface IntlMessages {
   nav: {
@@ -1917,6 +1889,10 @@ export interface IntlMessages {
       approve_member: string;
       approve_payment: string;
       enroll_club: string;
+      create_failed: string;
+      update_failed: string;
+      register_member_failed: string;
+      remove_member_failed: string;
     };
     list: {
       countSingular: string;
@@ -2176,6 +2152,21 @@ export interface IntlMessages {
       local_field_required: string;
       end_date_after_start: string;
       end_date_after_start_full: string;
+      field_required: string;
+      field_invalid: string;
+      dates_required: string;
+      no_changes: string;
+      user_id_required: string;
+      camporee_type_invalid: string;
+      insurance_invalid: string;
+      member_remove_not_identified: string;
+    };
+    fields: {
+      local_field: string;
+    };
+    success: {
+      member_registered: string;
+      member_removed: string;
     };
   };
   resources: {


### PR DESCRIPTION
## Summary

- Activates `IntlMessages` AppConfig augmentation in `src/i18n/messages.d.ts` — every `useTranslations(ns)` and `t(key)` call is now type-checked at compile time
- Updates `scripts/generate-messages-types.mjs` so future regenerations preserve strict mode (the generator itself emits the active block)
- Fixes 35 pre-existing call-sites that broke under strict mode (stale keys, loose translator types, dynamic key casts)
- Adds 14 missing keys to `messages/es.json > camporees` namespace that `src/lib/camporees/actions.ts` was referencing (real data gap surfaced by strict mode)

## Error categories fixed

| Category | Count | Fix |
|---|---|---|
| Custom `(key: string) => string` translator aliases | 4 types | Replaced with `ReturnType<typeof useTranslations<"ns">>` |
| Stale key names (`step_aria_completed` → `step_aria_complete`, etc.) | 4 | Fixed in `post-registration-tab.tsx` |
| Legitimate dynamic keys (field labels, nav titles, month templates, origin badge) | 11 call sites | `as Parameters<typeof t>[0]` cast |
| Typed record maps (`JOB_I18N_KEYS`, `QUEUE_I18N_KEYS`) | 3 | Record value typed via `Parameters<OverviewT>[0]` |
| Missing keys in `camporees` namespace | 14 keys | Added to `messages/es.json` + regenerated `messages.d.ts` |

## Result

```
pnpm typecheck → 0 errors ✓
```

Lint errors in output are pre-existing (unrelated files, same count as `development` branch).

## Test plan

- [ ] `pnpm typecheck` passes with 0 errors
- [ ] Add a new translation call with a fake key — TypeScript must error at compile time
- [ ] `node scripts/generate-messages-types.mjs` after a key change regenerates the file with strict mode still active
- [ ] Camporee create/update/member flows work correctly in the UI (new validation messages now have es.json backing)