### PR TITLE
feat(i18n): translate role names to user-friendly labels per locale

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -4758,5 +4758,29 @@
         "metadataTitle": "Scoring categories"
       }
     }
+  },
+  "roles": {
+    "super_admin": "Super Admin",
+    "admin": "Admin",
+    "coordinator": "Coordinator",
+    "zone_coordinator": "Zone Coordinator",
+    "general_coordinator": "General Coordinator",
+    "pastor": "Pastor",
+    "director": "Director",
+    "deputy_director": "Deputy Director",
+    "director_club": "Club Director",
+    "assistant_club": "Club Assistant",
+    "director_dia": "DIA Director",
+    "assistant_dia": "DIA Assistant",
+    "director_lf": "Local Field Director",
+    "assistant_lf": "Local Field Assistant",
+    "director_union": "Union Director",
+    "assistant_union": "Union Assistant",
+    "instructor": "Instructor",
+    "member": "Member",
+    "user": "User",
+    "secretary": "Secretary",
+    "treasurer": "Treasurer",
+    "counselor": "Counselor"
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -4777,5 +4777,29 @@
         "metadataTitle": "Categorías de puntuación"
       }
     }
+  },
+  "roles": {
+    "super_admin": "Super administrador",
+    "admin": "Administrador",
+    "coordinator": "Coordinador",
+    "zone_coordinator": "Coordinador de zona",
+    "general_coordinator": "Coordinador general",
+    "pastor": "Pastor",
+    "director": "Director",
+    "deputy_director": "Subdirector",
+    "director_club": "Director de club",
+    "assistant_club": "Subdirector de club",
+    "director_dia": "Director DIA",
+    "assistant_dia": "Asistente DIA",
+    "director_lf": "Director de campo local",
+    "assistant_lf": "Asistente de campo local",
+    "director_union": "Director de unión",
+    "assistant_union": "Asistente de unión",
+    "instructor": "Instructor",
+    "member": "Miembro",
+    "user": "Usuario",
+    "secretary": "Secretario",
+    "treasurer": "Tesorero",
+    "counselor": "Consejero"
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -4758,5 +4758,29 @@
         "metadataTitle": "Catégories de notation"
       }
     }
+  },
+  "roles": {
+    "super_admin": "Super Admin",
+    "admin": "Admin",
+    "coordinator": "Coordinateur",
+    "zone_coordinator": "Coordinateur de zone",
+    "general_coordinator": "Coordinateur général",
+    "pastor": "Pasteur",
+    "director": "Directeur",
+    "deputy_director": "Sous-directeur",
+    "director_club": "Directeur de club",
+    "assistant_club": "Assistant de club",
+    "director_dia": "Directeur DIA",
+    "assistant_dia": "Assistant DIA",
+    "director_lf": "Directeur de champ local",
+    "assistant_lf": "Assistant de champ local",
+    "director_union": "Directeur d'union",
+    "assistant_union": "Assistant d'union",
+    "instructor": "Instructeur",
+    "member": "Membre",
+    "user": "Utilisateur",
+    "secretary": "Secrétaire",
+    "treasurer": "Trésorier",
+    "counselor": "Conseiller"
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -4758,5 +4758,29 @@
         "metadataTitle": "Categorias de pontuação"
       }
     }
+  },
+  "roles": {
+    "super_admin": "Super Administrador",
+    "admin": "Administrador",
+    "coordinator": "Coordenador",
+    "zone_coordinator": "Coordenador de zona",
+    "general_coordinator": "Coordenador geral",
+    "pastor": "Pastor",
+    "director": "Diretor",
+    "deputy_director": "Subdiretor",
+    "director_club": "Diretor de clube",
+    "assistant_club": "Assistente de clube",
+    "director_dia": "Diretor DIA",
+    "assistant_dia": "Assistente DIA",
+    "director_lf": "Diretor de campo local",
+    "assistant_lf": "Assistente de campo local",
+    "director_union": "Diretor de união",
+    "assistant_union": "Assistente de união",
+    "instructor": "Instrutor",
+    "member": "Membro",
+    "user": "Usuário",
+    "secretary": "Secretário",
+    "treasurer": "Tesoureiro",
+    "counselor": "Conselheiro"
   }
 }

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -28,6 +28,7 @@ import {
 import { cn } from "@/lib/utils";
 import { PageHeader } from "@/components/shared/page-header";
 import { getTranslations } from "next-intl/server";
+import { buildRoleTranslator } from "@/lib/auth/role-labels";
 
 type StatsData = {
   totalUsers: number | null;
@@ -363,6 +364,8 @@ async function StatsSection() {
 
 async function RecentUsersSection() {
   const t = await getTranslations("dashboardHub");
+  const tRoles = await getTranslations("roles");
+  const translateRole = buildRoleTranslator(tRoles);
   const users = await fetchRecentUsers();
 
   const relativeDateTx: RelativeDateTranslations = {
@@ -450,7 +453,7 @@ async function RecentUsersSection() {
                         variant="secondary"
                         className="text-xs font-normal"
                       >
-                        {role}
+                        {translateRole(role)}
                       </Badge>
                     ))
                   ) : (

--- a/src/app/(dashboard)/dashboard/rbac/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/rbac/roles/[roleId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowLeft, ShieldCheck } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import { buildRoleTranslator } from "@/lib/auth/role-labels";
 import { redirect, notFound } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/shared/page-header";
@@ -19,6 +20,8 @@ interface EditRolePageProps {
 
 export default async function EditRolePage({ params }: EditRolePageProps) {
   const t = await getTranslations("rbac.pages.rolesDetail");
+  const tRoles = await getTranslations("roles");
+  const translateRole = buildRoleTranslator(tRoles);
   const { roleId } = await params;
 
   const user = await requireAdminUser();
@@ -61,7 +64,7 @@ export default async function EditRolePage({ params }: EditRolePageProps) {
           </Link>
         </Button>
         <PageHeader
-          title={role ? t("editTitle", { name: role.role_name }) : t("editTitleFallback")}
+          title={role ? t("editTitle", { name: translateRole(role.role_name) }) : t("editTitleFallback")}
           description={t("description")}
           className="flex-1"
         />

--- a/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/[userId]/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
+import { buildRoleTranslator } from "@/lib/auth/role-labels";
 import { notFound } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -214,6 +215,8 @@ function formatLegalRepresentative(value: Record<string, unknown> | null | undef
 export default async function UserDetailPage({ params }: { params: Params }) {
   const currentUser = await requireAdminUser();
   const t = await getTranslations("users.pages.detail");
+  const tRoles = await getTranslations("roles");
+  const translateRole = buildRoleTranslator(tRoles);
   const { userId } = await params;
 
   let user: AdminUserDetail;
@@ -324,7 +327,7 @@ export default async function UserDetailPage({ params }: { params: Params }) {
               </Badge>
               {roleNames.map((role) => (
                 <Badge key={role} variant="secondary">
-                  {role}
+                  {translateRole(role)}
                 </Badge>
               ))}
             </div>
@@ -621,7 +624,7 @@ export default async function UserDetailPage({ params }: { params: Params }) {
                                 </td>
                                 <td className="px-4 py-2">
                                   <Badge variant="secondary" className="text-xs">
-                                    {ca.role?.role_name ?? ca.role_name ?? "—"}
+                                    {translateRole(ca.role?.role_name ?? ca.role_name) || "—"}
                                   </Badge>
                                 </td>
                               </tr>

--- a/src/components/dashboard/role-distribution-chart-inner.tsx
+++ b/src/components/dashboard/role-distribution-chart-inner.tsx
@@ -10,24 +10,8 @@ import {
   Cell,
 } from "recharts";
 import { useTranslations } from "next-intl";
+import { useRoleLabel } from "@/lib/auth/role-labels";
 import type { RoleDistributionEntry } from "./role-distribution-chart";
-
-const ROLE_LABEL_KEYS: Record<string, string> = {
-  "super-admin": "superAdmin",
-  admin: "admin",
-  "assistant-admin": "assistantAdmin",
-  coordinator: "coordinator",
-  pastor: "pastor",
-  user: "user",
-  director: "director",
-  "deputy-director": "deputyDirector",
-  secretary: "secretary",
-  treasurer: "treasurer",
-  counselor: "counselor",
-  instructor: "instructor",
-  member: "member",
-  sin_rol: "noRole",
-};
 
 const ROLE_COLORS: Record<string, string> = {
   "super-admin": "var(--destructive)",
@@ -79,13 +63,11 @@ interface RoleDistributionChartInnerProps {
 
 export function RoleDistributionChartInner({ data, sampleSize }: RoleDistributionChartInnerProps) {
   const t = useTranslations("dashboardHub");
+  const translateRole = useRoleLabel();
 
   function roleLabel(role: string): string {
-    const key = ROLE_LABEL_KEYS[role];
-    if (key) {
-      return t(`roleLabels.${key}` as Parameters<typeof t>[0]);
-    }
-    return role.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+    if (role === "sin_rol") return t("roleChart.noRolesFound");
+    return translateRole(role);
   }
 
   function userCount(count: number, percentage: string): string {

--- a/src/components/membership/pending-members-table.tsx
+++ b/src/components/membership/pending-members-table.tsx
@@ -35,6 +35,7 @@ import {
 } from "@/lib/api/membership-requests";
 import { ApiError } from "@/lib/api/client";
 import { useFormatDate, useFormatDateTime } from "@/lib/format-locale";
+import { useRoleLabel } from "@/lib/auth/role-labels";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -47,10 +48,6 @@ function getUserName(user?: MembershipRequest["users"]): string {
 
 function getUserEmail(user?: MembershipRequest["users"]): string {
   return user?.email ?? "\u2014";
-}
-
-function getRoleName(role?: MembershipRequest["roles"]): string {
-  return role?.role_name ?? "miembro";
 }
 
 function isExpiringSoon(expiresAt?: string | null): boolean {
@@ -76,6 +73,12 @@ export function PendingMembersTable({
   const t = useTranslations("membership");
   const formatDate = useFormatDate();
   const formatDatetime = useFormatDateTime();
+  const translateRole = useRoleLabel();
+
+  const getRoleName = (role?: MembershipRequest["roles"]): string => {
+    const raw = role?.role_name ?? "member";
+    return translateRole(raw);
+  };
   const [requests, setRequests] = useState<MembershipRequest[]>(initialRequests);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const [processingId, setProcessingId] = useState<string | null>(null);

--- a/src/components/rbac/roles-table.tsx
+++ b/src/components/rbac/roles-table.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
+import { useRoleLabel } from "@/lib/auth/role-labels";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -149,6 +150,7 @@ function parseUsersCount(errorMessage: string): number | null {
 
 function DeactivateDialog({ role, open, onClose, onSuccess }: DeactivateDialogProps) {
   const t = useTranslations("rbac");
+  const translateRole = useRoleLabel();
   const [loading, setLoading] = useState(false);
   const [blockError, setBlockError] = useState<{ usersCount: number } | null>(null);
 
@@ -259,6 +261,7 @@ interface RolesTableProps {
 }
 
 export function RolesTable({ roles, isSuperAdmin }: RolesTableProps) {
+  const translateRole = useRoleLabel();
   const [search, setSearch] = useState("");
   const [activeTab, setActiveTab] = useState<ActiveFilter>("true");
   const [sortField, setSortField] = useState<SortField>("role_name");
@@ -469,7 +472,10 @@ export function RolesTable({ roles, isSuperAdmin }: RolesTableProps) {
                                 <TooltipContent>Rol protegido del sistema</TooltipContent>
                               </Tooltip>
                             )}
-                            <span className="font-mono text-sm font-medium">{role.role_name}</span>
+                            <div className="flex flex-col">
+                              <span className="text-sm font-medium">{translateRole(role.role_name)}</span>
+                              <span className="font-mono text-xs text-muted-foreground">{role.role_name}</span>
+                            </div>
                           </div>
                         </TableCell>
 
@@ -610,7 +616,8 @@ export function RolesTable({ roles, isSuperAdmin }: RolesTableProps) {
                         )}
                       </div>
                       <div className="min-w-0 flex-1">
-                        <p className="truncate font-mono text-sm font-medium">{role.role_name}</p>
+                        <p className="truncate text-sm font-medium">{translateRole(role.role_name)}</p>
+                        <p className="truncate font-mono text-xs text-muted-foreground">{role.role_name}</p>
                         {role.description && (
                           <p className="line-clamp-1 text-xs text-muted-foreground">
                             {role.description}

--- a/src/components/rbac/user-roles-panel.tsx
+++ b/src/components/rbac/user-roles-panel.tsx
@@ -4,6 +4,7 @@ import { useState, useTransition } from "react";
 import { Plus, X, ShieldAlert, Loader2, Search } from "lucide-react";
 import { toast } from "sonner";
 import { useTranslations } from "next-intl";
+import { useRoleLabel } from "@/lib/auth/role-labels";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -51,6 +52,7 @@ export function UserRolesPanel({
   allRoles,
 }: UserRolesPanelProps) {
   const t = useTranslations("rbac");
+  const translateRole = useRoleLabel();
   const [userRoles, setUserRoles] = useState<UserRole[]>(initialUserRoles);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [roleToRemove, setRoleToRemove] = useState<UserRole | null>(null);
@@ -196,13 +198,13 @@ export function UserRolesPanel({
                   variant={getRoleBadgeVariant(ur.roles.role_name)}
                   className="gap-1.5 pr-1 text-xs"
                 >
-                  {ur.roles.role_name}
+                  {translateRole(ur.roles.role_name)}
                   <button
                     type="button"
                     onClick={() => setRoleToRemove(ur)}
                     disabled={isPending}
                     className="ml-0.5 rounded-sm opacity-60 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none"
-                    title={t("userRolesPanel.removeRoleTitle", { name: ur.roles.role_name })}
+                    title={t("userRolesPanel.removeRoleTitle", { name: translateRole(ur.roles.role_name) })}
                   >
                     <X className="size-3" />
                     <span className="sr-only">{t("userRolesPanel.removeSrOnly")}</span>
@@ -261,9 +263,9 @@ export function UserRolesPanel({
                       .filter(Boolean)
                       .join(" ")}
                   >
-                    <span className="text-sm font-medium">{role.role_name}</span>
+                    <span className="text-sm font-medium">{translateRole(role.role_name)}</span>
                     <span className="text-xs text-muted-foreground">
-                      {t("userRolesPanel.categoryLabel")}: {role.role_category}
+                      <span className="font-mono">{role.role_name}</span> · {t("userRolesPanel.categoryLabel")}: {role.role_category}
                     </span>
                   </button>
                 ))}
@@ -306,7 +308,7 @@ export function UserRolesPanel({
               <AlertDialogDescription>
                 {t("userRolesPanel.removeDialogDescPre")}{" "}
                 <code className="rounded bg-muted px-1 py-0.5 text-xs font-semibold">
-                  {roleToRemove.roles.role_name}
+                  {translateRole(roleToRemove.roles.role_name)}
                 </code>{" "}
                 {t("userRolesPanel.removeDialogDescPost")}
               </AlertDialogDescription>

--- a/src/components/users/users-table.tsx
+++ b/src/components/users/users-table.tsx
@@ -13,6 +13,7 @@ import {
 import type { AdminUser } from "@/lib/api/admin-users";
 import { DataTableShell } from "@/components/shared/data-table-shell";
 import { getTranslations } from "next-intl/server";
+import { buildRoleTranslator, type RoleTranslator } from "@/lib/auth/role-labels";
 
 function extractRoleNames(user: AdminUser): string[] {
   const roles: string[] = [];
@@ -73,10 +74,12 @@ function UserMobileCard({
   user,
   showAdministrativeCompletion,
   t,
+  translateRole,
 }: {
   user: AdminUser;
   showAdministrativeCompletion: boolean;
   t: UsersTranslations;
+  translateRole: RoleTranslator;
 }) {
   const roleNames = extractRoleNames(user);
   const fullName = getFullName(user);
@@ -145,7 +148,7 @@ function UserMobileCard({
         <div className="mt-3 flex flex-wrap gap-1">
           {roleNames.map((role) => (
             <Badge key={role} variant="secondary" className="text-xs">
-              {role}
+              {translateRole(role)}
             </Badge>
           ))}
         </div>
@@ -172,6 +175,8 @@ export async function UsersTable({
   showAdministrativeCompletion = false,
 }: UsersTableProps) {
   const t = await getTranslations("users");
+  const tRoles = await getTranslations("roles");
+  const translateRole = buildRoleTranslator(tRoles);
 
   return (
     <>
@@ -225,7 +230,7 @@ export async function UsersTable({
                         {roleNames.length > 0 ? (
                           roleNames.map((role) => (
                             <Badge key={role} variant="secondary" className="text-xs">
-                              {role}
+                              {translateRole(role)}
                             </Badge>
                           ))
                         ) : (
@@ -288,6 +293,7 @@ export async function UsersTable({
               user={user}
               showAdministrativeCompletion={showAdministrativeCompletion}
               t={t}
+              translateRole={translateRole}
             />
           </li>
         ))}

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -4807,4 +4807,28 @@ export interface IntlMessages {
       };
     };
   };
+  roles: {
+    super_admin: string;
+    admin: string;
+    coordinator: string;
+    zone_coordinator: string;
+    general_coordinator: string;
+    pastor: string;
+    director: string;
+    deputy_director: string;
+    director_club: string;
+    assistant_club: string;
+    director_dia: string;
+    assistant_dia: string;
+    director_lf: string;
+    assistant_lf: string;
+    director_union: string;
+    assistant_union: string;
+    instructor: string;
+    member: string;
+    user: string;
+    secretary: string;
+    treasurer: string;
+    counselor: string;
+  };
 }

--- a/src/lib/auth/role-labels.ts
+++ b/src/lib/auth/role-labels.ts
@@ -1,0 +1,58 @@
+import { useTranslations } from "next-intl";
+
+const KNOWN_ROLE_KEYS = new Set([
+  "super_admin",
+  "admin",
+  "coordinator",
+  "zone_coordinator",
+  "general_coordinator",
+  "pastor",
+  "director",
+  "deputy_director",
+  "director_club",
+  "assistant_club",
+  "director_dia",
+  "assistant_dia",
+  "director_lf",
+  "assistant_lf",
+  "director_union",
+  "assistant_union",
+  "instructor",
+  "member",
+  "user",
+  "secretary",
+  "treasurer",
+  "counselor",
+]);
+
+export function roleToI18nKey(roleName: string): string {
+  return roleName.trim().toLowerCase().replace(/-/g, "_");
+}
+
+function fallbackTitleCase(roleName: string): string {
+  return roleName
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export type RoleTranslator = (roleName: string | null | undefined) => string;
+
+type RolesT = ReturnType<typeof useTranslations<"roles">>;
+
+export function buildRoleTranslator(t: RolesT): RoleTranslator {
+  return (roleName) => {
+    if (!roleName || typeof roleName !== "string") return "";
+    const key = roleToI18nKey(roleName);
+    if (KNOWN_ROLE_KEYS.has(key)) {
+      return t(key as Parameters<typeof t>[0]);
+    }
+    return fallbackTitleCase(roleName);
+  };
+}
+
+export function useRoleLabel(): RoleTranslator {
+  const t = useTranslations("roles");
+  return buildRoleTranslator(t);
+}


### PR DESCRIPTION
## Summary
- Add `roles` namespace in 4 locales (es/en/fr/pt-BR) with 22 canonical role mappings
- New helper `src/lib/auth/role-labels.ts`:
  - `roleToI18nKey()` normalizes hyphens to underscores
  - `buildRoleTranslator(t)` works for server (getTranslations) + client (useTranslations)
  - `useRoleLabel()` client hook
- Replace raw role_name displays across 8 display sites with translated labels
- RBAC management screens (roles-table) show both translated + canonical mono — admins need both

## Files changed (14)
- 4 locale JSONs + messages.d.ts regen
- 1 new helper file
- 8 display sites updated

## Translation examples
- `deputy-director` → es: \"Subdirector\" · en: \"Deputy Director\" · fr: \"Sous-directeur\" · pt-BR: \"Subdiretor\"
- `director-lf` → es: \"Director de campo local\" · en: \"Local Field Director\"
- Unknown roles → title-case fallback (no crash)

## Test plan
- [x] pnpm typecheck (clean)
- [x] pnpm test (668/668 pass)
- [x] pnpm lint (no new errors in changed files)
- [ ] Manual Vercel preview: switch locales, verify badges/tables/dashboard chart