### PR TITLE
feat(nav): reorg sidebar — split catalogs + rebalance sections

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -8,7 +8,9 @@
       "validation": "Validation and investitures",
       "communications": "Communications",
       "requests_reports": "Requests and reports",
-      "members": "Members"
+      "members": "Members",
+      "operations": "Operations",
+      "rankings_analytics": "Rankings & Analytics"
     },
     "items": {
       "dashboard": "Dashboard",
@@ -92,7 +94,15 @@
       "catalog_finance_categories": "Finance categories",
       "catalog_inventory_categories": "Inventory categories",
       "catalog_honors": "Honors (catalog)",
-      "catalog_master_honors": "Master honors"
+      "catalog_master_honors": "Master honors",
+      "subgroup_overview": "Overview",
+      "subgroup_geography": "Geography",
+      "subgroup_health": "Health",
+      "subgroup_clubs_cat": "Clubs",
+      "subgroup_academics": "Academics",
+      "subgroup_business": "Business",
+      "subgroup_honors_cat": "Honors",
+      "ranking_weights_root": "Weights configuration"
     },
     "breadcrumbs": {
       "dashboard": "Dashboard",

--- a/messages/es.json
+++ b/messages/es.json
@@ -8,7 +8,9 @@
       "validation": "Validación e investiduras",
       "communications": "Comunicaciones",
       "requests_reports": "Solicitudes y reportes",
-      "members": "Miembros"
+      "members": "Miembros",
+      "operations": "Operaciones",
+      "rankings_analytics": "Rankings y análisis"
     },
     "items": {
       "dashboard": "Dashboard",
@@ -92,7 +94,15 @@
       "catalog_finance_categories": "Categorías de finanzas",
       "catalog_inventory_categories": "Categorías de inventario",
       "catalog_honors": "Especialidades (catálogo)",
-      "catalog_master_honors": "Honores maestros"
+      "catalog_master_honors": "Honores maestros",
+      "subgroup_overview": "General",
+      "subgroup_geography": "Geografía",
+      "subgroup_health": "Salud",
+      "subgroup_clubs_cat": "Clubes",
+      "subgroup_academics": "Académicos",
+      "subgroup_business": "Negocio",
+      "subgroup_honors_cat": "Honores",
+      "ranking_weights_root": "Configuración de pesos"
     },
     "breadcrumbs": {
       "dashboard": "Dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -8,7 +8,9 @@
       "validation": "Validation et investitures",
       "communications": "Communications",
       "requests_reports": "Demandes et rapports",
-      "members": "Membres"
+      "members": "Membres",
+      "operations": "Opérations",
+      "rankings_analytics": "Classements & Analytique"
     },
     "items": {
       "dashboard": "Tableau de bord",
@@ -92,7 +94,15 @@
       "catalog_finance_categories": "Categories de finances",
       "catalog_inventory_categories": "Categories d'inventaire",
       "catalog_honors": "Specialites (catalogue)",
-      "catalog_master_honors": "Honneurs maitres"
+      "catalog_master_honors": "Honneurs maitres",
+      "subgroup_overview": "Aperçu",
+      "subgroup_geography": "Géographie",
+      "subgroup_health": "Santé",
+      "subgroup_clubs_cat": "Clubs",
+      "subgroup_academics": "Académiques",
+      "subgroup_business": "Affaires",
+      "subgroup_honors_cat": "Honneurs",
+      "ranking_weights_root": "Configuration des poids"
     },
     "breadcrumbs": {
       "dashboard": "Tableau de bord",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -8,7 +8,9 @@
       "validation": "Validação e investiduras",
       "communications": "Comunicações",
       "requests_reports": "Solicitações e relatórios",
-      "members": "Membros"
+      "members": "Membros",
+      "operations": "Operações",
+      "rankings_analytics": "Rankings e análises"
     },
     "items": {
       "dashboard": "Dashboard",
@@ -92,7 +94,15 @@
       "catalog_finance_categories": "Categorias de finanças",
       "catalog_inventory_categories": "Categorias de inventário",
       "catalog_honors": "Especialidades (catálogo)",
-      "catalog_master_honors": "Honras mestres"
+      "catalog_master_honors": "Honras mestres",
+      "subgroup_overview": "Geral",
+      "subgroup_geography": "Geografia",
+      "subgroup_health": "Saúde",
+      "subgroup_clubs_cat": "Clubes",
+      "subgroup_academics": "Acadêmicos",
+      "subgroup_business": "Negócio",
+      "subgroup_honors_cat": "Honras",
+      "ranking_weights_root": "Configuração de pesos"
     },
     "breadcrumbs": {
       "dashboard": "Painel",

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -35,7 +35,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useTranslations } from "next-intl";
 import { useAuth } from "@/lib/auth/auth-context";
 import { usePermissions } from "@/lib/auth/use-permissions";
-import { navConfig, type NavGroup, type NavItem } from "@/components/layout/nav-config";
+import { navConfig, isSubGroup, type NavGroup, type NavItem, type NavChild, type NavSubGroup } from "@/components/layout/nav-config";
 import { LocaleSwitcherMenu } from "@/components/layout/locale-switcher";
 
 function getInitials(name?: string | null, email?: string | null): string {
@@ -50,11 +50,43 @@ function getInitials(name?: string | null, email?: string | null): string {
   return (email?.[0] ?? "A").toUpperCase();
 }
 
+function flattenChildren(children: NavItem["children"]): NavChild[] {
+  if (!children) return [];
+  if (children.length === 0) return [];
+  if (isSubGroup(children[0])) {
+    return (children as NavSubGroup[]).flatMap((sg) => sg.items);
+  }
+  return children as NavChild[];
+}
+
+function NavSubChildLink({
+  child,
+  pathname,
+  t,
+}: {
+  child: NavChild;
+  pathname: string;
+  t: ReturnType<typeof useTranslations<"nav">>;
+}) {
+  const childTitle = t(child.title as Parameters<typeof t>[0]);
+  return (
+    <SidebarMenuSubItem>
+      <SidebarMenuSubButton asChild isActive={pathname === child.url}>
+        <Link href={child.url}>
+          <span className="truncate" title={childTitle}>{childTitle}</span>
+        </Link>
+      </SidebarMenuSubButton>
+    </SidebarMenuSubItem>
+  );
+}
+
 function NavItemWithChildren({ item, pathname }: { item: NavItem; pathname: string }) {
   const t = useTranslations("nav");
-  const isChildActive = item.children?.some((child) => pathname === child.url) ?? false;
+  const flatChildren = flattenChildren(item.children);
+  const isChildActive = flatChildren.some((child) => pathname === child.url);
   const isActive = pathname === item.url || isChildActive;
   const title = t(item.title as Parameters<typeof t>[0]);
+  const grouped = item.children && item.children.length > 0 && isSubGroup(item.children[0]);
 
   return (
     <Collapsible asChild defaultOpen={isActive}>
@@ -68,18 +100,23 @@ function NavItemWithChildren({ item, pathname }: { item: NavItem; pathname: stri
         </CollapsibleTrigger>
         <CollapsibleContent>
           <SidebarMenuSub>
-            {item.children!.map((child) => {
-              const childTitle = t(child.title as Parameters<typeof t>[0]);
-              return (
-                <SidebarMenuSubItem key={child.url}>
-                  <SidebarMenuSubButton asChild isActive={pathname === child.url}>
-                    <Link href={child.url}>
-                      <span className="truncate" title={childTitle}>{childTitle}</span>
-                    </Link>
-                  </SidebarMenuSubButton>
-                </SidebarMenuSubItem>
-              );
-            })}
+            {grouped
+              ? (item.children as NavSubGroup[]).map((sg) => {
+                  const sgLabel = t(sg.subgroup as Parameters<typeof t>[0]);
+                  return (
+                    <div key={sg.subgroup} className="mt-1 first:mt-0">
+                      <div className="px-2 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                        {sgLabel}
+                      </div>
+                      {sg.items.map((child) => (
+                        <NavSubChildLink key={child.url} child={child} pathname={pathname} t={t} />
+                      ))}
+                    </div>
+                  );
+                })
+              : (item.children as NavChild[]).map((child) => (
+                  <NavSubChildLink key={child.url} child={child} pathname={pathname} t={t} />
+                ))}
           </SidebarMenuSub>
         </CollapsibleContent>
       </SidebarMenuItem>

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -44,8 +44,10 @@ import {
  * Renderers (see `app-sidebar.tsx`) resolve them via next-intl
  * `useTranslations()` at render time so the sidebar re-renders on locale change.
  *
- * Key convention: `nav.sections.<id>` for group labels,
- * `nav.items.<id>` for entries. Translators edit `messages/<locale>.json`.
+ * Key convention:
+ *   - `nav.sections.<id>` for group labels
+ *   - `nav.items.<id>` for entries
+ *   - `nav.items.subgroup_<id>` for visual subgroup separators inside a dropdown
  */
 
 export type NavItem = {
@@ -53,7 +55,7 @@ export type NavItem = {
   url: string;
   icon: LucideIcon;
   permission?: string;
-  children?: NavChild[];
+  children?: NavChildren;
 };
 
 export type NavChild = {
@@ -61,6 +63,17 @@ export type NavChild = {
   url: string;
   permission?: string;
 };
+
+export type NavSubGroup = {
+  subgroup: string;
+  items: NavChild[];
+};
+
+export type NavChildren = NavChild[] | NavSubGroup[];
+
+export function isSubGroup(entry: NavChild | NavSubGroup): entry is NavSubGroup {
+  return "subgroup" in entry;
+}
 
 export type NavGroup = {
   label?: string;
@@ -86,7 +99,7 @@ export const navConfig: NavGroup[] = [
     ],
   },
 
-  // ─── Catálogos ───────────────────────────────────────────────────────────────
+  // ─── Catálogos (children agrupados por dominio) ──────────────────────────────
   {
     label: "sections.catalogs",
     items: [
@@ -95,31 +108,66 @@ export const navConfig: NavGroup[] = [
         url: "/dashboard/catalogs",
         icon: BookOpen,
         children: [
-          { title: "sections.overview", url: "/dashboard/catalogs" },
-          { title: "items.geography_countries", url: "/dashboard/catalogs/geography/countries", permission: "countries:read" },
-          { title: "items.geography_unions", url: "/dashboard/catalogs/geography/unions", permission: "unions:read" },
-          { title: "items.geography_local_fields", url: "/dashboard/catalogs/geography/local-fields", permission: "local_fields:read" },
-          { title: "items.geography_districts", url: "/dashboard/catalogs/geography/districts", permission: "districts:read" },
-          { title: "items.geography_churches", url: "/dashboard/catalogs/geography/churches", permission: "churches:read" },
-          { title: "items.allergies", url: "/dashboard/catalogs/allergies", permission: "catalogs:read" },
-          { title: "items.diseases", url: "/dashboard/catalogs/diseases", permission: "catalogs:read" },
-          { title: "items.medicines", url: "/dashboard/catalogs/medicines", permission: "catalogs:read" },
-          { title: "items.relationship_types", url: "/dashboard/catalogs/relationship-types", permission: "catalogs:read" },
-          { title: "items.ecclesiastical_years", url: "/dashboard/catalogs/ecclesiastical-years", permission: "ecclesiastical_years:read" },
-          { title: "items.club_types", url: "/dashboard/catalogs/club-types", permission: "catalogs:read" },
-          { title: "items.club_ideals", url: "/dashboard/catalogs/club-ideals", permission: "catalogs:read" },
-          { title: "items.honor_categories", url: "/dashboard/catalogs/honor-categories", permission: "honor_categories:read" },
-          { title: "items.activity_types", url: "/dashboard/catalogs/activity-types", permission: "catalogs:read" },
-          { title: "items.catalog_classes", url: "/dashboard/catalogs/classes", permission: "catalogs:read" },
-          { title: "items.catalog_class_modules", url: "/dashboard/catalogs/class-modules", permission: "catalogs:read" },
-          { title: "items.catalog_class_sections", url: "/dashboard/catalogs/class-sections", permission: "catalogs:read" },
-          { title: "items.catalog_folders", url: "/dashboard/catalogs/catalog-folders", permission: "catalogs:read" },
-          { title: "items.catalog_folder_modules", url: "/dashboard/catalogs/folder-modules", permission: "catalogs:read" },
-          { title: "items.catalog_folder_sections", url: "/dashboard/catalogs/folder-sections", permission: "catalogs:read" },
-          { title: "items.catalog_finance_categories", url: "/dashboard/catalogs/finance-categories", permission: "catalogs:read" },
-          { title: "items.catalog_inventory_categories", url: "/dashboard/catalogs/inventory-categories", permission: "catalogs:read" },
-          { title: "items.catalog_honors", url: "/dashboard/catalogs/honors-catalog", permission: "honors:read" },
-          { title: "items.catalog_master_honors", url: "/dashboard/catalogs/master-honors", permission: "catalogs:read" },
+          {
+            subgroup: "items.subgroup_overview",
+            items: [
+              { title: "sections.overview", url: "/dashboard/catalogs" },
+            ],
+          },
+          {
+            subgroup: "items.subgroup_geography",
+            items: [
+              { title: "items.geography_countries", url: "/dashboard/catalogs/geography/countries", permission: "countries:read" },
+              { title: "items.geography_unions", url: "/dashboard/catalogs/geography/unions", permission: "unions:read" },
+              { title: "items.geography_local_fields", url: "/dashboard/catalogs/geography/local-fields", permission: "local_fields:read" },
+              { title: "items.geography_districts", url: "/dashboard/catalogs/geography/districts", permission: "districts:read" },
+              { title: "items.geography_churches", url: "/dashboard/catalogs/geography/churches", permission: "churches:read" },
+            ],
+          },
+          {
+            subgroup: "items.subgroup_health",
+            items: [
+              { title: "items.allergies", url: "/dashboard/catalogs/allergies", permission: "catalogs:read" },
+              { title: "items.diseases", url: "/dashboard/catalogs/diseases", permission: "catalogs:read" },
+              { title: "items.medicines", url: "/dashboard/catalogs/medicines", permission: "catalogs:read" },
+            ],
+          },
+          {
+            subgroup: "items.subgroup_clubs_cat",
+            items: [
+              { title: "items.club_types", url: "/dashboard/catalogs/club-types", permission: "catalogs:read" },
+              { title: "items.club_ideals", url: "/dashboard/catalogs/club-ideals", permission: "catalogs:read" },
+              { title: "items.ecclesiastical_years", url: "/dashboard/catalogs/ecclesiastical-years", permission: "ecclesiastical_years:read" },
+              { title: "items.relationship_types", url: "/dashboard/catalogs/relationship-types", permission: "catalogs:read" },
+            ],
+          },
+          {
+            subgroup: "items.subgroup_academics",
+            items: [
+              { title: "items.catalog_classes", url: "/dashboard/catalogs/classes", permission: "catalogs:read" },
+              { title: "items.catalog_class_modules", url: "/dashboard/catalogs/class-modules", permission: "catalogs:read" },
+              { title: "items.catalog_class_sections", url: "/dashboard/catalogs/class-sections", permission: "catalogs:read" },
+              { title: "items.catalog_folders", url: "/dashboard/catalogs/catalog-folders", permission: "catalogs:read" },
+              { title: "items.catalog_folder_modules", url: "/dashboard/catalogs/folder-modules", permission: "catalogs:read" },
+              { title: "items.catalog_folder_sections", url: "/dashboard/catalogs/folder-sections", permission: "catalogs:read" },
+              { title: "items.activity_types", url: "/dashboard/catalogs/activity-types", permission: "catalogs:read" },
+            ],
+          },
+          {
+            subgroup: "items.subgroup_business",
+            items: [
+              { title: "items.catalog_finance_categories", url: "/dashboard/catalogs/finance-categories", permission: "catalogs:read" },
+              { title: "items.catalog_inventory_categories", url: "/dashboard/catalogs/inventory-categories", permission: "catalogs:read" },
+            ],
+          },
+          {
+            subgroup: "items.subgroup_honors_cat",
+            items: [
+              { title: "items.catalog_honors", url: "/dashboard/catalogs/honors-catalog", permission: "honors:read" },
+              { title: "items.catalog_master_honors", url: "/dashboard/catalogs/master-honors", permission: "catalogs:read" },
+              { title: "items.honor_categories", url: "/dashboard/catalogs/honor-categories", permission: "honor_categories:read" },
+            ],
+          },
         ],
       },
       {
@@ -131,39 +179,6 @@ export const navConfig: NavGroup[] = [
           { title: "items.resources_all", url: "/dashboard/resources", permission: "resources:read" },
           { title: "items.resources_categories", url: "/dashboard/resources/categories", permission: "resource_categories:read" },
         ],
-      },
-    ],
-  },
-
-  // ─── Sistema ─────────────────────────────────────────────────────────────────
-  {
-    label: "sections.administration",
-    items: [
-      {
-        title: "items.rbac",
-        url: "/dashboard/rbac",
-        icon: Shield,
-        permission: "permissions:read",
-        children: [
-          { title: "items.rbac_permissions", url: "/dashboard/rbac/permissions", permission: "permissions:read" },
-          { title: "items.rbac_roles", url: "/dashboard/rbac/roles", permission: "roles:read" },
-        ],
-      },
-      {
-        title: "items.configuration",
-        url: "/dashboard/settings",
-        icon: Settings2,
-        permission: "permissions:read",
-        children: [
-          { title: "items.settings_system", url: "/dashboard/settings", permission: "permissions:read" },
-          { title: "items.settings_scoring", url: "/dashboard/settings/scoring-categories", permission: "scoring_categories:read" },
-        ],
-      },
-      {
-        title: "items.jobs_queues",
-        url: "/dashboard/system/jobs",
-        icon: Activity,
-        permission: "permissions:read",
       },
     ],
   },
@@ -204,9 +219,9 @@ export const navConfig: NavGroup[] = [
     ],
   },
 
-  // ─── Validación e Investiduras ───────────────────────────────────────────────
+  // ─── Operaciones (validación + folders + year-end) ───────────────────────────
   {
-    label: "sections.validation",
+    label: "sections.operations",
     items: [
       {
         title: "items.validation",
@@ -231,35 +246,6 @@ export const navConfig: NavGroup[] = [
           { title: "items.investiture_config", url: "/dashboard/investiture/config", permission: "investiture:read" },
         ],
       },
-      {
-        title: "items.sla",
-        url: "/dashboard/sla",
-        icon: Activity,
-        permission: "investiture:read",
-      },
-      {
-        title: "items.year_end",
-        url: "/dashboard/year-end",
-        icon: CalendarOff,
-        permission: "permissions:read",
-      },
-    ],
-  },
-
-  // ─── Comunicaciones ──────────────────────────────────────────────────────────
-  {
-    label: "sections.communications",
-    items: [
-      {
-        title: "items.notifications",
-        url: "/dashboard/notifications",
-        icon: Bell,
-        permission: "notifications:send",
-        children: [
-          { title: "items.notifications_send", url: "/dashboard/notifications", permission: "notifications:send" },
-          { title: "items.notifications_history", url: "/dashboard/notifications/history", permission: "notifications:send" },
-        ],
-      },
       { title: "items.evidence_folders", url: "/dashboard/folders", icon: FolderOpen, permission: "user_folders:read" },
       {
         title: "items.annual_folders",
@@ -275,10 +261,23 @@ export const navConfig: NavGroup[] = [
         ],
       },
       {
-        title: "items.ranking_weights",
-        url: "/dashboard/ranking-weights",
-        icon: SlidersHorizontal,
-        permission: RANKING_WEIGHTS_READ,
+        title: "items.year_end",
+        url: "/dashboard/year-end",
+        icon: CalendarOff,
+        permission: "permissions:read",
+      },
+    ],
+  },
+
+  // ─── Rankings y análisis ─────────────────────────────────────────────────────
+  {
+    label: "sections.rankings_analytics",
+    items: [
+      {
+        title: "items.sla",
+        url: "/dashboard/sla",
+        icon: Activity,
+        permission: "investiture:read",
       },
       {
         title: "items.member_rankings",
@@ -287,16 +286,37 @@ export const navConfig: NavGroup[] = [
         permission: MEMBER_RANKINGS_READ_GLOBAL,
       },
       {
-        title: "items.member_ranking_weights",
-        url: "/dashboard/member-ranking-weights",
-        icon: SlidersHorizontal,
-        permission: MEMBER_RANKING_WEIGHTS_READ,
-      },
-      {
         title: "items.section_rankings",
         url: "/dashboard/section-rankings",
         icon: Layers,
         permission: SECTION_RANKINGS_READ_GLOBAL,
+      },
+      {
+        title: "items.ranking_weights_root",
+        url: "/dashboard/ranking-weights",
+        icon: SlidersHorizontal,
+        permission: RANKING_WEIGHTS_READ,
+        children: [
+          { title: "items.ranking_weights", url: "/dashboard/ranking-weights", permission: RANKING_WEIGHTS_READ },
+          { title: "items.member_ranking_weights", url: "/dashboard/member-ranking-weights", permission: MEMBER_RANKING_WEIGHTS_READ },
+        ],
+      },
+    ],
+  },
+
+  // ─── Comunicaciones (solo notificaciones) ────────────────────────────────────
+  {
+    label: "sections.communications",
+    items: [
+      {
+        title: "items.notifications",
+        url: "/dashboard/notifications",
+        icon: Bell,
+        permission: "notifications:send",
+        children: [
+          { title: "items.notifications_send", url: "/dashboard/notifications", permission: "notifications:send" },
+          { title: "items.notifications_history", url: "/dashboard/notifications/history", permission: "notifications:send" },
+        ],
       },
     ],
   },
@@ -331,6 +351,39 @@ export const navConfig: NavGroup[] = [
         url: "/dashboard/member-of-month",
         icon: Trophy,
         permission: "mom:supervise",
+      },
+    ],
+  },
+
+  // ─── Administración ──────────────────────────────────────────────────────────
+  {
+    label: "sections.administration",
+    items: [
+      {
+        title: "items.rbac",
+        url: "/dashboard/rbac",
+        icon: Shield,
+        permission: "permissions:read",
+        children: [
+          { title: "items.rbac_permissions", url: "/dashboard/rbac/permissions", permission: "permissions:read" },
+          { title: "items.rbac_roles", url: "/dashboard/rbac/roles", permission: "roles:read" },
+        ],
+      },
+      {
+        title: "items.configuration",
+        url: "/dashboard/settings",
+        icon: Settings2,
+        permission: "permissions:read",
+        children: [
+          { title: "items.settings_system", url: "/dashboard/settings", permission: "permissions:read" },
+          { title: "items.settings_scoring", url: "/dashboard/settings/scoring-categories", permission: "scoring_categories:read" },
+        ],
+      },
+      {
+        title: "items.jobs_queues",
+        url: "/dashboard/system/jobs",
+        icon: Activity,
+        permission: "permissions:read",
       },
     ],
   },

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -38,6 +38,8 @@ export interface IntlMessages {
       communications: string;
       requests_reports: string;
       members: string;
+      operations: string;
+      rankings_analytics: string;
     };
     items: {
       dashboard: string;
@@ -122,6 +124,14 @@ export interface IntlMessages {
       catalog_inventory_categories: string;
       catalog_honors: string;
       catalog_master_honors: string;
+      subgroup_overview: string;
+      subgroup_geography: string;
+      subgroup_health: string;
+      subgroup_clubs_cat: string;
+      subgroup_academics: string;
+      subgroup_business: string;
+      subgroup_honors_cat: string;
+      ranking_weights_root: string;
     };
     breadcrumbs: {
       dashboard: string;
@@ -166,6 +176,25 @@ export interface IntlMessages {
     };
     a11y: {
       skipToContent: string;
+    };
+    profile: string;
+    logout: string;
+    adminPanel: string;
+    commandPalette: {
+      title: string;
+      description: string;
+      placeholder: string;
+      empty: string;
+      general: string;
+    };
+    activeContext: {
+      noClub: string;
+      noYear: string;
+      clubLabel: string;
+      yearLabel: string;
+      clear: string;
+      loading: string;
+      unavailable: string;
     };
   };
   permissions: {
@@ -316,6 +345,7 @@ export interface IntlMessages {
       delete: string;
       editItem: string;
       deleteItem: string;
+      saving: string;
     };
     deleteDialog: {
       title: string;


### PR DESCRIPTION
## Summary
- Simplify sidebar: 24-item flat catalogs dropdown → 6 visual subgroups (geography, health, clubs, academics, business, honors)
- New **Operations** group (validation + investiture + folders + year-end) — moved from Validation + Communications
- New **Rankings & Analytics** group (SLA + member/section rankings + weights) — extracted from Communications
- Communications now holds only Notifications
- Member ranking weights nested under unified Weights configuration parent

## Type changes
- New `NavSubGroup = { subgroup: string; items: NavChild[] }` type
- New `NavChildren = NavChild[] | NavSubGroup[]` union
- New `isSubGroup` type guard
- `app-sidebar.tsx` renders subgroup labels above grouped children

## Permission filter behavior
Per-child permission filter unchanged (children render unconditionally; URL middleware enforces).

## Test plan
- [x] pnpm typecheck (clean)
- [x] pnpm test (668/668 pass)
- [x] pnpm lint (no new errors in changed files)
- [ ] Manual sidebar walkthrough on dev preview (Vercel)