### PR TITLE
feat(admin): add baseline animations across panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "framer-motion": "^12.38.0",
     "lucide-react": "^0.563.0",
     "next": "16.2.4",
     "next-intl": "^4.9.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      framer-motion:
+        specifier: ^12.38.0
+        version: 12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.3)
@@ -3405,6 +3408,20 @@ packages:
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
 
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3954,6 +3971,12 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -8375,6 +8398,15 @@ snapshots:
 
   forwarded-parse@2.1.2: {}
 
+  framer-motion@12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   fsevents@2.3.3:
     optional: true
 
@@ -8903,6 +8935,12 @@ snapshots:
   minipass@7.1.3: {}
 
   module-details-from-path@1.0.4: {}
+
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
+  motion-utils@12.36.0: {}
 
   ms@2.1.3: {}
 

--- a/src/app/(dashboard)/dashboard/catalogs/loading.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/loading.tsx
@@ -12,7 +12,14 @@ export default function CatalogsLoading() {
           <Skeleton className="mb-3 h-6 w-24" />
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="rounded-lg border p-4">
+              <div
+                key={i}
+                className="rounded-lg border p-4 animate-in fade-in slide-in-from-bottom-2 duration-300"
+                style={{
+                  animationDelay: `${Math.min((g * 5 + i) * 50, 400)}ms`,
+                  animationFillMode: "backwards",
+                }}
+              >
                 <div className="flex items-center gap-3">
                   <Skeleton className="size-10 rounded-lg" />
                   <div className="space-y-1">

--- a/src/app/(dashboard)/dashboard/clubs/loading.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/loading.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { DataTableShell } from "@/components/shared/data-table-shell";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 export default function ClubsLoading() {
   return (
@@ -13,7 +14,7 @@ export default function ClubsLoading() {
       </div>
       <DataTableShell>
         {Array.from({ length: 6 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
+          <div key={i} className={`flex items-center gap-4 border-b p-4 last:border-b-0 ${STAGGER_CLASSES}`} style={getStaggerStyle(i, 50)}>
             <Skeleton className="h-4 w-40" />
             <Skeleton className="hidden h-4 w-24 md:block" />
             <Skeleton className="h-5 w-14" />

--- a/src/app/(dashboard)/dashboard/loading.tsx
+++ b/src/app/(dashboard)/dashboard/loading.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from "@/components/ui/skeleton";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 export default function DashboardLoading() {
   return (
@@ -9,7 +10,7 @@ export default function DashboardLoading() {
       </div>
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="rounded-xl border border-border/60 bg-card p-5">
+          <div key={i} className={`rounded-xl border border-border/60 bg-card p-5 ${STAGGER_CLASSES}`} style={getStaggerStyle(i, 50)}>
             <Skeleton className="h-4 w-24" />
             <Skeleton className="mt-3 h-7 w-16" />
             <Skeleton className="mt-2 h-3 w-32" />
@@ -21,7 +22,7 @@ export default function DashboardLoading() {
           <Skeleton className="mb-4 h-5 w-40" />
           <div className="space-y-3">
             {Array.from({ length: 5 }).map((_, i) => (
-              <div key={i} className="flex items-center gap-3">
+              <div key={i} className={`flex items-center gap-3 ${STAGGER_CLASSES}`} style={getStaggerStyle(i, 50)}>
                 <Skeleton className="size-9 rounded-full" />
                 <div className="flex-1 space-y-1">
                   <Skeleton className="h-4 w-32" />

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -29,6 +29,7 @@ import { cn } from "@/lib/utils";
 import { PageHeader } from "@/components/shared/page-header";
 import { getTranslations } from "next-intl/server";
 import { buildRoleTranslator } from "@/lib/auth/role-labels";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 type StatsData = {
   totalUsers: number | null;
@@ -356,7 +357,9 @@ async function StatsSection() {
   return (
     <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {statCards.map((card, index) => (
-        <StatCard key={card.title} {...card} colorIndex={index} />
+        <div key={card.title} className={STAGGER_CLASSES} style={getStaggerStyle(index, 50)}>
+          <StatCard {...card} colorIndex={index} />
+        </div>
       ))}
     </div>
   );
@@ -417,7 +420,7 @@ async function RecentUsersSection() {
       </CardHeader>
       <CardContent>
         <div className="divide-y divide-border/60">
-          {users.map((user) => {
+          {users.map((user, index) => {
             const roleNames = extractRoleNames(user);
             const fullName =
               [user.name, user.paternal_last_name].filter(Boolean).join(" ") ||
@@ -427,7 +430,8 @@ async function RecentUsersSection() {
             return (
               <div
                 key={user.user_id}
-                className="flex items-center gap-3 py-3 first:pt-0 last:pb-0"
+                className={`flex items-center gap-3 py-3 first:pt-0 last:pb-0 ${STAGGER_CLASSES}`}
+                style={getStaggerStyle(index)}
               >
                 <Avatar className="size-8 shrink-0">
                   <AvatarFallback className="text-xs font-medium">
@@ -649,11 +653,11 @@ export default async function DashboardPage() {
           <h2 className="text-base font-semibold">{t("quickLinks.title")}</h2>
         </div>
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          {quickLinks.map((link) => {
+          {quickLinks.map((link, index) => {
             const config =
               statCardConfig[link.colorIndex % statCardConfig.length];
             return (
-              <Link key={link.href} href={link.href}>
+              <Link key={link.href} href={link.href} className={STAGGER_CLASSES} style={getStaggerStyle(index, 50)}>
                 <Card className="group h-full transition-all hover:border-primary/20 hover:shadow-md">
                   <CardContent className="flex items-center gap-3.5 p-4">
                     <div

--- a/src/app/(dashboard)/dashboard/reports/loading.tsx
+++ b/src/app/(dashboard)/dashboard/reports/loading.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { DataTableShell } from "@/components/shared/data-table-shell";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 export default function ReportsLoading() {
   return (
@@ -20,7 +21,7 @@ export default function ReportsLoading() {
       </div>
       <DataTableShell>
         {Array.from({ length: 5 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
+          <div key={i} className={`flex items-center gap-4 border-b p-4 last:border-b-0 ${STAGGER_CLASSES}`} style={getStaggerStyle(i, 50)}>
             <Skeleton className="h-4 w-24" />
             <Skeleton className="h-4 w-12" />
             <Skeleton className="h-5 w-20 rounded-full" />

--- a/src/app/(dashboard)/dashboard/users/loading.tsx
+++ b/src/app/(dashboard)/dashboard/users/loading.tsx
@@ -1,5 +1,6 @@
 import { Skeleton } from "@/components/ui/skeleton";
 import { DataTableShell } from "@/components/shared/data-table-shell";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 export default function UsersLoading() {
   return (
@@ -15,7 +16,7 @@ export default function UsersLoading() {
       </div>
       <DataTableShell>
         {Array.from({ length: 8 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-4 border-b p-4 last:border-b-0">
+          <div key={i} className={`flex items-center gap-4 border-b p-4 last:border-b-0 ${STAGGER_CLASSES}`} style={getStaggerStyle(i, 50)}>
             <Skeleton className="size-8 rounded-full" />
             <div className="flex-1 space-y-1">
               <Skeleton className="h-4 w-40" />

--- a/src/app/(dashboard)/template.tsx
+++ b/src/app/(dashboard)/template.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export default function DashboardTemplate({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/src/components/camporees/camporees-view.tsx
+++ b/src/components/camporees/camporees-view.tsx
@@ -28,6 +28,7 @@ const CamporeeFormDialog = dynamic<CamporeeFormDialogProps>(
   { ssr: false, loading: () => null }
 );
 import { useTranslations } from "next-intl";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 import { listCamporees } from "@/lib/api/camporees";
 import type { Camporee } from "@/lib/api/camporees";
 import { Tent } from "lucide-react";
@@ -166,10 +167,10 @@ export function CampoReesView({ initialCamporees }: CampoReesViewProps) {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {camporees.map((camporee) => {
+              {camporees.map((camporee, index) => {
                 const id = camporee.camporee_id ?? camporee.id ?? 0;
                 return (
-                  <TableRow key={id} className="hover:bg-muted/30">
+                  <TableRow key={id} className={`hover:bg-muted/30 ${STAGGER_CLASSES}`} style={getStaggerStyle(index, 50)}>
                     <TableCell className="px-3 py-2.5 align-middle">
                       <span className="font-medium">{camporee.name}</span>
                     </TableCell>

--- a/src/components/catalogs/catalog-crud-page.tsx
+++ b/src/components/catalogs/catalog-crud-page.tsx
@@ -248,7 +248,11 @@ export function CatalogCrudPage({
                       return (
                         <TableRow
                           key={rowKey}
-                          className={`${ROW_H} border-b border-border transition-colors hover:bg-muted/30`}
+                          className={`${ROW_H} border-b border-border transition-colors hover:bg-muted/30 animate-in fade-in slide-in-from-bottom-2 duration-300`}
+                          style={{
+                            animationDelay: `${Math.min(idx * 40, 400)}ms`,
+                            animationFillMode: "backwards",
+                          }}
                         >
                           {/* ID — first column */}
                           <TableCell
@@ -374,7 +378,14 @@ export function CatalogCrudPage({
               const secondaryFields = displayFields.slice(1, 3);
 
               return (
-                <li key={rowKey}>
+                <li
+                  key={rowKey}
+                  className="animate-in fade-in slide-in-from-bottom-2 duration-300"
+                  style={{
+                    animationDelay: `${Math.min(idx * 40, 400)}ms`,
+                    animationFillMode: "backwards",
+                  }}
+                >
                   <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none">
                     {/* Card header: icon + name + edit chevron */}
                     <div className="flex items-center gap-3">

--- a/src/components/enrollments/enrollments-table.tsx
+++ b/src/components/enrollments/enrollments-table.tsx
@@ -29,6 +29,7 @@ import {
 import { validateEnrollment, type Enrollment, type InvestitureStatus } from "@/lib/api/enrollments";
 import { ApiError } from "@/lib/api/client";
 import { useFormatDate } from "@/lib/format-locale";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 // ─── Status badge ─────────────────────────────────────────────────────────────
 
@@ -194,13 +195,13 @@ export function EnrollmentsTable({ enrollments, onRefresh }: EnrollmentsTablePro
           </TableRow>
         </TableHeader>
         <TableBody>
-          {enrollments.map((enrollment) => {
+          {enrollments.map((enrollment, index) => {
             const isProcessing = processingId === enrollment.enrollment_id;
             const isPendingValidation =
               enrollment.investiture_status === "SUBMITTED_FOR_VALIDATION";
 
             return (
-              <TableRow key={enrollment.enrollment_id}>
+              <TableRow key={enrollment.enrollment_id} className={STAGGER_CLASSES} style={getStaggerStyle(index)}>
                 {/* Member */}
                 <TableCell>
                   <div className="space-y-0.5">

--- a/src/components/evidence-review/evidence-review-table.tsx
+++ b/src/components/evidence-review/evidence-review-table.tsx
@@ -51,6 +51,7 @@ const EvidenceBulkActionBar = dynamic<EvidenceBulkActionBarProps>(
   { ssr: false, loading: () => null }
 );
 import { useFormatDate } from "@/lib/format-locale";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 function isPending(status: string, type: EvidenceType): boolean {
   void type;
@@ -281,14 +282,15 @@ export function EvidenceReviewTable({ items, onRefresh }: EvidenceReviewTablePro
           </TableHeader>
 
           <TableBody>
-            {items.map((item) => {
+            {items.map((item, index) => {
               const isSelected = selectedIds.has(item.id);
               const selectable = isPending(item.status, item.type);
 
               return (
                 <TableRow
                   key={`${item.type}-${item.id}`}
-                  className={`hover:bg-muted/30 ${isSelected ? "bg-muted/50" : ""}`}
+                  className={`hover:bg-muted/30 ${isSelected ? "bg-muted/50" : ""} ${STAGGER_CLASSES}`}
+                  style={getStaggerStyle(index)}
                 >
                   {/* Checkbox */}
                   <TableCell className="px-3 py-2.5 align-middle">

--- a/src/components/inventory/inventory-table.tsx
+++ b/src/components/inventory/inventory-table.tsx
@@ -16,6 +16,7 @@ import {
 import { EmptyState } from "@/components/shared/empty-state";
 import { InventoryHistoryDialog } from "@/components/inventory/inventory-history-dialog";
 import type { InventoryItem } from "@/lib/api/inventory";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
@@ -71,13 +72,13 @@ export function InventoryTable({ items, onEdit, onDelete }: InventoryTableProps)
           </TableRow>
         </TableHeader>
         <TableBody>
-          {items.map((item) => {
+          {items.map((item, index) => {
             const categoryName =
               item.inventory_category?.name ??
               t("table.category_fallback", { id: item.inventory_category_id });
 
             return (
-              <TableRow key={item.inventory_id} className="hover:bg-muted/30">
+              <TableRow key={item.inventory_id} className={`hover:bg-muted/30 ${STAGGER_CLASSES}`} style={getStaggerStyle(index)}>
                 <TableCell className="px-3 py-2.5 align-middle">
                   <span className="font-medium">{item.name}</span>
                 </TableCell>

--- a/src/components/investiture/config-table.tsx
+++ b/src/components/investiture/config-table.tsx
@@ -17,6 +17,7 @@ import { EmptyState } from "@/components/shared/empty-state";
 import { Settings2 } from "lucide-react";
 import type { InvestitureConfig } from "@/lib/api/investiture";
 import { useFormatDate } from "@/lib/format-locale";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -68,8 +69,8 @@ export function ConfigTable({ configs, onEdit, onDelete }: ConfigTableProps) {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {configs.map((config) => (
-            <TableRow key={config.investiture_config_id} className="hover:bg-muted/30">
+          {configs.map((config, index) => (
+            <TableRow key={config.investiture_config_id} className={`hover:bg-muted/30 ${STAGGER_CLASSES}`} style={getStaggerStyle(index)}>
               <TableCell className="px-3 py-2.5 align-middle font-medium">
                 {config.local_fields?.name ?? t("configTable.fieldFallback", { id: config.local_field_id })}
               </TableCell>

--- a/src/components/investiture/pending-table.tsx
+++ b/src/components/investiture/pending-table.tsx
@@ -46,6 +46,7 @@ import {
 } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
 import { useFormatDate } from "@/lib/format-locale";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -148,7 +149,7 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {enrollments.map((enrollment) => {
+            {enrollments.map((enrollment, index) => {
               const name = getMemberName(
                 enrollment,
                 t("pendingTable.enrollmentFallback", { id: enrollment.enrollment_id }),
@@ -160,7 +161,8 @@ export function PendingTable({ enrollments, onRefresh }: PendingTableProps) {
               return (
                 <TableRow
                   key={enrollment.enrollment_id}
-                  className="hover:bg-muted/30"
+                  className={`hover:bg-muted/30 ${STAGGER_CLASSES}`}
+                  style={getStaggerStyle(index)}
                 >
                   <TableCell className="px-3 py-2.5 align-middle">
                     <span className="font-medium">{name}</span>

--- a/src/components/investiture/pipeline-table.tsx
+++ b/src/components/investiture/pipeline-table.tsx
@@ -57,6 +57,7 @@ import {
 } from "@/lib/api/investiture";
 import { ApiError } from "@/lib/api/client";
 import { useFormatDate } from "@/lib/format-locale";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -401,14 +402,15 @@ export function PipelineTable({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {enrollments.map((enrollment) => {
+            {enrollments.map((enrollment, index) => {
               const isSelected = selectedIds.has(enrollment.enrollment_id);
               const selectable = isSelectableForRole(enrollment.status, userRole);
 
               return (
                 <TableRow
                   key={enrollment.enrollment_id}
-                  className={`hover:bg-muted/30 ${isSelected ? "bg-muted/50" : ""}`}
+                  className={`hover:bg-muted/30 ${isSelected ? "bg-muted/50" : ""} ${STAGGER_CLASSES}`}
+                  style={getStaggerStyle(index)}
                 >
                   {/* Checkbox cell */}
                   <TableCell className="px-3 py-2.5 align-middle">

--- a/src/components/layout/app-sidebar.tsx
+++ b/src/components/layout/app-sidebar.tsx
@@ -92,7 +92,7 @@ function NavItemWithChildren({ item, pathname }: { item: NavItem; pathname: stri
     <Collapsible asChild defaultOpen={isActive}>
       <SidebarMenuItem>
         <CollapsibleTrigger asChild>
-          <SidebarMenuButton tooltip={title} isActive={isActive}>
+          <SidebarMenuButton tooltip={title} isActive={isActive} className="transition-colors duration-200">
             <item.icon className="h-[18px] w-[18px] shrink-0" />
             <span className="truncate">{title}</span>
             <ChevronRight className="ml-auto h-[18px] w-[18px] shrink-0 transition-transform group-data-[state=open]/collapsible:rotate-90" />
@@ -131,7 +131,7 @@ function NavItemSimple({ item, pathname }: { item: NavItem; pathname: string }) 
 
   return (
     <SidebarMenuItem>
-      <SidebarMenuButton asChild tooltip={title} isActive={isActive}>
+      <SidebarMenuButton asChild tooltip={title} isActive={isActive} className="transition-colors duration-200">
         <Link href={item.url}>
           <item.icon className="h-[18px] w-[18px] shrink-0" />
           <span className="truncate">{title}</span>

--- a/src/components/layout/global-command-palette.tsx
+++ b/src/components/layout/global-command-palette.tsx
@@ -13,7 +13,13 @@ import {
   CommandSeparator,
   CommandShortcut,
 } from "@/components/ui/command";
-import { navConfig, type NavItem, type NavChild } from "@/components/layout/nav-config";
+import {
+  navConfig,
+  isSubGroup,
+  type NavItem,
+  type NavChild,
+  type NavSubGroup,
+} from "@/components/layout/nav-config";
 import { usePermissions } from "@/lib/auth/use-permissions";
 
 type SearchableEntry = {
@@ -69,7 +75,16 @@ export function GlobalCommandPalette({ open, onOpenChange }: GlobalCommandPalett
             keywords: [parentTitle, groupLabel, item.url],
           });
 
-          for (const child of item.children as NavChild[]) {
+          const flatChildren: NavChild[] = [];
+          for (const child of item.children!) {
+            if (isSubGroup(child)) {
+              flatChildren.push(...(child as NavSubGroup).items);
+            } else {
+              flatChildren.push(child as NavChild);
+            }
+          }
+
+          for (const child of flatChildren) {
             if (!check(child.permission)) continue;
             const childTitle = t(child.title as Parameters<typeof t>[0]);
             flat.push({

--- a/src/components/rbac/permissions-table.tsx
+++ b/src/components/rbac/permissions-table.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { EmptyState } from "@/components/shared/empty-state";
 import type { Permission, RbacActionState } from "@/lib/rbac/types";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
@@ -115,8 +116,8 @@ export function PermissionsTable({ items, createAction, updateAction, deleteActi
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {items.map((perm) => (
-                    <TableRow key={perm.permission_id}>
+                  {items.map((perm, index) => (
+                    <TableRow key={perm.permission_id} className={STAGGER_CLASSES} style={getStaggerStyle(index)}>
                       <TableCell className="text-xs text-muted-foreground">{perm.permission_id}</TableCell>
                       <TableCell>
                         <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
@@ -150,8 +151,8 @@ export function PermissionsTable({ items, createAction, updateAction, deleteActi
 
           {/* Mobile cards */}
           <ul className="space-y-3 md:hidden" aria-label={t("permissionsTable.mobileListLabel")}>
-            {items.map((perm) => (
-              <li key={perm.permission_id}>
+            {items.map((perm, index) => (
+              <li key={perm.permission_id} className={STAGGER_CLASSES} style={getStaggerStyle(index)}>
                 <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none">
                   <div className="flex items-center gap-3">
                     <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">

--- a/src/components/rbac/roles-table.tsx
+++ b/src/components/rbac/roles-table.tsx
@@ -59,6 +59,7 @@ import {
 } from "@/components/shared/sortable-header";
 import { deactivateRoleAction } from "@/lib/rbac/actions";
 import type { Role } from "@/lib/rbac/types";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 // ─── Alert component — may not exist yet, using inline div fallback ──────────
 // The admin uses a generic Alert from shadcn. We check for it and fallback gracefully.
@@ -600,12 +601,12 @@ export function RolesTable({ roles, isSuperAdmin }: RolesTableProps) {
 
           {/* Mobile: descriptive cards */}
           <ul className="space-y-3 md:hidden" aria-label="Lista de roles">
-            {filtered.map((role) => {
+            {filtered.map((role, index) => {
               const protected_ = isProtected(role);
               const permCount = role.role_permissions?.length ?? 0;
 
               return (
-                <li key={role.role_id}>
+                <li key={role.role_id} className={STAGGER_CLASSES} style={getStaggerStyle(index)}>
                   <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs transition-colors hover:bg-accent/40 focus-visible:outline-none">
                     <div className="flex items-center gap-3">
                       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">

--- a/src/components/reports/reports-list-client.tsx
+++ b/src/components/reports/reports-list-client.tsx
@@ -49,6 +49,7 @@ import {
   type ReportStatus,
 } from "@/lib/api/monthly-reports";
 import { useFormatDate } from "@/lib/format-locale";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
@@ -373,7 +374,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {reports.map((report) => {
+                  {reports.map((report, index) => {
                     const statusVariant = (
                       {
                         draft: "warning",
@@ -387,7 +388,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
                     const isGenerated = report.status === "generated";
 
                     return (
-                      <TableRow key={report.report_id}>
+                      <TableRow key={report.report_id} className={STAGGER_CLASSES} style={getStaggerStyle(index, 50)}>
                         <TableCell className="font-medium">
                           {t(`months.${report.month}` as Parameters<typeof t>[0])}
                         </TableCell>
@@ -470,7 +471,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
 
           {/* Mobile: descriptive cards */}
           <ul className="space-y-3 md:hidden" aria-label={t("list.ariaListLabel")}>
-            {reports.map((report) => {
+            {reports.map((report, index) => {
               const statusVariant = (
                 {
                   draft: "warning",
@@ -484,7 +485,7 @@ export function ReportsListClient({ enrollmentId }: ReportsListClientProps) {
               const isGenerated = report.status === "generated";
 
               return (
-                <li key={report.report_id}>
+                <li key={report.report_id} className={STAGGER_CLASSES} style={getStaggerStyle(index, 50)}>
                   <div className="rounded-xl border border-border/60 bg-card p-4 shadow-xs">
                     <div className="flex items-center gap-3">
                       <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">

--- a/src/components/requests/assignments-table.tsx
+++ b/src/components/requests/assignments-table.tsx
@@ -23,6 +23,7 @@ import {
   type ReviewRequestPayload,
 } from "@/lib/api/requests";
 import { useFormatDate } from "@/lib/format-locale";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -99,10 +100,10 @@ export function AssignmentsTable({ requests, onRefresh }: AssignmentsTableProps)
             </TableRow>
           </TableHeader>
           <TableBody>
-            {requests.map((req) => {
+            {requests.map((req, index) => {
               const isPending = req.status === "PENDING";
               return (
-                <TableRow key={String(req.request_id)} className="hover:bg-muted/30">
+                <TableRow key={String(req.request_id)} className={`hover:bg-muted/30 ${STAGGER_CLASSES}`} style={getStaggerStyle(index)}>
                   <TableCell className="px-3 py-2.5 align-middle font-medium">
                     {getUserName(req.target_user)}
                   </TableCell>

--- a/src/components/requests/transfers-table.tsx
+++ b/src/components/requests/transfers-table.tsx
@@ -23,6 +23,7 @@ import {
   type ReviewRequestPayload,
 } from "@/lib/api/requests";
 import { useFormatDate } from "@/lib/format-locale";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -99,10 +100,10 @@ export function TransfersTable({ requests, onRefresh }: TransfersTableProps) {
             </TableRow>
           </TableHeader>
           <TableBody>
-            {requests.map((req) => {
+            {requests.map((req, index) => {
               const isPending = req.status === "PENDING";
               return (
-                <TableRow key={String(req.request_id)} className="hover:bg-muted/30">
+                <TableRow key={String(req.request_id)} className={`hover:bg-muted/30 ${STAGGER_CLASSES}`} style={getStaggerStyle(index)}>
                   <TableCell className="px-3 py-2.5 align-middle font-medium">
                     {getUserName(req.requester)}
                   </TableCell>

--- a/src/components/shared/page-header.tsx
+++ b/src/components/shared/page-header.tsx
@@ -27,7 +27,7 @@ export function PageHeader({
   const rightSlot = actions ?? children;
 
   return (
-    <header className={cn("space-y-3", className)}>
+    <header className={cn("space-y-3 animate-in fade-in slide-in-from-top-1 duration-300", className)}>
       {breadcrumbs && breadcrumbs.length > 0 && (
         <nav
           aria-label="Breadcrumb"

--- a/src/components/users/users-table.tsx
+++ b/src/components/users/users-table.tsx
@@ -14,6 +14,7 @@ import type { AdminUser } from "@/lib/api/admin-users";
 import { DataTableShell } from "@/components/shared/data-table-shell";
 import { getTranslations } from "next-intl/server";
 import { buildRoleTranslator, type RoleTranslator } from "@/lib/auth/role-labels";
+import { STAGGER_CLASSES, getStaggerStyle } from "@/lib/animations";
 
 function extractRoleNames(user: AdminUser): string[] {
   const roles: string[] = [];
@@ -198,12 +199,12 @@ export async function UsersTable({
               </TableRow>
             </TableHeader>
             <TableBody>
-              {users.map((user) => {
+              {users.map((user, index) => {
                 const roleNames = extractRoleNames(user);
                 const fullName = getFullName(user);
 
                 return (
-                  <TableRow key={user.user_id}>
+                  <TableRow key={user.user_id} className={STAGGER_CLASSES} style={getStaggerStyle(index)}>
                     <TableCell className="pl-6">
                       <div className="flex items-center gap-3">
                         <UserAvatar
@@ -287,8 +288,8 @@ export async function UsersTable({
 
       {/* Mobile: descriptive cards */}
       <ul className="space-y-3 md:hidden" aria-label={t("list.ariaLabel")}>
-        {users.map((user) => (
-          <li key={user.user_id}>
+        {users.map((user, index) => (
+          <li key={user.user_id} className={STAGGER_CLASSES} style={getStaggerStyle(index)}>
             <UserMobileCard
               user={user}
               showAdministrativeCompletion={showAdministrativeCompletion}

--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -1,0 +1,15 @@
+import type React from "react";
+
+export const STAGGER_CLASSES =
+  "animate-in fade-in slide-in-from-bottom-2 duration-300";
+
+export function getStaggerStyle(
+  index: number,
+  step = 40,
+  cap = 400,
+): React.CSSProperties {
+  return {
+    animationDelay: `${Math.min(index * step, cap)}ms`,
+    animationFillMode: "backwards",
+  };
+}


### PR DESCRIPTION
## Summary

- Adds shared stagger utility (`src/lib/animations.ts`) and applies consistent entry animations to 11 tables, 5 loading skeletons, dashboard home, sidebar, and PageHeader.
- New route transitions via `framer-motion` scoped to `(dashboard)/template.tsx` only — everything else uses existing `tw-animate-css` to avoid bundle bloat.
- Single import pattern for new tables/lists: `className={STAGGER_CLASSES} style={getStaggerStyle(index)}`.

## Scope

- **New files:** `src/lib/animations.ts`, `src/app/(dashboard)/template.tsx`
- **Tables (stagger on rows + mobile cards):** users, rbac/roles, rbac/permissions, evidence-review, investiture (pending/pipeline/config), enrollments, requests (assignments/transfers), inventory, camporees, reports, catalog-crud
- **Loading skeletons:** dashboard, clubs, users, reports, catalogs
- **Dashboard home:** stat cards, recent users, quick links
- **Sidebar:** `transition-colors duration-200` on active nav button
- **PageHeader:** `animate-in fade-in slide-in-from-top-1 duration-300`

## Animation parameters

- Tables: step=40ms, cap=400ms
- Skeletons / cards: step=50ms, cap=400ms
- Route transitions: fade + 8px slide-up, 0.25s easeOut

## Test plan

- [ ] `pnpm dev` and navigate across `(dashboard)` routes — verify smooth page fade-in
- [ ] Open `/dashboard` — stat cards, quick links, recent users stagger in
- [ ] Open `/dashboard/users` — table rows stagger from bottom
- [ ] Open `/dashboard/catalogs` — skeleton stagger then table stagger
- [ ] Open `/dashboard/evidence-review`, `/dashboard/investiture/pending` — table stagger
- [ ] Active sidebar nav item color transitions smoothly on hover/route change
- [ ] Dark mode unaffected
- [ ] No bundle size regression beyond framer-motion (~30kb gzip) on `(dashboard)` route group