### PR TITLE
docs(i18n): document 24 catalog i18n coverage + remove stale MIGRATED comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,18 @@ lib/
 - **Styling**: Tailwind v4 + `cn()` utility de class-variance-authority
 - **Forms**: Siempre validar con Zod + React Hook Form
 
+## i18n catalogs (24 catálogos)
+
+- **Approach X**: español queda en columna principal, locales pt-BR/en/fr en tabla `<entity>_translations`. Backend overlay vía `TranslationService.translateMany` por `Accept-Language`.
+- **12 Phase E + 12 generic** = 24 catálogos i18n-aware. Lista generic: countries, unions, local-fields, districts, churches, relationship-types, allergies, diseases, medicines, club-types, club-ideals, activity-types.
+- **UI patterns**:
+  - `PhaseECatalogCrudPage` (Dialog + tabs) — usado por 22 catálogos. Viola DS rule actualizada (tabs → dedicated page) pero deferred como tech debt.
+  - **club-ideals dedicated page** (`components/catalogs/club-ideal-form-page.tsx`) — única página dedicada DS-compliant. Razón: >4 fields + relación club_type + tabs.
+- **Componente**: `TranslationsTabsField` con prop `secondField?: SecondFieldConfig` (default `description`, override para `ideal` u otros).
+- **Factory actions**: `lib/generic-catalogs-i18n/actions.ts` con `makeActions` extendido (`translatableFields`, `customFormFields`). Sync helpers en `helpers.ts` separados por constraint Next.js Server Actions ("use server" requires async exports).
+- **Permissions**: 8 nuevos grupos (DISTRICTS/RELATIONSHIP_TYPES/ALLERGIES/DISEASES/MEDICINES/CLUB_TYPES/CLUB_IDEALS/ACTIVITY_TYPES) con READ/CREATE/UPDATE/DELETE + fallback CATALOGS_*.
+- **Tech debt**: parent-filter regression para unions/local-fields/districts/churches (PhaseECatalogCrudPage no soporta filtros padre).
+
 ## Autenticación
 
 El admin no usa Supabase. La auth se resuelve llamando al backend API (`NEXT_PUBLIC_API_URL`).

--- a/src/lib/catalogs/entities.ts
+++ b/src/lib/catalogs/entities.ts
@@ -48,7 +48,6 @@ export const ENTITY_KEYS = [
 export type EntityKey = (typeof ENTITY_KEYS)[number];
 
 export const entityConfigs: Record<EntityKey, EntityConfig> = {
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   countries: {
     key: "countries",
     title: "Países",
@@ -65,7 +64,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   unions: {
     key: "unions",
     title: "Uniones",
@@ -89,7 +87,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   "local-fields": {
     key: "local-fields",
     title: "Campos Locales",
@@ -113,7 +110,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   districts: {
     key: "districts",
     title: "Distritos",
@@ -142,7 +138,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   churches: {
     key: "churches",
     title: "Iglesias",
@@ -165,7 +160,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   "relationship-types": {
     key: "relationship-types",
     title: "Tipos de Relación",
@@ -182,7 +176,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   allergies: {
     key: "allergies",
     title: "Alergias",
@@ -199,7 +192,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   diseases: {
     key: "diseases",
     title: "Enfermedades",
@@ -216,7 +208,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   medicines: {
     key: "medicines",
     title: "Medicamentos",
@@ -249,7 +240,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   "club-types": {
     key: "club-types",
     title: "Tipos de Club",
@@ -288,7 +278,6 @@ export const entityConfigs: Record<EntityKey, EntityConfig> = {
       { name: "active", label: "fields.active", type: "checkbox", required: false },
     ],
   },
-  // MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup
   "activity-types": {
     key: "activity-types",
     title: "Tipos de Actividad",


### PR DESCRIPTION
## Summary
PR-6 cleanup of the SDD i18n-generic-catalogs change. Final piece before archive.

### Changes
1. **CLAUDE.md** — adds an `i18n catalogs (24 catálogos)` section documenting:
   - Approach X coverage (es in main, non-es in `_translations`)
   - PhaseECatalogCrudPage Dialog+tabs pattern (22 catalogs) vs club-ideals dedicated page (DS-compliant)
   - `TranslationsTabsField.secondField` extension prop
   - `lib/generic-catalogs-i18n/actions.ts` factory + `helpers.ts` separation
   - 8 new permission groups
   - Tech debt: parent-filter regression for unions/local-fields/districts/churches

2. **`src/lib/catalogs/entities.ts`** — removes 12 stale `MIGRATED to PhaseECatalogCrudPage in PR-4b — remove after PR-6 cleanup` comments. The 12 entity entries themselves stay because:
   - `getSelectOptions("local-fields"|"districts"|"churches")` is still consumed by `clubs/new/page.tsx` and `clubs/[id]/page.tsx` (data-fetching configs for select dropdowns, NOT catalog admin pages)
   - Removing them would break club creation/edit flows
   - Full removal requires a broader refactor — out of scope here

### Verify
- `pnpm tsc --noEmit` → 0 errors
- All 5 SDD apply PRs MERGED to development:
  - sacdia-backend: #104 (foundation), #107 (geo+ref consolidated)
  - sacdia-admin: #153 (actions), #156 (page migrations), #159 (club-ideals dedicated)

### SDD artifacts (engram, ready for archive)
- proposal #2313, spec #2320, design #2322, tasks #2324, apply-progress #2325, verify-report #2359 (PASS, 0 CRITICAL/WARNING, 4 SUGGESTIONS handled here)