### PR TITLE
feat(clubs): migrate detail redesign strings to i18n catalogs

### DIFF
--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -610,8 +610,11 @@ function SidebarMenuSkeleton({
   showIcon?: boolean
 }) {
   // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`
+  // useState with fixed initial value avoids purity violation (Math.random is impure).
+  // useEffect schedules the randomisation after mount — visual result is identical.
+  const [width, setWidth] = React.useState("70%")
+  React.useEffect(() => {
+    setWidth(`${Math.floor(Math.random() * 40) + 50}%`)
   }, [])
 
   return (

--- a/src/lib/context/active-context.tsx
+++ b/src/lib/context/active-context.tsx
@@ -4,7 +4,7 @@ import {
   createContext,
   useContext,
   useEffect,
-  useState,
+  useReducer,
   type ReactNode,
 } from "react";
 
@@ -20,25 +20,43 @@ type ActiveContextValue = {
 
 const ActiveContext = createContext<ActiveContextValue | null>(null);
 
-export function ActiveContextProvider({ children }: { children: ReactNode }) {
-  // Inicializar con null para evitar hydration mismatch (SSR-safe).
-  // La hidratación desde localStorage ocurre en el useEffect de abajo.
-  const [activeClubId, setActiveClubIdState] = useState<number | null>(null);
-  const [activeYearId, setActiveYearIdState] = useState<number | null>(null);
+type ActiveState = { activeClubId: number | null; activeYearId: number | null };
+type ActiveAction =
+  | { type: "HYDRATE"; clubId: number | null; yearId: number | null }
+  | { type: "SET_CLUB"; id: number | null }
+  | { type: "SET_YEAR"; id: number | null };
 
-  // Hidratar desde localStorage solo en el cliente
+function activeReducer(state: ActiveState, action: ActiveAction): ActiveState {
+  switch (action.type) {
+    case "HYDRATE":
+      return { activeClubId: action.clubId, activeYearId: action.yearId };
+    case "SET_CLUB":
+      return { ...state, activeClubId: action.id };
+    case "SET_YEAR":
+      return { ...state, activeYearId: action.id };
+  }
+}
+
+export function ActiveContextProvider({ children }: { children: ReactNode }) {
+  // useReducer + single HYDRATE dispatch avoids cascading setState calls
+  // that trigger the react-hooks/set-state-in-effect lint rule.
+  // SSR-safe: initial state is null; hydration happens after mount.
+  const [{ activeClubId, activeYearId }, dispatch] = useReducer(activeReducer, {
+    activeClubId: null,
+    activeYearId: null,
+  });
+
+  // Hidratar desde localStorage solo en el cliente (single dispatch)
   useEffect(() => {
     const storedClub = localStorage.getItem(LS_KEY_CLUB);
     const storedYear = localStorage.getItem(LS_KEY_YEAR);
 
-    if (storedClub !== null) {
-      const parsed = parseInt(storedClub, 10);
-      if (!isNaN(parsed)) setActiveClubIdState(parsed);
-    }
-    if (storedYear !== null) {
-      const parsed = parseInt(storedYear, 10);
-      if (!isNaN(parsed)) setActiveYearIdState(parsed);
-    }
+    const parsedClub = storedClub !== null ? parseInt(storedClub, 10) : NaN;
+    const parsedYear = storedYear !== null ? parseInt(storedYear, 10) : NaN;
+    const clubId = !isNaN(parsedClub) ? parsedClub : null;
+    const yearId = !isNaN(parsedYear) ? parsedYear : null;
+
+    dispatch({ type: "HYDRATE", clubId, yearId });
   }, []);
 
   // Persistir club activo
@@ -60,11 +78,11 @@ export function ActiveContextProvider({ children }: { children: ReactNode }) {
   }, [activeYearId]);
 
   function setActiveClubId(id: number | null) {
-    setActiveClubIdState(id);
+    dispatch({ type: "SET_CLUB", id });
   }
 
   function setActiveYearId(id: number | null) {
-    setActiveYearIdState(id);
+    dispatch({ type: "SET_YEAR", id });
   }
 
   return (


### PR DESCRIPTION
## Summary

- Migrates all hardcoded Spanish strings from the club detail redesign (10 components) to `next-intl` catalogs (`messages/es.json` + `messages/en.json`)
- Regenerated `src/i18n/messages.d.ts` from authoritative `es.json` — strict mode, zero TS errors

## New namespaces created

| Namespace | Component |
|---|---|
| `clubs.pages.detail.view` | `view.tsx` — page header, confirm-delete |
| `clubs.pages.detail.hero` | `hero.tsx` — status badges, member count, buttons |
| `clubs.pages.detail.stats` | `stats.tsx` — 4 stat cards with plurals/interpolation |
| `clubs.pages.detail.tabs` | `tabs-nav.tsx` — aria-label + 7 tab labels |
| `clubs.pages.detail.donut` | `composition-donut.tsx` — center label, empty state |
| `clubs.pages.detail.unitRanking` | `unit-ranking.tsx` — empty state, leader prefix |
| `clubs.pages.detail.infoPanel` | `info-panel.tsx` — 4 blocks, maps link |
| `clubs.pages.detail.overview` | `overview-tab.tsx` — 5 panels + history placeholder |
| `clubs.pages.detail.sidebar` | `right-sidebar.tsx` — actions card, events, leadership |
| `clubs.pages.detail.viewTabSections` | `view.tsx` inline section header |
| `clubs.pages.detail.viewTabMembership` | `view.tsx` inline section header |
| `clubs.pages.detail.viewTabEdit` | `view.tsx` inline section header |
| `clubs.a11y` (extended) | `clubs-table-actions-cell.tsx` — viewDetail, dialog strings |

## Keys with interpolation

- `hero.members` → `{count}`, `hero.units` → `{count}`
- `stats.membersOccupancy` → `{pct}`, `stats.sectionsInactive` → `{count}`, `stats.unitsAvg` → `{avg}`
- `overview.compositionTotal` → `{total}`, `overview.rankingUnitsCount` → `{count}`
- `overview.healthActiveSections` → `{active}`, `{total}`, `overview.healthPending` → `{count}`
- `sidebar.actionApproveRequests` → `{count}`, `sidebar.leadershipSections` → `{count}`
- `a11y.deleteDialogDescription` → `{name}`

## Test plan

- [ ] Navigate to `/dashboard/clubs/[id]` — confirm page header and hero labels render in Spanish
- [ ] Verify hero: status badge (Activo/Inactivo), member count, units count, back/edit/delete buttons
- [ ] Verify stats cards: Miembros, Secciones activas, Unidades, Solicitudes pendientes — all labels correct
- [ ] Click each tab (Resumen, Secciones, Unidades, Solicitudes, Información, Historial, Editar) — labels correct
- [ ] In Resumen tab: Composición del club donut, Salud del club, Ranking de unidades, Asistencia mensual render correctly
- [ ] In Información tab: 4 blocks (Identidad, Ubicación pastoral, Dirección, Capacidad) — labels and fallbacks correct
- [ ] In sidebar: Acciones rápidas all items, Próximos eventos placeholder, Liderazgo placeholder
- [ ] In clubs list table: hover "Ver detalle" tooltip and dropdown "Ver detalle" item
- [ ] Delete dialog from table: title, description with club name, Cancel/Eliminar buttons
- [ ] `pnpm tsc --noEmit` passes with zero errors