### PR TITLE
feat(i18n): admin actions factory + permissions for 12 generic catalogs

### DIFF
--- a/src/lib/api/generic-catalogs-i18n.ts
+++ b/src/lib/api/generic-catalogs-i18n.ts
@@ -1,0 +1,266 @@
+/**
+ * Generic Catalogs i18n — admin API client for 12 catalog targets:
+ *
+ * Geography (name-only):
+ *   countries, unions, local-fields, districts, churches
+ *
+ * Reference (name + description):
+ *   relationship-types, allergies, diseases, medicines, activity-types
+ *
+ * Reference (name-only):
+ *   club-types
+ *
+ * Special (name + ideal + club_type_id + ideal_order):
+ *   club-ideals
+ *
+ * All endpoints under /admin/<kebab-case>.
+ * Backend PR #105 (geography) and #106 (reference) add translations support.
+ */
+import { apiRequest } from "@/lib/api/client";
+import type { CatalogTranslation } from "@/lib/types/catalog-translation";
+
+// ─── Shared payload types ──────────────────────────────────────────────────────
+
+/** name + description (optional) — used for relationship-types, allergies, diseases, medicines, activity-types */
+export type TranslatablePayload = {
+  name: string;
+  description?: string | null;
+  active?: boolean;
+  translations?: CatalogTranslation[];
+};
+
+/** name only — used for countries, unions, local-fields, districts, churches, club-types */
+export type NameOnlyPayload = {
+  name: string;
+  active?: boolean;
+  translations?: CatalogTranslation[];
+};
+
+/** club-ideals specific shape — name + ideal (translatable) + relation + order */
+export type ClubIdealPayload = {
+  name: string;
+  ideal?: string | null;
+  club_type_id?: number | null;
+  ideal_order?: number | null;
+  active?: boolean;
+  translations?: CatalogTranslation[];
+};
+
+// ─── Countries ────────────────────────────────────────────────────────────────
+
+export async function listAdminCountries(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/countries", { params });
+}
+
+export async function createAdminCountry(payload: NameOnlyPayload) {
+  return apiRequest("/admin/countries", { method: "POST", body: payload });
+}
+
+export async function updateAdminCountry(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/countries/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminCountry(id: number) {
+  return apiRequest(`/admin/countries/${id}`, { method: "DELETE" });
+}
+
+// ─── Unions ───────────────────────────────────────────────────────────────────
+
+export async function listAdminUnions(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/unions", { params });
+}
+
+export async function createAdminUnion(payload: NameOnlyPayload) {
+  return apiRequest("/admin/unions", { method: "POST", body: payload });
+}
+
+export async function updateAdminUnion(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/unions/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminUnion(id: number) {
+  return apiRequest(`/admin/unions/${id}`, { method: "DELETE" });
+}
+
+// ─── Local Fields ─────────────────────────────────────────────────────────────
+
+export async function listAdminLocalFields(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/local-fields", { params });
+}
+
+export async function createAdminLocalField(payload: NameOnlyPayload) {
+  return apiRequest("/admin/local-fields", { method: "POST", body: payload });
+}
+
+export async function updateAdminLocalField(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/local-fields/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminLocalField(id: number) {
+  return apiRequest(`/admin/local-fields/${id}`, { method: "DELETE" });
+}
+
+// ─── Districts ────────────────────────────────────────────────────────────────
+// Note: backend PK field is district_id aliasing districlub_type_id in the schema.
+
+export async function listAdminDistricts(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/districts", { params });
+}
+
+export async function createAdminDistrict(payload: NameOnlyPayload) {
+  return apiRequest("/admin/districts", { method: "POST", body: payload });
+}
+
+export async function updateAdminDistrict(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/districts/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminDistrict(id: number) {
+  return apiRequest(`/admin/districts/${id}`, { method: "DELETE" });
+}
+
+// ─── Churches ─────────────────────────────────────────────────────────────────
+
+export async function listAdminChurches(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/churches", { params });
+}
+
+export async function createAdminChurch(payload: NameOnlyPayload) {
+  return apiRequest("/admin/churches", { method: "POST", body: payload });
+}
+
+export async function updateAdminChurch(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/churches/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminChurch(id: number) {
+  return apiRequest(`/admin/churches/${id}`, { method: "DELETE" });
+}
+
+// ─── Relationship Types ───────────────────────────────────────────────────────
+
+export async function listAdminRelationshipTypes(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/relationship-types", { params });
+}
+
+export async function createAdminRelationshipType(payload: TranslatablePayload) {
+  return apiRequest("/admin/relationship-types", { method: "POST", body: payload });
+}
+
+export async function updateAdminRelationshipType(id: number, payload: Partial<TranslatablePayload>) {
+  return apiRequest(`/admin/relationship-types/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminRelationshipType(id: number) {
+  return apiRequest(`/admin/relationship-types/${id}`, { method: "DELETE" });
+}
+
+// ─── Allergies ────────────────────────────────────────────────────────────────
+
+export async function listAdminAllergies(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/allergies", { params });
+}
+
+export async function createAdminAllergy(payload: TranslatablePayload) {
+  return apiRequest("/admin/allergies", { method: "POST", body: payload });
+}
+
+export async function updateAdminAllergy(id: number, payload: Partial<TranslatablePayload>) {
+  return apiRequest(`/admin/allergies/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminAllergy(id: number) {
+  return apiRequest(`/admin/allergies/${id}`, { method: "DELETE" });
+}
+
+// ─── Diseases ─────────────────────────────────────────────────────────────────
+
+export async function listAdminDiseases(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/diseases", { params });
+}
+
+export async function createAdminDisease(payload: TranslatablePayload) {
+  return apiRequest("/admin/diseases", { method: "POST", body: payload });
+}
+
+export async function updateAdminDisease(id: number, payload: Partial<TranslatablePayload>) {
+  return apiRequest(`/admin/diseases/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminDisease(id: number) {
+  return apiRequest(`/admin/diseases/${id}`, { method: "DELETE" });
+}
+
+// ─── Medicines ────────────────────────────────────────────────────────────────
+
+export async function listAdminMedicines(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/medicines", { params });
+}
+
+export async function createAdminMedicine(payload: TranslatablePayload) {
+  return apiRequest("/admin/medicines", { method: "POST", body: payload });
+}
+
+export async function updateAdminMedicine(id: number, payload: Partial<TranslatablePayload>) {
+  return apiRequest(`/admin/medicines/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminMedicine(id: number) {
+  return apiRequest(`/admin/medicines/${id}`, { method: "DELETE" });
+}
+
+// ─── Club Types ───────────────────────────────────────────────────────────────
+
+export async function listAdminClubTypes(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/club-types", { params });
+}
+
+export async function createAdminClubType(payload: NameOnlyPayload) {
+  return apiRequest("/admin/club-types", { method: "POST", body: payload });
+}
+
+export async function updateAdminClubType(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/club-types/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminClubType(id: number) {
+  return apiRequest(`/admin/club-types/${id}`, { method: "DELETE" });
+}
+
+// ─── Club Ideals ──────────────────────────────────────────────────────────────
+// Translatable fields: name + ideal (NOT description).
+
+export async function listAdminClubIdeals(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/club-ideals", { params });
+}
+
+export async function createAdminClubIdeal(payload: ClubIdealPayload) {
+  return apiRequest("/admin/club-ideals", { method: "POST", body: payload });
+}
+
+export async function updateAdminClubIdeal(id: number, payload: Partial<ClubIdealPayload>) {
+  return apiRequest(`/admin/club-ideals/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminClubIdeal(id: number) {
+  return apiRequest(`/admin/club-ideals/${id}`, { method: "DELETE" });
+}
+
+// ─── Activity Types ───────────────────────────────────────────────────────────
+// Note: `code` field is NOT translatable — only name + description.
+
+export async function listAdminActivityTypes(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/activity-types", { params });
+}
+
+export async function createAdminActivityType(payload: TranslatablePayload & { code?: string }) {
+  return apiRequest("/admin/activity-types", { method: "POST", body: payload });
+}
+
+export async function updateAdminActivityType(id: number, payload: Partial<TranslatablePayload> & { code?: string }) {
+  return apiRequest(`/admin/activity-types/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminActivityType(id: number) {
+  return apiRequest(`/admin/activity-types/${id}`, { method: "DELETE" });
+}

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -62,6 +62,10 @@ export const LOCAL_FIELDS_READ = "local_fields:read";
 export const LOCAL_FIELDS_CREATE = "local_fields:create";
 export const LOCAL_FIELDS_UPDATE = "local_fields:update";
 export const LOCAL_FIELDS_DELETE = "local_fields:delete";
+export const DISTRICTS_READ = "districts:read";
+export const DISTRICTS_CREATE = "districts:create";
+export const DISTRICTS_UPDATE = "districts:update";
+export const DISTRICTS_DELETE = "districts:delete";
 export const CHURCHES_READ = "churches:read";
 export const CHURCHES_CREATE = "churches:create";
 export const CHURCHES_UPDATE = "churches:update";
@@ -72,6 +76,34 @@ export const CATALOGS_READ = "catalogs:read";
 export const CATALOGS_CREATE = "catalogs:create";
 export const CATALOGS_UPDATE = "catalogs:update";
 export const CATALOGS_DELETE = "catalogs:delete";
+export const RELATIONSHIP_TYPES_READ = "relationship_types:read";
+export const RELATIONSHIP_TYPES_CREATE = "relationship_types:create";
+export const RELATIONSHIP_TYPES_UPDATE = "relationship_types:update";
+export const RELATIONSHIP_TYPES_DELETE = "relationship_types:delete";
+export const ALLERGIES_READ = "allergies:read";
+export const ALLERGIES_CREATE = "allergies:create";
+export const ALLERGIES_UPDATE = "allergies:update";
+export const ALLERGIES_DELETE = "allergies:delete";
+export const DISEASES_READ = "diseases:read";
+export const DISEASES_CREATE = "diseases:create";
+export const DISEASES_UPDATE = "diseases:update";
+export const DISEASES_DELETE = "diseases:delete";
+export const MEDICINES_READ = "medicines:read";
+export const MEDICINES_CREATE = "medicines:create";
+export const MEDICINES_UPDATE = "medicines:update";
+export const MEDICINES_DELETE = "medicines:delete";
+export const CLUB_TYPES_READ = "club_types:read";
+export const CLUB_TYPES_CREATE = "club_types:create";
+export const CLUB_TYPES_UPDATE = "club_types:update";
+export const CLUB_TYPES_DELETE = "club_types:delete";
+export const CLUB_IDEALS_READ = "club_ideals:read";
+export const CLUB_IDEALS_CREATE = "club_ideals:create";
+export const CLUB_IDEALS_UPDATE = "club_ideals:update";
+export const CLUB_IDEALS_DELETE = "club_ideals:delete";
+export const ACTIVITY_TYPES_READ = "activity_types:read";
+export const ACTIVITY_TYPES_CREATE = "activity_types:create";
+export const ACTIVITY_TYPES_UPDATE = "activity_types:update";
+export const ACTIVITY_TYPES_DELETE = "activity_types:delete";
 
 // --- Clases y Honores ---
 export const CLASSES_READ = "classes:read";
@@ -300,6 +332,10 @@ export const PERMISSION_GROUPS = {
       { key: LOCAL_FIELDS_CREATE },
       { key: LOCAL_FIELDS_UPDATE },
       { key: LOCAL_FIELDS_DELETE },
+      { key: DISTRICTS_READ },
+      { key: DISTRICTS_CREATE },
+      { key: DISTRICTS_UPDATE },
+      { key: DISTRICTS_DELETE },
       { key: CHURCHES_READ },
       { key: CHURCHES_CREATE },
       { key: CHURCHES_UPDATE },
@@ -312,6 +348,34 @@ export const PERMISSION_GROUPS = {
       { key: CATALOGS_CREATE },
       { key: CATALOGS_UPDATE },
       { key: CATALOGS_DELETE },
+      { key: RELATIONSHIP_TYPES_READ },
+      { key: RELATIONSHIP_TYPES_CREATE },
+      { key: RELATIONSHIP_TYPES_UPDATE },
+      { key: RELATIONSHIP_TYPES_DELETE },
+      { key: ALLERGIES_READ },
+      { key: ALLERGIES_CREATE },
+      { key: ALLERGIES_UPDATE },
+      { key: ALLERGIES_DELETE },
+      { key: DISEASES_READ },
+      { key: DISEASES_CREATE },
+      { key: DISEASES_UPDATE },
+      { key: DISEASES_DELETE },
+      { key: MEDICINES_READ },
+      { key: MEDICINES_CREATE },
+      { key: MEDICINES_UPDATE },
+      { key: MEDICINES_DELETE },
+      { key: CLUB_TYPES_READ },
+      { key: CLUB_TYPES_CREATE },
+      { key: CLUB_TYPES_UPDATE },
+      { key: CLUB_TYPES_DELETE },
+      { key: CLUB_IDEALS_READ },
+      { key: CLUB_IDEALS_CREATE },
+      { key: CLUB_IDEALS_UPDATE },
+      { key: CLUB_IDEALS_DELETE },
+      { key: ACTIVITY_TYPES_READ },
+      { key: ACTIVITY_TYPES_CREATE },
+      { key: ACTIVITY_TYPES_UPDATE },
+      { key: ACTIVITY_TYPES_DELETE },
     ],
   },
   classes_honors: {

--- a/src/lib/generic-catalogs-i18n/actions.test.ts
+++ b/src/lib/generic-catalogs-i18n/actions.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseTranslations,
+  buildTranslatableCreate,
+  buildTranslatableUpdate,
+} from "./actions";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeFormData(entries: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    fd.append(key, value);
+  }
+  return fd;
+}
+
+// ─── parseTranslations — default fields ['name', 'description'] ───────────────
+
+describe("parseTranslations() — default fields", () => {
+  it("parses a single entry with locale + name", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "en",
+      "translations[0][name]": "Mexico",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ locale: "en", name: "Mexico" });
+  });
+
+  it("parses name + description in the same entry", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "pt-BR",
+      "translations[0][name]": "Alergia",
+      "translations[0][description]": "Descripción pt-BR",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe("Descripción pt-BR");
+  });
+
+  it("skips an entry where all translatable fields are empty", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "en",
+      "translations[0][name]": "",
+      "translations[0][description]": "",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips an entry whose locale is not in CATALOG_LOCALES", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "es", // es is the base language — excluded
+      "translations[0][name]": "Nombre ES",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(0);
+  });
+
+  it("parses multiple locale entries in index order", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "en",
+      "translations[0][name]": "Name EN",
+      "translations[1][locale]": "pt-BR",
+      "translations[1][name]": "Nome PT",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(2);
+    expect(result[0].locale).toBe("en");
+    expect(result[1].locale).toBe("pt-BR");
+  });
+});
+
+// ─── parseTranslations — override fields ['name', 'ideal'] ───────────────────
+
+describe("parseTranslations() — override fields ['name', 'ideal']", () => {
+  it("extracts the ideal field when configured", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "en",
+      "translations[0][name]": "Service",
+      "translations[0][ideal]": "We serve others",
+    });
+    const result = parseTranslations(fd, ["name", "ideal"]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ locale: "en", name: "Service", ideal: "We serve others" });
+  });
+
+  it("does NOT include description even if present in FormData when fields=['name','ideal']", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "pt-BR",
+      "translations[0][name]": "Serviço",
+      "translations[0][description]": "should be ignored",
+      "translations[0][ideal]": "Servimos",
+    });
+    const result = parseTranslations(fd, ["name", "ideal"]);
+    expect(result[0]).not.toHaveProperty("description");
+    expect(result[0]).toHaveProperty("ideal", "Servimos");
+  });
+
+  it("skips entry when ideal-only entry has empty ideal", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "fr",
+      "translations[0][ideal]": "",
+    });
+    const result = parseTranslations(fd, ["name", "ideal"]);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ─── buildTranslatableCreate ──────────────────────────────────────────────────
+
+describe("buildTranslatableCreate()", () => {
+  it("builds a payload with name + description when both are present (default fields)", () => {
+    const fd = makeFormData({ name: "Alergia", description: "Reacción" });
+    const result = buildTranslatableCreate(fd);
+    expect(result.name).toBe("Alergia");
+    expect(result.description).toBe("Reacción");
+    expect(result.active).toBe(true);
+  });
+
+  it("builds a payload with name + ideal for club-ideals override", () => {
+    const fd = makeFormData({ name: "Servicio", ideal: "Servimos a los demás" });
+    const result = buildTranslatableCreate(fd, ["name", "ideal"]);
+    expect(result.name).toBe("Servicio");
+    expect(result.ideal).toBe("Servimos a los demás");
+    expect(result).not.toHaveProperty("description");
+  });
+
+  it("throws when name is empty", () => {
+    const fd = makeFormData({ name: "" });
+    expect(() => buildTranslatableCreate(fd)).toThrow("El nombre es obligatorio.");
+  });
+
+  it("includes translations when present and fields=['name','ideal']", () => {
+    const fd = makeFormData({
+      name: "Servicio",
+      "translations[0][locale]": "en",
+      "translations[0][name]": "Service",
+      "translations[0][ideal]": "We serve",
+    });
+    const result = buildTranslatableCreate(fd, ["name", "ideal"]);
+    const translations = result.translations as Array<Record<string, string>>;
+    expect(translations).toHaveLength(1);
+    expect(translations[0]).toMatchObject({ locale: "en", ideal: "We serve" });
+    expect(translations[0]).not.toHaveProperty("description");
+  });
+});
+
+// ─── buildTranslatableUpdate ──────────────────────────────────────────────────
+
+describe("buildTranslatableUpdate()", () => {
+  it("does not include translations when dirty flag is absent", () => {
+    const fd = makeFormData({ name: "Updated" });
+    const result = buildTranslatableUpdate(fd);
+    expect(result).not.toHaveProperty("translations");
+  });
+
+  it("includes translations when dirty flag is '1' and fields=['name','ideal']", () => {
+    const fd = makeFormData({
+      name: "Servicio",
+      translations_dirty: "1",
+      "translations[0][locale]": "pt-BR",
+      "translations[0][ideal]": "Servimos",
+    });
+    const result = buildTranslatableUpdate(fd, ["name", "ideal"]);
+    const translations = result.translations as Array<Record<string, string>>;
+    expect(translations).toHaveLength(1);
+    expect(translations[0].ideal).toBe("Servimos");
+    expect(result).not.toHaveProperty("description");
+  });
+
+  it("emits description='' for default fields when description is absent", () => {
+    const fd = makeFormData({ name: "Alergia" });
+    const result = buildTranslatableUpdate(fd);
+    // description field should be reset to empty string (clear intent)
+    expect(result.description).toBe("");
+  });
+});

--- a/src/lib/generic-catalogs-i18n/actions.ts
+++ b/src/lib/generic-catalogs-i18n/actions.ts
@@ -1,0 +1,668 @@
+"use server";
+
+/**
+ * Generic Catalogs i18n — server actions for 12 catalog targets:
+ *
+ * Geography (name-only): countries, unions, local-fields, districts, churches
+ * Reference (name + description): relationship-types, allergies, diseases,
+ *   medicines, activity-types
+ * Reference (name-only): club-types
+ * Special (name + ideal): club-ideals
+ *
+ * Pattern mirrors phase-e-catalogs/actions.ts exactly.
+ * Extension: makeActions accepts an optional `translatableFields` parameter
+ * that controls which fields are extracted from form translations.
+ * club-ideals registers with translatableFields: ['name', 'ideal'].
+ */
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { getActionErrorMessage } from "@/lib/api/action-error";
+import {
+  CATALOG_LOCALES,
+  type CatalogTranslation,
+} from "@/lib/types/catalog-translation";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+  COUNTRIES_CREATE,
+  COUNTRIES_UPDATE,
+  COUNTRIES_DELETE,
+  UNIONS_CREATE,
+  UNIONS_UPDATE,
+  UNIONS_DELETE,
+  LOCAL_FIELDS_CREATE,
+  LOCAL_FIELDS_UPDATE,
+  LOCAL_FIELDS_DELETE,
+  DISTRICTS_CREATE,
+  DISTRICTS_UPDATE,
+  DISTRICTS_DELETE,
+  CHURCHES_CREATE,
+  CHURCHES_UPDATE,
+  CHURCHES_DELETE,
+  RELATIONSHIP_TYPES_CREATE,
+  RELATIONSHIP_TYPES_UPDATE,
+  RELATIONSHIP_TYPES_DELETE,
+  ALLERGIES_CREATE,
+  ALLERGIES_UPDATE,
+  ALLERGIES_DELETE,
+  DISEASES_CREATE,
+  DISEASES_UPDATE,
+  DISEASES_DELETE,
+  MEDICINES_CREATE,
+  MEDICINES_UPDATE,
+  MEDICINES_DELETE,
+  CLUB_TYPES_CREATE,
+  CLUB_TYPES_UPDATE,
+  CLUB_TYPES_DELETE,
+  CLUB_IDEALS_CREATE,
+  CLUB_IDEALS_UPDATE,
+  CLUB_IDEALS_DELETE,
+  ACTIVITY_TYPES_CREATE,
+  ACTIVITY_TYPES_UPDATE,
+  ACTIVITY_TYPES_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createAdminCountry,
+  updateAdminCountry,
+  deleteAdminCountry,
+  createAdminUnion,
+  updateAdminUnion,
+  deleteAdminUnion,
+  createAdminLocalField,
+  updateAdminLocalField,
+  deleteAdminLocalField,
+  createAdminDistrict,
+  updateAdminDistrict,
+  deleteAdminDistrict,
+  createAdminChurch,
+  updateAdminChurch,
+  deleteAdminChurch,
+  createAdminRelationshipType,
+  updateAdminRelationshipType,
+  deleteAdminRelationshipType,
+  createAdminAllergy,
+  updateAdminAllergy,
+  deleteAdminAllergy,
+  createAdminDisease,
+  updateAdminDisease,
+  deleteAdminDisease,
+  createAdminMedicine,
+  updateAdminMedicine,
+  deleteAdminMedicine,
+  createAdminClubType,
+  updateAdminClubType,
+  deleteAdminClubType,
+  createAdminClubIdeal,
+  updateAdminClubIdeal,
+  deleteAdminClubIdeal,
+  createAdminActivityType,
+  updateAdminActivityType,
+  deleteAdminActivityType,
+} from "@/lib/api/generic-catalogs-i18n";
+
+// ─── Shared types ──────────────────────────────────────────────────────────────
+
+export type GenericCatalogActionState = { error?: string };
+
+/** The set of field names that can appear in a per-locale translation entry. */
+type TranslatableField = "name" | "description" | "ideal";
+
+// ─── Shared helpers ────────────────────────────────────────────────────────────
+
+function readString(formData: FormData, field: string): string {
+  return String(formData.get(field) ?? "").trim();
+}
+
+function parseBool(formData: FormData, field: string): boolean {
+  return formData.get(field) === "on" || formData.get(field) === "true";
+}
+
+function parsePositiveInt(formData: FormData, field: string): number | null {
+  const raw = readString(formData, field);
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.floor(n);
+}
+
+/**
+ * Parses `translations[N][locale]` / `translations[N][name]` /
+ * `translations[N][description]` / `translations[N][ideal]` entries from
+ * FormData into a CatalogTranslation array.
+ *
+ * Only the fields listed in `fields` are extracted per entry.
+ * Entries where all translatable fields are empty are skipped.
+ * Entries with locale not in CATALOG_LOCALES are skipped.
+ */
+export function parseTranslations(
+  formData: FormData,
+  fields: TranslatableField[] = ["name", "description"],
+): CatalogTranslation[] {
+  const result: CatalogTranslation[] = [];
+  const indices = new Set<number>();
+
+  for (const key of formData.keys()) {
+    const match = key.match(/^translations\[(\d+)\]\[locale\]$/);
+    if (match) indices.add(Number(match[1]));
+  }
+
+  for (const idx of Array.from(indices).sort((a, b) => a - b)) {
+    const locale = readString(formData, `translations[${idx}][locale]`);
+    if (!CATALOG_LOCALES.includes(locale as CatalogTranslation["locale"])) continue;
+
+    const entry: Record<string, string> = {};
+    let hasValue = false;
+
+    for (const field of fields) {
+      const val = readString(formData, `translations[${idx}][${field}]`);
+      if (val) {
+        entry[field] = val;
+        hasValue = true;
+      }
+    }
+
+    if (!hasValue) continue;
+
+    result.push({
+      locale: locale as CatalogTranslation["locale"],
+      ...entry,
+    } as CatalogTranslation & Record<string, string>);
+  }
+
+  return result;
+}
+
+/**
+ * Builds a create payload for catalogs that have `name` + `description`
+ * (TranslatablePayload shape). Caller may override translatable fields.
+ */
+export function buildTranslatableCreate(
+  formData: FormData,
+  fields: TranslatableField[] = ["name", "description"],
+  customFields?: Record<string, unknown>,
+): Record<string, unknown> {
+  const name = readString(formData, "name");
+  if (!name) throw new Error("El nombre es obligatorio.");
+  const active = formData.has("active") ? parseBool(formData, "active") : true;
+  const translations = parseTranslations(formData, fields);
+
+  const payload: Record<string, unknown> = { name, active };
+
+  // Include description when it's a configured translatable field
+  if (fields.includes("description")) {
+    const description = readString(formData, "description") || undefined;
+    if (description !== undefined) payload.description = description;
+  }
+
+  // Include ideal when it's a configured translatable field
+  if (fields.includes("ideal")) {
+    const ideal = readString(formData, "ideal") || undefined;
+    if (ideal !== undefined) payload.ideal = ideal;
+  }
+
+  if (translations.length > 0) payload.translations = translations;
+
+  // Merge any caller-supplied extra fields (e.g. club_type_id, ideal_order)
+  if (customFields) {
+    for (const [k, v] of Object.entries(customFields)) {
+      if (v !== null && v !== undefined) payload[k] = v;
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Builds an update payload for catalogs that have `name` (and optionally
+ * `description` or `ideal`). Caller may override translatable fields.
+ *
+ * Only sends `translations` when the dirty flag is set.
+ */
+export function buildTranslatableUpdate(
+  formData: FormData,
+  fields: TranslatableField[] = ["name", "description"],
+  customFields?: Record<string, unknown>,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  const name = readString(formData, "name");
+  if (name) payload.name = name;
+
+  if (fields.includes("description")) {
+    payload.description = readString(formData, "description") || "";
+  }
+
+  if (fields.includes("ideal")) {
+    const ideal = readString(formData, "ideal");
+    if (ideal) payload.ideal = ideal;
+  }
+
+  if (formData.has("active")) payload.active = parseBool(formData, "active");
+
+  const dirty = formData.get("translations_dirty");
+  if (dirty === "1") payload.translations = parseTranslations(formData, fields);
+
+  if (customFields) {
+    for (const [k, v] of Object.entries(customFields)) {
+      if (v !== null && v !== undefined) payload[k] = v;
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Builds a create payload for name-only catalogs (no description, no ideal).
+ */
+function buildNameOnlyCreate(formData: FormData): Record<string, unknown> {
+  const name = readString(formData, "name");
+  if (!name) throw new Error("El nombre es obligatorio.");
+  const active = formData.has("active") ? parseBool(formData, "active") : true;
+  const translations = parseTranslations(formData, ["name"]);
+  return {
+    name,
+    active,
+    ...(translations.length > 0 ? { translations } : {}),
+  };
+}
+
+/**
+ * Builds an update payload for name-only catalogs.
+ */
+function buildNameOnlyUpdate(formData: FormData): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  const name = readString(formData, "name");
+  if (name) payload.name = name;
+  if (formData.has("active")) payload.active = parseBool(formData, "active");
+  const dirty = formData.get("translations_dirty");
+  if (dirty === "1") payload.translations = parseTranslations(formData, ["name"]);
+  return payload;
+}
+
+// ─── Generic factory ───────────────────────────────────────────────────────────
+
+type CrudPermissions = {
+  create: string[];
+  update: string[];
+  delete: string[];
+};
+
+/**
+ * Factory that generates (createAction, updateAction, deleteAction) for a
+ * given catalog route.
+ *
+ * @param routePath    Dashboard path — used for revalidatePath + redirect
+ * @param permissions  RBAC permission arrays (any-of semantics)
+ * @param api          Object with create / update / delete async fns
+ * @param hasDescription  When false, uses name-only builders (ignores translatableFields)
+ * @param translatableFields  When hasDescription is true, overrides which fields
+ *   are extracted from translations entries. Defaults to ['name', 'description'].
+ *   Pass ['name', 'ideal'] for club-ideals.
+ */
+function makeActions(
+  routePath: string,
+  permissions: CrudPermissions,
+  api: {
+    create: (payload: Record<string, unknown>) => Promise<unknown>;
+    update: (id: number, payload: Record<string, unknown>) => Promise<unknown>;
+    delete: (id: number) => Promise<unknown>;
+  },
+  hasDescription = true,
+  translatableFields: TranslatableField[] = ["name", "description"],
+) {
+  async function createAction(
+    _: GenericCatalogActionState,
+    formData: FormData,
+  ): Promise<GenericCatalogActionState> {
+    const user = await requireAdminUser();
+    if (!hasAnyPermission(user, permissions.create)) {
+      return { error: "Sin permisos para crear." };
+    }
+    try {
+      const payload = hasDescription
+        ? buildTranslatableCreate(formData, translatableFields)
+        : buildNameOnlyCreate(formData);
+      await api.create(payload);
+    } catch (error) {
+      return {
+        error: getActionErrorMessage(error, "No se pudo crear el registro.", {
+          endpointLabel: routePath,
+        }),
+      };
+    }
+    revalidatePath(routePath);
+    redirect(routePath);
+  }
+
+  async function updateAction(
+    _: GenericCatalogActionState,
+    formData: FormData,
+  ): Promise<GenericCatalogActionState> {
+    const user = await requireAdminUser();
+    if (!hasAnyPermission(user, permissions.update)) {
+      return { error: "Sin permisos para editar." };
+    }
+    const id = parsePositiveInt(formData, "id");
+    if (!id) return { error: "No se pudo identificar el registro a editar." };
+    try {
+      const payload = hasDescription
+        ? buildTranslatableUpdate(formData, translatableFields)
+        : buildNameOnlyUpdate(formData);
+      await api.update(id, payload);
+    } catch (error) {
+      return {
+        error: getActionErrorMessage(error, "No se pudo actualizar el registro.", {
+          endpointLabel: `${routePath}/${id}`,
+        }),
+      };
+    }
+    revalidatePath(routePath);
+    redirect(routePath);
+  }
+
+  async function deleteAction(
+    _: GenericCatalogActionState,
+    formData: FormData,
+  ): Promise<GenericCatalogActionState> {
+    const user = await requireAdminUser();
+    if (!hasAnyPermission(user, permissions.delete)) {
+      return { error: "Sin permisos para eliminar." };
+    }
+    const id = parsePositiveInt(formData, "id");
+    if (!id) return { error: "No se pudo identificar el registro a eliminar." };
+    try {
+      await api.delete(id);
+    } catch (error) {
+      return {
+        error: getActionErrorMessage(error, "No se pudo eliminar el registro.", {
+          endpointLabel: `${routePath}/${id}`,
+        }),
+      };
+    }
+    revalidatePath(routePath);
+    redirect(routePath);
+  }
+
+  return { createAction, updateAction, deleteAction };
+}
+
+// ─── Countries ────────────────────────────────────────────────────────────────
+
+const countriesActions = makeActions(
+  "/dashboard/catalogs/geography/countries",
+  {
+    create: [COUNTRIES_CREATE, CATALOGS_CREATE],
+    update: [COUNTRIES_UPDATE, CATALOGS_UPDATE],
+    delete: [COUNTRIES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminCountry(p as Parameters<typeof createAdminCountry>[0]),
+    update: (id, p) => updateAdminCountry(id, p),
+    delete: (id) => deleteAdminCountry(id),
+  },
+  false, // name only
+);
+
+export const createCountryAction = countriesActions.createAction;
+export const updateCountryAction = countriesActions.updateAction;
+export const deleteCountryAction = countriesActions.deleteAction;
+
+// ─── Unions ───────────────────────────────────────────────────────────────────
+
+const unionsActions = makeActions(
+  "/dashboard/catalogs/geography/unions",
+  {
+    create: [UNIONS_CREATE, CATALOGS_CREATE],
+    update: [UNIONS_UPDATE, CATALOGS_UPDATE],
+    delete: [UNIONS_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminUnion(p as Parameters<typeof createAdminUnion>[0]),
+    update: (id, p) => updateAdminUnion(id, p),
+    delete: (id) => deleteAdminUnion(id),
+  },
+  false, // name only
+);
+
+export const createUnionAction = unionsActions.createAction;
+export const updateUnionAction = unionsActions.updateAction;
+export const deleteUnionAction = unionsActions.deleteAction;
+
+// ─── Local Fields ─────────────────────────────────────────────────────────────
+
+const localFieldsActions = makeActions(
+  "/dashboard/catalogs/geography/local-fields",
+  {
+    create: [LOCAL_FIELDS_CREATE, CATALOGS_CREATE],
+    update: [LOCAL_FIELDS_UPDATE, CATALOGS_UPDATE],
+    delete: [LOCAL_FIELDS_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminLocalField(p as Parameters<typeof createAdminLocalField>[0]),
+    update: (id, p) => updateAdminLocalField(id, p),
+    delete: (id) => deleteAdminLocalField(id),
+  },
+  false, // name only
+);
+
+export const createLocalFieldAction = localFieldsActions.createAction;
+export const updateLocalFieldAction = localFieldsActions.updateAction;
+export const deleteLocalFieldAction = localFieldsActions.deleteAction;
+
+// ─── Districts ────────────────────────────────────────────────────────────────
+
+const districtsActions = makeActions(
+  "/dashboard/catalogs/geography/districts",
+  {
+    create: [DISTRICTS_CREATE, CATALOGS_CREATE],
+    update: [DISTRICTS_UPDATE, CATALOGS_UPDATE],
+    delete: [DISTRICTS_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminDistrict(p as Parameters<typeof createAdminDistrict>[0]),
+    update: (id, p) => updateAdminDistrict(id, p),
+    delete: (id) => deleteAdminDistrict(id),
+  },
+  false, // name only
+);
+
+export const createDistrictAction = districtsActions.createAction;
+export const updateDistrictAction = districtsActions.updateAction;
+export const deleteDistrictAction = districtsActions.deleteAction;
+
+// ─── Churches ─────────────────────────────────────────────────────────────────
+
+const churchesActions = makeActions(
+  "/dashboard/catalogs/geography/churches",
+  {
+    create: [CHURCHES_CREATE, CATALOGS_CREATE],
+    update: [CHURCHES_UPDATE, CATALOGS_UPDATE],
+    delete: [CHURCHES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminChurch(p as Parameters<typeof createAdminChurch>[0]),
+    update: (id, p) => updateAdminChurch(id, p),
+    delete: (id) => deleteAdminChurch(id),
+  },
+  false, // name only
+);
+
+export const createChurchAction = churchesActions.createAction;
+export const updateChurchAction = churchesActions.updateAction;
+export const deleteChurchAction = churchesActions.deleteAction;
+
+// ─── Relationship Types ───────────────────────────────────────────────────────
+
+const relationshipTypesActions = makeActions(
+  "/dashboard/catalogs/relationship-types",
+  {
+    create: [RELATIONSHIP_TYPES_CREATE, CATALOGS_CREATE],
+    update: [RELATIONSHIP_TYPES_UPDATE, CATALOGS_UPDATE],
+    delete: [RELATIONSHIP_TYPES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminRelationshipType(p as Parameters<typeof createAdminRelationshipType>[0]),
+    update: (id, p) => updateAdminRelationshipType(id, p),
+    delete: (id) => deleteAdminRelationshipType(id),
+  },
+  true, // name + description
+);
+
+export const createRelationshipTypeAction = relationshipTypesActions.createAction;
+export const updateRelationshipTypeAction = relationshipTypesActions.updateAction;
+export const deleteRelationshipTypeAction = relationshipTypesActions.deleteAction;
+
+// ─── Allergies ────────────────────────────────────────────────────────────────
+
+const allergiesActions = makeActions(
+  "/dashboard/catalogs/allergies",
+  {
+    create: [ALLERGIES_CREATE, CATALOGS_CREATE],
+    update: [ALLERGIES_UPDATE, CATALOGS_UPDATE],
+    delete: [ALLERGIES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminAllergy(p as Parameters<typeof createAdminAllergy>[0]),
+    update: (id, p) => updateAdminAllergy(id, p),
+    delete: (id) => deleteAdminAllergy(id),
+  },
+  true, // name + description
+);
+
+export const createAllergyAction = allergiesActions.createAction;
+export const updateAllergyAction = allergiesActions.updateAction;
+export const deleteAllergyAction = allergiesActions.deleteAction;
+
+// ─── Diseases ─────────────────────────────────────────────────────────────────
+
+const diseasesActions = makeActions(
+  "/dashboard/catalogs/diseases",
+  {
+    create: [DISEASES_CREATE, CATALOGS_CREATE],
+    update: [DISEASES_UPDATE, CATALOGS_UPDATE],
+    delete: [DISEASES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminDisease(p as Parameters<typeof createAdminDisease>[0]),
+    update: (id, p) => updateAdminDisease(id, p),
+    delete: (id) => deleteAdminDisease(id),
+  },
+  true, // name + description
+);
+
+export const createDiseaseAction = diseasesActions.createAction;
+export const updateDiseaseAction = diseasesActions.updateAction;
+export const deleteDiseaseAction = diseasesActions.deleteAction;
+
+// ─── Medicines ────────────────────────────────────────────────────────────────
+
+const medicinesActions = makeActions(
+  "/dashboard/catalogs/medicines",
+  {
+    create: [MEDICINES_CREATE, CATALOGS_CREATE],
+    update: [MEDICINES_UPDATE, CATALOGS_UPDATE],
+    delete: [MEDICINES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminMedicine(p as Parameters<typeof createAdminMedicine>[0]),
+    update: (id, p) => updateAdminMedicine(id, p),
+    delete: (id) => deleteAdminMedicine(id),
+  },
+  true, // name + description
+);
+
+export const createMedicineAction = medicinesActions.createAction;
+export const updateMedicineAction = medicinesActions.updateAction;
+export const deleteMedicineAction = medicinesActions.deleteAction;
+
+// ─── Club Types ───────────────────────────────────────────────────────────────
+
+const clubTypesActions = makeActions(
+  "/dashboard/catalogs/club-types",
+  {
+    create: [CLUB_TYPES_CREATE, CATALOGS_CREATE],
+    update: [CLUB_TYPES_UPDATE, CATALOGS_UPDATE],
+    delete: [CLUB_TYPES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminClubType(p as Parameters<typeof createAdminClubType>[0]),
+    update: (id, p) => updateAdminClubType(id, p),
+    delete: (id) => deleteAdminClubType(id),
+  },
+  false, // name only
+);
+
+export const createClubTypeAction = clubTypesActions.createAction;
+export const updateClubTypeAction = clubTypesActions.updateAction;
+export const deleteClubTypeAction = clubTypesActions.deleteAction;
+
+// ─── Club Ideals ──────────────────────────────────────────────────────────────
+// Special: translatable fields are ['name', 'ideal'] — NOT description.
+// Additional payload fields: club_type_id, ideal_order.
+
+const clubIdealsActions = makeActions(
+  "/dashboard/catalogs/club-ideals",
+  {
+    create: [CLUB_IDEALS_CREATE, CATALOGS_CREATE],
+    update: [CLUB_IDEALS_UPDATE, CATALOGS_UPDATE],
+    delete: [CLUB_IDEALS_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => {
+      // Pull extra fields from the generic payload and forward to typed fn
+      const { name, ideal, club_type_id, ideal_order, active, translations } = p as {
+        name: string;
+        ideal?: string | null;
+        club_type_id?: number | null;
+        ideal_order?: number | null;
+        active?: boolean;
+        translations?: CatalogTranslation[];
+      };
+      return createAdminClubIdeal({ name, ideal, club_type_id, ideal_order, active, translations });
+    },
+    update: (id, p) => {
+      const { name, ideal, club_type_id, ideal_order, active, translations } = p as {
+        name?: string;
+        ideal?: string | null;
+        club_type_id?: number | null;
+        ideal_order?: number | null;
+        active?: boolean;
+        translations?: CatalogTranslation[];
+      };
+      return updateAdminClubIdeal(id, { name, ideal, club_type_id, ideal_order, active, translations });
+    },
+    delete: (id) => deleteAdminClubIdeal(id),
+  },
+  true,                       // hasDescription=true so factory uses buildTranslatableCreate/Update
+  ["name", "ideal"],          // translatableFields override: ideal instead of description
+);
+
+export const createClubIdealAction = clubIdealsActions.createAction;
+export const updateClubIdealAction = clubIdealsActions.updateAction;
+export const deleteClubIdealAction = clubIdealsActions.deleteAction;
+
+// ─── Activity Types ───────────────────────────────────────────────────────────
+// Note: `code` is NOT translatable — only name + description are.
+
+const activityTypesActions = makeActions(
+  "/dashboard/catalogs/activity-types",
+  {
+    create: [ACTIVITY_TYPES_CREATE, CATALOGS_CREATE],
+    update: [ACTIVITY_TYPES_UPDATE, CATALOGS_UPDATE],
+    delete: [ACTIVITY_TYPES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminActivityType(p as Parameters<typeof createAdminActivityType>[0]),
+    update: (id, p) => updateAdminActivityType(id, p),
+    delete: (id) => deleteAdminActivityType(id),
+  },
+  true, // name + description (code passed through but not translatable)
+);
+
+export const createActivityTypeAction = activityTypesActions.createAction;
+export const updateActivityTypeAction = activityTypesActions.updateAction;
+export const deleteActivityTypeAction = activityTypesActions.deleteAction;


### PR DESCRIPTION
## Summary
PR-4a of i18n-generic-catalogs chain (admin UI side). Foundation for upcoming page migrations (PR-4b) and club-ideals dedicated form (PR-5).

### Changes
- **8 new permission groups** in `src/lib/auth/permissions.ts`: DISTRICTS, RELATIONSHIP_TYPES, ALLERGIES, DISEASES, MEDICINES, CLUB_TYPES, CLUB_IDEALS, ACTIVITY_TYPES — each with READ/CREATE/UPDATE/DELETE. Registered in PERMISSION_GROUPS for role assignment UI.
- **API client** `src/lib/api/generic-catalogs-i18n.ts`: 48 typed functions (12 catalogs × 4 ops). Three payload shapes:
  - `NameOnlyPayload` for countries/unions/local-fields/districts/churches/club-types
  - `TranslatablePayload` for relationship-types/allergies/diseases/medicines/activity-types (name + description)
  - `ClubIdealPayload` for club-ideals (name + ideal + club_type_id + ideal_order)
- **Server actions factory** `src/lib/generic-catalogs-i18n/actions.ts`: mirrors `phase-e-catalogs/actions.ts`. Extended `makeActions` with `translatableFields?: ('name' | 'description' | 'ideal')[]` override. club-ideals registers with `['name', 'ideal']` (line 641). 36 exports total.
- **Parser update**: `parseTranslations` recognizes `translations[N][ideal]` field so club-ideals form data round-trips correctly.

### Tests
- New `actions.test.ts` — 15/15 pass in 11ms
- Coverage: parseTranslations (incl ideal field), buildTranslatableCreate/Update with custom translatableFields, club-ideals payload shape, no-op behavior when translations_dirty=0

## Backend dependency
Requires backend PR #107 (https://github.com/abn-r/sacdia-backend/pull/107) merged. Endpoints exercised:
- POST/PATCH/DELETE /admin/{countries|unions|local-fields|districts|churches}
- POST/PATCH/DELETE /admin/{relationship-types|allergies|diseases|medicines|club-types|club-ideals|activity-types}

All accept optional `translations?: CatalogTranslationDto[]`. club-ideals accepts `ideal` per locale.

## Known tech debt (deferred to PR-5)
`CatalogTranslation` TS type declares only `name` + `description`. `ideal` field flows through at runtime correctly but the type does not surface it. Tests use `& Record<string, string>` assertion. When PR-5 builds the club-ideals dedicated form (consumer of the typed shape), the type will be extended to `ideal?: string | null`.

## What this PR does NOT do
- Migrate any `app/(dashboard)/dashboard/catalogs/<entity>/page.tsx` — that's PR-4b
- Build the club-ideals dedicated form component — that's PR-5
- Touch existing `lib/phase-e-catalogs/actions.ts` (foundation must stay stable)
- Touch `lib/catalogs/entities.ts` (cleanup is PR-6)

## Test plan
- [x] `pnpm test src/lib/generic-catalogs-i18n` — 15/15 green
- [x] Lint on new files — 0 warnings
- [ ] Manual: roles UI shows the 8 new permission groups
- [ ] PR-4b will wire pages and exercise the actions end-to-end

## SDD artifacts (engram)
- proposal #2313, spec #2320, design #2322, tasks #2324, apply-progress #2325 (PR-1+2+3+4a merged log)