### PR TITLE
feat(clubs): redesign club detail page

### DIFF
--- a/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/[id]/page.tsx
@@ -1,152 +1,14 @@
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { notFound } from "next/navigation";
-import { getTranslations } from "next-intl/server";
-import dynamic from "next/dynamic";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Skeleton } from "@/components/ui/skeleton";
-import { PageHeader } from "@/components/shared/page-header";
-import { EditClubForm } from "@/components/clubs/edit-club-form";
-import { ClubSectionsPanel } from "@/components/clubs/club-sections-panel";
-import { apiRequest, ApiError } from "@/lib/api/client";
-
-const PendingMembersPanel = dynamic(
-  () =>
-    import("@/components/membership/pending-members-panel").then((m) => ({
-      default: m.PendingMembersPanel,
-    })),
-  {
-    loading: () => (
-      <div className="space-y-3">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-4 rounded-md border p-4">
-            <Skeleton className="h-4 w-40" />
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-4 w-20" />
-          </div>
-        ))}
-      </div>
-    ),
-  }
-);
-
-const UnitsTab = dynamic(
-  () =>
-    import("@/components/units/units-tab").then((m) => ({
-      default: m.UnitsTab,
-    })),
-  {
-    loading: () => (
-      <div className="space-y-3">
-        {Array.from({ length: 3 }).map((_, i) => (
-          <div key={i} className="flex items-center gap-3 rounded-xl border bg-card p-4">
-            <Skeleton className="size-9 rounded-lg" />
-            <div className="flex-1 space-y-1.5">
-              <Skeleton className="h-4 w-36" />
-              <Skeleton className="h-3 w-24" />
-            </div>
-          </div>
-        ))}
-      </div>
-    ),
-  }
-);
 import { requireAdminUser } from "@/lib/auth/session";
+import { apiRequest, ApiError } from "@/lib/api/client";
 import { getSelectOptions } from "@/lib/catalogs/service";
 import { updateClubAction, deleteClubAction } from "@/lib/clubs/actions";
-import type { ClubActionState } from "@/lib/clubs/actions";
+import { ClubDetailView } from "@/components/clubs/detail/view";
+import { resolveTabFromString } from "@/components/clubs/detail/tab-utils";
+import type { ClubFull } from "@/components/clubs/detail/types";
 
 type Params = Promise<{ id: string }>;
 type SearchParams = Promise<{ tab?: string }>;
-
-type Club = {
-  club_id?: number;
-  id?: number;
-  name?: string;
-  description?: string | null;
-  active?: boolean;
-  local_field_id?: number;
-  district_id?: number;
-  church_id?: number;
-  address?: string | null;
-  latitude?: number | null;
-  longitude?: number | null;
-  coordinates?: { lat?: number; lng?: number } | null;
-  local_field?: { name?: string } | null;
-  district?: { name?: string } | null;
-  church?: { name?: string } | null;
-  sections?: Array<{
-    club_section_id?: number;
-    club_type_id?: number;
-    club_type?: { name?: string } | null;
-    name?: string;
-    active?: boolean;
-    souls_target?: number | null;
-    fee?: number | null;
-    members_count?: number;
-  }>;
-  [key: string]: unknown;
-};
-
-function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
-  return (
-    <div className="flex flex-col gap-1 sm:flex-row sm:items-center sm:gap-4">
-      <span className="min-w-[160px] text-sm font-medium text-muted-foreground">{label}</span>
-      <span className="text-sm">{value ?? <span className="text-muted-foreground">—</span>}</span>
-    </div>
-  );
-}
-
-function ClubViewCard({ club, labels }: { club: Club; labels: {
-  infoCardTitle: string; labelName: string; labelDescription: string; labelStatus: string;
-  labelLocalField: string; labelDistrict: string; labelChurch: string; labelAddress: string;
-  labelCoordinates: string; statusActive: string; statusInactive: string;
-} }) {
-  const lat = (club.coordinates as { lat?: number } | null)?.lat ?? club.latitude;
-  const lng = (club.coordinates as { lng?: number } | null)?.lng ?? club.longitude;
-
-  return (
-    <div className="space-y-4">
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">{labels.infoCardTitle}</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <InfoRow label={labels.labelName} value={club.name} />
-          <InfoRow label={labels.labelDescription} value={club.description} />
-          <InfoRow
-            label={labels.labelStatus}
-            value={
-              <Badge variant={club.active !== false ? "soft-success" : "outline"}>
-                {club.active !== false ? labels.statusActive : labels.statusInactive}
-              </Badge>
-            }
-          />
-          <InfoRow label={labels.labelLocalField} value={club.local_field?.name} />
-          <InfoRow label={labels.labelDistrict} value={club.district?.name} />
-          <InfoRow label={labels.labelChurch} value={club.church?.name} />
-          <InfoRow label={labels.labelAddress} value={club.address} />
-          {(lat != null || lng != null) && (
-            <InfoRow label={labels.labelCoordinates} value={`${lat ?? "—"}, ${lng ?? "—"}`} />
-          )}
-        </CardContent>
-      </Card>
-    </div>
-  );
-}
-
-const VALID_TABS = ["view", "edit", "sections", "units", "membership"] as const;
-type ValidTab = (typeof VALID_TABS)[number];
-
-function resolveTab(raw: string | undefined): ValidTab {
-  if (raw && (VALID_TABS as readonly string[]).includes(raw)) {
-    return raw as ValidTab;
-  }
-  return "view";
-}
 
 export default async function ClubDetailPage({
   params,
@@ -156,26 +18,27 @@ export default async function ClubDetailPage({
   searchParams: SearchParams;
 }) {
   await requireAdminUser();
-  const t = await getTranslations("clubs.pages.detail");
   const { id } = await params;
   const { tab: tabParam } = await searchParams;
-  const defaultTab = resolveTab(tabParam);
 
-  let club: Club;
+  let club: ClubFull;
   try {
     const payload = await apiRequest<unknown>(`/clubs/${id}`);
-    const res = payload as { data?: Club; status?: string } | Club;
-    club = ("data" in res && res.data && typeof res.data === "object" ? res.data : res) as Club;
+    const res = payload as { data?: ClubFull; status?: string } | ClubFull;
+    club = ("data" in res && res.data && typeof res.data === "object"
+      ? res.data
+      : res) as ClubFull;
   } catch (error) {
-    if (error instanceof ApiError && (error.status === 404 || error.status === 403)) {
+    if (
+      error instanceof ApiError &&
+      (error.status === 404 || error.status === 403)
+    ) {
       notFound();
     }
     throw error;
   }
 
   const clubId = Number(club.club_id ?? club.id ?? id);
-  const clubName = club.name ?? "Club";
-  const sections = club.sections ?? [];
 
   const [localFields, districts, churches] = await Promise.all([
     getSelectOptions("local-fields").catch(() => []),
@@ -186,71 +49,15 @@ export default async function ClubDetailPage({
   const boundUpdateAction = updateClubAction.bind(null, clubId);
 
   return (
-    <div className="space-y-6">
-      <PageHeader title={clubName}>
-        <div className="flex gap-2">
-          <form action={deleteClubAction}>
-            <input type="hidden" name="id" value={clubId} />
-            <Button variant="destructive" size="sm" type="submit">
-              {t("deleteButton")}
-            </Button>
-          </form>
-          <Button variant="outline" size="sm" asChild>
-            <Link href="/dashboard/clubs">
-              <ArrowLeft className="size-4" />
-              {t("back")}
-            </Link>
-          </Button>
-        </div>
-      </PageHeader>
-
-      <Tabs defaultValue={defaultTab}>
-        <TabsList>
-          <TabsTrigger value="view">{t("tabView")}</TabsTrigger>
-          <TabsTrigger value="edit">{t("tabEdit")}</TabsTrigger>
-          <TabsTrigger value="sections">{t("tabSections", { count: sections.length })}</TabsTrigger>
-          <TabsTrigger value="units">{t("tabUnits")}</TabsTrigger>
-          <TabsTrigger value="membership">{t("tabMembership")}</TabsTrigger>
-        </TabsList>
-
-        <TabsContent value="view" className="mt-4">
-          <ClubViewCard club={club} labels={{
-            infoCardTitle: t("infoCardTitle"),
-            labelName: t("labelName"),
-            labelDescription: t("labelDescription"),
-            labelStatus: t("labelStatus"),
-            labelLocalField: t("labelLocalField"),
-            labelDistrict: t("labelDistrict"),
-            labelChurch: t("labelChurch"),
-            labelAddress: t("labelAddress"),
-            labelCoordinates: t("labelCoordinates"),
-            statusActive: t("statusActive"),
-            statusInactive: t("statusInactive"),
-          }} />
-        </TabsContent>
-
-        <TabsContent value="edit" className="mt-4">
-          <EditClubForm
-            club={club}
-            localFields={localFields}
-            districts={districts}
-            churches={churches}
-            formAction={boundUpdateAction}
-          />
-        </TabsContent>
-
-        <TabsContent value="sections" className="mt-4 space-y-4">
-          <ClubSectionsPanel clubId={clubId} sections={sections} />
-        </TabsContent>
-
-        <TabsContent value="units" className="mt-4">
-          <UnitsTab clubId={clubId} localFieldId={club.local_field_id ?? null} />
-        </TabsContent>
-
-        <TabsContent value="membership" className="mt-4 space-y-4">
-          <PendingMembersPanel sections={sections} />
-        </TabsContent>
-      </Tabs>
-    </div>
+    <ClubDetailView
+      club={club}
+      clubId={clubId}
+      defaultTab={resolveTabFromString(tabParam)}
+      localFieldOptions={localFields}
+      districtOptions={districts}
+      churchOptions={churches}
+      updateAction={boundUpdateAction}
+      deleteAction={deleteClubAction}
+    />
   );
 }

--- a/src/app/(dashboard)/dashboard/clubs/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/page.tsx
@@ -216,7 +216,14 @@ async function ClubsContent({
                 const clubId = club.club_id ?? club.id;
                 return (
                   <TableRow key={clubId}>
-                    <TableCell className="font-medium">{club.name ?? "—"}</TableCell>
+                    <TableCell className="font-medium">
+                      <Link
+                        href={`/dashboard/clubs/${clubId}`}
+                        className="hover:text-primary hover:underline underline-offset-4"
+                      >
+                        {club.name ?? "—"}
+                      </Link>
+                    </TableCell>
                     <TableCell className="hidden text-sm text-muted-foreground md:table-cell">
                       {club.local_field?.name ?? club.local_field_id ?? "—"}
                     </TableCell>

--- a/src/components/clubs/clubs-table-actions-cell.tsx
+++ b/src/components/clubs/clubs-table-actions-cell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { useFormStatus } from "react-dom";
 import { useTranslations } from "next-intl";
-import { Loader2, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { Eye, Loader2, MoreHorizontal, Pencil, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   AlertDialog,
@@ -63,11 +63,23 @@ export function ClubsTableActionsCell({
   const [deleteItem, setDeleteItem] = useState<ClubActionItem | null>(null);
 
   const editHref = `/dashboard/clubs/${club.id}?tab=edit`;
+  const viewHref = `/dashboard/clubs/${club.id}`;
 
   return (
     <>
       {/* Desktop: icon buttons */}
       <div className="hidden gap-1 md:flex">
+        <Button
+          variant="ghost"
+          size="icon"
+          className="size-8"
+          asChild
+          title="Ver detalle"
+        >
+          <Link href={viewHref} aria-label={`Ver ${club.name}`}>
+            <Eye className="size-3.5" />
+          </Link>
+        </Button>
         {canEdit && (
           <Button
             variant="ghost"
@@ -104,6 +116,12 @@ export function ClubsTableActionsCell({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
+            <DropdownMenuItem asChild>
+              <Link href={viewHref}>
+                <Eye className="size-4" />
+                Ver detalle
+              </Link>
+            </DropdownMenuItem>
             {canEdit && (
               <DropdownMenuItem asChild>
                 <Link href={editHref}>

--- a/src/components/clubs/detail/composition-donut.tsx
+++ b/src/components/clubs/detail/composition-donut.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { SectionView } from "./types";
+
+interface CompositionDonutProps {
+  sections: SectionView[];
+  total: number;
+}
+
+const RADIUS = 62;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function CompositionDonut({ sections, total }: CompositionDonutProps) {
+  const safeTotal = Math.max(total, 1);
+  let offset = 0;
+
+  return (
+    <div className="grid items-center gap-4 sm:grid-cols-[160px_1fr]">
+      <div className="relative mx-auto h-40 w-40">
+        <svg
+          width="160"
+          height="160"
+          viewBox="0 0 160 160"
+          style={{ transform: "rotate(-90deg)" }}
+        >
+          <circle
+            cx="80"
+            cy="80"
+            r={RADIUS}
+            fill="none"
+            stroke="var(--color-muted)"
+            strokeWidth="18"
+          />
+          {total === 0 && (
+            <circle
+              cx="80"
+              cy="80"
+              r={RADIUS}
+              fill="none"
+              stroke="var(--color-muted-foreground)"
+              strokeOpacity="0.2"
+              strokeWidth="18"
+              strokeDasharray={`${CIRCUMFERENCE} 0`}
+            />
+          )}
+          {total > 0 &&
+            sections.map((s, i) => {
+              const pct = s.members / safeTotal;
+              const len = CIRCUMFERENCE * pct;
+              const dash = `${len} ${CIRCUMFERENCE - len}`;
+              const dashOffset = -offset;
+              offset += len;
+              return (
+                <circle
+                  key={s.kind + i}
+                  cx="80"
+                  cy="80"
+                  r={RADIUS}
+                  fill="none"
+                  className={s.meta.barBg.replace("bg-", "stroke-")}
+                  stroke="currentColor"
+                  strokeWidth="18"
+                  strokeDasharray={dash}
+                  strokeDashoffset={dashOffset}
+                />
+              );
+            })}
+        </svg>
+        <div className="absolute inset-0 grid place-items-center">
+          <div className="text-center">
+            <div className="text-2xl font-extrabold leading-none tracking-tight text-foreground">
+              {total}
+            </div>
+            <div className="mt-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+              Miembros
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <ul className="grid gap-2">
+        {sections.length === 0 && (
+          <li className="text-sm text-muted-foreground">
+            Aún no hay secciones registradas.
+          </li>
+        )}
+        {sections.map((s) => {
+          const pct = total > 0 ? Math.round((s.members / safeTotal) * 100) : 0;
+          return (
+            <li
+              key={s.kind + (s.sectionId ?? "")}
+              className="grid grid-cols-[14px_1fr_auto_auto] items-center gap-3 border-b border-border/60 py-2 last:border-0"
+            >
+              <span
+                className={cn("size-3 rounded-sm", s.meta.barBg)}
+                aria-hidden
+              />
+              <div className="min-w-0">
+                <div className="truncate text-sm font-semibold text-foreground">
+                  {s.label}
+                </div>
+                <div className="truncate text-xs text-muted-foreground">
+                  {s.range} · {s.unitsCount}u
+                </div>
+              </div>
+              <span className="font-mono text-xs text-muted-foreground tabular-nums">
+                {pct}%
+              </span>
+              <span className="text-sm font-bold text-foreground tabular-nums">
+                {s.members}
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/src/components/clubs/detail/helpers.ts
+++ b/src/components/clubs/detail/helpers.ts
@@ -1,0 +1,146 @@
+import type { Unit } from "@/lib/api/units";
+import {
+  detectSectionKind,
+  getSectionMeta,
+  type ClubFull,
+  type ClubSectionRaw,
+  type SectionView,
+} from "./types";
+
+export function getClubInitials(name: string | null | undefined): string {
+  if (!name) return "CL";
+  const cleaned = name.trim();
+  if (!cleaned) return "CL";
+  const parts = cleaned.split(/\s+/).filter(Boolean);
+  if (parts.length === 1) return parts[0].slice(0, 3).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
+
+export function getClubCode(club: ClubFull): string {
+  const id = club.club_id ?? club.id;
+  if (id == null) return "—";
+  return `CLB-${String(id).padStart(3, "0")}`;
+}
+
+export function getClubCoordinates(
+  club: ClubFull,
+): { lat: number; lng: number } | null {
+  const lat = club.coordinates?.lat ?? club.latitude;
+  const lng = club.coordinates?.lng ?? club.longitude;
+  if (typeof lat !== "number" || typeof lng !== "number") return null;
+  return { lat, lng };
+}
+
+export function getClubLocations(club: ClubFull) {
+  return {
+    localField:
+      club.local_fields?.name ?? club.local_field?.name ?? null,
+    district: club.districts?.name ?? club.district?.name ?? null,
+    church: club.churches?.name ?? club.church?.name ?? null,
+  };
+}
+
+export function getRawSections(club: ClubFull): ClubSectionRaw[] {
+  return club.club_sections ?? club.sections ?? [];
+}
+
+export function getFoundedYear(club: ClubFull): number | null {
+  if (!club.created_at) return null;
+  const date = new Date(club.created_at);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.getFullYear();
+}
+
+export function buildSectionViews(
+  club: ClubFull,
+  units: Unit[],
+): SectionView[] {
+  const rawSections = getRawSections(club);
+
+  return rawSections
+    .map((raw) => {
+      const kind = detectSectionKind(raw);
+      const meta = getSectionMeta(kind);
+      const sectionId = raw.club_section_id ?? null;
+      const sectionUnits = sectionId
+        ? units.filter((u) => u.club_section_id === sectionId && u.active)
+        : [];
+      const members = sectionUnits.reduce(
+        (acc, u) =>
+          acc + (u.unit_members?.filter((m) => m.active).length ?? 0),
+        0,
+      );
+      const label = raw.name?.trim() || raw.club_type?.name || meta.label;
+      const capacity = raw.souls_target ?? null;
+
+      return {
+        raw,
+        kind,
+        meta,
+        sectionId,
+        label,
+        range: meta.range,
+        active: raw.active !== false,
+        members,
+        units: sectionUnits,
+        unitsCount: sectionUnits.length,
+        capacity,
+      } satisfies SectionView;
+    })
+    .sort((a, b) => {
+      const order: Record<typeof a.kind, number> = {
+        adventurers: 0,
+        pathfinders: 1,
+        master_guilds: 2,
+        unknown: 3,
+      };
+      return order[a.kind] - order[b.kind];
+    });
+}
+
+export function getTotalMembers(sections: SectionView[]): number {
+  return sections.reduce((acc, s) => acc + s.members, 0);
+}
+
+export function getTotalCapacity(sections: SectionView[]): number | null {
+  let total = 0;
+  let hasAny = false;
+  for (const s of sections) {
+    if (s.capacity != null && s.capacity > 0) {
+      total += s.capacity;
+      hasAny = true;
+    }
+  }
+  return hasAny ? total : null;
+}
+
+export function pctOf(
+  numerator: number,
+  denominator: number | null | undefined,
+): number {
+  if (!denominator || denominator <= 0) return 0;
+  return Math.min(100, Math.round((numerator / denominator) * 100));
+}
+
+export function getActiveUnits(units: Unit[]): Unit[] {
+  return units.filter((u) => u.active);
+}
+
+export function countUnitMembers(unit: Unit): number {
+  return unit.unit_members?.filter((m) => m.active).length ?? 0;
+}
+
+export function getUnitLeaderName(unit: Unit): string {
+  const user = unit.users_units_captain_idTousers;
+  if (!user) return "Sin líder";
+  const parts = [user.name, user.paternal_last_name].filter(Boolean);
+  return parts.join(" ").trim() || "Sin líder";
+}
+
+export function getUnitLeaderInitials(unit: Unit): string {
+  const user = unit.users_units_captain_idTousers;
+  if (!user?.name) return "?";
+  const first = user.name?.[0] ?? "";
+  const last = user.paternal_last_name?.[0] ?? "";
+  return (first + last).toUpperCase() || "?";
+}

--- a/src/components/clubs/detail/hero.tsx
+++ b/src/components/clubs/detail/hero.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowLeft, Building2, Edit3, MapPin, MoreHorizontal, Users } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import {
+  getClubCode,
+  getClubInitials,
+  getClubLocations,
+  getFoundedYear,
+  getTotalMembers,
+} from "./helpers";
+import type { ClubFull, SectionView } from "./types";
+
+interface HeroProps {
+  club: ClubFull;
+  sections: SectionView[];
+  unitsCount: number;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export function ClubDetailHero({
+  club,
+  sections,
+  unitsCount,
+  onEdit,
+  onDelete,
+}: HeroProps) {
+  const name = club.name ?? "Club";
+  const initials = getClubInitials(name);
+  const code = getClubCode(club);
+  const foundedYear = getFoundedYear(club);
+  const total = getTotalMembers(sections);
+  const isActive = club.active !== false;
+  const { localField, district, church } = getClubLocations(club);
+
+  return (
+    <section className="relative overflow-hidden rounded-2xl border bg-card shadow-sm">
+      <div
+        aria-hidden
+        className="absolute inset-y-0 left-0 w-1 bg-gradient-to-b from-primary via-primary/60 to-warning"
+      />
+
+      <div className="grid grid-cols-1 gap-6 p-6 md:grid-cols-[110px_1fr_auto] md:items-center">
+        <div className="relative">
+          <div
+            aria-hidden
+            className="grid h-[110px] w-[110px] place-items-center rounded-3xl bg-gradient-to-br from-primary to-primary/70 text-3xl font-extrabold tracking-wide text-primary-foreground shadow-lg shadow-primary/30"
+          >
+            {initials}
+          </div>
+          <span
+            aria-hidden
+            className={cn(
+              "absolute -right-1.5 -top-1.5 size-7 rounded-full border-4 border-card",
+              isActive ? "bg-success" : "bg-muted-foreground",
+            )}
+          />
+        </div>
+
+        <div className="min-w-0 space-y-2">
+          <div className="flex flex-wrap items-center gap-3">
+            <h1 className="text-2xl font-semibold leading-tight tracking-tight text-foreground sm:text-3xl">
+              {name}
+            </h1>
+            <span className="font-mono text-sm font-semibold text-muted-foreground">
+              {code}
+            </span>
+          </div>
+          {(club.description || foundedYear) && (
+            <p className="text-sm text-muted-foreground">
+              {club.description ?? "Sin descripción"}
+              {foundedYear && (
+                <>
+                  {" "}
+                  · fundado en <span className="font-medium">{foundedYear}</span>
+                </>
+              )}
+            </p>
+          )}
+
+          <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+            {church && (
+              <span className="inline-flex items-center gap-1.5">
+                <MapPin className="size-3.5" /> {church}
+                {district && <> · {district}</>}
+              </span>
+            )}
+            {localField && (
+              <>
+                {church && <span aria-hidden className="size-1 rounded-full bg-border" />}
+                <span className="inline-flex items-center gap-1.5">
+                  <Building2 className="size-3.5" /> {localField}
+                </span>
+              </>
+            )}
+            <span aria-hidden className="size-1 rounded-full bg-border" />
+            <span className="inline-flex items-center gap-1.5">
+              <Users className="size-3.5" /> {total} miembros
+            </span>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 pt-1">
+            <Badge variant={isActive ? "soft-success" : "outline"}>
+              <span
+                aria-hidden
+                className={cn(
+                  "size-1.5 rounded-full",
+                  isActive ? "bg-success" : "bg-muted-foreground",
+                )}
+              />
+              {isActive ? "Activo" : "Inactivo"}
+            </Badge>
+            {sections.map((s) => (
+              <span
+                key={s.kind + (s.sectionId ?? "")}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-semibold",
+                  s.meta.pill,
+                )}
+              >
+                {s.label} · {s.members}
+              </span>
+            ))}
+            <Badge variant="outline">{unitsCount} unidades</Badge>
+          </div>
+        </div>
+
+        <div className="flex flex-col items-stretch gap-2 sm:flex-row md:flex-col md:items-end">
+          <div className="flex gap-2">
+            <Button variant="outline" size="sm" asChild>
+              <Link href="/dashboard/clubs">
+                <ArrowLeft className="size-3.5" /> Volver
+              </Link>
+            </Button>
+            <Button variant="outline" size="icon-sm" aria-label="Más acciones">
+              <MoreHorizontal className="size-4" />
+            </Button>
+          </div>
+          <div className="flex gap-2">
+            {onDelete && (
+              <Button variant="destructive" size="sm" onClick={onDelete}>
+                Eliminar
+              </Button>
+            )}
+            {onEdit && (
+              <Button size="sm" onClick={onEdit}>
+                <Edit3 className="size-3.5" /> Editar club
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/clubs/detail/info-panel.tsx
+++ b/src/components/clubs/detail/info-panel.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { Edit3, MapPin } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  getClubCode,
+  getClubCoordinates,
+  getClubLocations,
+  getTotalCapacity,
+  getTotalMembers,
+  pctOf,
+} from "./helpers";
+import type { ClubFull, SectionView } from "./types";
+
+interface ClubInfoPanelProps {
+  club: ClubFull;
+  sections: SectionView[];
+  onEdit?: () => void;
+}
+
+export function ClubInfoPanel({ club, sections, onEdit }: ClubInfoPanelProps) {
+  const code = getClubCode(club);
+  const coords = getClubCoordinates(club);
+  const { localField, district, church } = getClubLocations(club);
+  const members = getTotalMembers(sections);
+  const capacity = getTotalCapacity(sections);
+  const occupancy = pctOf(members, capacity);
+  const address = club.address ?? null;
+
+  return (
+    <section className="rounded-2xl border bg-card p-5 shadow-sm">
+      <header className="mb-4 flex flex-wrap items-start justify-between gap-2">
+        <div>
+          <h3 className="text-sm font-bold text-foreground">
+            Información general &amp; ubicación
+          </h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            Datos editables · alcance geográfico
+          </p>
+        </div>
+        {onEdit && (
+          <Button variant="outline" size="sm" onClick={onEdit}>
+            <Edit3 className="size-3.5" /> Editar
+          </Button>
+        )}
+      </header>
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        <Block label="Identidad">
+          <div className="text-sm font-semibold text-foreground">
+            {club.name ?? "—"}
+          </div>
+          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+            {club.description ?? "Sin descripción"}
+          </div>
+          <div className="mt-1 font-mono text-[11px] text-muted-foreground">
+            {code}
+          </div>
+        </Block>
+
+        <Block label="Ubicación pastoral">
+          <div className="text-sm text-foreground">{localField ?? "—"}</div>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {district ?? "Distrito sin definir"}
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {church ?? "Iglesia sin definir"}
+          </div>
+        </Block>
+
+        <Block label="Dirección">
+          <div className="text-sm text-foreground">
+            {address ?? "Dirección sin registrar"}
+          </div>
+          {coords && (
+            <div className="mt-1 font-mono text-[11px] text-muted-foreground">
+              {coords.lat.toFixed(4)}, {coords.lng.toFixed(4)}
+            </div>
+          )}
+        </Block>
+
+        <Block label="Capacidad">
+          <div className="text-lg font-extrabold tracking-tight text-foreground">
+            {members}
+            {capacity != null ? (
+              <span className="ml-1 text-sm font-medium text-muted-foreground">
+                / {capacity}
+              </span>
+            ) : null}
+          </div>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            {capacity != null
+              ? `${occupancy}% del cupo objetivo`
+              : "Sin meta de almas definida"}
+          </div>
+          {capacity != null && (
+            <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-gradient-to-r from-primary to-warning"
+                style={{ width: `${occupancy}%` }}
+              />
+            </div>
+          )}
+        </Block>
+      </div>
+
+      {(coords || address) && (
+        <div className="mt-6 overflow-hidden rounded-2xl border">
+          <MapPlaceholder
+            label={church ?? club.name ?? "Sede"}
+            address={address}
+          />
+          {coords && (
+            <a
+              className="flex items-center justify-center gap-1.5 border-t bg-muted/30 py-2 text-xs font-semibold text-foreground transition-colors hover:bg-muted"
+              href={`https://www.google.com/maps?q=${coords.lat},${coords.lng}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <MapPin className="size-3.5" /> Ver en Google Maps
+            </a>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Block({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <div className="mb-1.5 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+        {label}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function MapPlaceholder({
+  label,
+  address,
+}: {
+  label: string;
+  address: string | null;
+}) {
+  return (
+    <div className="relative h-44 bg-gradient-to-b from-muted to-muted/50">
+      <div
+        aria-hidden
+        className="absolute inset-0 opacity-40 [background-image:linear-gradient(var(--color-border)_1px,transparent_1px),linear-gradient(90deg,var(--color-border)_1px,transparent_1px)] [background-size:32px_32px]"
+      />
+      <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-full">
+        <div className="mx-auto size-4 rounded-full border-[3px] border-card bg-primary shadow-lg shadow-primary/30" />
+        <div className="mx-auto h-3 w-0.5 bg-primary" />
+      </div>
+      <div className="absolute bottom-3 left-3 max-w-xs rounded-lg border bg-card px-2.5 py-2 text-xs shadow-md">
+        <b className="block">{label}</b>
+        {address && (
+          <span className="block text-muted-foreground">{address}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/clubs/detail/overview-tab.tsx
+++ b/src/components/clubs/detail/overview-tab.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import { Activity, BarChart3, History, TrendingUp, Trophy } from "lucide-react";
+import type { Unit } from "@/lib/api/units";
+import { CompositionDonut } from "./composition-donut";
+import { UnitRanking } from "./unit-ranking";
+import { getTotalMembers } from "./helpers";
+import type { ClubSectionRaw, SectionView } from "./types";
+
+interface OverviewTabProps {
+  sections: SectionView[];
+  units: Unit[];
+  sectionLookup: Map<number, ClubSectionRaw>;
+  pendingRequests?: number | null;
+}
+
+export function ClubOverviewTab({
+  sections,
+  units,
+  sectionLookup,
+  pendingRequests,
+}: OverviewTabProps) {
+  const total = getTotalMembers(sections);
+
+  return (
+    <div className="grid grid-cols-1 gap-3 lg:grid-cols-12">
+      <PanelCard
+        className="lg:col-span-7"
+        title="Composición del club"
+        subtitle="Distribución de miembros entre las tres secciones"
+        right={
+          <span className="text-[11px] text-muted-foreground">
+            Total · {total}
+          </span>
+        }
+      >
+        <CompositionDonut sections={sections} total={total} />
+      </PanelCard>
+
+      <PanelCard
+        className="lg:col-span-5"
+        title="Salud del club"
+        subtitle="Score compuesto (próximamente)"
+      >
+        <HealthPlaceholder sections={sections} pending={pendingRequests} />
+      </PanelCard>
+
+      <PanelCard
+        className="lg:col-span-7"
+        title="Ranking de unidades"
+        subtitle="Por tamaño · todas las secciones"
+        right={
+          <span className="text-[11px] text-muted-foreground">
+            {units.length} unidades
+          </span>
+        }
+      >
+        <UnitRanking units={units} sectionLookup={sectionLookup} limit={8} />
+      </PanelCard>
+
+      <PanelCard
+        className="lg:col-span-5"
+        title="Asistencia mensual"
+        subtitle="Últimos 12 sábados"
+      >
+        <Placeholder
+          icon={<TrendingUp className="size-5" />}
+          title="Sin agregación disponible"
+          description="Conectar `weekly-records` para mostrar tendencias de asistencia."
+        />
+      </PanelCard>
+    </div>
+  );
+}
+
+function PanelCard({
+  className = "",
+  title,
+  subtitle,
+  right,
+  children,
+}: {
+  className?: string;
+  title: string;
+  subtitle?: string;
+  right?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className={`rounded-2xl border bg-card p-5 shadow-sm ${className}`}>
+      <header className="mb-4 flex items-start justify-between">
+        <div>
+          <h3 className="text-sm font-bold text-foreground">{title}</h3>
+          {subtitle && (
+            <p className="mt-0.5 text-[11px] text-muted-foreground">{subtitle}</p>
+          )}
+        </div>
+        {right}
+      </header>
+      {children}
+    </section>
+  );
+}
+
+function HealthPlaceholder({
+  sections,
+  pending,
+}: {
+  sections: SectionView[];
+  pending?: number | null;
+}) {
+  const activeSections = sections.filter((s) => s.active).length;
+  return (
+    <div className="grid grid-cols-[100px_1fr] items-center gap-4">
+      <div className="relative grid h-24 w-24 place-items-center rounded-full border-[10px] border-muted text-center">
+        <div>
+          <div className="text-2xl font-extrabold leading-none tracking-tight text-foreground">
+            —
+          </div>
+          <div className="mt-1 text-[9px] font-bold uppercase tracking-widest text-muted-foreground">
+            Salud
+          </div>
+        </div>
+      </div>
+      <div className="space-y-2 text-xs text-muted-foreground">
+        <p className="text-foreground">
+          Aún no hay un score consolidado. Mientras tanto, estos son los
+          indicadores duros del club:
+        </p>
+        <ul className="grid gap-1.5">
+          <Row
+            icon={<Activity className="size-3.5" />}
+            label={`${activeSections} de ${sections.length || 3} secciones activas`}
+          />
+          <Row
+            icon={<Trophy className="size-3.5" />}
+            label={
+              pending == null
+                ? "Sin lectura de solicitudes pendientes"
+                : `${pending} solicitudes pendientes`
+            }
+          />
+          <Row
+            icon={<BarChart3 className="size-3.5" />}
+            label="Pendiente: definir cálculo de score 360°"
+          />
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function Row({ icon, label }: { icon: React.ReactNode; label: string }) {
+  return (
+    <li className="flex items-center gap-2 text-xs text-foreground">
+      <span className="grid size-5 place-items-center rounded-md bg-muted text-muted-foreground">
+        {icon}
+      </span>
+      {label}
+    </li>
+  );
+}
+
+function Placeholder({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-4 py-8 text-center">
+      <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
+        {icon}
+      </span>
+      <p className="text-sm font-semibold text-foreground">{title}</p>
+      <p className="max-w-xs text-xs text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+export function ClubHistoryPlaceholder() {
+  return (
+    <section className="rounded-2xl border bg-card p-5 shadow-sm">
+      <header className="mb-4">
+        <h3 className="text-sm font-bold text-foreground">Historial del club</h3>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">
+          Eventos importantes desde la creación
+        </p>
+      </header>
+      <Placeholder
+        icon={<History className="size-5" />}
+        title="Aún sin línea de tiempo"
+        description="El backend todavía no expone eventos de auditoría (creación, cambios de director, investiduras). Cuando se publique, se renderizará aquí."
+      />
+    </section>
+  );
+}

--- a/src/components/clubs/detail/right-sidebar.tsx
+++ b/src/components/clubs/detail/right-sidebar.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import Link from "next/link";
+import {
+  Award,
+  CalendarPlus,
+  ClipboardList,
+  Edit3,
+  Layers,
+  Plus,
+  Trash2,
+  Users,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+interface RightSidebarProps {
+  clubId: number;
+  pendingRequests?: number | null;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}
+
+export function ClubRightSidebar({
+  clubId,
+  pendingRequests,
+  onEdit,
+  onDelete,
+}: RightSidebarProps) {
+  return (
+    <aside className="grid gap-3">
+      <ActionsCard
+        clubId={clubId}
+        pending={pendingRequests}
+        onEdit={onEdit}
+        onDelete={onDelete}
+      />
+      <UpcomingEventsCard />
+    </aside>
+  );
+}
+
+function CardShell({
+  title,
+  hint,
+  children,
+}: {
+  title: string;
+  hint?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="rounded-2xl border bg-card p-5 shadow-sm">
+      <h3 className="mb-3.5 flex items-center justify-between text-sm font-semibold text-foreground">
+        {title}
+        {hint && (
+          <span className="text-[11px] font-medium text-muted-foreground">
+            {hint}
+          </span>
+        )}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function ActionsCard({
+  clubId,
+  pending,
+  onEdit,
+  onDelete,
+}: {
+  clubId: number;
+  pending?: number | null;
+  onEdit?: () => void;
+  onDelete?: () => void;
+}) {
+  return (
+    <CardShell title="Acciones rápidas">
+      <div className="grid gap-1">
+        <ActionRow icon={<Edit3 className="size-3.5" />} label="Editar club" onClick={onEdit} />
+        <ActionRow
+          icon={<Plus className="size-3.5" />}
+          label="Crear unidad"
+          href={`/dashboard/clubs/${clubId}/units/new`}
+        />
+        <ActionRow
+          icon={<Users className="size-3.5" />}
+          label={
+            pending != null
+              ? `Aprobar solicitudes (${pending})`
+              : "Revisar solicitudes"
+          }
+        />
+        <ActionRow
+          icon={<Layers className="size-3.5" />}
+          label="Configurar secciones"
+        />
+        <ActionRow
+          icon={<Award className="size-3.5" />}
+          label="Ceremonia de investidura"
+          disabled
+        />
+        <div className="my-1.5 h-px bg-border" />
+        <ActionRow
+          icon={<Trash2 className="size-3.5" />}
+          label="Eliminar club"
+          danger
+          onClick={onDelete}
+        />
+      </div>
+    </CardShell>
+  );
+}
+
+function ActionRow({
+  icon,
+  label,
+  danger,
+  onClick,
+  href,
+  disabled,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  danger?: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  href?: string;
+}) {
+  const inner = (
+    <span
+      className={cn(
+        "grid grid-cols-[28px_1fr] items-center gap-2.5 rounded-lg border border-transparent px-2.5 py-2 text-left text-sm transition-colors",
+        disabled
+          ? "cursor-not-allowed text-muted-foreground/60"
+          : danger
+            ? "text-destructive hover:border-destructive/30 hover:bg-destructive/5"
+            : "text-foreground hover:border-border hover:bg-muted/60",
+      )}
+    >
+      <span
+        className={cn(
+          "grid size-7 place-items-center rounded-md",
+          danger
+            ? "bg-destructive/10 text-destructive"
+            : "bg-muted text-muted-foreground",
+        )}
+      >
+        {icon}
+      </span>
+      <span>{label}</span>
+    </span>
+  );
+
+  if (href && !disabled) {
+    return (
+      <Link href={href} className="block">
+        {inner}
+      </Link>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="block text-left"
+    >
+      {inner}
+    </button>
+  );
+}
+
+function UpcomingEventsCard() {
+  return (
+    <CardShell title="Próximos eventos" hint="—">
+      <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-3 py-6 text-center">
+        <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
+          <CalendarPlus className="size-5" />
+        </span>
+        <p className="text-sm font-semibold text-foreground">Sin agenda visible</p>
+        <p className="max-w-[200px] text-xs text-muted-foreground">
+          Conectar `activities` para listar próximos compromisos del club.
+        </p>
+        <Button size="xs" variant="outline" disabled>
+          Programar evento
+        </Button>
+      </div>
+    </CardShell>
+  );
+}
+
+interface LeadershipPlaceholderProps {
+  totalSections: number;
+}
+
+export function LeadershipPlaceholder({
+  totalSections,
+}: LeadershipPlaceholderProps) {
+  return (
+    <CardShell
+      title="Liderazgo"
+      hint={
+        <span className="text-[11px] text-muted-foreground">
+          {totalSections > 0 ? `${totalSections} secciones` : "—"}
+        </span>
+      }
+    >
+      <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-3 py-6 text-center">
+        <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
+          <ClipboardList className="size-5" />
+        </span>
+        <p className="text-sm font-semibold text-foreground">
+          Director y staff por enlazar
+        </p>
+        <p className="max-w-[220px] text-xs text-muted-foreground">
+          Vinculación con `club_role_assignments` pendiente. Aquí mostraremos
+          director, deputy y secretarios cuando esté disponible.
+        </p>
+      </div>
+    </CardShell>
+  );
+}

--- a/src/components/clubs/detail/stats.tsx
+++ b/src/components/clubs/detail/stats.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Award, ClipboardList, Layers, Users } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  getTotalCapacity,
+  getTotalMembers,
+  pctOf,
+} from "./helpers";
+import type { SectionView } from "./types";
+
+interface StatsProps {
+  sections: SectionView[];
+  unitsCount: number;
+  pendingRequests?: number | null;
+}
+
+export function ClubDetailStats({
+  sections,
+  unitsCount,
+  pendingRequests,
+}: StatsProps) {
+  const members = getTotalMembers(sections);
+  const capacity = getTotalCapacity(sections);
+  const occupancyPct = pctOf(members, capacity);
+  const activeSections = sections.filter((s) => s.active).length;
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+      <StatCard
+        icon={<Users className="size-3 " />}
+        label="Miembros"
+      >
+        <div className="text-2xl font-bold tracking-tight text-foreground">
+          {members}
+          {capacity != null && (
+            <span className="ml-1 text-sm font-medium text-muted-foreground">
+              / {capacity}
+            </span>
+          )}
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {capacity != null
+            ? `${occupancyPct}% del cupo objetivo`
+            : "Sin meta de cupo definida"}
+        </p>
+        {capacity != null && (
+          <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-primary to-warning"
+              style={{ width: `${occupancyPct}%` }}
+            />
+          </div>
+        )}
+      </StatCard>
+
+      <StatCard
+        icon={<Layers className="size-3" />}
+        label="Secciones activas"
+      >
+        <div className="text-2xl font-bold tracking-tight text-foreground">
+          {activeSections}
+          <span className="ml-1 text-sm font-medium text-muted-foreground">
+            / {sections.length || 3}
+          </span>
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {activeSections === 3
+            ? "Las tres secciones operando"
+            : `${3 - activeSections} sin activar`}
+        </p>
+        <div className="mt-3 flex gap-1">
+          {sections.map((s) => (
+            <span
+              key={s.kind + (s.sectionId ?? "")}
+              className={cn(
+                "h-1.5 flex-1 rounded-sm",
+                s.active ? s.meta.barBg : "bg-muted",
+              )}
+              title={`${s.label} · ${s.active ? "activa" : "inactiva"}`}
+            />
+          ))}
+        </div>
+      </StatCard>
+
+      <StatCard
+        icon={<Award className="size-3" />}
+        label="Unidades"
+      >
+        <div className="text-2xl font-bold tracking-tight text-foreground">
+          {unitsCount}
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {unitsCount === 0
+            ? "Aún sin unidades creadas"
+            : `Promedio ${Math.round(members / Math.max(1, unitsCount))} miembros/unidad`}
+        </p>
+      </StatCard>
+
+      <StatCard
+        icon={<ClipboardList className="size-3" />}
+        label="Solicitudes pendientes"
+      >
+        <div className="text-2xl font-bold tracking-tight text-foreground">
+          {pendingRequests ?? "—"}
+        </div>
+        <p className="mt-0.5 text-xs text-muted-foreground">
+          {pendingRequests == null
+            ? "Sin datos cargados"
+            : pendingRequests === 0
+              ? "Bandeja al día"
+              : "Esperan revisión del coordinador"}
+        </p>
+      </StatCard>
+    </div>
+  );
+}
+
+function StatCard({
+  icon,
+  label,
+  children,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-2xl border bg-card p-4 shadow-sm">
+      <div className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-1.5">{children}</div>
+    </div>
+  );
+}

--- a/src/components/clubs/detail/tab-utils.ts
+++ b/src/components/clubs/detail/tab-utils.ts
@@ -1,0 +1,21 @@
+import type { ClubTabId } from "./tabs-nav";
+
+export type { ClubTabId };
+
+const TAB_KEYS: ClubTabId[] = [
+  "overview",
+  "sections",
+  "units",
+  "membership",
+  "info",
+  "history",
+  "edit",
+];
+
+export function resolveTabFromString(raw: string | undefined): ClubTabId {
+  if (raw && (TAB_KEYS as string[]).includes(raw)) {
+    return raw as ClubTabId;
+  }
+  if (raw === "view") return "overview";
+  return "overview";
+}

--- a/src/components/clubs/detail/tabs-nav.tsx
+++ b/src/components/clubs/detail/tabs-nav.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+export type ClubTabId =
+  | "overview"
+  | "sections"
+  | "units"
+  | "membership"
+  | "info"
+  | "history"
+  | "edit";
+
+export interface ClubTabDef {
+  id: ClubTabId;
+  label: string;
+  count?: number | null;
+}
+
+interface TabsNavProps {
+  tabs: ClubTabDef[];
+  value: ClubTabId;
+  onChange: (id: ClubTabId) => void;
+  className?: string;
+}
+
+export function ClubTabsNav({ tabs, value, onChange, className }: TabsNavProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Secciones del detalle del club"
+      className={cn(
+        "inline-flex flex-wrap gap-1 rounded-xl border border-border bg-muted p-1",
+        className,
+      )}
+    >
+      {tabs.map((tab) => {
+        const active = tab.id === value;
+        return (
+          <button
+            key={tab.id}
+            role="tab"
+            type="button"
+            aria-selected={active}
+            onClick={() => onChange(tab.id)}
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-semibold transition-colors",
+              active
+                ? "bg-card text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {tab.label}
+            {tab.count != null && (
+              <span
+                className={cn(
+                  "rounded-full px-1.5 py-0.5 text-[10px] font-semibold",
+                  active
+                    ? "bg-primary/10 text-primary"
+                    : "bg-background text-muted-foreground",
+                )}
+              >
+                {tab.count}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/clubs/detail/types.ts
+++ b/src/components/clubs/detail/types.ts
@@ -1,0 +1,155 @@
+import type { Unit } from "@/lib/api/units";
+
+export type ClubSectionRaw = {
+  club_section_id?: number;
+  club_type_id?: number;
+  club_type?: { name?: string } | null;
+  name?: string | null;
+  active?: boolean;
+  souls_target?: number | null;
+  fee?: number | null;
+  members_count?: number;
+};
+
+export type ClubLocationRef = { name?: string | null } | null | undefined;
+
+export type ClubFull = {
+  club_id?: number;
+  id?: number;
+  name?: string | null;
+  description?: string | null;
+  active?: boolean;
+  local_field_id?: number;
+  district_id?: number;
+  church_id?: number;
+  address?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  coordinates?: { lat?: number; lng?: number } | null;
+  created_at?: string | null;
+  modified_at?: string | null;
+  local_fields?: ClubLocationRef;
+  districts?: ClubLocationRef;
+  churches?: ClubLocationRef;
+  local_field?: ClubLocationRef;
+  district?: ClubLocationRef;
+  church?: ClubLocationRef;
+  club_sections?: ClubSectionRaw[];
+  sections?: ClubSectionRaw[];
+};
+
+export type SectionKind =
+  | "adventurers"
+  | "pathfinders"
+  | "master_guilds"
+  | "unknown";
+
+export type SectionTone = "rose" | "primary" | "warning" | "muted";
+
+export interface SectionMetaEntry {
+  kind: SectionKind;
+  label: string;
+  range: string;
+  tone: SectionTone;
+  swatch: string;
+  pill: string;
+  iconBg: string;
+  barBg: string;
+  donutHex: string;
+}
+
+const SECTION_META_BY_KIND: Record<SectionKind, SectionMetaEntry> = {
+  adventurers: {
+    kind: "adventurers",
+    label: "Aventureros",
+    range: "6–9 años",
+    tone: "rose",
+    swatch: "bg-rose-500/15 text-rose-700 dark:text-rose-300",
+    pill: "bg-rose-500/10 text-rose-700 dark:text-rose-300 border-rose-500/20",
+    iconBg: "bg-rose-500 text-white",
+    barBg: "bg-rose-500",
+    donutHex: "var(--rose-donut, #f43f5e)",
+  },
+  pathfinders: {
+    kind: "pathfinders",
+    label: "Conquistadores",
+    range: "10–15 años",
+    tone: "primary",
+    swatch: "bg-primary/15 text-primary",
+    pill: "bg-primary/10 text-primary border-primary/20",
+    iconBg: "bg-primary text-primary-foreground",
+    barBg: "bg-primary",
+    donutHex: "var(--color-primary)",
+  },
+  master_guilds: {
+    kind: "master_guilds",
+    label: "Guías Mayores",
+    range: "16+ años",
+    tone: "warning",
+    swatch: "bg-warning/20 text-warning-foreground",
+    pill: "bg-warning/15 text-warning-foreground border-warning/30",
+    iconBg: "bg-warning text-warning-foreground",
+    barBg: "bg-warning",
+    donutHex: "var(--color-warning)",
+  },
+  unknown: {
+    kind: "unknown",
+    label: "Sección",
+    range: "—",
+    tone: "muted",
+    swatch: "bg-muted text-muted-foreground",
+    pill: "bg-muted text-muted-foreground border-border",
+    iconBg: "bg-muted text-muted-foreground",
+    barBg: "bg-muted-foreground/40",
+    donutHex: "var(--color-muted-foreground)",
+  },
+};
+
+function normalizeName(raw: string): string {
+  return raw
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "");
+}
+
+export function detectSectionKind(
+  section: Pick<ClubSectionRaw, "club_type" | "name" | "club_type_id">,
+): SectionKind {
+  const candidates: string[] = [];
+  if (section.club_type?.name) candidates.push(section.club_type.name);
+  if (section.name) candidates.push(section.name);
+
+  for (const raw of candidates) {
+    const slug = normalizeName(raw);
+    if (slug.includes("aventur") || slug.includes("adventur"))
+      return "adventurers";
+    if (slug.includes("conquist") || slug.includes("pathfind"))
+      return "pathfinders";
+    if (
+      slug.includes("guia") ||
+      slug.includes("guías") ||
+      slug.includes("master") ||
+      slug.includes("guild")
+    )
+      return "master_guilds";
+  }
+  return "unknown";
+}
+
+export function getSectionMeta(kind: SectionKind): SectionMetaEntry {
+  return SECTION_META_BY_KIND[kind];
+}
+
+export interface SectionView {
+  raw: ClubSectionRaw;
+  kind: SectionKind;
+  meta: SectionMetaEntry;
+  sectionId: number | null;
+  label: string;
+  range: string;
+  active: boolean;
+  members: number;
+  units: Unit[];
+  unitsCount: number;
+  capacity: number | null;
+}

--- a/src/components/clubs/detail/unit-ranking.tsx
+++ b/src/components/clubs/detail/unit-ranking.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { Unit } from "@/lib/api/units";
+import {
+  countUnitMembers,
+  getUnitLeaderInitials,
+  getUnitLeaderName,
+} from "./helpers";
+import {
+  detectSectionKind,
+  getSectionMeta,
+  type ClubSectionRaw,
+} from "./types";
+
+interface UnitRankingProps {
+  units: Unit[];
+  sectionLookup: Map<number, ClubSectionRaw>;
+  limit?: number;
+}
+
+export function UnitRanking({
+  units,
+  sectionLookup,
+  limit,
+}: UnitRankingProps) {
+  if (units.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Aún no hay unidades para rankear. Crea la primera para ver este panel
+        poblarse.
+      </p>
+    );
+  }
+
+  const ranked = [...units]
+    .map((unit) => {
+      const sectionRaw =
+        unit.club_section_id != null
+          ? sectionLookup.get(unit.club_section_id)
+          : undefined;
+      const kind = sectionRaw
+        ? detectSectionKind(sectionRaw)
+        : "unknown";
+      const meta = getSectionMeta(kind);
+      const members = countUnitMembers(unit);
+      return { unit, kind, meta, members };
+    })
+    .sort((a, b) => b.members - a.members);
+
+  const top = limit ? ranked.slice(0, limit) : ranked;
+  const maxMembers = Math.max(1, ...top.map((r) => r.members));
+
+  return (
+    <ul className="grid gap-1.5">
+      {top.map((row, idx) => {
+        const pct = (row.members / maxMembers) * 100;
+        return (
+          <li
+            key={row.unit.unit_id}
+            className="grid grid-cols-[28px_1fr_auto] items-center gap-3 rounded-lg bg-muted/40 px-3 py-2 transition-colors hover:bg-muted"
+          >
+            <span className="font-mono text-xs font-bold text-muted-foreground">
+              #{String(idx + 1).padStart(2, "0")}
+            </span>
+            <div className="flex min-w-0 items-center gap-2.5">
+              <div
+                className={cn(
+                  "grid size-7 place-items-center rounded-md text-[10px] font-bold",
+                  row.meta.iconBg,
+                )}
+              >
+                {getUnitLeaderInitials(row.unit)}
+              </div>
+              <div className="min-w-0">
+                <div className="flex items-center gap-1.5 truncate text-sm font-semibold text-foreground">
+                  <span className="truncate">{row.unit.name}</span>
+                  <span
+                    className={cn(
+                      "rounded px-1.5 text-[9.5px] font-semibold uppercase tracking-wider",
+                      row.meta.pill,
+                    )}
+                  >
+                    {row.meta.label.slice(0, 4)}
+                  </span>
+                </div>
+                <div className="truncate text-xs text-muted-foreground">
+                  Líder · {getUnitLeaderName(row.unit)}
+                </div>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="h-1.5 w-12 overflow-hidden rounded-full bg-muted">
+                <div
+                  className={cn("h-full rounded-full", row.meta.barBg)}
+                  style={{ width: `${pct}%` }}
+                />
+              </div>
+              <span className="w-6 text-right text-sm font-bold text-foreground tabular-nums">
+                {row.members}
+              </span>
+            </div>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/src/components/clubs/detail/view.tsx
+++ b/src/components/clubs/detail/view.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EditClubForm } from "@/components/clubs/edit-club-form";
+import { ClubSectionsPanel } from "@/components/clubs/club-sections-panel";
+import { PendingMembersPanel } from "@/components/membership/pending-members-panel";
+import { UnitsTab } from "@/components/units/units-tab";
+import { listUnits } from "@/lib/api/units";
+import type { ClubActionState } from "@/lib/clubs/actions";
+import { ClubDetailHero } from "./hero";
+import { ClubDetailStats } from "./stats";
+import { ClubTabsNav } from "./tabs-nav";
+import type { ClubTabId } from "./tab-utils";
+import {
+  ClubHistoryPlaceholder,
+  ClubOverviewTab,
+} from "./overview-tab";
+import { ClubInfoPanel } from "./info-panel";
+import {
+  ClubRightSidebar,
+  LeadershipPlaceholder,
+} from "./right-sidebar";
+import { buildSectionViews, getActiveUnits } from "./helpers";
+import type { ClubFull, ClubSectionRaw } from "./types";
+
+interface SelectOption {
+  label: string;
+  value: number;
+}
+
+interface ClubDetailViewProps {
+  club: ClubFull;
+  clubId: number;
+  defaultTab: ClubTabId;
+  localFieldOptions: SelectOption[];
+  districtOptions: SelectOption[];
+  churchOptions: SelectOption[];
+  updateAction: (
+    prevState: ClubActionState,
+    formData: FormData,
+  ) => Promise<ClubActionState>;
+  deleteAction: (formData: FormData) => Promise<unknown> | void;
+}
+
+export function ClubDetailView({
+  club,
+  clubId,
+  defaultTab,
+  localFieldOptions,
+  districtOptions,
+  churchOptions,
+  updateAction,
+  deleteAction,
+}: ClubDetailViewProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [tab, setTab] = useState<ClubTabId>(defaultTab);
+
+  const { data: units = [] } = useQuery({
+    queryKey: ["club-detail-units", clubId],
+    queryFn: () => listUnits(clubId),
+    staleTime: 30_000,
+  });
+
+  const activeUnits = useMemo(() => getActiveUnits(units), [units]);
+  const sections = useMemo(() => buildSectionViews(club, activeUnits), [club, activeUnits]);
+  const sectionLookup = useMemo(() => {
+    const map = new Map<number, ClubSectionRaw>();
+    for (const s of sections) {
+      if (s.sectionId != null) map.set(s.sectionId, s.raw);
+    }
+    return map;
+  }, [sections]);
+
+  const rawSections = useMemo(
+    () =>
+      (club.club_sections ?? club.sections ?? []).map((s) => ({
+        ...s,
+        name: s.name ?? undefined,
+      })),
+    [club.club_sections, club.sections],
+  );
+
+  const editClubProps = useMemo(
+    () => ({
+      name: club.name ?? undefined,
+      description: club.description ?? undefined,
+      active: club.active,
+      local_field_id: club.local_field_id,
+      district_id: club.district_id,
+      church_id: club.church_id,
+      address: club.address ?? undefined,
+      latitude: club.latitude ?? undefined,
+      longitude: club.longitude ?? undefined,
+      coordinates: club.coordinates ?? undefined,
+    }),
+    [club],
+  );
+
+  const tabs = useMemo(
+    () => [
+      { id: "overview" as const, label: "Resumen" },
+      { id: "sections" as const, label: "Secciones", count: sections.length },
+      { id: "units" as const, label: "Unidades", count: activeUnits.length },
+      { id: "membership" as const, label: "Solicitudes" },
+      { id: "info" as const, label: "Información" },
+      { id: "history" as const, label: "Historial" },
+      { id: "edit" as const, label: "Editar" },
+    ],
+    [sections.length, activeUnits.length],
+  );
+
+  function setActiveTab(next: ClubTabId) {
+    setTab(next);
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(searchParams?.toString() ?? "");
+    params.set("tab", next);
+    router.replace(`?${params.toString()}`, { scroll: false });
+  }
+
+  function handleDelete() {
+    if (typeof window === "undefined") return;
+    if (
+      !window.confirm(
+        "¿Eliminar este club? Esta acción lo desactivará en el sistema.",
+      )
+    ) {
+      return;
+    }
+    const data = new FormData();
+    data.set("id", String(clubId));
+    void deleteAction(data);
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="space-y-1">
+        <p className="text-[11px] font-semibold uppercase tracking-widest text-primary">
+          Detalle de club
+        </p>
+        <h2 className="text-2xl font-semibold leading-tight tracking-tight text-foreground">
+          Operación completa del club
+        </h2>
+      </div>
+
+      <ClubDetailHero
+        club={club}
+        sections={sections}
+        unitsCount={activeUnits.length}
+        onEdit={() => setActiveTab("edit")}
+        onDelete={handleDelete}
+      />
+
+      <ClubDetailStats
+        sections={sections}
+        unitsCount={activeUnits.length}
+        pendingRequests={null}
+      />
+
+      <ClubTabsNav tabs={tabs} value={tab} onChange={setActiveTab} />
+
+      <div className="grid grid-cols-1 gap-5 lg:grid-cols-[minmax(0,1fr)_320px]">
+        <div className="min-w-0 space-y-5">
+          {tab === "overview" && (
+            <ClubOverviewTab
+              sections={sections}
+              units={activeUnits}
+              sectionLookup={sectionLookup}
+              pendingRequests={null}
+            />
+          )}
+
+          {tab === "sections" && (
+            <section className="rounded-2xl border bg-card p-5 shadow-sm">
+              <header className="mb-4">
+                <h3 className="text-sm font-bold text-foreground">
+                  Secciones del club
+                </h3>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Tres rangos por edad — cada uno con sus propias unidades.
+                </p>
+              </header>
+              <ClubSectionsPanel clubId={clubId} sections={rawSections} />
+            </section>
+          )}
+
+          {tab === "units" && (
+            <section className="rounded-2xl border bg-card p-5 shadow-sm">
+              <UnitsTab
+                clubId={clubId}
+                localFieldId={club.local_field_id ?? null}
+              />
+            </section>
+          )}
+
+          {tab === "membership" && (
+            <section className="rounded-2xl border bg-card p-5 shadow-sm">
+              <header className="mb-4">
+                <h3 className="text-sm font-bold text-foreground">
+                  Solicitudes de membresía
+                </h3>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Aprueba o rechaza nuevos miembros por sección.
+                </p>
+              </header>
+              <PendingMembersPanel sections={rawSections} />
+            </section>
+          )}
+
+          {tab === "info" && (
+            <ClubInfoPanel
+              club={club}
+              sections={sections}
+              onEdit={() => setActiveTab("edit")}
+            />
+          )}
+
+          {tab === "history" && <ClubHistoryPlaceholder />}
+
+          {tab === "edit" && (
+            <section className="rounded-2xl border bg-card p-5 shadow-sm">
+              <header className="mb-4">
+                <h3 className="text-sm font-bold text-foreground">
+                  Editar información del club
+                </h3>
+                <p className="mt-0.5 text-xs text-muted-foreground">
+                  Actualiza la identidad, ubicación y datos generales.
+                </p>
+              </header>
+              <EditClubForm
+                club={editClubProps}
+                localFields={localFieldOptions}
+                districts={districtOptions}
+                churches={churchOptions}
+                formAction={updateAction}
+              />
+            </section>
+          )}
+        </div>
+
+        <ClubRightSidebar
+          clubId={clubId}
+          pendingRequests={null}
+          onEdit={() => setActiveTab("edit")}
+          onDelete={handleDelete}
+        />
+      </div>
+
+      <LeadershipPlaceholder totalSections={sections.length} />
+    </div>
+  );
+}
+
+export function ClubDetailLoadingSkeleton() {
+  return (
+    <div className="space-y-5">
+      <Skeleton className="h-7 w-48" />
+      <Skeleton className="h-32 w-full rounded-2xl" />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-24 rounded-2xl" />
+        ))}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- Rebuild `/dashboard/clubs/[id]` per new mock: hero with gradient avatar + section pills, 4-stat row, pill tab nav (overview / sections / units / membership / info / history / edit).
- Overview tab uses real backend data: composition donut (members per section derived from `unit_members`) and unit ranking. Health, attendance, leadership, events and history are explicit placeholders for missing backend aggregations.
- Preserves existing flows untouched inside the new tabs: `EditClubForm`, `ClubSectionsPanel`, `UnitsTab`, `PendingMembersPanel`.
- Maps mock custom tokens (coral/mint/amber/rose) to shadcn semantic tokens (primary/success/warning/rose) per DESIGN-SYSTEM.md.
- Tab state synced to `?tab=` query param.
- List page: club name is now a link to detail; actions cell adds "Ver detalle" eye icon and mobile dropdown entry.

## Architecture notes
- New components live in `src/components/clubs/detail/`.
- `tab-utils.ts` (non-client) exposes `resolveTabFromString` so the server page can resolve the active tab without crossing the client boundary.
- `buildSectionViews` aggregates active units + members per section. `detectSectionKind` normalizes names (NFD + lowercase) to support both ES and EN club_type names.

## Test plan
- [ ] `pnpm tsc --noEmit` → clean (verified locally, exit 0).
- [ ] Navigate `/dashboard/clubs` → click club name → detail loads on `Resumen` tab.
- [ ] Use Eye icon in actions cell on desktop and "Ver detalle" entry on mobile dropdown.
- [ ] Switch between tabs; URL updates `?tab=` and survives reload.
- [ ] Hero pills reflect active state and per-section member counts; donut renders with real distribution.
- [ ] Edit tab still saves through the existing server action.
- [ ] Sections / Units / Solicitudes tabs still load their data via existing panels.
- [ ] Confirm placeholders ("Salud del club", "Asistencia mensual", "Historial del club", "Próximos eventos", "Liderazgo") render copy explaining missing backend pieces.