### PR TITLE
feat(i18n): migrate 11 catalog admin pages + fix command palette

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -419,22 +419,30 @@
       "countries": {
         "title": "Countries",
         "description": "System country catalog.",
-        "metadataTitle": "Countries"
+        "metadataTitle": "Countries",
+        "entityLabel": "Country",
+        "loadError": "Could not load countries."
       },
       "churches": {
         "title": "Churches",
         "description": "System church catalog.",
-        "metadataTitle": "Churches"
+        "metadataTitle": "Churches",
+        "entityLabel": "Church",
+        "loadError": "Could not load churches."
       },
       "districts": {
         "title": "Districts",
         "description": "System district catalog.",
-        "metadataTitle": "Districts"
+        "metadataTitle": "Districts",
+        "entityLabel": "District",
+        "loadError": "Could not load districts."
       },
       "unions": {
         "title": "Unions",
         "description": "System union catalog.",
-        "metadataTitle": "Unions"
+        "metadataTitle": "Unions",
+        "entityLabel": "Union",
+        "loadError": "Could not load unions."
       },
       "unionsDetail": {
         "back": "Back",
@@ -451,7 +459,9 @@
       "localFields": {
         "title": "Local Fields",
         "description": "System local field catalog.",
-        "metadataTitle": "Local fields"
+        "metadataTitle": "Local fields",
+        "entityLabel": "Local Field",
+        "loadError": "Could not load local fields."
       },
       "localFieldsDetail": {
         "back": "Back",
@@ -468,7 +478,9 @@
       "activityTypes": {
         "title": "Activity types",
         "description": "System activity type catalog.",
-        "metadataTitle": "Activity types"
+        "metadataTitle": "Activity types",
+        "entityLabel": "Activity Type",
+        "loadError": "Could not load activity types."
       },
       "folderSections": {
         "title": "Folder sections",
@@ -591,17 +603,23 @@
       "diseases": {
         "title": "Diseases",
         "description": "Chronic diseases or relevant medical conditions.",
-        "metadataTitle": "Diseases"
+        "metadataTitle": "Diseases",
+        "entityLabel": "Disease",
+        "loadError": "Could not load diseases."
       },
       "clubTypes": {
         "title": "Club types",
         "description": "Club types available in the system.",
-        "metadataTitle": "Club types"
+        "metadataTitle": "Club types",
+        "entityLabel": "Club Type",
+        "loadError": "Could not load club types."
       },
       "medicines": {
         "title": "Medicines",
         "description": "Commonly used medications for members.",
-        "metadataTitle": "Medicines"
+        "metadataTitle": "Medicines",
+        "entityLabel": "Medicine",
+        "loadError": "Could not load medicines."
       },
       "clubIdeals": {
         "title": "Club ideals",
@@ -611,12 +629,16 @@
       "allergies": {
         "title": "Allergies",
         "description": "List of allergies for the members' health profile.",
-        "metadataTitle": "Allergies"
+        "metadataTitle": "Allergies",
+        "entityLabel": "Allergy",
+        "loadError": "Could not load allergies."
       },
       "relationshipTypes": {
         "title": "Relationship types",
         "description": "Family or emergency contact relationships.",
-        "metadataTitle": "Relationship types"
+        "metadataTitle": "Relationship types",
+        "entityLabel": "Relationship Type",
+        "loadError": "Could not load relationship types."
       },
       "ecclesiasticalYears": {
         "title": "Ecclesiastical years",

--- a/messages/es.json
+++ b/messages/es.json
@@ -419,22 +419,30 @@
       "countries": {
         "title": "Países",
         "description": "Catálogo de países del sistema.",
-        "metadataTitle": "Países"
+        "metadataTitle": "Países",
+        "entityLabel": "País",
+        "loadError": "No se pudieron cargar los países."
       },
       "churches": {
         "title": "Iglesias",
         "description": "Catálogo de iglesias del sistema.",
-        "metadataTitle": "Iglesias"
+        "metadataTitle": "Iglesias",
+        "entityLabel": "Iglesia",
+        "loadError": "No se pudieron cargar las iglesias."
       },
       "districts": {
         "title": "Distritos",
         "description": "Catálogo de distritos del sistema.",
-        "metadataTitle": "Distritos"
+        "metadataTitle": "Distritos",
+        "entityLabel": "Distrito",
+        "loadError": "No se pudieron cargar los distritos."
       },
       "unions": {
         "title": "Uniones",
         "description": "Catálogo de uniones del sistema.",
-        "metadataTitle": "Uniones"
+        "metadataTitle": "Uniones",
+        "entityLabel": "Unión",
+        "loadError": "No se pudieron cargar las uniones."
       },
       "unionsDetail": {
         "back": "Volver",
@@ -451,7 +459,9 @@
       "localFields": {
         "title": "Campos Locales",
         "description": "Catálogo de campos locales del sistema.",
-        "metadataTitle": "Campos locales"
+        "metadataTitle": "Campos locales",
+        "entityLabel": "Campo Local",
+        "loadError": "No se pudieron cargar los campos locales."
       },
       "localFieldsDetail": {
         "back": "Volver",
@@ -468,7 +478,9 @@
       "activityTypes": {
         "title": "Tipos de actividad",
         "description": "Catálogo de tipos de actividad del sistema.",
-        "metadataTitle": "Tipos de actividad"
+        "metadataTitle": "Tipos de actividad",
+        "entityLabel": "Tipo de actividad",
+        "loadError": "No se pudieron cargar los tipos de actividad."
       },
       "folderSections": {
         "title": "Secciones de carpeta",
@@ -591,17 +603,23 @@
       "diseases": {
         "title": "Enfermedades",
         "description": "Enfermedades crónicas o condiciones médicas relevantes.",
-        "metadataTitle": "Enfermedades"
+        "metadataTitle": "Enfermedades",
+        "entityLabel": "Enfermedad",
+        "loadError": "No se pudieron cargar las enfermedades."
       },
       "clubTypes": {
         "title": "Tipos de club",
         "description": "Tipos de club disponibles en el sistema.",
-        "metadataTitle": "Tipos de club"
+        "metadataTitle": "Tipos de club",
+        "entityLabel": "Tipo de club",
+        "loadError": "No se pudieron cargar los tipos de club."
       },
       "medicines": {
         "title": "Medicamentos",
         "description": "Medicamentos de uso habitual para los miembros.",
-        "metadataTitle": "Medicamentos"
+        "metadataTitle": "Medicamentos",
+        "entityLabel": "Medicamento",
+        "loadError": "No se pudieron cargar los medicamentos."
       },
       "clubIdeals": {
         "title": "Ideales de club",
@@ -611,12 +629,16 @@
       "allergies": {
         "title": "Alergias",
         "description": "Listado de alergias para el perfil de salud de los miembros.",
-        "metadataTitle": "Alergias"
+        "metadataTitle": "Alergias",
+        "entityLabel": "Alergia",
+        "loadError": "No se pudieron cargar las alergias."
       },
       "relationshipTypes": {
         "title": "Tipos de relación",
         "description": "Vínculos familiares o de contacto de emergencia.",
-        "metadataTitle": "Tipos de relación"
+        "metadataTitle": "Tipos de relación",
+        "entityLabel": "Tipo de relación",
+        "loadError": "No se pudieron cargar los tipos de relación."
       },
       "ecclesiasticalYears": {
         "title": "Años eclesiásticos",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -419,22 +419,30 @@
       "countries": {
         "title": "Pays",
         "description": "Catalogue des pays du système.",
-        "metadataTitle": "Pays"
+        "metadataTitle": "Pays",
+        "entityLabel": "Pays",
+        "loadError": "Impossible de charger les pays."
       },
       "churches": {
         "title": "Églises",
         "description": "Catalogue des églises du système.",
-        "metadataTitle": "Églises"
+        "metadataTitle": "Églises",
+        "entityLabel": "Église",
+        "loadError": "Impossible de charger les églises."
       },
       "districts": {
         "title": "Districts",
         "description": "Catalogue des districts du système.",
-        "metadataTitle": "Districts"
+        "metadataTitle": "Districts",
+        "entityLabel": "District",
+        "loadError": "Impossible de charger les districts."
       },
       "unions": {
         "title": "Unions",
         "description": "Catalogue des unions du système.",
-        "metadataTitle": "Unions"
+        "metadataTitle": "Unions",
+        "entityLabel": "Union",
+        "loadError": "Impossible de charger les unions."
       },
       "unionsDetail": {
         "back": "Retour",
@@ -451,7 +459,9 @@
       "localFields": {
         "title": "Champs locaux",
         "description": "Catalogue des champs locaux du système.",
-        "metadataTitle": "Champs locaux"
+        "metadataTitle": "Champs locaux",
+        "entityLabel": "Champ local",
+        "loadError": "Impossible de charger les champs locaux."
       },
       "localFieldsDetail": {
         "back": "Retour",
@@ -468,7 +478,9 @@
       "activityTypes": {
         "title": "Types d'activité",
         "description": "Catalogue des types d'activité du système.",
-        "metadataTitle": "Types d'activité"
+        "metadataTitle": "Types d'activité",
+        "entityLabel": "Type d'activité",
+        "loadError": "Impossible de charger les types d'activité."
       },
       "folderSections": {
         "title": "Sections de dossier",
@@ -591,17 +603,23 @@
       "diseases": {
         "title": "Maladies",
         "description": "Maladies chroniques ou conditions médicales pertinentes.",
-        "metadataTitle": "Maladies"
+        "metadataTitle": "Maladies",
+        "entityLabel": "Maladie",
+        "loadError": "Impossible de charger les maladies."
       },
       "clubTypes": {
         "title": "Types de club",
         "description": "Types de club disponibles dans le système.",
-        "metadataTitle": "Types de club"
+        "metadataTitle": "Types de club",
+        "entityLabel": "Type de club",
+        "loadError": "Impossible de charger les types de club."
       },
       "medicines": {
         "title": "Médicaments",
         "description": "Médicaments couramment utilisés par les membres.",
-        "metadataTitle": "Médicaments"
+        "metadataTitle": "Médicaments",
+        "entityLabel": "Médicament",
+        "loadError": "Impossible de charger les médicaments."
       },
       "clubIdeals": {
         "title": "Idéaux de club",
@@ -611,12 +629,16 @@
       "allergies": {
         "title": "Allergies",
         "description": "Liste des allergies pour le profil de santé des membres.",
-        "metadataTitle": "Allergies"
+        "metadataTitle": "Allergies",
+        "entityLabel": "Allergie",
+        "loadError": "Impossible de charger les allergies."
       },
       "relationshipTypes": {
         "title": "Types de relation",
         "description": "Liens familiaux ou de contact d'urgence.",
-        "metadataTitle": "Types de relation"
+        "metadataTitle": "Types de relation",
+        "entityLabel": "Type de relation",
+        "loadError": "Impossible de charger les types de relation."
       },
       "ecclesiasticalYears": {
         "title": "Années ecclésiastiques",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -419,22 +419,30 @@
       "countries": {
         "title": "Países",
         "description": "Catálogo de países do sistema.",
-        "metadataTitle": "Países"
+        "metadataTitle": "Países",
+        "entityLabel": "País",
+        "loadError": "Não foi possível carregar os países."
       },
       "churches": {
         "title": "Igrejas",
         "description": "Catálogo de igrejas do sistema.",
-        "metadataTitle": "Igrejas"
+        "metadataTitle": "Igrejas",
+        "entityLabel": "Igreja",
+        "loadError": "Não foi possível carregar as igrejas."
       },
       "districts": {
         "title": "Distritos",
         "description": "Catálogo de distritos do sistema.",
-        "metadataTitle": "Distritos"
+        "metadataTitle": "Distritos",
+        "entityLabel": "Distrito",
+        "loadError": "Não foi possível carregar os distritos."
       },
       "unions": {
         "title": "Uniões",
         "description": "Catálogo de uniões do sistema.",
-        "metadataTitle": "Uniões"
+        "metadataTitle": "Uniões",
+        "entityLabel": "União",
+        "loadError": "Não foi possível carregar as uniões."
       },
       "unionsDetail": {
         "back": "Voltar",
@@ -451,7 +459,9 @@
       "localFields": {
         "title": "Campos Locais",
         "description": "Catálogo de campos locais do sistema.",
-        "metadataTitle": "Campos locais"
+        "metadataTitle": "Campos locais",
+        "entityLabel": "Campo Local",
+        "loadError": "Não foi possível carregar os campos locais."
       },
       "localFieldsDetail": {
         "back": "Voltar",
@@ -468,7 +478,9 @@
       "activityTypes": {
         "title": "Tipos de atividade",
         "description": "Catálogo de tipos de atividade do sistema.",
-        "metadataTitle": "Tipos de atividade"
+        "metadataTitle": "Tipos de atividade",
+        "entityLabel": "Tipo de atividade",
+        "loadError": "Não foi possível carregar os tipos de atividade."
       },
       "folderSections": {
         "title": "Seções de pasta",
@@ -591,17 +603,23 @@
       "diseases": {
         "title": "Doenças",
         "description": "Doenças crônicas ou condições médicas relevantes.",
-        "metadataTitle": "Doenças"
+        "metadataTitle": "Doenças",
+        "entityLabel": "Doença",
+        "loadError": "Não foi possível carregar as doenças."
       },
       "clubTypes": {
         "title": "Tipos de clube",
         "description": "Tipos de clube disponíveis no sistema.",
-        "metadataTitle": "Tipos de clube"
+        "metadataTitle": "Tipos de clube",
+        "entityLabel": "Tipo de clube",
+        "loadError": "Não foi possível carregar os tipos de clube."
       },
       "medicines": {
         "title": "Medicamentos",
         "description": "Medicamentos de uso habitual dos membros.",
-        "metadataTitle": "Medicamentos"
+        "metadataTitle": "Medicamentos",
+        "entityLabel": "Medicamento",
+        "loadError": "Não foi possível carregar os medicamentos."
       },
       "clubIdeals": {
         "title": "Ideais de clube",
@@ -611,12 +629,16 @@
       "allergies": {
         "title": "Alergias",
         "description": "Lista de alergias para o perfil de saúde dos membros.",
-        "metadataTitle": "Alergias"
+        "metadataTitle": "Alergias",
+        "entityLabel": "Alergia",
+        "loadError": "Não foi possível carregar as alergias."
       },
       "relationshipTypes": {
         "title": "Tipos de relacionamento",
         "description": "Vínculos familiares ou de contato de emergência.",
-        "metadataTitle": "Tipos de relacionamento"
+        "metadataTitle": "Tipos de relacionamento",
+        "entityLabel": "Tipo de relação",
+        "loadError": "Não foi possível carregar os tipos de relação."
       },
       "ecclesiasticalYears": {
         "title": "Anos eclesiásticos",

--- a/src/app/(dashboard)/dashboard/catalogs/activity-types/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/activity-types/page.tsx
@@ -1,12 +1,104 @@
-import type { Metadata } from "next";
+import { Calendar } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminActivityTypes } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  ACTIVITY_TYPES_CREATE,
+  ACTIVITY_TYPES_UPDATE,
+  ACTIVITY_TYPES_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createActivityTypeAction,
+  updateActivityTypeAction,
+  deleteActivityTypeAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function ActivityTypesPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.activityTypes");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function ActivityTypesPage() {
-  return <CatalogEntityPage entityKey="activity-types" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminActivityTypes(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [ACTIVITY_TYPES_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [ACTIVITY_TYPES_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [ACTIVITY_TYPES_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={Calendar}
+        includeDescription={true}
+        idField="activity_type_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createActivityTypeAction}
+        updateAction={updateActivityTypeAction}
+        deleteAction={deleteActivityTypeAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/allergies/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/allergies/page.tsx
@@ -1,12 +1,104 @@
-import type { Metadata } from "next";
+import { AlertCircle } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminAllergies } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  ALLERGIES_CREATE,
+  ALLERGIES_UPDATE,
+  ALLERGIES_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createAllergyAction,
+  updateAllergyAction,
+  deleteAllergyAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function AllergiesPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.allergies");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function AllergiesPage() {
-  return <CatalogEntityPage entityKey="allergies" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminAllergies(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [ALLERGIES_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [ALLERGIES_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [ALLERGIES_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={AlertCircle}
+        includeDescription={true}
+        idField="allergy_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createAllergyAction}
+        updateAction={updateAllergyAction}
+        deleteAction={deleteAllergyAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/club-types/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/club-types/page.tsx
@@ -1,12 +1,104 @@
-import type { Metadata } from "next";
+import { Tent } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminClubTypes } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  CLUB_TYPES_CREATE,
+  CLUB_TYPES_UPDATE,
+  CLUB_TYPES_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createClubTypeAction,
+  updateClubTypeAction,
+  deleteClubTypeAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function ClubTypesPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.clubTypes");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function ClubTypesPage() {
-  return <CatalogEntityPage entityKey="club-types" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminClubTypes(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [CLUB_TYPES_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [CLUB_TYPES_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [CLUB_TYPES_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={Tent}
+        includeDescription={false}
+        idField="club_type_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createClubTypeAction}
+        updateAction={updateClubTypeAction}
+        deleteAction={deleteClubTypeAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/diseases/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/diseases/page.tsx
@@ -1,12 +1,104 @@
-import type { Metadata } from "next";
+import { Activity } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminDiseases } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  DISEASES_CREATE,
+  DISEASES_UPDATE,
+  DISEASES_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createDiseaseAction,
+  updateDiseaseAction,
+  deleteDiseaseAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function DiseasesPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.diseases");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function DiseasesPage() {
-  return <CatalogEntityPage entityKey="diseases" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminDiseases(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [DISEASES_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [DISEASES_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [DISEASES_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={Activity}
+        includeDescription={true}
+        idField="disease_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createDiseaseAction}
+        updateAction={updateDiseaseAction}
+        deleteAction={deleteDiseaseAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/geography/churches/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/churches/page.tsx
@@ -1,12 +1,108 @@
-import type { Metadata } from "next";
+import { Building2 } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminChurches } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  CHURCHES_CREATE,
+  CHURCHES_UPDATE,
+  CHURCHES_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createChurchAction,
+  updateChurchAction,
+  deleteChurchAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+// NOTE: parent-filter (district_id) is defined in entities.ts for legacy CatalogCrudPage.
+// PhaseECatalogCrudPage does NOT support parent filters — filtering by district is not
+// rendered in this view. Tracked as tech debt for PR-6 follow-up if needed.
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function ChurchesPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.churches");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function ChurchesPage() {
-  return <CatalogEntityPage entityKey="churches" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminChurches(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [CHURCHES_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [CHURCHES_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [CHURCHES_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={Building2}
+        includeDescription={false}
+        idField="church_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createChurchAction}
+        updateAction={updateChurchAction}
+        deleteAction={deleteChurchAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/geography/countries/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/countries/page.tsx
@@ -1,12 +1,104 @@
-import type { Metadata } from "next";
+import { Globe } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminCountries } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  COUNTRIES_CREATE,
+  COUNTRIES_UPDATE,
+  COUNTRIES_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createCountryAction,
+  updateCountryAction,
+  deleteCountryAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function CountriesPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.countries");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function CountriesPage() {
-  return <CatalogEntityPage entityKey="countries" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminCountries(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [COUNTRIES_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [COUNTRIES_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [COUNTRIES_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={Globe}
+        includeDescription={false}
+        idField="country_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createCountryAction}
+        updateAction={updateCountryAction}
+        deleteAction={deleteCountryAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/geography/districts/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/districts/page.tsx
@@ -1,12 +1,110 @@
-import type { Metadata } from "next";
+import { MapPin } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminDistricts } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  DISTRICTS_CREATE,
+  DISTRICTS_UPDATE,
+  DISTRICTS_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createDistrictAction,
+  updateDistrictAction,
+  deleteDistrictAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+// NOTE: parent-filter (local_field_id) is defined in entities.ts for legacy CatalogCrudPage.
+// PhaseECatalogCrudPage does NOT support parent filters — filtering by local field is not
+// rendered in this view. Tracked as tech debt for PR-6 follow-up if needed.
+//
+// NOTE: backend PK field is `districlub_type_id` (legacy name). API response uses this field name.
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function DistrictsPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.districts");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function DistrictsPage() {
-  return <CatalogEntityPage entityKey="districts" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminDistricts(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [DISTRICTS_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [DISTRICTS_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [DISTRICTS_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={MapPin}
+        includeDescription={false}
+        idField="districlub_type_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createDistrictAction}
+        updateAction={updateDistrictAction}
+        deleteAction={deleteDistrictAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/geography/local-fields/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/local-fields/page.tsx
@@ -1,12 +1,108 @@
-import type { Metadata } from "next";
+import { Map } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminLocalFields } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  LOCAL_FIELDS_CREATE,
+  LOCAL_FIELDS_UPDATE,
+  LOCAL_FIELDS_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createLocalFieldAction,
+  updateLocalFieldAction,
+  deleteLocalFieldAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+// NOTE: parent-filter (union_id) is defined in entities.ts for legacy CatalogCrudPage.
+// PhaseECatalogCrudPage does NOT support parent filters — filtering by union is not
+// rendered in this view. Tracked as tech debt for PR-6 follow-up if needed.
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function LocalFieldsPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.localFields");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function LocalFieldsPage() {
-  return <CatalogEntityPage entityKey="local-fields" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminLocalFields(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [LOCAL_FIELDS_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [LOCAL_FIELDS_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [LOCAL_FIELDS_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={Map}
+        includeDescription={false}
+        idField="local_field_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createLocalFieldAction}
+        updateAction={updateLocalFieldAction}
+        deleteAction={deleteLocalFieldAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/geography/unions/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/unions/page.tsx
@@ -1,12 +1,108 @@
-import type { Metadata } from "next";
+import { Network } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminUnions } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  UNIONS_CREATE,
+  UNIONS_UPDATE,
+  UNIONS_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createUnionAction,
+  updateUnionAction,
+  deleteUnionAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+// NOTE: parent-filter (country_id) is defined in entities.ts for legacy CatalogCrudPage.
+// PhaseECatalogCrudPage does NOT support parent filters — filtering by country is not
+// rendered in this view. Tracked as tech debt for PR-6 follow-up if needed.
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function UnionsPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.unions");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function UnionsPage() {
-  return <CatalogEntityPage entityKey="unions" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminUnions(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [UNIONS_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [UNIONS_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [UNIONS_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={Network}
+        includeDescription={false}
+        idField="union_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createUnionAction}
+        updateAction={updateUnionAction}
+        deleteAction={deleteUnionAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/medicines/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/medicines/page.tsx
@@ -1,12 +1,104 @@
-import type { Metadata } from "next";
+import { Pill } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminMedicines } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  MEDICINES_CREATE,
+  MEDICINES_UPDATE,
+  MEDICINES_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createMedicineAction,
+  updateMedicineAction,
+  deleteMedicineAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function MedicinesPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.medicines");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function MedicinesPage() {
-  return <CatalogEntityPage entityKey="medicines" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminMedicines(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [MEDICINES_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [MEDICINES_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [MEDICINES_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={Pill}
+        includeDescription={true}
+        idField="medicine_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createMedicineAction}
+        updateAction={updateMedicineAction}
+        deleteAction={deleteMedicineAction}
+      />
+    </div>
+  );
 }

--- a/src/app/(dashboard)/dashboard/catalogs/relationship-types/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/relationship-types/page.tsx
@@ -1,12 +1,104 @@
-import type { Metadata } from "next";
+import { Users } from "lucide-react";
 import { getTranslations } from "next-intl/server";
-import { CatalogEntityPage } from "@/components/catalogs/catalog-entity-page";
+import dynamic from "next/dynamic";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 
-export async function generateMetadata(): Promise<Metadata> {
+const PhaseECatalogCrudPage = dynamic(
+  () =>
+    import("@/components/catalogs/phase-e-catalog-crud-page").then((m) => ({
+      default: m.PhaseECatalogCrudPage,
+    })),
+  {
+    loading: () => (
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-8 w-48 rounded-md" />
+          <Skeleton className="h-9 w-28 rounded-md" />
+        </div>
+        <Skeleton className="h-10 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+        <Skeleton className="h-12 w-full rounded-md" />
+      </div>
+    ),
+  }
+);
+import { ApiError } from "@/lib/api/client";
+import { listAdminRelationshipTypes } from "@/lib/api/generic-catalogs-i18n";
+import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  RELATIONSHIP_TYPES_CREATE,
+  RELATIONSHIP_TYPES_UPDATE,
+  RELATIONSHIP_TYPES_DELETE,
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createRelationshipTypeAction,
+  updateRelationshipTypeAction,
+  deleteRelationshipTypeAction,
+} from "@/lib/generic-catalogs-i18n/actions";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+export default async function RelationshipTypesPage({ searchParams }: { searchParams: SearchParams }) {
+  const user = await requireAdminUser();
   const t = await getTranslations("catalogs.pages.relationshipTypes");
-  return { title: t("metadataTitle") };
-}
+  const raw = await searchParams;
 
-export default function RelationshipTypesPage() {
-  return <CatalogEntityPage entityKey="relationship-types" />;
+  const page = readPositiveNumberParam(raw, "page") ?? 1;
+  const limit = readPositiveNumberParam(raw, "limit") ?? 20;
+  const search = readParam(raw, "search") ?? readParam(raw, "name") ?? readParam(raw, "q");
+  const activeRaw = readParam(raw, "active");
+
+  let items: Record<string, unknown>[] = [];
+  let meta = { page, limit, total: 0, totalPages: 1 };
+  let loadError: string | null = null;
+
+  try {
+    const params: Record<string, string | number | boolean> = { page, limit };
+    if (search) params.search = search;
+    if (activeRaw === "true") params.active = true;
+    if (activeRaw === "false") params.active = false;
+
+    const payload = await listAdminRelationshipTypes(params);
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  const canCreate = hasAnyPermission(user, [RELATIONSHIP_TYPES_CREATE, CATALOGS_CREATE]);
+  const canEdit = hasAnyPermission(user, [RELATIONSHIP_TYPES_UPDATE, CATALOGS_UPDATE]);
+  const canDelete = hasAnyPermission(user, [RELATIONSHIP_TYPES_DELETE, CATALOGS_DELETE]);
+
+  return (
+    <div className="space-y-6">
+      {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
+      <PhaseECatalogCrudPage
+        title={t("title")}
+        description={t("description")}
+        entityLabel={t("entityLabel")}
+        emptyIcon={Users}
+        includeDescription={true}
+        idField="relationship_type_id"
+        nameField="name"
+        items={items}
+        meta={meta}
+        canCreate={canCreate}
+        canEdit={canEdit}
+        canDelete={canDelete}
+        createAction={createRelationshipTypeAction}
+        updateAction={updateRelationshipTypeAction}
+        deleteAction={deleteRelationshipTypeAction}
+      />
+    </div>
+  );
 }

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -449,21 +449,29 @@ export interface IntlMessages {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       churches: {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       districts: {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       unions: {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       unionsDetail: {
         back: string;
@@ -481,6 +489,8 @@ export interface IntlMessages {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       localFieldsDetail: {
         back: string;
@@ -498,6 +508,8 @@ export interface IntlMessages {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       folderSections: {
         title: string;
@@ -621,16 +633,22 @@ export interface IntlMessages {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       clubTypes: {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       medicines: {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       clubIdeals: {
         title: string;
@@ -641,11 +659,15 @@ export interface IntlMessages {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       relationshipTypes: {
         title: string;
         description: string;
         metadataTitle: string;
+        entityLabel: string;
+        loadError: string;
       };
       ecclesiasticalYears: {
         title: string;

--- a/src/lib/api/generic-catalogs-i18n.ts
+++ b/src/lib/api/generic-catalogs-i18n.ts
@@ -1,0 +1,266 @@
+/**
+ * Generic Catalogs i18n — admin API client for 12 catalog targets:
+ *
+ * Geography (name-only):
+ *   countries, unions, local-fields, districts, churches
+ *
+ * Reference (name + description):
+ *   relationship-types, allergies, diseases, medicines, activity-types
+ *
+ * Reference (name-only):
+ *   club-types
+ *
+ * Special (name + ideal + club_type_id + ideal_order):
+ *   club-ideals
+ *
+ * All endpoints under /admin/<kebab-case>.
+ * Backend PR #105 (geography) and #106 (reference) add translations support.
+ */
+import { apiRequest } from "@/lib/api/client";
+import type { CatalogTranslation } from "@/lib/types/catalog-translation";
+
+// ─── Shared payload types ──────────────────────────────────────────────────────
+
+/** name + description (optional) — used for relationship-types, allergies, diseases, medicines, activity-types */
+export type TranslatablePayload = {
+  name: string;
+  description?: string | null;
+  active?: boolean;
+  translations?: CatalogTranslation[];
+};
+
+/** name only — used for countries, unions, local-fields, districts, churches, club-types */
+export type NameOnlyPayload = {
+  name: string;
+  active?: boolean;
+  translations?: CatalogTranslation[];
+};
+
+/** club-ideals specific shape — name + ideal (translatable) + relation + order */
+export type ClubIdealPayload = {
+  name: string;
+  ideal?: string | null;
+  club_type_id?: number | null;
+  ideal_order?: number | null;
+  active?: boolean;
+  translations?: CatalogTranslation[];
+};
+
+// ─── Countries ────────────────────────────────────────────────────────────────
+
+export async function listAdminCountries(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/countries", { params });
+}
+
+export async function createAdminCountry(payload: NameOnlyPayload) {
+  return apiRequest("/admin/countries", { method: "POST", body: payload });
+}
+
+export async function updateAdminCountry(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/countries/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminCountry(id: number) {
+  return apiRequest(`/admin/countries/${id}`, { method: "DELETE" });
+}
+
+// ─── Unions ───────────────────────────────────────────────────────────────────
+
+export async function listAdminUnions(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/unions", { params });
+}
+
+export async function createAdminUnion(payload: NameOnlyPayload) {
+  return apiRequest("/admin/unions", { method: "POST", body: payload });
+}
+
+export async function updateAdminUnion(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/unions/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminUnion(id: number) {
+  return apiRequest(`/admin/unions/${id}`, { method: "DELETE" });
+}
+
+// ─── Local Fields ─────────────────────────────────────────────────────────────
+
+export async function listAdminLocalFields(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/local-fields", { params });
+}
+
+export async function createAdminLocalField(payload: NameOnlyPayload) {
+  return apiRequest("/admin/local-fields", { method: "POST", body: payload });
+}
+
+export async function updateAdminLocalField(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/local-fields/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminLocalField(id: number) {
+  return apiRequest(`/admin/local-fields/${id}`, { method: "DELETE" });
+}
+
+// ─── Districts ────────────────────────────────────────────────────────────────
+// Note: backend PK field is district_id aliasing districlub_type_id in the schema.
+
+export async function listAdminDistricts(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/districts", { params });
+}
+
+export async function createAdminDistrict(payload: NameOnlyPayload) {
+  return apiRequest("/admin/districts", { method: "POST", body: payload });
+}
+
+export async function updateAdminDistrict(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/districts/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminDistrict(id: number) {
+  return apiRequest(`/admin/districts/${id}`, { method: "DELETE" });
+}
+
+// ─── Churches ─────────────────────────────────────────────────────────────────
+
+export async function listAdminChurches(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/churches", { params });
+}
+
+export async function createAdminChurch(payload: NameOnlyPayload) {
+  return apiRequest("/admin/churches", { method: "POST", body: payload });
+}
+
+export async function updateAdminChurch(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/churches/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminChurch(id: number) {
+  return apiRequest(`/admin/churches/${id}`, { method: "DELETE" });
+}
+
+// ─── Relationship Types ───────────────────────────────────────────────────────
+
+export async function listAdminRelationshipTypes(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/relationship-types", { params });
+}
+
+export async function createAdminRelationshipType(payload: TranslatablePayload) {
+  return apiRequest("/admin/relationship-types", { method: "POST", body: payload });
+}
+
+export async function updateAdminRelationshipType(id: number, payload: Partial<TranslatablePayload>) {
+  return apiRequest(`/admin/relationship-types/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminRelationshipType(id: number) {
+  return apiRequest(`/admin/relationship-types/${id}`, { method: "DELETE" });
+}
+
+// ─── Allergies ────────────────────────────────────────────────────────────────
+
+export async function listAdminAllergies(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/allergies", { params });
+}
+
+export async function createAdminAllergy(payload: TranslatablePayload) {
+  return apiRequest("/admin/allergies", { method: "POST", body: payload });
+}
+
+export async function updateAdminAllergy(id: number, payload: Partial<TranslatablePayload>) {
+  return apiRequest(`/admin/allergies/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminAllergy(id: number) {
+  return apiRequest(`/admin/allergies/${id}`, { method: "DELETE" });
+}
+
+// ─── Diseases ─────────────────────────────────────────────────────────────────
+
+export async function listAdminDiseases(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/diseases", { params });
+}
+
+export async function createAdminDisease(payload: TranslatablePayload) {
+  return apiRequest("/admin/diseases", { method: "POST", body: payload });
+}
+
+export async function updateAdminDisease(id: number, payload: Partial<TranslatablePayload>) {
+  return apiRequest(`/admin/diseases/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminDisease(id: number) {
+  return apiRequest(`/admin/diseases/${id}`, { method: "DELETE" });
+}
+
+// ─── Medicines ────────────────────────────────────────────────────────────────
+
+export async function listAdminMedicines(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/medicines", { params });
+}
+
+export async function createAdminMedicine(payload: TranslatablePayload) {
+  return apiRequest("/admin/medicines", { method: "POST", body: payload });
+}
+
+export async function updateAdminMedicine(id: number, payload: Partial<TranslatablePayload>) {
+  return apiRequest(`/admin/medicines/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminMedicine(id: number) {
+  return apiRequest(`/admin/medicines/${id}`, { method: "DELETE" });
+}
+
+// ─── Club Types ───────────────────────────────────────────────────────────────
+
+export async function listAdminClubTypes(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/club-types", { params });
+}
+
+export async function createAdminClubType(payload: NameOnlyPayload) {
+  return apiRequest("/admin/club-types", { method: "POST", body: payload });
+}
+
+export async function updateAdminClubType(id: number, payload: Partial<NameOnlyPayload>) {
+  return apiRequest(`/admin/club-types/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminClubType(id: number) {
+  return apiRequest(`/admin/club-types/${id}`, { method: "DELETE" });
+}
+
+// ─── Club Ideals ──────────────────────────────────────────────────────────────
+// Translatable fields: name + ideal (NOT description).
+
+export async function listAdminClubIdeals(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/club-ideals", { params });
+}
+
+export async function createAdminClubIdeal(payload: ClubIdealPayload) {
+  return apiRequest("/admin/club-ideals", { method: "POST", body: payload });
+}
+
+export async function updateAdminClubIdeal(id: number, payload: Partial<ClubIdealPayload>) {
+  return apiRequest(`/admin/club-ideals/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminClubIdeal(id: number) {
+  return apiRequest(`/admin/club-ideals/${id}`, { method: "DELETE" });
+}
+
+// ─── Activity Types ───────────────────────────────────────────────────────────
+// Note: `code` field is NOT translatable — only name + description.
+
+export async function listAdminActivityTypes(params?: Record<string, string | number | boolean>) {
+  return apiRequest<unknown>("/admin/activity-types", { params });
+}
+
+export async function createAdminActivityType(payload: TranslatablePayload & { code?: string }) {
+  return apiRequest("/admin/activity-types", { method: "POST", body: payload });
+}
+
+export async function updateAdminActivityType(id: number, payload: Partial<TranslatablePayload> & { code?: string }) {
+  return apiRequest(`/admin/activity-types/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function deleteAdminActivityType(id: number) {
+  return apiRequest(`/admin/activity-types/${id}`, { method: "DELETE" });
+}

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -62,6 +62,10 @@ export const LOCAL_FIELDS_READ = "local_fields:read";
 export const LOCAL_FIELDS_CREATE = "local_fields:create";
 export const LOCAL_FIELDS_UPDATE = "local_fields:update";
 export const LOCAL_FIELDS_DELETE = "local_fields:delete";
+export const DISTRICTS_READ = "districts:read";
+export const DISTRICTS_CREATE = "districts:create";
+export const DISTRICTS_UPDATE = "districts:update";
+export const DISTRICTS_DELETE = "districts:delete";
 export const CHURCHES_READ = "churches:read";
 export const CHURCHES_CREATE = "churches:create";
 export const CHURCHES_UPDATE = "churches:update";
@@ -72,6 +76,34 @@ export const CATALOGS_READ = "catalogs:read";
 export const CATALOGS_CREATE = "catalogs:create";
 export const CATALOGS_UPDATE = "catalogs:update";
 export const CATALOGS_DELETE = "catalogs:delete";
+export const RELATIONSHIP_TYPES_READ = "relationship_types:read";
+export const RELATIONSHIP_TYPES_CREATE = "relationship_types:create";
+export const RELATIONSHIP_TYPES_UPDATE = "relationship_types:update";
+export const RELATIONSHIP_TYPES_DELETE = "relationship_types:delete";
+export const ALLERGIES_READ = "allergies:read";
+export const ALLERGIES_CREATE = "allergies:create";
+export const ALLERGIES_UPDATE = "allergies:update";
+export const ALLERGIES_DELETE = "allergies:delete";
+export const DISEASES_READ = "diseases:read";
+export const DISEASES_CREATE = "diseases:create";
+export const DISEASES_UPDATE = "diseases:update";
+export const DISEASES_DELETE = "diseases:delete";
+export const MEDICINES_READ = "medicines:read";
+export const MEDICINES_CREATE = "medicines:create";
+export const MEDICINES_UPDATE = "medicines:update";
+export const MEDICINES_DELETE = "medicines:delete";
+export const CLUB_TYPES_READ = "club_types:read";
+export const CLUB_TYPES_CREATE = "club_types:create";
+export const CLUB_TYPES_UPDATE = "club_types:update";
+export const CLUB_TYPES_DELETE = "club_types:delete";
+export const CLUB_IDEALS_READ = "club_ideals:read";
+export const CLUB_IDEALS_CREATE = "club_ideals:create";
+export const CLUB_IDEALS_UPDATE = "club_ideals:update";
+export const CLUB_IDEALS_DELETE = "club_ideals:delete";
+export const ACTIVITY_TYPES_READ = "activity_types:read";
+export const ACTIVITY_TYPES_CREATE = "activity_types:create";
+export const ACTIVITY_TYPES_UPDATE = "activity_types:update";
+export const ACTIVITY_TYPES_DELETE = "activity_types:delete";
 
 // --- Clases y Honores ---
 export const CLASSES_READ = "classes:read";
@@ -300,6 +332,10 @@ export const PERMISSION_GROUPS = {
       { key: LOCAL_FIELDS_CREATE },
       { key: LOCAL_FIELDS_UPDATE },
       { key: LOCAL_FIELDS_DELETE },
+      { key: DISTRICTS_READ },
+      { key: DISTRICTS_CREATE },
+      { key: DISTRICTS_UPDATE },
+      { key: DISTRICTS_DELETE },
       { key: CHURCHES_READ },
       { key: CHURCHES_CREATE },
       { key: CHURCHES_UPDATE },
@@ -312,6 +348,34 @@ export const PERMISSION_GROUPS = {
       { key: CATALOGS_CREATE },
       { key: CATALOGS_UPDATE },
       { key: CATALOGS_DELETE },
+      { key: RELATIONSHIP_TYPES_READ },
+      { key: RELATIONSHIP_TYPES_CREATE },
+      { key: RELATIONSHIP_TYPES_UPDATE },
+      { key: RELATIONSHIP_TYPES_DELETE },
+      { key: ALLERGIES_READ },
+      { key: ALLERGIES_CREATE },
+      { key: ALLERGIES_UPDATE },
+      { key: ALLERGIES_DELETE },
+      { key: DISEASES_READ },
+      { key: DISEASES_CREATE },
+      { key: DISEASES_UPDATE },
+      { key: DISEASES_DELETE },
+      { key: MEDICINES_READ },
+      { key: MEDICINES_CREATE },
+      { key: MEDICINES_UPDATE },
+      { key: MEDICINES_DELETE },
+      { key: CLUB_TYPES_READ },
+      { key: CLUB_TYPES_CREATE },
+      { key: CLUB_TYPES_UPDATE },
+      { key: CLUB_TYPES_DELETE },
+      { key: CLUB_IDEALS_READ },
+      { key: CLUB_IDEALS_CREATE },
+      { key: CLUB_IDEALS_UPDATE },
+      { key: CLUB_IDEALS_DELETE },
+      { key: ACTIVITY_TYPES_READ },
+      { key: ACTIVITY_TYPES_CREATE },
+      { key: ACTIVITY_TYPES_UPDATE },
+      { key: ACTIVITY_TYPES_DELETE },
     ],
   },
   classes_honors: {

--- a/src/lib/catalogs/entities.ts
+++ b/src/lib/catalogs/entities.ts
@@ -48,6 +48,7 @@ export const ENTITY_KEYS = [
 export type EntityKey = (typeof ENTITY_KEYS)[number];
 
 export const entityConfigs: Record<EntityKey, EntityConfig> = {
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   countries: {
     key: "countries",
     title: "Países",
@@ -64,6 +65,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   unions: {
     key: "unions",
     title: "Uniones",
@@ -87,6 +89,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   "local-fields": {
     key: "local-fields",
     title: "Campos Locales",
@@ -110,6 +113,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   districts: {
     key: "districts",
     title: "Distritos",
@@ -138,6 +142,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   churches: {
     key: "churches",
     title: "Iglesias",
@@ -160,6 +165,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   "relationship-types": {
     key: "relationship-types",
     title: "Tipos de Relación",
@@ -176,6 +182,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   allergies: {
     key: "allergies",
     title: "Alergias",
@@ -192,6 +199,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   diseases: {
     key: "diseases",
     title: "Enfermedades",
@@ -208,6 +216,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   medicines: {
     key: "medicines",
     title: "Medicamentos",
@@ -240,6 +249,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   "club-types": {
     key: "club-types",
     title: "Tipos de Club",
@@ -278,6 +288,7 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
+  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   "activity-types": {
     key: "activity-types",
     title: "Tipos de Actividad",

--- a/src/lib/generic-catalogs-i18n/actions.test.ts
+++ b/src/lib/generic-catalogs-i18n/actions.test.ts
@@ -3,7 +3,7 @@ import {
   parseTranslations,
   buildTranslatableCreate,
   buildTranslatableUpdate,
-} from "./actions";
+} from "./helpers";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/src/lib/generic-catalogs-i18n/actions.test.ts
+++ b/src/lib/generic-catalogs-i18n/actions.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseTranslations,
+  buildTranslatableCreate,
+  buildTranslatableUpdate,
+} from "./actions";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeFormData(entries: Record<string, string>): FormData {
+  const fd = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    fd.append(key, value);
+  }
+  return fd;
+}
+
+// ─── parseTranslations — default fields ['name', 'description'] ───────────────
+
+describe("parseTranslations() — default fields", () => {
+  it("parses a single entry with locale + name", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "en",
+      "translations[0][name]": "Mexico",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ locale: "en", name: "Mexico" });
+  });
+
+  it("parses name + description in the same entry", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "pt-BR",
+      "translations[0][name]": "Alergia",
+      "translations[0][description]": "Descripción pt-BR",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(1);
+    expect(result[0].description).toBe("Descripción pt-BR");
+  });
+
+  it("skips an entry where all translatable fields are empty", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "en",
+      "translations[0][name]": "",
+      "translations[0][description]": "",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(0);
+  });
+
+  it("skips an entry whose locale is not in CATALOG_LOCALES", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "es", // es is the base language — excluded
+      "translations[0][name]": "Nombre ES",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(0);
+  });
+
+  it("parses multiple locale entries in index order", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "en",
+      "translations[0][name]": "Name EN",
+      "translations[1][locale]": "pt-BR",
+      "translations[1][name]": "Nome PT",
+    });
+    const result = parseTranslations(fd);
+    expect(result).toHaveLength(2);
+    expect(result[0].locale).toBe("en");
+    expect(result[1].locale).toBe("pt-BR");
+  });
+});
+
+// ─── parseTranslations — override fields ['name', 'ideal'] ───────────────────
+
+describe("parseTranslations() — override fields ['name', 'ideal']", () => {
+  it("extracts the ideal field when configured", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "en",
+      "translations[0][name]": "Service",
+      "translations[0][ideal]": "We serve others",
+    });
+    const result = parseTranslations(fd, ["name", "ideal"]);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ locale: "en", name: "Service", ideal: "We serve others" });
+  });
+
+  it("does NOT include description even if present in FormData when fields=['name','ideal']", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "pt-BR",
+      "translations[0][name]": "Serviço",
+      "translations[0][description]": "should be ignored",
+      "translations[0][ideal]": "Servimos",
+    });
+    const result = parseTranslations(fd, ["name", "ideal"]);
+    expect(result[0]).not.toHaveProperty("description");
+    expect(result[0]).toHaveProperty("ideal", "Servimos");
+  });
+
+  it("skips entry when ideal-only entry has empty ideal", () => {
+    const fd = makeFormData({
+      "translations[0][locale]": "fr",
+      "translations[0][ideal]": "",
+    });
+    const result = parseTranslations(fd, ["name", "ideal"]);
+    expect(result).toHaveLength(0);
+  });
+});
+
+// ─── buildTranslatableCreate ──────────────────────────────────────────────────
+
+describe("buildTranslatableCreate()", () => {
+  it("builds a payload with name + description when both are present (default fields)", () => {
+    const fd = makeFormData({ name: "Alergia", description: "Reacción" });
+    const result = buildTranslatableCreate(fd);
+    expect(result.name).toBe("Alergia");
+    expect(result.description).toBe("Reacción");
+    expect(result.active).toBe(true);
+  });
+
+  it("builds a payload with name + ideal for club-ideals override", () => {
+    const fd = makeFormData({ name: "Servicio", ideal: "Servimos a los demás" });
+    const result = buildTranslatableCreate(fd, ["name", "ideal"]);
+    expect(result.name).toBe("Servicio");
+    expect(result.ideal).toBe("Servimos a los demás");
+    expect(result).not.toHaveProperty("description");
+  });
+
+  it("throws when name is empty", () => {
+    const fd = makeFormData({ name: "" });
+    expect(() => buildTranslatableCreate(fd)).toThrow("El nombre es obligatorio.");
+  });
+
+  it("includes translations when present and fields=['name','ideal']", () => {
+    const fd = makeFormData({
+      name: "Servicio",
+      "translations[0][locale]": "en",
+      "translations[0][name]": "Service",
+      "translations[0][ideal]": "We serve",
+    });
+    const result = buildTranslatableCreate(fd, ["name", "ideal"]);
+    const translations = result.translations as Array<Record<string, string>>;
+    expect(translations).toHaveLength(1);
+    expect(translations[0]).toMatchObject({ locale: "en", ideal: "We serve" });
+    expect(translations[0]).not.toHaveProperty("description");
+  });
+});
+
+// ─── buildTranslatableUpdate ──────────────────────────────────────────────────
+
+describe("buildTranslatableUpdate()", () => {
+  it("does not include translations when dirty flag is absent", () => {
+    const fd = makeFormData({ name: "Updated" });
+    const result = buildTranslatableUpdate(fd);
+    expect(result).not.toHaveProperty("translations");
+  });
+
+  it("includes translations when dirty flag is '1' and fields=['name','ideal']", () => {
+    const fd = makeFormData({
+      name: "Servicio",
+      translations_dirty: "1",
+      "translations[0][locale]": "pt-BR",
+      "translations[0][ideal]": "Servimos",
+    });
+    const result = buildTranslatableUpdate(fd, ["name", "ideal"]);
+    const translations = result.translations as Array<Record<string, string>>;
+    expect(translations).toHaveLength(1);
+    expect(translations[0].ideal).toBe("Servimos");
+    expect(result).not.toHaveProperty("description");
+  });
+
+  it("emits description='' for default fields when description is absent", () => {
+    const fd = makeFormData({ name: "Alergia" });
+    const result = buildTranslatableUpdate(fd);
+    // description field should be reset to empty string (clear intent)
+    expect(result.description).toBe("");
+  });
+});

--- a/src/lib/generic-catalogs-i18n/actions.ts
+++ b/src/lib/generic-catalogs-i18n/actions.ts
@@ -1,0 +1,668 @@
+"use server";
+
+/**
+ * Generic Catalogs i18n — server actions for 12 catalog targets:
+ *
+ * Geography (name-only): countries, unions, local-fields, districts, churches
+ * Reference (name + description): relationship-types, allergies, diseases,
+ *   medicines, activity-types
+ * Reference (name-only): club-types
+ * Special (name + ideal): club-ideals
+ *
+ * Pattern mirrors phase-e-catalogs/actions.ts exactly.
+ * Extension: makeActions accepts an optional `translatableFields` parameter
+ * that controls which fields are extracted from form translations.
+ * club-ideals registers with translatableFields: ['name', 'ideal'].
+ */
+
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { getActionErrorMessage } from "@/lib/api/action-error";
+import {
+  CATALOG_LOCALES,
+  type CatalogTranslation,
+} from "@/lib/types/catalog-translation";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  CATALOGS_CREATE,
+  CATALOGS_UPDATE,
+  CATALOGS_DELETE,
+  COUNTRIES_CREATE,
+  COUNTRIES_UPDATE,
+  COUNTRIES_DELETE,
+  UNIONS_CREATE,
+  UNIONS_UPDATE,
+  UNIONS_DELETE,
+  LOCAL_FIELDS_CREATE,
+  LOCAL_FIELDS_UPDATE,
+  LOCAL_FIELDS_DELETE,
+  DISTRICTS_CREATE,
+  DISTRICTS_UPDATE,
+  DISTRICTS_DELETE,
+  CHURCHES_CREATE,
+  CHURCHES_UPDATE,
+  CHURCHES_DELETE,
+  RELATIONSHIP_TYPES_CREATE,
+  RELATIONSHIP_TYPES_UPDATE,
+  RELATIONSHIP_TYPES_DELETE,
+  ALLERGIES_CREATE,
+  ALLERGIES_UPDATE,
+  ALLERGIES_DELETE,
+  DISEASES_CREATE,
+  DISEASES_UPDATE,
+  DISEASES_DELETE,
+  MEDICINES_CREATE,
+  MEDICINES_UPDATE,
+  MEDICINES_DELETE,
+  CLUB_TYPES_CREATE,
+  CLUB_TYPES_UPDATE,
+  CLUB_TYPES_DELETE,
+  CLUB_IDEALS_CREATE,
+  CLUB_IDEALS_UPDATE,
+  CLUB_IDEALS_DELETE,
+  ACTIVITY_TYPES_CREATE,
+  ACTIVITY_TYPES_UPDATE,
+  ACTIVITY_TYPES_DELETE,
+} from "@/lib/auth/permissions";
+import {
+  createAdminCountry,
+  updateAdminCountry,
+  deleteAdminCountry,
+  createAdminUnion,
+  updateAdminUnion,
+  deleteAdminUnion,
+  createAdminLocalField,
+  updateAdminLocalField,
+  deleteAdminLocalField,
+  createAdminDistrict,
+  updateAdminDistrict,
+  deleteAdminDistrict,
+  createAdminChurch,
+  updateAdminChurch,
+  deleteAdminChurch,
+  createAdminRelationshipType,
+  updateAdminRelationshipType,
+  deleteAdminRelationshipType,
+  createAdminAllergy,
+  updateAdminAllergy,
+  deleteAdminAllergy,
+  createAdminDisease,
+  updateAdminDisease,
+  deleteAdminDisease,
+  createAdminMedicine,
+  updateAdminMedicine,
+  deleteAdminMedicine,
+  createAdminClubType,
+  updateAdminClubType,
+  deleteAdminClubType,
+  createAdminClubIdeal,
+  updateAdminClubIdeal,
+  deleteAdminClubIdeal,
+  createAdminActivityType,
+  updateAdminActivityType,
+  deleteAdminActivityType,
+} from "@/lib/api/generic-catalogs-i18n";
+
+// ─── Shared types ──────────────────────────────────────────────────────────────
+
+export type GenericCatalogActionState = { error?: string };
+
+/** The set of field names that can appear in a per-locale translation entry. */
+type TranslatableField = "name" | "description" | "ideal";
+
+// ─── Shared helpers ────────────────────────────────────────────────────────────
+
+function readString(formData: FormData, field: string): string {
+  return String(formData.get(field) ?? "").trim();
+}
+
+function parseBool(formData: FormData, field: string): boolean {
+  return formData.get(field) === "on" || formData.get(field) === "true";
+}
+
+function parsePositiveInt(formData: FormData, field: string): number | null {
+  const raw = readString(formData, field);
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.floor(n);
+}
+
+/**
+ * Parses `translations[N][locale]` / `translations[N][name]` /
+ * `translations[N][description]` / `translations[N][ideal]` entries from
+ * FormData into a CatalogTranslation array.
+ *
+ * Only the fields listed in `fields` are extracted per entry.
+ * Entries where all translatable fields are empty are skipped.
+ * Entries with locale not in CATALOG_LOCALES are skipped.
+ */
+export function parseTranslations(
+  formData: FormData,
+  fields: TranslatableField[] = ["name", "description"],
+): CatalogTranslation[] {
+  const result: CatalogTranslation[] = [];
+  const indices = new Set<number>();
+
+  for (const key of formData.keys()) {
+    const match = key.match(/^translations\[(\d+)\]\[locale\]$/);
+    if (match) indices.add(Number(match[1]));
+  }
+
+  for (const idx of Array.from(indices).sort((a, b) => a - b)) {
+    const locale = readString(formData, `translations[${idx}][locale]`);
+    if (!CATALOG_LOCALES.includes(locale as CatalogTranslation["locale"])) continue;
+
+    const entry: Record<string, string> = {};
+    let hasValue = false;
+
+    for (const field of fields) {
+      const val = readString(formData, `translations[${idx}][${field}]`);
+      if (val) {
+        entry[field] = val;
+        hasValue = true;
+      }
+    }
+
+    if (!hasValue) continue;
+
+    result.push({
+      locale: locale as CatalogTranslation["locale"],
+      ...entry,
+    } as CatalogTranslation & Record<string, string>);
+  }
+
+  return result;
+}
+
+/**
+ * Builds a create payload for catalogs that have `name` + `description`
+ * (TranslatablePayload shape). Caller may override translatable fields.
+ */
+export function buildTranslatableCreate(
+  formData: FormData,
+  fields: TranslatableField[] = ["name", "description"],
+  customFields?: Record<string, unknown>,
+): Record<string, unknown> {
+  const name = readString(formData, "name");
+  if (!name) throw new Error("El nombre es obligatorio.");
+  const active = formData.has("active") ? parseBool(formData, "active") : true;
+  const translations = parseTranslations(formData, fields);
+
+  const payload: Record<string, unknown> = { name, active };
+
+  // Include description when it's a configured translatable field
+  if (fields.includes("description")) {
+    const description = readString(formData, "description") || undefined;
+    if (description !== undefined) payload.description = description;
+  }
+
+  // Include ideal when it's a configured translatable field
+  if (fields.includes("ideal")) {
+    const ideal = readString(formData, "ideal") || undefined;
+    if (ideal !== undefined) payload.ideal = ideal;
+  }
+
+  if (translations.length > 0) payload.translations = translations;
+
+  // Merge any caller-supplied extra fields (e.g. club_type_id, ideal_order)
+  if (customFields) {
+    for (const [k, v] of Object.entries(customFields)) {
+      if (v !== null && v !== undefined) payload[k] = v;
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Builds an update payload for catalogs that have `name` (and optionally
+ * `description` or `ideal`). Caller may override translatable fields.
+ *
+ * Only sends `translations` when the dirty flag is set.
+ */
+export function buildTranslatableUpdate(
+  formData: FormData,
+  fields: TranslatableField[] = ["name", "description"],
+  customFields?: Record<string, unknown>,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  const name = readString(formData, "name");
+  if (name) payload.name = name;
+
+  if (fields.includes("description")) {
+    payload.description = readString(formData, "description") || "";
+  }
+
+  if (fields.includes("ideal")) {
+    const ideal = readString(formData, "ideal");
+    if (ideal) payload.ideal = ideal;
+  }
+
+  if (formData.has("active")) payload.active = parseBool(formData, "active");
+
+  const dirty = formData.get("translations_dirty");
+  if (dirty === "1") payload.translations = parseTranslations(formData, fields);
+
+  if (customFields) {
+    for (const [k, v] of Object.entries(customFields)) {
+      if (v !== null && v !== undefined) payload[k] = v;
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Builds a create payload for name-only catalogs (no description, no ideal).
+ */
+function buildNameOnlyCreate(formData: FormData): Record<string, unknown> {
+  const name = readString(formData, "name");
+  if (!name) throw new Error("El nombre es obligatorio.");
+  const active = formData.has("active") ? parseBool(formData, "active") : true;
+  const translations = parseTranslations(formData, ["name"]);
+  return {
+    name,
+    active,
+    ...(translations.length > 0 ? { translations } : {}),
+  };
+}
+
+/**
+ * Builds an update payload for name-only catalogs.
+ */
+function buildNameOnlyUpdate(formData: FormData): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  const name = readString(formData, "name");
+  if (name) payload.name = name;
+  if (formData.has("active")) payload.active = parseBool(formData, "active");
+  const dirty = formData.get("translations_dirty");
+  if (dirty === "1") payload.translations = parseTranslations(formData, ["name"]);
+  return payload;
+}
+
+// ─── Generic factory ───────────────────────────────────────────────────────────
+
+type CrudPermissions = {
+  create: string[];
+  update: string[];
+  delete: string[];
+};
+
+/**
+ * Factory that generates (createAction, updateAction, deleteAction) for a
+ * given catalog route.
+ *
+ * @param routePath    Dashboard path — used for revalidatePath + redirect
+ * @param permissions  RBAC permission arrays (any-of semantics)
+ * @param api          Object with create / update / delete async fns
+ * @param hasDescription  When false, uses name-only builders (ignores translatableFields)
+ * @param translatableFields  When hasDescription is true, overrides which fields
+ *   are extracted from translations entries. Defaults to ['name', 'description'].
+ *   Pass ['name', 'ideal'] for club-ideals.
+ */
+function makeActions(
+  routePath: string,
+  permissions: CrudPermissions,
+  api: {
+    create: (payload: Record<string, unknown>) => Promise<unknown>;
+    update: (id: number, payload: Record<string, unknown>) => Promise<unknown>;
+    delete: (id: number) => Promise<unknown>;
+  },
+  hasDescription = true,
+  translatableFields: TranslatableField[] = ["name", "description"],
+) {
+  async function createAction(
+    _: GenericCatalogActionState,
+    formData: FormData,
+  ): Promise<GenericCatalogActionState> {
+    const user = await requireAdminUser();
+    if (!hasAnyPermission(user, permissions.create)) {
+      return { error: "Sin permisos para crear." };
+    }
+    try {
+      const payload = hasDescription
+        ? buildTranslatableCreate(formData, translatableFields)
+        : buildNameOnlyCreate(formData);
+      await api.create(payload);
+    } catch (error) {
+      return {
+        error: getActionErrorMessage(error, "No se pudo crear el registro.", {
+          endpointLabel: routePath,
+        }),
+      };
+    }
+    revalidatePath(routePath);
+    redirect(routePath);
+  }
+
+  async function updateAction(
+    _: GenericCatalogActionState,
+    formData: FormData,
+  ): Promise<GenericCatalogActionState> {
+    const user = await requireAdminUser();
+    if (!hasAnyPermission(user, permissions.update)) {
+      return { error: "Sin permisos para editar." };
+    }
+    const id = parsePositiveInt(formData, "id");
+    if (!id) return { error: "No se pudo identificar el registro a editar." };
+    try {
+      const payload = hasDescription
+        ? buildTranslatableUpdate(formData, translatableFields)
+        : buildNameOnlyUpdate(formData);
+      await api.update(id, payload);
+    } catch (error) {
+      return {
+        error: getActionErrorMessage(error, "No se pudo actualizar el registro.", {
+          endpointLabel: `${routePath}/${id}`,
+        }),
+      };
+    }
+    revalidatePath(routePath);
+    redirect(routePath);
+  }
+
+  async function deleteAction(
+    _: GenericCatalogActionState,
+    formData: FormData,
+  ): Promise<GenericCatalogActionState> {
+    const user = await requireAdminUser();
+    if (!hasAnyPermission(user, permissions.delete)) {
+      return { error: "Sin permisos para eliminar." };
+    }
+    const id = parsePositiveInt(formData, "id");
+    if (!id) return { error: "No se pudo identificar el registro a eliminar." };
+    try {
+      await api.delete(id);
+    } catch (error) {
+      return {
+        error: getActionErrorMessage(error, "No se pudo eliminar el registro.", {
+          endpointLabel: `${routePath}/${id}`,
+        }),
+      };
+    }
+    revalidatePath(routePath);
+    redirect(routePath);
+  }
+
+  return { createAction, updateAction, deleteAction };
+}
+
+// ─── Countries ────────────────────────────────────────────────────────────────
+
+const countriesActions = makeActions(
+  "/dashboard/catalogs/geography/countries",
+  {
+    create: [COUNTRIES_CREATE, CATALOGS_CREATE],
+    update: [COUNTRIES_UPDATE, CATALOGS_UPDATE],
+    delete: [COUNTRIES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminCountry(p as Parameters<typeof createAdminCountry>[0]),
+    update: (id, p) => updateAdminCountry(id, p),
+    delete: (id) => deleteAdminCountry(id),
+  },
+  false, // name only
+);
+
+export const createCountryAction = countriesActions.createAction;
+export const updateCountryAction = countriesActions.updateAction;
+export const deleteCountryAction = countriesActions.deleteAction;
+
+// ─── Unions ───────────────────────────────────────────────────────────────────
+
+const unionsActions = makeActions(
+  "/dashboard/catalogs/geography/unions",
+  {
+    create: [UNIONS_CREATE, CATALOGS_CREATE],
+    update: [UNIONS_UPDATE, CATALOGS_UPDATE],
+    delete: [UNIONS_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminUnion(p as Parameters<typeof createAdminUnion>[0]),
+    update: (id, p) => updateAdminUnion(id, p),
+    delete: (id) => deleteAdminUnion(id),
+  },
+  false, // name only
+);
+
+export const createUnionAction = unionsActions.createAction;
+export const updateUnionAction = unionsActions.updateAction;
+export const deleteUnionAction = unionsActions.deleteAction;
+
+// ─── Local Fields ─────────────────────────────────────────────────────────────
+
+const localFieldsActions = makeActions(
+  "/dashboard/catalogs/geography/local-fields",
+  {
+    create: [LOCAL_FIELDS_CREATE, CATALOGS_CREATE],
+    update: [LOCAL_FIELDS_UPDATE, CATALOGS_UPDATE],
+    delete: [LOCAL_FIELDS_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminLocalField(p as Parameters<typeof createAdminLocalField>[0]),
+    update: (id, p) => updateAdminLocalField(id, p),
+    delete: (id) => deleteAdminLocalField(id),
+  },
+  false, // name only
+);
+
+export const createLocalFieldAction = localFieldsActions.createAction;
+export const updateLocalFieldAction = localFieldsActions.updateAction;
+export const deleteLocalFieldAction = localFieldsActions.deleteAction;
+
+// ─── Districts ────────────────────────────────────────────────────────────────
+
+const districtsActions = makeActions(
+  "/dashboard/catalogs/geography/districts",
+  {
+    create: [DISTRICTS_CREATE, CATALOGS_CREATE],
+    update: [DISTRICTS_UPDATE, CATALOGS_UPDATE],
+    delete: [DISTRICTS_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminDistrict(p as Parameters<typeof createAdminDistrict>[0]),
+    update: (id, p) => updateAdminDistrict(id, p),
+    delete: (id) => deleteAdminDistrict(id),
+  },
+  false, // name only
+);
+
+export const createDistrictAction = districtsActions.createAction;
+export const updateDistrictAction = districtsActions.updateAction;
+export const deleteDistrictAction = districtsActions.deleteAction;
+
+// ─── Churches ─────────────────────────────────────────────────────────────────
+
+const churchesActions = makeActions(
+  "/dashboard/catalogs/geography/churches",
+  {
+    create: [CHURCHES_CREATE, CATALOGS_CREATE],
+    update: [CHURCHES_UPDATE, CATALOGS_UPDATE],
+    delete: [CHURCHES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminChurch(p as Parameters<typeof createAdminChurch>[0]),
+    update: (id, p) => updateAdminChurch(id, p),
+    delete: (id) => deleteAdminChurch(id),
+  },
+  false, // name only
+);
+
+export const createChurchAction = churchesActions.createAction;
+export const updateChurchAction = churchesActions.updateAction;
+export const deleteChurchAction = churchesActions.deleteAction;
+
+// ─── Relationship Types ───────────────────────────────────────────────────────
+
+const relationshipTypesActions = makeActions(
+  "/dashboard/catalogs/relationship-types",
+  {
+    create: [RELATIONSHIP_TYPES_CREATE, CATALOGS_CREATE],
+    update: [RELATIONSHIP_TYPES_UPDATE, CATALOGS_UPDATE],
+    delete: [RELATIONSHIP_TYPES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminRelationshipType(p as Parameters<typeof createAdminRelationshipType>[0]),
+    update: (id, p) => updateAdminRelationshipType(id, p),
+    delete: (id) => deleteAdminRelationshipType(id),
+  },
+  true, // name + description
+);
+
+export const createRelationshipTypeAction = relationshipTypesActions.createAction;
+export const updateRelationshipTypeAction = relationshipTypesActions.updateAction;
+export const deleteRelationshipTypeAction = relationshipTypesActions.deleteAction;
+
+// ─── Allergies ────────────────────────────────────────────────────────────────
+
+const allergiesActions = makeActions(
+  "/dashboard/catalogs/allergies",
+  {
+    create: [ALLERGIES_CREATE, CATALOGS_CREATE],
+    update: [ALLERGIES_UPDATE, CATALOGS_UPDATE],
+    delete: [ALLERGIES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminAllergy(p as Parameters<typeof createAdminAllergy>[0]),
+    update: (id, p) => updateAdminAllergy(id, p),
+    delete: (id) => deleteAdminAllergy(id),
+  },
+  true, // name + description
+);
+
+export const createAllergyAction = allergiesActions.createAction;
+export const updateAllergyAction = allergiesActions.updateAction;
+export const deleteAllergyAction = allergiesActions.deleteAction;
+
+// ─── Diseases ─────────────────────────────────────────────────────────────────
+
+const diseasesActions = makeActions(
+  "/dashboard/catalogs/diseases",
+  {
+    create: [DISEASES_CREATE, CATALOGS_CREATE],
+    update: [DISEASES_UPDATE, CATALOGS_UPDATE],
+    delete: [DISEASES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminDisease(p as Parameters<typeof createAdminDisease>[0]),
+    update: (id, p) => updateAdminDisease(id, p),
+    delete: (id) => deleteAdminDisease(id),
+  },
+  true, // name + description
+);
+
+export const createDiseaseAction = diseasesActions.createAction;
+export const updateDiseaseAction = diseasesActions.updateAction;
+export const deleteDiseaseAction = diseasesActions.deleteAction;
+
+// ─── Medicines ────────────────────────────────────────────────────────────────
+
+const medicinesActions = makeActions(
+  "/dashboard/catalogs/medicines",
+  {
+    create: [MEDICINES_CREATE, CATALOGS_CREATE],
+    update: [MEDICINES_UPDATE, CATALOGS_UPDATE],
+    delete: [MEDICINES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminMedicine(p as Parameters<typeof createAdminMedicine>[0]),
+    update: (id, p) => updateAdminMedicine(id, p),
+    delete: (id) => deleteAdminMedicine(id),
+  },
+  true, // name + description
+);
+
+export const createMedicineAction = medicinesActions.createAction;
+export const updateMedicineAction = medicinesActions.updateAction;
+export const deleteMedicineAction = medicinesActions.deleteAction;
+
+// ─── Club Types ───────────────────────────────────────────────────────────────
+
+const clubTypesActions = makeActions(
+  "/dashboard/catalogs/club-types",
+  {
+    create: [CLUB_TYPES_CREATE, CATALOGS_CREATE],
+    update: [CLUB_TYPES_UPDATE, CATALOGS_UPDATE],
+    delete: [CLUB_TYPES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminClubType(p as Parameters<typeof createAdminClubType>[0]),
+    update: (id, p) => updateAdminClubType(id, p),
+    delete: (id) => deleteAdminClubType(id),
+  },
+  false, // name only
+);
+
+export const createClubTypeAction = clubTypesActions.createAction;
+export const updateClubTypeAction = clubTypesActions.updateAction;
+export const deleteClubTypeAction = clubTypesActions.deleteAction;
+
+// ─── Club Ideals ──────────────────────────────────────────────────────────────
+// Special: translatable fields are ['name', 'ideal'] — NOT description.
+// Additional payload fields: club_type_id, ideal_order.
+
+const clubIdealsActions = makeActions(
+  "/dashboard/catalogs/club-ideals",
+  {
+    create: [CLUB_IDEALS_CREATE, CATALOGS_CREATE],
+    update: [CLUB_IDEALS_UPDATE, CATALOGS_UPDATE],
+    delete: [CLUB_IDEALS_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => {
+      // Pull extra fields from the generic payload and forward to typed fn
+      const { name, ideal, club_type_id, ideal_order, active, translations } = p as {
+        name: string;
+        ideal?: string | null;
+        club_type_id?: number | null;
+        ideal_order?: number | null;
+        active?: boolean;
+        translations?: CatalogTranslation[];
+      };
+      return createAdminClubIdeal({ name, ideal, club_type_id, ideal_order, active, translations });
+    },
+    update: (id, p) => {
+      const { name, ideal, club_type_id, ideal_order, active, translations } = p as {
+        name?: string;
+        ideal?: string | null;
+        club_type_id?: number | null;
+        ideal_order?: number | null;
+        active?: boolean;
+        translations?: CatalogTranslation[];
+      };
+      return updateAdminClubIdeal(id, { name, ideal, club_type_id, ideal_order, active, translations });
+    },
+    delete: (id) => deleteAdminClubIdeal(id),
+  },
+  true,                       // hasDescription=true so factory uses buildTranslatableCreate/Update
+  ["name", "ideal"],          // translatableFields override: ideal instead of description
+);
+
+export const createClubIdealAction = clubIdealsActions.createAction;
+export const updateClubIdealAction = clubIdealsActions.updateAction;
+export const deleteClubIdealAction = clubIdealsActions.deleteAction;
+
+// ─── Activity Types ───────────────────────────────────────────────────────────
+// Note: `code` is NOT translatable — only name + description are.
+
+const activityTypesActions = makeActions(
+  "/dashboard/catalogs/activity-types",
+  {
+    create: [ACTIVITY_TYPES_CREATE, CATALOGS_CREATE],
+    update: [ACTIVITY_TYPES_UPDATE, CATALOGS_UPDATE],
+    delete: [ACTIVITY_TYPES_DELETE, CATALOGS_DELETE],
+  },
+  {
+    create: (p) => createAdminActivityType(p as Parameters<typeof createAdminActivityType>[0]),
+    update: (id, p) => updateAdminActivityType(id, p),
+    delete: (id) => deleteAdminActivityType(id),
+  },
+  true, // name + description (code passed through but not translatable)
+);
+
+export const createActivityTypeAction = activityTypesActions.createAction;
+export const updateActivityTypeAction = activityTypesActions.updateAction;
+export const deleteActivityTypeAction = activityTypesActions.deleteAction;

--- a/src/lib/generic-catalogs-i18n/actions.ts
+++ b/src/lib/generic-catalogs-i18n/actions.ts
@@ -18,12 +18,17 @@
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 import { getActionErrorMessage } from "@/lib/api/action-error";
-import {
-  CATALOG_LOCALES,
-  type CatalogTranslation,
-} from "@/lib/types/catalog-translation";
 import { requireAdminUser } from "@/lib/auth/session";
 import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import type { CatalogTranslation } from "@/lib/types/catalog-translation";
+import {
+  type TranslatableField,
+  parsePositiveInt,
+  buildTranslatableCreate,
+  buildTranslatableUpdate,
+  buildNameOnlyCreate,
+  buildNameOnlyUpdate,
+} from "@/lib/generic-catalogs-i18n/helpers";
 import {
   CATALOGS_CREATE,
   CATALOGS_UPDATE,
@@ -107,181 +112,6 @@ import {
 // ─── Shared types ──────────────────────────────────────────────────────────────
 
 export type GenericCatalogActionState = { error?: string };
-
-/** The set of field names that can appear in a per-locale translation entry. */
-type TranslatableField = "name" | "description" | "ideal";
-
-// ─── Shared helpers ────────────────────────────────────────────────────────────
-
-function readString(formData: FormData, field: string): string {
-  return String(formData.get(field) ?? "").trim();
-}
-
-function parseBool(formData: FormData, field: string): boolean {
-  return formData.get(field) === "on" || formData.get(field) === "true";
-}
-
-function parsePositiveInt(formData: FormData, field: string): number | null {
-  const raw = readString(formData, field);
-  if (!raw) return null;
-  const n = Number(raw);
-  if (!Number.isFinite(n) || n <= 0) return null;
-  return Math.floor(n);
-}
-
-/**
- * Parses `translations[N][locale]` / `translations[N][name]` /
- * `translations[N][description]` / `translations[N][ideal]` entries from
- * FormData into a CatalogTranslation array.
- *
- * Only the fields listed in `fields` are extracted per entry.
- * Entries where all translatable fields are empty are skipped.
- * Entries with locale not in CATALOG_LOCALES are skipped.
- */
-export function parseTranslations(
-  formData: FormData,
-  fields: TranslatableField[] = ["name", "description"],
-): CatalogTranslation[] {
-  const result: CatalogTranslation[] = [];
-  const indices = new Set<number>();
-
-  for (const key of formData.keys()) {
-    const match = key.match(/^translations\[(\d+)\]\[locale\]$/);
-    if (match) indices.add(Number(match[1]));
-  }
-
-  for (const idx of Array.from(indices).sort((a, b) => a - b)) {
-    const locale = readString(formData, `translations[${idx}][locale]`);
-    if (!CATALOG_LOCALES.includes(locale as CatalogTranslation["locale"])) continue;
-
-    const entry: Record<string, string> = {};
-    let hasValue = false;
-
-    for (const field of fields) {
-      const val = readString(formData, `translations[${idx}][${field}]`);
-      if (val) {
-        entry[field] = val;
-        hasValue = true;
-      }
-    }
-
-    if (!hasValue) continue;
-
-    result.push({
-      locale: locale as CatalogTranslation["locale"],
-      ...entry,
-    } as CatalogTranslation & Record<string, string>);
-  }
-
-  return result;
-}
-
-/**
- * Builds a create payload for catalogs that have `name` + `description`
- * (TranslatablePayload shape). Caller may override translatable fields.
- */
-export function buildTranslatableCreate(
-  formData: FormData,
-  fields: TranslatableField[] = ["name", "description"],
-  customFields?: Record<string, unknown>,
-): Record<string, unknown> {
-  const name = readString(formData, "name");
-  if (!name) throw new Error("El nombre es obligatorio.");
-  const active = formData.has("active") ? parseBool(formData, "active") : true;
-  const translations = parseTranslations(formData, fields);
-
-  const payload: Record<string, unknown> = { name, active };
-
-  // Include description when it's a configured translatable field
-  if (fields.includes("description")) {
-    const description = readString(formData, "description") || undefined;
-    if (description !== undefined) payload.description = description;
-  }
-
-  // Include ideal when it's a configured translatable field
-  if (fields.includes("ideal")) {
-    const ideal = readString(formData, "ideal") || undefined;
-    if (ideal !== undefined) payload.ideal = ideal;
-  }
-
-  if (translations.length > 0) payload.translations = translations;
-
-  // Merge any caller-supplied extra fields (e.g. club_type_id, ideal_order)
-  if (customFields) {
-    for (const [k, v] of Object.entries(customFields)) {
-      if (v !== null && v !== undefined) payload[k] = v;
-    }
-  }
-
-  return payload;
-}
-
-/**
- * Builds an update payload for catalogs that have `name` (and optionally
- * `description` or `ideal`). Caller may override translatable fields.
- *
- * Only sends `translations` when the dirty flag is set.
- */
-export function buildTranslatableUpdate(
-  formData: FormData,
-  fields: TranslatableField[] = ["name", "description"],
-  customFields?: Record<string, unknown>,
-): Record<string, unknown> {
-  const payload: Record<string, unknown> = {};
-
-  const name = readString(formData, "name");
-  if (name) payload.name = name;
-
-  if (fields.includes("description")) {
-    payload.description = readString(formData, "description") || "";
-  }
-
-  if (fields.includes("ideal")) {
-    const ideal = readString(formData, "ideal");
-    if (ideal) payload.ideal = ideal;
-  }
-
-  if (formData.has("active")) payload.active = parseBool(formData, "active");
-
-  const dirty = formData.get("translations_dirty");
-  if (dirty === "1") payload.translations = parseTranslations(formData, fields);
-
-  if (customFields) {
-    for (const [k, v] of Object.entries(customFields)) {
-      if (v !== null && v !== undefined) payload[k] = v;
-    }
-  }
-
-  return payload;
-}
-
-/**
- * Builds a create payload for name-only catalogs (no description, no ideal).
- */
-function buildNameOnlyCreate(formData: FormData): Record<string, unknown> {
-  const name = readString(formData, "name");
-  if (!name) throw new Error("El nombre es obligatorio.");
-  const active = formData.has("active") ? parseBool(formData, "active") : true;
-  const translations = parseTranslations(formData, ["name"]);
-  return {
-    name,
-    active,
-    ...(translations.length > 0 ? { translations } : {}),
-  };
-}
-
-/**
- * Builds an update payload for name-only catalogs.
- */
-function buildNameOnlyUpdate(formData: FormData): Record<string, unknown> {
-  const payload: Record<string, unknown> = {};
-  const name = readString(formData, "name");
-  if (name) payload.name = name;
-  if (formData.has("active")) payload.active = parseBool(formData, "active");
-  const dirty = formData.get("translations_dirty");
-  if (dirty === "1") payload.translations = parseTranslations(formData, ["name"]);
-  return payload;
-}
 
 // ─── Generic factory ───────────────────────────────────────────────────────────
 

--- a/src/lib/generic-catalogs-i18n/helpers.ts
+++ b/src/lib/generic-catalogs-i18n/helpers.ts
@@ -1,0 +1,190 @@
+/**
+ * Generic Catalogs i18n — pure (non-server-action) helpers.
+ *
+ * Lives outside `actions.ts` because that file is annotated with
+ * `"use server"`, and Next.js requires every exported function from a
+ * "use server" module to be async. These helpers are synchronous form
+ * parsers / payload builders shared by the server-action factory.
+ */
+
+import {
+  CATALOG_LOCALES,
+  type CatalogTranslation,
+} from "@/lib/types/catalog-translation";
+
+/** The set of field names that can appear in a per-locale translation entry. */
+export type TranslatableField = "name" | "description" | "ideal";
+
+export function readString(formData: FormData, field: string): string {
+  return String(formData.get(field) ?? "").trim();
+}
+
+export function parseBool(formData: FormData, field: string): boolean {
+  return formData.get(field) === "on" || formData.get(field) === "true";
+}
+
+export function parsePositiveInt(
+  formData: FormData,
+  field: string,
+): number | null {
+  const raw = readString(formData, field);
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.floor(n);
+}
+
+/**
+ * Parses `translations[N][locale]` / `translations[N][name]` /
+ * `translations[N][description]` / `translations[N][ideal]` entries from
+ * FormData into a CatalogTranslation array.
+ *
+ * Only the fields listed in `fields` are extracted per entry.
+ * Entries where all translatable fields are empty are skipped.
+ * Entries with locale not in CATALOG_LOCALES are skipped.
+ */
+export function parseTranslations(
+  formData: FormData,
+  fields: TranslatableField[] = ["name", "description"],
+): CatalogTranslation[] {
+  const result: CatalogTranslation[] = [];
+  const indices = new Set<number>();
+
+  for (const key of formData.keys()) {
+    const match = key.match(/^translations\[(\d+)\]\[locale\]$/);
+    if (match) indices.add(Number(match[1]));
+  }
+
+  for (const idx of Array.from(indices).sort((a, b) => a - b)) {
+    const locale = readString(formData, `translations[${idx}][locale]`);
+    if (!CATALOG_LOCALES.includes(locale as CatalogTranslation["locale"])) continue;
+
+    const entry: Record<string, string> = {};
+    let hasValue = false;
+
+    for (const field of fields) {
+      const val = readString(formData, `translations[${idx}][${field}]`);
+      if (val) {
+        entry[field] = val;
+        hasValue = true;
+      }
+    }
+
+    if (!hasValue) continue;
+
+    result.push({
+      locale: locale as CatalogTranslation["locale"],
+      ...entry,
+    } as CatalogTranslation & Record<string, string>);
+  }
+
+  return result;
+}
+
+/**
+ * Builds a create payload for catalogs that have `name` + `description`
+ * (TranslatablePayload shape). Caller may override translatable fields.
+ */
+export function buildTranslatableCreate(
+  formData: FormData,
+  fields: TranslatableField[] = ["name", "description"],
+  customFields?: Record<string, unknown>,
+): Record<string, unknown> {
+  const name = readString(formData, "name");
+  if (!name) throw new Error("El nombre es obligatorio.");
+  const active = formData.has("active") ? parseBool(formData, "active") : true;
+  const translations = parseTranslations(formData, fields);
+
+  const payload: Record<string, unknown> = { name, active };
+
+  if (fields.includes("description")) {
+    const description = readString(formData, "description") || undefined;
+    if (description !== undefined) payload.description = description;
+  }
+
+  if (fields.includes("ideal")) {
+    const ideal = readString(formData, "ideal") || undefined;
+    if (ideal !== undefined) payload.ideal = ideal;
+  }
+
+  if (translations.length > 0) payload.translations = translations;
+
+  if (customFields) {
+    for (const [k, v] of Object.entries(customFields)) {
+      if (v !== null && v !== undefined) payload[k] = v;
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Builds an update payload for catalogs that have `name` (and optionally
+ * `description` or `ideal`). Caller may override translatable fields.
+ *
+ * Only sends `translations` when the dirty flag is set.
+ */
+export function buildTranslatableUpdate(
+  formData: FormData,
+  fields: TranslatableField[] = ["name", "description"],
+  customFields?: Record<string, unknown>,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+
+  const name = readString(formData, "name");
+  if (name) payload.name = name;
+
+  if (fields.includes("description")) {
+    payload.description = readString(formData, "description") || "";
+  }
+
+  if (fields.includes("ideal")) {
+    const ideal = readString(formData, "ideal");
+    if (ideal) payload.ideal = ideal;
+  }
+
+  if (formData.has("active")) payload.active = parseBool(formData, "active");
+
+  const dirty = formData.get("translations_dirty");
+  if (dirty === "1") payload.translations = parseTranslations(formData, fields);
+
+  if (customFields) {
+    for (const [k, v] of Object.entries(customFields)) {
+      if (v !== null && v !== undefined) payload[k] = v;
+    }
+  }
+
+  return payload;
+}
+
+/**
+ * Builds a create payload for name-only catalogs (no description, no ideal).
+ */
+export function buildNameOnlyCreate(
+  formData: FormData,
+): Record<string, unknown> {
+  const name = readString(formData, "name");
+  if (!name) throw new Error("El nombre es obligatorio.");
+  const active = formData.has("active") ? parseBool(formData, "active") : true;
+  const translations = parseTranslations(formData, ["name"]);
+  return {
+    name,
+    active,
+    ...(translations.length > 0 ? { translations } : {}),
+  };
+}
+
+/**
+ * Builds an update payload for name-only catalogs.
+ */
+export function buildNameOnlyUpdate(
+  formData: FormData,
+): Record<string, unknown> {
+  const payload: Record<string, unknown> = {};
+  const name = readString(formData, "name");
+  if (name) payload.name = name;
+  if (formData.has("active")) payload.active = parseBool(formData, "active");
+  const dirty = formData.get("translations_dirty");
+  if (dirty === "1") payload.translations = parseTranslations(formData, ["name"]);
+  return payload;
+}


### PR DESCRIPTION
## Summary

- Adds generic catalog admin actions factory and permissions for 12 catalogs (`d09e545`)
- Migrates 11 catalog admin pages to the shared `PhaseECatalogCrudPage` component with i18n support (`01d191d`)
- Fixes `MISSING_MESSAGE` crash in global command palette when iterating subgrouped catalog children (`cbe8fcf`)

## Scope

**New shared lib:**
- `src/lib/api/generic-catalogs-i18n.ts` — list helpers for admin catalogs
- `src/lib/generic-catalogs-i18n/actions.ts` + tests — create/update/delete factory
- `src/lib/phase-e-catalogs/` — fetch helpers

**Migrated pages (11):**
- `dashboard/catalogs/{activity-types,allergies,club-types,diseases,medicines,relationship-types}/page.tsx`
- `dashboard/catalogs/geography/{churches,countries,districts,local-fields,unions}/page.tsx`

**i18n:**
- `messages/{en,es,fr,pt-BR}.json` updated with new keys
- `src/lib/catalogs/entities.ts` updated

**Bug fix (`global-command-palette.tsx`):**
The catalogs section uses `NavSubGroup[]` children (post nav reorg), but the palette iterated `item.children as NavChild[]` producing undefined `child.title` → `MISSING_MESSAGE: Cannot read properties of undefined (reading 'split')` crash. Flatten subgroups into `NavChild[]` before iterating so both flat and nested shapes work.

## Test plan

- [ ] `pnpm dev` — verify all 11 migrated pages compile and render
- [ ] Visit `/dashboard/catalogs/geography/countries` — table renders with i18n labels
- [ ] Open command palette (Cmd+K) — no MISSING_MESSAGE errors in console
- [ ] Verify dropdown for "Catálogos" sidebar entry expands and shows subgrouped items
- [ ] Test create/update/delete on a migrated catalog (e.g. medicines)
- [ ] Switch locale to en/fr/pt-BR — labels translate correctly