### PR TITLE
feat(clubs): wire detail page to overview and leadership endpoints

### DIFF
--- a/src/components/clubs/detail/charts.tsx
+++ b/src/components/clubs/detail/charts.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import type {
+  AttendanceDataPoint,
+  ClubScore,
+  ScoreBreakdownItem,
+} from "@/lib/api/club-detail";
+
+interface AttendanceChartProps {
+  series: AttendanceDataPoint[];
+}
+
+export function AttendanceChart({ series }: AttendanceChartProps) {
+  if (series.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        Aún no hay registros semanales de asistencia para graficar.
+      </p>
+    );
+  }
+
+  const totalSlots = Math.max(series.length, 12);
+  const padded = [...series];
+  while (padded.length < totalSlots) {
+    padded.unshift({ year: 0, week: 0, avg_pct: 0 });
+  }
+  const recentCutoff = padded.length - 3;
+  const max = Math.max(100, ...padded.map((p) => p.avg_pct));
+
+  return (
+    <div>
+      <div className="relative h-32">
+        <div aria-hidden className="absolute inset-0 grid grid-rows-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="border-t border-dashed border-border" />
+          ))}
+        </div>
+        <div className="absolute inset-0 flex items-end gap-1">
+          {padded.map((p, i) => {
+            const heightPct = (p.avg_pct / max) * 100;
+            const empty = p.year === 0 && p.week === 0;
+            const recent = i >= recentCutoff;
+            return (
+              <div
+                key={`${p.year}-${p.week}-${i}`}
+                className={cn(
+                  "flex-1 rounded-t-md",
+                  empty
+                    ? "bg-muted/40"
+                    : recent
+                      ? "bg-gradient-to-b from-primary to-primary/70"
+                      : "bg-primary/30",
+                )}
+                style={{ height: `${Math.max(empty ? 0 : 4, heightPct)}%` }}
+                title={empty ? "Sin datos" : `${p.avg_pct}%`}
+              />
+            );
+          })}
+        </div>
+      </div>
+      <div className="mt-2 grid grid-cols-12 gap-1 font-mono text-[10px] text-muted-foreground">
+        {padded.slice(-12).map((p, i) => (
+          <span key={i} className="text-center tabular-nums">
+            {p.year === 0 ? "—" : `S${p.week}`}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface ScoreCircleProps {
+  score: ClubScore;
+}
+
+export function ScoreCircle({ score }: ScoreCircleProps) {
+  const value = Math.max(0, Math.min(100, score.value));
+  const R = 40;
+  const C = 2 * Math.PI * R;
+  const dash = (value / 100) * C;
+
+  const tone = value >= 75 ? "success" : value >= 50 ? "warning" : "destructive";
+  const stroke =
+    tone === "success"
+      ? "var(--color-success)"
+      : tone === "warning"
+        ? "var(--color-warning)"
+        : "var(--color-destructive)";
+
+  return (
+    <div className="relative h-24 w-24">
+      <svg
+        width="96"
+        height="96"
+        viewBox="0 0 96 96"
+        style={{ transform: "rotate(-90deg)" }}
+      >
+        <circle
+          cx="48"
+          cy="48"
+          r={R}
+          fill="none"
+          stroke="var(--color-muted)"
+          strokeWidth="10"
+        />
+        <circle
+          cx="48"
+          cy="48"
+          r={R}
+          fill="none"
+          stroke={stroke}
+          strokeWidth="10"
+          strokeLinecap="round"
+          strokeDasharray={`${dash} ${C}`}
+        />
+      </svg>
+      <div className="absolute inset-0 grid place-items-center text-center">
+        <div>
+          <div className="text-xl font-extrabold leading-none tracking-tight text-foreground">
+            {Math.round(value)}
+          </div>
+          <div className="mt-1 text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+            {score.grade}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface ScoreBreakdownProps {
+  items: ScoreBreakdownItem[];
+}
+
+export function ScoreBreakdown({ items }: ScoreBreakdownProps) {
+  if (items.length === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        Score sin componentes — sin agregados disponibles.
+      </p>
+    );
+  }
+  return (
+    <ul className="grid gap-2">
+      {items.map((item) => (
+        <li key={item.label}>
+          <div className="mb-1 flex items-center justify-between gap-2 text-xs">
+            <span className="text-foreground">{item.label}</span>
+            <span className="font-mono tabular-nums text-muted-foreground">
+              {Math.round(item.value_pct)}% · w{(item.weight * 100).toFixed(0)}
+            </span>
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-primary"
+              style={{ width: `${Math.min(100, item.value_pct)}%` }}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/components/clubs/detail/overview-tab.tsx
+++ b/src/components/clubs/detail/overview-tab.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { Activity, BarChart3, History, TrendingUp, Trophy } from "lucide-react";
+import { History, Loader2, TrendingUp } from "lucide-react";
 import type { Unit } from "@/lib/api/units";
+import type { ClubOverview } from "@/lib/api/club-detail";
 import { CompositionDonut } from "./composition-donut";
 import { UnitRanking } from "./unit-ranking";
+import { AttendanceChart, ScoreBreakdown, ScoreCircle } from "./charts";
 import { getTotalMembers } from "./helpers";
 import type { ClubSectionRaw, SectionView } from "./types";
 
@@ -11,14 +13,18 @@ interface OverviewTabProps {
   sections: SectionView[];
   units: Unit[];
   sectionLookup: Map<number, ClubSectionRaw>;
-  pendingRequests?: number | null;
+  overview: ClubOverview | undefined;
+  isLoadingOverview: boolean;
+  overviewError: Error | null;
 }
 
 export function ClubOverviewTab({
   sections,
   units,
   sectionLookup,
-  pendingRequests,
+  overview,
+  isLoadingOverview,
+  overviewError,
 }: OverviewTabProps) {
   const total = getTotalMembers(sections);
 
@@ -40,9 +46,13 @@ export function ClubOverviewTab({
       <PanelCard
         className="lg:col-span-5"
         title="Salud del club"
-        subtitle="Score compuesto (próximamente)"
+        subtitle="Score compuesto"
       >
-        <HealthPlaceholder sections={sections} pending={pendingRequests} />
+        <HealthBlock
+          overview={overview}
+          isLoading={isLoadingOverview}
+          error={overviewError}
+        />
       </PanelCard>
 
       <PanelCard
@@ -60,13 +70,23 @@ export function ClubOverviewTab({
 
       <PanelCard
         className="lg:col-span-5"
-        title="Asistencia mensual"
-        subtitle="Últimos 12 sábados"
+        title="Asistencia semanal"
+        subtitle="Promedio % por semana"
+        right={
+          overview?.attendance_average != null && (
+            <span className="text-[11px] text-muted-foreground">
+              Promedio ·{" "}
+              <b className="text-foreground">
+                {Math.round(overview.attendance_average)}%
+              </b>
+            </span>
+          )
+        }
       >
-        <Placeholder
-          icon={<TrendingUp className="size-5" />}
-          title="Sin agregación disponible"
-          description="Conectar `weekly-records` para mostrar tendencias de asistencia."
+        <AttendanceBlock
+          overview={overview}
+          isLoading={isLoadingOverview}
+          error={overviewError}
         />
       </PanelCard>
     </div>
@@ -102,81 +122,81 @@ function PanelCard({
   );
 }
 
-function HealthPlaceholder({
-  sections,
-  pending,
+function HealthBlock({
+  overview,
+  isLoading,
+  error,
 }: {
-  sections: SectionView[];
-  pending?: number | null;
+  overview: ClubOverview | undefined;
+  isLoading: boolean;
+  error: Error | null;
 }) {
-  const activeSections = sections.filter((s) => s.active).length;
+  if (isLoading) return <CardLoader />;
+  if (error || !overview) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No se pudo cargar el score del club.
+      </p>
+    );
+  }
   return (
-    <div className="grid grid-cols-[100px_1fr] items-center gap-4">
-      <div className="relative grid h-24 w-24 place-items-center rounded-full border-[10px] border-muted text-center">
-        <div>
-          <div className="text-2xl font-extrabold leading-none tracking-tight text-foreground">
-            —
-          </div>
-          <div className="mt-1 text-[9px] font-bold uppercase tracking-widest text-muted-foreground">
-            Salud
-          </div>
-        </div>
-      </div>
-      <div className="space-y-2 text-xs text-muted-foreground">
-        <p className="text-foreground">
-          Aún no hay un score consolidado. Mientras tanto, estos son los
-          indicadores duros del club:
+    <div className="space-y-4">
+      <div className="grid grid-cols-[96px_1fr] items-center gap-4">
+        <ScoreCircle score={overview.score} />
+        <p className="text-xs text-muted-foreground">
+          Score compuesto basado en asistencia, secciones activas y ocupación de
+          cupo. Grado actual:{" "}
+          <span className="font-semibold text-foreground">
+            {overview.score.grade}
+          </span>
+          .
         </p>
-        <ul className="grid gap-1.5">
-          <Row
-            icon={<Activity className="size-3.5" />}
-            label={`${activeSections} de ${sections.length || 3} secciones activas`}
-          />
-          <Row
-            icon={<Trophy className="size-3.5" />}
-            label={
-              pending == null
-                ? "Sin lectura de solicitudes pendientes"
-                : `${pending} solicitudes pendientes`
-            }
-          />
-          <Row
-            icon={<BarChart3 className="size-3.5" />}
-            label="Pendiente: definir cálculo de score 360°"
-          />
-        </ul>
       </div>
+      <ScoreBreakdown items={overview.score.breakdown} />
     </div>
   );
 }
 
-function Row({ icon, label }: { icon: React.ReactNode; label: string }) {
-  return (
-    <li className="flex items-center gap-2 text-xs text-foreground">
-      <span className="grid size-5 place-items-center rounded-md bg-muted text-muted-foreground">
-        {icon}
-      </span>
-      {label}
-    </li>
-  );
+function AttendanceBlock({
+  overview,
+  isLoading,
+  error,
+}: {
+  overview: ClubOverview | undefined;
+  isLoading: boolean;
+  error: Error | null;
+}) {
+  if (isLoading) return <CardLoader />;
+  if (error) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No se pudo cargar la serie de asistencia.
+      </p>
+    );
+  }
+  if (!overview?.attendance || overview.attendance.length === 0) {
+    return (
+      <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-4 py-8 text-center">
+        <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
+          <TrendingUp className="size-5" />
+        </span>
+        <p className="text-sm font-semibold text-foreground">
+          Sin registros semanales todavía
+        </p>
+        <p className="max-w-xs text-xs text-muted-foreground">
+          Cuando se capturen `weekly-records`, aquí aparecerá la tendencia de
+          asistencia.
+        </p>
+      </div>
+    );
+  }
+  return <AttendanceChart series={overview.attendance} />;
 }
 
-function Placeholder({
-  icon,
-  title,
-  description,
-}: {
-  icon: React.ReactNode;
-  title: string;
-  description: string;
-}) {
+function CardLoader() {
   return (
-    <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-4 py-8 text-center">
-      <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
-        {icon}
-      </span>
-      <p className="text-sm font-semibold text-foreground">{title}</p>
-      <p className="max-w-xs text-xs text-muted-foreground">{description}</p>
+    <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+      <Loader2 className="size-4 animate-spin" /> Cargando…
     </div>
   );
 }
@@ -190,11 +210,18 @@ export function ClubHistoryPlaceholder() {
           Eventos importantes desde la creación
         </p>
       </header>
-      <Placeholder
-        icon={<History className="size-5" />}
-        title="Aún sin línea de tiempo"
-        description="El backend todavía no expone eventos de auditoría (creación, cambios de director, investiduras). Cuando se publique, se renderizará aquí."
-      />
+      <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-4 py-8 text-center">
+        <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
+          <History className="size-5" />
+        </span>
+        <p className="text-sm font-semibold text-foreground">
+          Aún sin línea de tiempo
+        </p>
+        <p className="max-w-xs text-xs text-muted-foreground">
+          El backend todavía no expone eventos de auditoría (creación, cambios
+          de director, investiduras). Cuando se publique, se renderizará aquí.
+        </p>
+      </div>
     </section>
   );
 }

--- a/src/components/clubs/detail/right-sidebar.tsx
+++ b/src/components/clubs/detail/right-sidebar.tsx
@@ -7,16 +7,24 @@ import {
   ClipboardList,
   Edit3,
   Layers,
+  Loader2,
   Plus,
   Trash2,
   Users,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import type {
+  ClubLeadership,
+  LeadershipMember,
+  UpcomingEvent,
+} from "@/lib/api/club-detail";
 
 interface RightSidebarProps {
   clubId: number;
   pendingRequests?: number | null;
+  upcomingEvents?: UpcomingEvent[] | null;
+  isLoadingEvents?: boolean;
   onEdit?: () => void;
   onDelete?: () => void;
 }
@@ -24,6 +32,8 @@ interface RightSidebarProps {
 export function ClubRightSidebar({
   clubId,
   pendingRequests,
+  upcomingEvents,
+  isLoadingEvents,
   onEdit,
   onDelete,
 }: RightSidebarProps) {
@@ -35,7 +45,10 @@ export function ClubRightSidebar({
         onEdit={onEdit}
         onDelete={onDelete}
       />
-      <UpcomingEventsCard />
+      <UpcomingEventsCard
+        events={upcomingEvents ?? []}
+        isLoading={!!isLoadingEvents}
+      />
     </aside>
   );
 }
@@ -78,7 +91,11 @@ function ActionsCard({
   return (
     <CardShell title="Acciones rápidas">
       <div className="grid gap-1">
-        <ActionRow icon={<Edit3 className="size-3.5" />} label="Editar club" onClick={onEdit} />
+        <ActionRow
+          icon={<Edit3 className="size-3.5" />}
+          label="Editar club"
+          onClick={onEdit}
+        />
         <ActionRow
           icon={<Plus className="size-3.5" />}
           label="Crear unidad"
@@ -172,53 +189,281 @@ function ActionRow({
   );
 }
 
-function UpcomingEventsCard() {
+function UpcomingEventsCard({
+  events,
+  isLoading,
+}: {
+  events: UpcomingEvent[];
+  isLoading: boolean;
+}) {
   return (
-    <CardShell title="Próximos eventos" hint="—">
-      <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-3 py-6 text-center">
-        <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
-          <CalendarPlus className="size-5" />
-        </span>
-        <p className="text-sm font-semibold text-foreground">Sin agenda visible</p>
-        <p className="max-w-[200px] text-xs text-muted-foreground">
-          Conectar `activities` para listar próximos compromisos del club.
-        </p>
-        <Button size="xs" variant="outline" disabled>
-          Programar evento
-        </Button>
-      </div>
+    <CardShell
+      title="Próximos eventos"
+      hint={events.length > 0 ? events.length : "—"}
+    >
+      {isLoading ? (
+        <div className="flex items-center justify-center gap-2 py-6 text-xs text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" /> Cargando…
+        </div>
+      ) : events.length === 0 ? (
+        <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-3 py-6 text-center">
+          <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
+            <CalendarPlus className="size-5" />
+          </span>
+          <p className="text-sm font-semibold text-foreground">
+            Sin agenda visible
+          </p>
+          <p className="max-w-[200px] text-xs text-muted-foreground">
+            No hay actividades futuras registradas para este club.
+          </p>
+        </div>
+      ) : (
+        <ul className="grid gap-0">
+          {events.map((ev) => {
+            const date = ev.activity_date ? new Date(ev.activity_date) : null;
+            const day = date ? date.getDate() : "—";
+            const month = date
+              ? date
+                  .toLocaleString("es", { month: "short" })
+                  .replace(".", "")
+                  .toUpperCase()
+              : "—";
+            return (
+              <li
+                key={ev.activity_id}
+                className="grid grid-cols-[56px_1fr] items-center gap-3 border-b border-border/60 py-2.5 last:border-0"
+              >
+                <div className="rounded-xl bg-primary/10 px-2 py-2 text-center text-xs font-bold leading-tight text-primary">
+                  <b className="block text-lg leading-none">{day}</b>
+                  {month}
+                </div>
+                <div className="min-w-0">
+                  <div className="truncate text-sm font-semibold text-foreground">
+                    {ev.name}
+                  </div>
+                  <div className="truncate text-xs text-muted-foreground">
+                    {ev.section_name ?? "Club"}
+                    {ev.kind ? ` · ${ev.kind}` : ""}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
     </CardShell>
   );
 }
 
-interface LeadershipPlaceholderProps {
-  totalSections: number;
+interface LeadershipPanelProps {
+  leadership: ClubLeadership | undefined;
+  isLoading: boolean;
+  error: Error | null;
 }
 
-export function LeadershipPlaceholder({
-  totalSections,
-}: LeadershipPlaceholderProps) {
+export function LeadershipPanel({
+  leadership,
+  isLoading,
+  error,
+}: LeadershipPanelProps) {
+  if (isLoading) {
+    return (
+      <CardShell title="Liderazgo">
+        <div className="flex items-center gap-2 py-6 text-xs text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" /> Cargando…
+        </div>
+      </CardShell>
+    );
+  }
+
+  if (error || !leadership) {
+    return (
+      <CardShell title="Liderazgo">
+        <p className="text-sm text-muted-foreground">
+          No se pudo cargar el liderazgo del club.
+        </p>
+      </CardShell>
+    );
+  }
+
+  const totalSecondary =
+    leadership.deputies.length + leadership.secretaries.length;
+  const hasAnyone =
+    !!leadership.director || totalSecondary > 0 || leadership.others.length > 0;
+
+  if (!hasAnyone) {
+    return (
+      <CardShell title="Liderazgo">
+        <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-3 py-6 text-center">
+          <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
+            <ClipboardList className="size-5" />
+          </span>
+          <p className="text-sm font-semibold text-foreground">
+            Aún sin liderazgo asignado
+          </p>
+          <p className="max-w-[260px] text-xs text-muted-foreground">
+            Asigná director, subdirectores y secretarios desde las secciones
+            del club.
+          </p>
+        </div>
+      </CardShell>
+    );
+  }
+
   return (
     <CardShell
       title="Liderazgo"
       hint={
         <span className="text-[11px] text-muted-foreground">
-          {totalSections > 0 ? `${totalSections} secciones` : "—"}
+          {1 + totalSecondary} activos
         </span>
       }
     >
-      <div className="grid place-items-center gap-2 rounded-xl border border-dashed bg-muted/30 px-3 py-6 text-center">
-        <span className="grid size-9 place-items-center rounded-full bg-muted text-muted-foreground">
-          <ClipboardList className="size-5" />
-        </span>
-        <p className="text-sm font-semibold text-foreground">
-          Director y staff por enlazar
-        </p>
-        <p className="max-w-[220px] text-xs text-muted-foreground">
-          Vinculación con `club_role_assignments` pendiente. Aquí mostraremos
-          director, deputy y secretarios cuando esté disponible.
-        </p>
+      <div className="grid gap-3">
+        {leadership.director && <DirectorRow member={leadership.director} />}
+
+        {leadership.deputies.length > 0 && (
+          <Group
+            label="Subdirectores"
+            members={leadership.deputies}
+            tone="primary"
+          />
+        )}
+        {leadership.secretaries.length > 0 && (
+          <Group
+            label="Secretaría"
+            members={leadership.secretaries}
+            tone="info"
+          />
+        )}
+        {leadership.others.length > 0 && (
+          <Group label="Otros roles" members={leadership.others} tone="muted" />
+        )}
       </div>
     </CardShell>
   );
+}
+
+function DirectorRow({ member }: { member: LeadershipMember }) {
+  const fullName = getFullName(member);
+  return (
+    <div className="grid grid-cols-[44px_1fr] items-center gap-3 rounded-xl border border-primary/20 bg-primary/5 p-2.5">
+      <Avatar member={member} className="bg-primary text-primary-foreground" />
+      <div className="min-w-0">
+        <div className="truncate text-sm font-bold text-primary">{fullName}</div>
+        <div className="truncate text-[11px] text-primary/80">
+          Director{member.section_name ? ` · ${member.section_name}` : ""}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Group({
+  label,
+  members,
+  tone,
+}: {
+  label: string;
+  members: LeadershipMember[];
+  tone: "primary" | "info" | "muted";
+}) {
+  const avatarTone =
+    tone === "primary"
+      ? "bg-primary/15 text-primary"
+      : tone === "info"
+        ? "bg-info/15 text-info"
+        : "bg-muted text-muted-foreground";
+  const labelTone =
+    tone === "primary"
+      ? "text-primary"
+      : tone === "info"
+        ? "text-info"
+        : "text-muted-foreground";
+
+  return (
+    <div>
+      <div className="mb-1 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">
+        {label}
+      </div>
+      <ul className="grid gap-1.5">
+        {members.map((member) => (
+          <li
+            key={member.assignment_id}
+            className="grid grid-cols-[32px_1fr_auto] items-center gap-2.5 rounded-lg bg-muted/40 px-2.5 py-2"
+          >
+            <Avatar member={member} className={avatarTone} />
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold text-foreground">
+                {getFullName(member)}
+              </div>
+              {member.section_name && (
+                <div className="truncate text-[11px] text-muted-foreground">
+                  {member.section_name}
+                </div>
+              )}
+            </div>
+            <span
+              className={cn(
+                "text-[10px] font-semibold uppercase tracking-wider",
+                labelTone,
+              )}
+            >
+              {humanizeRoleName(member.role_name)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function Avatar({
+  member,
+  className,
+}: {
+  member: LeadershipMember;
+  className?: string;
+}) {
+  if (member.user_image) {
+    return (
+      <img
+        src={member.user_image}
+        alt={getFullName(member)}
+        className={cn(
+          "grid size-8 place-items-center rounded-full object-cover",
+          className,
+        )}
+      />
+    );
+  }
+  return (
+    <div
+      className={cn(
+        "grid size-8 place-items-center rounded-full text-[11px] font-bold",
+        className,
+      )}
+    >
+      {getInitials(member)}
+    </div>
+  );
+}
+
+function getFullName(member: LeadershipMember): string {
+  const parts = [member.name, member.paternal_last_name].filter(Boolean);
+  const joined = parts.join(" ").trim();
+  return joined || member.email || "—";
+}
+
+function getInitials(member: LeadershipMember): string {
+  const first = member.name?.[0] ?? "";
+  const last = member.paternal_last_name?.[0] ?? "";
+  return (first + last).toUpperCase() || "?";
+}
+
+function humanizeRoleName(roleName: string): string {
+  return roleName
+    .replace(/[_-]+/g, " ")
+    .replace(/\b(\w)/g, (m) => m.toUpperCase())
+    .trim();
 }

--- a/src/components/clubs/detail/view.tsx
+++ b/src/components/clubs/detail/view.tsx
@@ -9,6 +9,10 @@ import { ClubSectionsPanel } from "@/components/clubs/club-sections-panel";
 import { PendingMembersPanel } from "@/components/membership/pending-members-panel";
 import { UnitsTab } from "@/components/units/units-tab";
 import { listUnits } from "@/lib/api/units";
+import {
+  getClubLeadershipFromClient,
+  getClubOverviewFromClient,
+} from "@/lib/api/club-detail";
 import type { ClubActionState } from "@/lib/clubs/actions";
 import { ClubDetailHero } from "./hero";
 import { ClubDetailStats } from "./stats";
@@ -21,7 +25,7 @@ import {
 import { ClubInfoPanel } from "./info-panel";
 import {
   ClubRightSidebar,
-  LeadershipPlaceholder,
+  LeadershipPanel,
 } from "./right-sidebar";
 import { buildSectionViews, getActiveUnits } from "./helpers";
 import type { ClubFull, ClubSectionRaw } from "./types";
@@ -64,6 +68,32 @@ export function ClubDetailView({
     queryFn: () => listUnits(clubId),
     staleTime: 30_000,
   });
+
+  const {
+    data: overview,
+    isLoading: isLoadingOverview,
+    error: overviewErrorRaw,
+  } = useQuery({
+    queryKey: ["club-detail-overview", clubId],
+    queryFn: () => getClubOverviewFromClient(clubId),
+    staleTime: 60_000,
+  });
+  const overviewError = overviewErrorRaw instanceof Error ? overviewErrorRaw : null;
+
+  const {
+    data: leadership,
+    isLoading: isLoadingLeadership,
+    error: leadershipErrorRaw,
+  } = useQuery({
+    queryKey: ["club-detail-leadership", clubId],
+    queryFn: () => getClubLeadershipFromClient(clubId),
+    staleTime: 60_000,
+  });
+  const leadershipError =
+    leadershipErrorRaw instanceof Error ? leadershipErrorRaw : null;
+
+  const pendingRequests = overview?.funnel.pending_requests ?? null;
+  const upcomingEvents = overview?.upcoming_events ?? null;
 
   const activeUnits = useMemo(() => getActiveUnits(units), [units]);
   const sections = useMemo(() => buildSectionViews(club, activeUnits), [club, activeUnits]);
@@ -157,7 +187,7 @@ export function ClubDetailView({
       <ClubDetailStats
         sections={sections}
         unitsCount={activeUnits.length}
-        pendingRequests={null}
+        pendingRequests={pendingRequests}
       />
 
       <ClubTabsNav tabs={tabs} value={tab} onChange={setActiveTab} />
@@ -169,7 +199,9 @@ export function ClubDetailView({
               sections={sections}
               units={activeUnits}
               sectionLookup={sectionLookup}
-              pendingRequests={null}
+              overview={overview}
+              isLoadingOverview={isLoadingOverview}
+              overviewError={overviewError}
             />
           )}
 
@@ -243,13 +275,19 @@ export function ClubDetailView({
 
         <ClubRightSidebar
           clubId={clubId}
-          pendingRequests={null}
+          pendingRequests={pendingRequests}
+          upcomingEvents={upcomingEvents}
+          isLoadingEvents={isLoadingOverview}
           onEdit={() => setActiveTab("edit")}
           onDelete={handleDelete}
         />
       </div>
 
-      <LeadershipPlaceholder totalSections={sections.length} />
+      <LeadershipPanel
+        leadership={leadership}
+        isLoading={isLoadingLeadership}
+        error={leadershipError}
+      />
     </div>
   );
 }

--- a/src/lib/api/club-detail.ts
+++ b/src/lib/api/club-detail.ts
@@ -1,0 +1,102 @@
+import { apiRequest, apiRequestFromClient } from "@/lib/api/client";
+
+export type AttendanceDataPoint = {
+  year: number;
+  week: number;
+  avg_pct: number;
+};
+
+export type ScoreBreakdownItem = {
+  label: string;
+  value_pct: number;
+  weight: number;
+};
+
+export type ClubScore = {
+  value: number;
+  grade: string;
+  breakdown: ScoreBreakdownItem[];
+};
+
+export type UpcomingEvent = {
+  activity_id: number;
+  name: string;
+  kind: string | null;
+  activity_date: string | null;
+  section_name: string | null;
+};
+
+export type ClubFunnel = {
+  pending_requests: number;
+  active_members: number;
+  investidos_year: number;
+};
+
+export type ClubOverview = {
+  attendance: AttendanceDataPoint[] | null;
+  attendance_average: number | null;
+  score: ClubScore;
+  upcoming_events: UpcomingEvent[];
+  funnel: ClubFunnel;
+};
+
+export type LeadershipMember = {
+  assignment_id: string;
+  user_id: string;
+  name: string | null;
+  paternal_last_name: string | null;
+  maternal_last_name: string | null;
+  user_image: string | null;
+  email: string | null;
+  role_name: string;
+  section_name: string | null;
+  start_date: string;
+};
+
+export type ClubLeadership = {
+  director: LeadershipMember | null;
+  deputies: LeadershipMember[];
+  secretaries: LeadershipMember[];
+  others: LeadershipMember[];
+};
+
+function unwrap<T>(payload: unknown): T {
+  const wrapped = payload as { data?: T } | T;
+  if (
+    wrapped &&
+    typeof wrapped === "object" &&
+    "data" in (wrapped as Record<string, unknown>) &&
+    (wrapped as { data?: T }).data
+  ) {
+    return (wrapped as { data: T }).data;
+  }
+  return wrapped as T;
+}
+
+export async function getClubOverview(clubId: number): Promise<ClubOverview> {
+  const payload = await apiRequest<unknown>(`/clubs/${clubId}/overview`);
+  return unwrap<ClubOverview>(payload);
+}
+
+export async function getClubOverviewFromClient(
+  clubId: number,
+): Promise<ClubOverview> {
+  const payload = await apiRequestFromClient<unknown>(
+    `/clubs/${clubId}/overview`,
+  );
+  return unwrap<ClubOverview>(payload);
+}
+
+export async function getClubLeadership(clubId: number): Promise<ClubLeadership> {
+  const payload = await apiRequest<unknown>(`/clubs/${clubId}/leadership`);
+  return unwrap<ClubLeadership>(payload);
+}
+
+export async function getClubLeadershipFromClient(
+  clubId: number,
+): Promise<ClubLeadership> {
+  const payload = await apiRequestFromClient<unknown>(
+    `/clubs/${clubId}/leadership`,
+  );
+  return unwrap<ClubLeadership>(payload);
+}


### PR DESCRIPTION
## Summary
Replace the placeholders introduced in #161 with live data from the aggregation endpoints landed in sacdia-backend #125.

- New API client at \`src/lib/api/club-detail.ts\` for \`GET /clubs/:id/overview\` and \`GET /clubs/:id/leadership\`.
- New chart components in \`src/components/clubs/detail/charts.tsx\`: \`AttendanceChart\` (weekly bars), \`ScoreCircle\` (SVG arc tinted by tone), \`ScoreBreakdown\` (component bars).
- \`overview-tab\` now renders the real Salud del club score with breakdown and a real Asistencia semanal series. Empty/error states preserved when the backend returns \`null\` or fails.
- \`right-sidebar\` renders real \`upcoming_events\` and exposes \`LeadershipPanel\` that groups director / deputies / secretaries / others.
- \`view\` fetches both endpoints via React Query (\`staleTime: 60s\`), propagates \`funnel.pending_requests\` into stats and sidebar actions, and replaces the legacy \`LeadershipPlaceholder\` with the live panel.

History tab stays as a placeholder until an audit log lands.

## Test plan
- [ ] \`pnpm tsc --noEmit\` exit 0 (verified locally — preexisting errors in \`users/[userId]\` page are unrelated).
- [ ] Open \`/dashboard/clubs/<id>\` and confirm Salud card shows score circle + grade + breakdown bars.
- [ ] Asistencia card shows weekly bars when backend has weekly_records, otherwise an empty card.
- [ ] Right sidebar lists upcoming activities with date pill + section name.
- [ ] Liderazgo panel renders director (highlighted) and groups for deputies/secretaries/others.
- [ ] Stats card and Acciones rápidas show real pending requests count.
- [ ] Loading state visible briefly on first paint; error fallback copy if endpoint fails.