### PR TITLE
feat(admin): role chart redesign + manual & bulk user creation

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -906,7 +906,8 @@
       "description": "Assignments in the last 100 users",
       "noRolesFound": "No assigned roles found in the sample.",
       "basedOn": "Based on the last {count} registered users",
-      "userCount": "{count, plural, one {{count} user} other {{count} users}} — {percentage}%"
+      "userCount": "{count, plural, one {{count} user} other {{count} users}} — {percentage}%",
+      "noRoleChip": "No role assigned: {count, plural, one {{count} user} other {{count} users}} ({percentage}%)"
     },
     "quickLinks": {
       "title": "Quick links",
@@ -2770,7 +2771,64 @@
         "description": "System user management.",
         "cannotShow": "Cannot display users",
         "emptyTitle": "No users found",
-        "emptyDescription": "Try adjusting the search filters."
+        "emptyDescription": "Try adjusting the search filters.",
+        "actions": {
+          "addUser": "Add user",
+          "bulkUpload": "Bulk upload"
+        }
+      },
+      "new": {
+        "title": "Add user",
+        "description": "Create a new user and send them an invitation by email.",
+        "breadcrumb": "Add user",
+        "fields": {
+          "name": "First name",
+          "paternal_last_name": "Paternal last name",
+          "maternal_last_name": "Maternal last name",
+          "email": "Email address",
+          "role": "Role",
+          "country": "Country",
+          "union": "Union",
+          "local_field": "Local field"
+        },
+        "placeholders": {
+          "name": "E.g. María",
+          "paternal_last_name": "E.g. González",
+          "maternal_last_name": "E.g. Pérez",
+          "email": "user@example.com",
+          "role": "Select a role",
+          "country": "Select a country",
+          "union": "Select a union",
+          "local_field": "Select a local field"
+        },
+        "help": {
+          "maternal_last_name": "Optional. Leave blank if not applicable.",
+          "role": "You can only assign roles equal to or lower than yours.",
+          "union": "First select a country.",
+          "local_field": "First select a union."
+        },
+        "actions": {
+          "submit": "Create user",
+          "cancel": "Cancel",
+          "submitting": "Creating…"
+        },
+        "toast": {
+          "success": "User created. Invitation sent to {email}.",
+          "inviteNotSent": "User created, but the invitation email could not be sent.",
+          "emailExists": "A user with that email already exists.",
+          "forbidden": "You do not have permission to assign that role.",
+          "validationFailed": "Please review the form fields.",
+          "generic": "Could not create the user. Please try again."
+        },
+        "validation": {
+          "nameRequired": "First name is required.",
+          "paternalRequired": "Paternal last name is required.",
+          "emailRequired": "Email is required.",
+          "emailInvalid": "Invalid email format.",
+          "roleRequired": "Please select a role.",
+          "countryRequired": "Please select a country.",
+          "unionRequired": "Please select a union."
+        }
       },
       "detail": {
         "title": "User detail",
@@ -2784,6 +2842,70 @@
         "tabSecurity": "Security",
         "tabSessions": "Sessions",
         "postRegistrationUnavailable": "Could not retrieve post-registration status. The user may not have started the process or there may be a connectivity error."
+      },
+      "bulk": {
+        "title": "Bulk user upload",
+        "description": "Create multiple users at once by uploading an Excel or CSV file with the required data.",
+        "breadcrumb": "Bulk upload",
+        "downloadTemplate": "Download template",
+        "dropZone": {
+          "title": "Drag and drop your file here",
+          "subtitle": "or click to browse from your computer",
+          "browse": "Browse file",
+          "accept": "Accepted formats: .xlsx, .csv — Max. 5 MB and 500 rows"
+        },
+        "preview": {
+          "title": "File preview",
+          "subtitle": "Remaining rows will be processed on the server.",
+          "showingRowsOf": "Showing {shown} of {total} rows",
+          "moreColumns": "more columns",
+          "headersOk": "Valid headers",
+          "headersInvalid": "The file is missing the required 'email' column.",
+          "emptyFile": "The file contains no data rows.",
+          "tooManyRows": "The file exceeds the maximum of 500 rows."
+        },
+        "actions": {
+          "submit": "Process upload",
+          "cancel": "Cancel",
+          "uploadAnother": "Upload another file",
+          "filterAll": "All",
+          "filterSuccess": "Successful",
+          "filterError": "With errors"
+        },
+        "results": {
+          "totalLabel": "Total",
+          "succeededLabel": "Successful",
+          "failedLabel": "Failed",
+          "inviteSent": "Invitation sent",
+          "inviteNotSent": "User created without invitation",
+          "createdHeader": "Created",
+          "emailHeader": "Email",
+          "rowHeader": "Row",
+          "detailHeader": "Detail",
+          "statusHeader": "Status"
+        },
+        "statusBadges": {
+          "success": "Created",
+          "error": "Error"
+        },
+        "errorCodes": {
+          "validationFailed": "Invalid data",
+          "duplicateInFile": "Duplicate email in file",
+          "emailAlreadyInUse": "Email already registered",
+          "invalidRole": "Invalid role",
+          "forbiddenRoleForActor": "You cannot create that role",
+          "internalError": "Internal error"
+        },
+        "toast": {
+          "success": "All users were created successfully.",
+          "partialSuccess": "Upload completed with some errors. Review the results.",
+          "allFailed": "No users could be created. Check the file data.",
+          "fileTooLarge": "File too large (max. 5 MB).",
+          "fileTypeInvalid": "Unsupported file format. Use .xlsx or .csv.",
+          "fileEmpty": "The file contains no data.",
+          "tooManyRows": "The file exceeds the 500-row limit.",
+          "generic": "An error occurred while processing the upload. Please try again."
+        }
       }
     }
   },

--- a/messages/es.json
+++ b/messages/es.json
@@ -906,7 +906,8 @@
       "description": "Asignaciones en los últimos 100 usuarios",
       "noRolesFound": "No se encontraron roles asignados en la muestra.",
       "basedOn": "Basado en los últimos {count} usuarios registrados",
-      "userCount": "{count, plural, one {{count} usuario} other {{count} usuarios}} — {percentage}%"
+      "userCount": "{count, plural, one {{count} usuario} other {{count} usuarios}} — {percentage}%",
+      "noRoleChip": "Sin rol asignado: {count, plural, one {{count} usuario} other {{count} usuarios}} ({percentage}%)"
     },
     "quickLinks": {
       "title": "Accesos rápidos",
@@ -2789,7 +2790,64 @@
         "description": "Gestión de usuarios del sistema.",
         "cannotShow": "No se pueden mostrar usuarios",
         "emptyTitle": "No se encontraron usuarios",
-        "emptyDescription": "Intenta ajustar los filtros de búsqueda."
+        "emptyDescription": "Intenta ajustar los filtros de búsqueda.",
+        "actions": {
+          "addUser": "Agregar usuario",
+          "bulkUpload": "Carga masiva"
+        }
+      },
+      "new": {
+        "title": "Agregar usuario",
+        "description": "Crear un nuevo usuario y enviarle invitación por email.",
+        "breadcrumb": "Agregar usuario",
+        "fields": {
+          "name": "Nombre",
+          "paternal_last_name": "Apellido paterno",
+          "maternal_last_name": "Apellido materno",
+          "email": "Correo electrónico",
+          "role": "Rol",
+          "country": "País",
+          "union": "Unión",
+          "local_field": "Campo local"
+        },
+        "placeholders": {
+          "name": "Ej. María",
+          "paternal_last_name": "Ej. González",
+          "maternal_last_name": "Ej. Pérez",
+          "email": "usuario@ejemplo.com",
+          "role": "Seleccioná un rol",
+          "country": "Seleccioná un país",
+          "union": "Seleccioná una unión",
+          "local_field": "Seleccioná un campo local"
+        },
+        "help": {
+          "maternal_last_name": "Opcional. Dejá vacío si no aplica.",
+          "role": "Solo podés asignar roles iguales o inferiores al tuyo.",
+          "union": "Primero seleccioná un país.",
+          "local_field": "Primero seleccioná una unión."
+        },
+        "actions": {
+          "submit": "Crear usuario",
+          "cancel": "Cancelar",
+          "submitting": "Creando…"
+        },
+        "toast": {
+          "success": "Usuario creado. Se envió invitación a {email}.",
+          "inviteNotSent": "Usuario creado, pero no se pudo enviar el email de invitación.",
+          "emailExists": "Ya existe un usuario con ese correo.",
+          "forbidden": "No tenés permisos para crear ese rol.",
+          "validationFailed": "Revisá los campos del formulario.",
+          "generic": "No se pudo crear el usuario. Intentá de nuevo."
+        },
+        "validation": {
+          "nameRequired": "El nombre es obligatorio.",
+          "paternalRequired": "El apellido paterno es obligatorio.",
+          "emailRequired": "El correo es obligatorio.",
+          "emailInvalid": "Formato de correo inválido.",
+          "roleRequired": "Seleccioná un rol.",
+          "countryRequired": "Seleccioná un país.",
+          "unionRequired": "Seleccioná una unión."
+        }
       },
       "detail": {
         "title": "Detalle de usuario",
@@ -2803,6 +2861,70 @@
         "tabSecurity": "Seguridad",
         "tabSessions": "Sesiones",
         "postRegistrationUnavailable": "No se pudo obtener el estado del post-registro. El usuario puede no haber iniciado el proceso o puede haber un error de conectividad."
+      },
+      "bulk": {
+        "title": "Carga masiva de usuarios",
+        "description": "Creá múltiples usuarios a la vez subiendo un archivo Excel o CSV con los datos requeridos.",
+        "breadcrumb": "Carga masiva",
+        "downloadTemplate": "Descargar plantilla",
+        "dropZone": {
+          "title": "Arrastrá y soltá tu archivo aquí",
+          "subtitle": "o hacé clic para seleccionar desde tu equipo",
+          "browse": "Seleccionar archivo",
+          "accept": "Formatos aceptados: .xlsx, .csv — Máx. 5 MB y 500 filas"
+        },
+        "preview": {
+          "title": "Vista previa del archivo",
+          "subtitle": "Las filas restantes se procesarán en el servidor.",
+          "showingRowsOf": "Mostrando {shown} de {total} filas",
+          "moreColumns": "columnas más",
+          "headersOk": "Cabeceras correctas",
+          "headersInvalid": "El archivo no contiene la columna 'email' requerida.",
+          "emptyFile": "El archivo no contiene filas de datos.",
+          "tooManyRows": "El archivo supera el máximo de 500 filas."
+        },
+        "actions": {
+          "submit": "Procesar carga",
+          "cancel": "Cancelar",
+          "uploadAnother": "Cargar otro archivo",
+          "filterAll": "Todos",
+          "filterSuccess": "Exitosos",
+          "filterError": "Con errores"
+        },
+        "results": {
+          "totalLabel": "Total",
+          "succeededLabel": "Exitosos",
+          "failedLabel": "Fallidos",
+          "inviteSent": "Invitación enviada",
+          "inviteNotSent": "Usuario creado sin invitación",
+          "createdHeader": "Creado",
+          "emailHeader": "Email",
+          "rowHeader": "Fila",
+          "detailHeader": "Detalle",
+          "statusHeader": "Estado"
+        },
+        "statusBadges": {
+          "success": "Creado",
+          "error": "Error"
+        },
+        "errorCodes": {
+          "validationFailed": "Datos inválidos",
+          "duplicateInFile": "Email duplicado en el archivo",
+          "emailAlreadyInUse": "Email ya registrado",
+          "invalidRole": "Rol inválido",
+          "forbiddenRoleForActor": "No podés crear ese rol",
+          "internalError": "Error interno"
+        },
+        "toast": {
+          "success": "Todos los usuarios fueron creados correctamente.",
+          "partialSuccess": "Carga completada con algunos errores. Revisá los resultados.",
+          "allFailed": "No se pudo crear ningún usuario. Revisá los datos del archivo.",
+          "fileTooLarge": "Archivo demasiado grande (máx. 5 MB).",
+          "fileTypeInvalid": "Formato de archivo no soportado. Usá .xlsx o .csv.",
+          "fileEmpty": "El archivo no contiene datos.",
+          "tooManyRows": "El archivo supera el límite de 500 filas.",
+          "generic": "Ocurrió un error al procesar la carga. Intentá de nuevo."
+        }
       }
     }
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -71,7 +71,7 @@ const cspValue = [
   `style-src 'self' 'unsafe-inline'`,
   `img-src 'self' data: blob: https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://pub-c8aa231ae66c46ff96fc5e811994d9d2.r2.dev https://pub-c0e79f5fa4634581867fab5b0fed605c.r2.dev https://5da196c051c48c7a4ebeea275a2b23d1.r2.cloudflarestorage.com`,
   `font-src 'self' data:`,
-  `connect-src 'self' ${backendOrigin} https://*.sentry.io https://*.ingest.sentry.io https://*.ingest.us.sentry.io`,
+  `connect-src 'self' ${backendOrigin} https://*.r2.cloudflarestorage.com https://*.sentry.io https://*.ingest.sentry.io https://*.ingest.us.sentry.io`,
   `frame-ancestors 'none'`,
   `base-uri 'self'`,
   `form-action 'self'`,
@@ -80,6 +80,14 @@ const cspValue = [
   .concat(";");
 
 const nextConfig: NextConfig = {
+  // Bumping default 1MB so Server Actions still work as a fallback path. Large
+  // files (>25MB) MUST go through the presigned R2 PUT flow — see
+  // /resources/upload-url and createResourceFromUploadedAction.
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "25mb",
+    },
+  },
   async headers() {
     return [
       {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "recharts": "^3.7.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2722,6 +2725,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
+
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -2892,6 +2899,10 @@ packages:
   caniuse-lite@1.0.30001766:
     resolution: {integrity: sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -2935,6 +2946,10 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2961,6 +2976,11 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3407,6 +3427,10 @@ packages:
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
@@ -4509,6 +4533,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -4954,9 +4982,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -4973,6 +5009,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -7549,6 +7590,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  adler-32@1.3.1: {}
+
   agent-base@6.0.2:
     dependencies:
       debug: 4.4.3
@@ -7747,6 +7790,11 @@ snapshots:
 
   caniuse-lite@1.0.30001766: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -7794,6 +7842,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  codepage@1.15.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -7813,6 +7863,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -8397,6 +8449,8 @@ snapshots:
       mime-types: 2.1.35
 
   forwarded-parse@2.1.2: {}
+
+  frac@1.1.2: {}
 
   framer-motion@12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -9595,6 +9649,10 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -10125,7 +10183,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -10134,6 +10196,16 @@ snapshots:
       strip-ansi: 6.0.1
 
   ws@8.20.0: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-name-validator@5.0.0: {}
 

--- a/src/app/(dashboard)/dashboard/resources/page.tsx
+++ b/src/app/(dashboard)/dashboard/resources/page.tsx
@@ -268,6 +268,42 @@ export default async function ResourcesPage({
   const canEdit = hasAnyPermission(user, [RESOURCES_UPDATE]);
   const canDelete = hasAnyPermission(user, [RESOURCES_DELETE]);
 
+  // Resolve user's effective global scope to limit available scope levels and
+  // pre-select / lock the scope_id in the create form per RBAC hierarchy.
+  const globalScope = (user.authorization?.effective as { scope?: { global?: unknown } } | undefined)
+    ?.scope?.global as
+    | {
+        country?: { id?: unknown } | null;
+        union?: { id?: unknown } | null;
+        local_field?: { id?: unknown } | null;
+      }
+    | undefined;
+
+  const userCountryId = toPositiveNumber(globalScope?.country?.id);
+  const userUnionId = toPositiveNumber(globalScope?.union?.id);
+  const userLocalFieldId = toPositiveNumber(globalScope?.local_field?.id);
+
+  let allowedScopeLevels: ScopeLevel[];
+  let lockedScopeId: number | null = null;
+  let scopedUnions = unions;
+  let scopedLocalFields = localFields;
+
+  if (userCountryId) {
+    allowedScopeLevels = ["system", "union", "local_field"];
+  } else if (userUnionId) {
+    allowedScopeLevels = ["union"];
+    lockedScopeId = userUnionId;
+    scopedUnions = unions.filter((u) => u.union_id === userUnionId);
+    scopedLocalFields = [];
+  } else if (userLocalFieldId) {
+    allowedScopeLevels = ["local_field"];
+    lockedScopeId = userLocalFieldId;
+    scopedUnions = [];
+    scopedLocalFields = localFields.filter((lf) => lf.local_field_id === userLocalFieldId);
+  } else {
+    allowedScopeLevels = [];
+  }
+
   return (
     <div className="space-y-6">
       {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
@@ -276,8 +312,10 @@ export default async function ResourcesPage({
         items={items}
         meta={meta}
         categories={categories}
-        unions={unions}
-        localFields={localFields}
+        unions={scopedUnions}
+        localFields={scopedLocalFields}
+        allowedScopeLevels={allowedScopeLevels}
+        lockedScopeId={lockedScopeId}
         canCreate={canCreate}
         canEdit={canEdit}
         canDelete={canDelete}

--- a/src/app/(dashboard)/dashboard/users/bulk-upload/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/bulk-upload/page.tsx
@@ -1,0 +1,46 @@
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { PageHeader } from "@/components/shared/page-header";
+import { BulkUploadClient } from "@/components/users/bulk-upload-client";
+import { requireAdminUser } from "@/lib/auth/session";
+import { extractRoles } from "@/lib/auth/roles";
+
+// Same set as /users/new — same permission gate
+const ALLOWED_PAGE_ROLES = new Set([
+  "super-admin",
+  "admin",
+  "director-dia",
+  "assistant-dia",
+  "director-union",
+  "assistant-union",
+  "director-lf",
+  "assistant-lf",
+]);
+
+export default async function BulkUploadPage() {
+  const currentUser = await requireAdminUser();
+  const userRoles = extractRoles(currentUser);
+
+  const hasAccess = userRoles.some((r) => ALLOWED_PAGE_ROLES.has(r));
+  if (!hasAccess) {
+    notFound();
+  }
+
+  const t = await getTranslations("users.pages.bulk");
+  const tList = await getTranslations("users.pages.list");
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("title")}
+        description={t("description")}
+        breadcrumbs={[
+          { label: tList("title"), href: "/dashboard/users" },
+          { label: t("breadcrumb") },
+        ]}
+      />
+
+      <BulkUploadClient />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/users/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/new/page.tsx
@@ -1,0 +1,103 @@
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { PageHeader } from "@/components/shared/page-header";
+import { NewUserForm } from "@/components/users/new-user-form";
+import { requireAdminUser } from "@/lib/auth/session";
+import { extractRoles } from "@/lib/auth/roles";
+import type { AdminCreatableRole } from "@/lib/api/admin-users";
+
+// ─── Role-to-allowed-creatable-roles mapping ──────────────────────────────────
+
+const ALLOWED_PAGE_ROLES = new Set([
+  "super-admin",
+  "admin",
+  "director-dia",
+  "assistant-dia",
+  "director-union",
+  "assistant-union",
+  "director-lf",
+  "assistant-lf",
+]);
+
+/**
+ * Returns the subset of AdminCreatableRole values the actor may assign.
+ *
+ * Hierarchy rule (Adventist club authority chain — must mirror backend
+ * `ROLE_HIERARCHY` in `admin-users.service.ts`):
+ *   - super-admin → all roles, including admin
+ *   - admin → everything below admin (NOT admin itself; only super-admin
+ *     creates admin). admin assigns director-dia.
+ *   - director-dia / assistant-dia → UNION + LF + base (NOT DIA peers).
+ *   - director-union / assistant-union → LF + base (NOT UNION peers).
+ *   - director-lf / assistant-lf → base only (NOT LF peers). LF directors
+ *     are appointed by the union, so the LF tier cannot grow itself.
+ *
+ * The backend enforces this server-side too; the UI filters the dropdown to
+ * match so the actor never sees options that would bounce with a 403.
+ */
+const BASE_T5_ROLES: AdminCreatableRole[] = [
+  "user",
+  "coordinator",
+  "zone-coordinator",
+  "general-coordinator",
+  "pastor",
+];
+const LF_ROLES: AdminCreatableRole[] = ["assistant-lf", "director-lf"];
+const UNION_ROLES: AdminCreatableRole[] = [
+  "assistant-union",
+  "director-union",
+];
+const DIA_ROLES: AdminCreatableRole[] = ["assistant-dia", "director-dia"];
+
+function resolveAllowedRoles(userRoles: string[]): AdminCreatableRole[] {
+  const roleSet = new Set(userRoles);
+
+  if (roleSet.has("super-admin")) {
+    return [...BASE_T5_ROLES, ...LF_ROLES, ...UNION_ROLES, ...DIA_ROLES, "admin"];
+  }
+  if (roleSet.has("admin")) {
+    return [...BASE_T5_ROLES, ...LF_ROLES, ...UNION_ROLES, ...DIA_ROLES];
+  }
+  if (roleSet.has("director-dia") || roleSet.has("assistant-dia")) {
+    return [...BASE_T5_ROLES, ...LF_ROLES, ...UNION_ROLES];
+  }
+  if (roleSet.has("director-union") || roleSet.has("assistant-union")) {
+    return [...BASE_T5_ROLES, ...LF_ROLES];
+  }
+  if (roleSet.has("director-lf") || roleSet.has("assistant-lf")) {
+    return [...BASE_T5_ROLES];
+  }
+  return [];
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function NewUserPage() {
+  const currentUser = await requireAdminUser();
+  const userRoles = extractRoles(currentUser);
+
+  // Check that at least one of the allowed page roles is present
+  const hasAccess = userRoles.some((r) => ALLOWED_PAGE_ROLES.has(r));
+  if (!hasAccess) {
+    notFound();
+  }
+
+  const allowedRoles = resolveAllowedRoles(userRoles);
+  const t = await getTranslations("users.pages.new");
+  const tList = await getTranslations("users.pages.list");
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("title")}
+        description={t("description")}
+        breadcrumbs={[
+          { label: tList("title"), href: "/dashboard/users" },
+          { label: t("breadcrumb") },
+        ]}
+      />
+
+      <NewUserForm allowedRoles={allowedRoles} />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/users/page.tsx
+++ b/src/app/(dashboard)/dashboard/users/page.tsx
@@ -9,6 +9,7 @@ import { DataTableShell } from "@/components/shared/data-table-shell";
 import { DataTablePagination } from "@/components/shared/data-table-pagination";
 import { UsersFilters } from "@/components/users/users-filters";
 import { UsersTable } from "@/components/users/users-table";
+import { UsersToolbarActions } from "@/components/users/users-toolbar-actions";
 import { listAdminUsers, type AdminUsersQuery } from "@/lib/api/admin-users";
 import { requireAdminUser } from "@/lib/auth/session";
 import { canViewAdministrativeCompletion } from "@/lib/auth/permission-utils";
@@ -135,6 +136,7 @@ export default async function UsersPage({
       <PageHeader
         title={t("title")}
         description={t("description")}
+        actions={<UsersToolbarActions />}
       />
 
       <Suspense fallback={<UsersListSkeleton />}>

--- a/src/components/dashboard/role-distribution-chart-inner.tsx
+++ b/src/components/dashboard/role-distribution-chart-inner.tsx
@@ -1,59 +1,43 @@
 "use client";
 
-import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  Tooltip,
-  ResponsiveContainer,
-  Cell,
-} from "recharts";
+import { useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { useRoleLabel } from "@/lib/auth/role-labels";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import type { RoleDistributionEntry } from "./role-distribution-chart";
 
-const ROLE_COLORS: Record<string, string> = {
-  "super-admin": "var(--destructive)",
-  admin: "var(--primary)",
-  "assistant-admin": "color-mix(in oklch, var(--primary) 70%, transparent)",
-  coordinator: "var(--info)",
-  pastor: "var(--warning)",
-  user: "var(--success)",
-  director: "var(--chart-1)",
-  "deputy-director": "var(--chart-2)",
-  secretary: "var(--chart-3)",
-  treasurer: "var(--chart-4)",
-  counselor: "var(--chart-5)",
-  instructor: "color-mix(in oklch, var(--chart-1) 60%, var(--chart-3) 40%)",
-  member: "color-mix(in oklch, var(--muted-foreground) 80%, transparent)",
-  sin_rol: "color-mix(in oklch, var(--muted-foreground) 50%, transparent)",
+type RoleVisualWeight = {
+  fill: string;
+  opacity: number;
 };
 
-const DEFAULT_COLOR = "color-mix(in oklch, var(--muted-foreground) 40%, transparent)";
+const ROLE_WEIGHTS: Record<string, RoleVisualWeight> = {
+  "super-admin": { fill: "var(--chart-1)", opacity: 1 },
+  admin: { fill: "var(--chart-2)", opacity: 1 },
+  "assistant-admin": { fill: "var(--chart-3)", opacity: 1 },
+  coordinator: { fill: "var(--chart-4)", opacity: 1 },
+  pastor: { fill: "var(--chart-5)", opacity: 1 },
+  director: { fill: "var(--primary)", opacity: 0.65 },
+  "deputy-director": { fill: "var(--primary)", opacity: 0.5 },
+  secretary: { fill: "var(--muted-foreground)", opacity: 0.7 },
+  treasurer: { fill: "var(--muted-foreground)", opacity: 0.55 },
+  counselor: { fill: "var(--muted-foreground)", opacity: 0.45 },
+  instructor: { fill: "var(--muted-foreground)", opacity: 0.4 },
+  member: { fill: "var(--muted-foreground)", opacity: 0.35 },
+  user: { fill: "var(--muted-foreground)", opacity: 0.3 },
+};
 
-function roleColor(role: string): string {
-  return ROLE_COLORS[role] ?? DEFAULT_COLOR;
-}
+const FALLBACK_WEIGHT: RoleVisualWeight = {
+  fill: "var(--muted-foreground)",
+  opacity: 0.25,
+};
 
-interface CustomTooltipProps {
-  active?: boolean;
-  payload?: Array<{ payload: RoleDistributionEntry }>;
-  roleLabel: (role: string) => string;
-  userCount: (count: number, percentage: string) => string;
-}
-
-function CustomTooltip({ active, payload, roleLabel, userCount }: CustomTooltipProps) {
-  if (!active || !payload?.length) return null;
-  const entry = payload[0].payload;
-  return (
-    <div className="rounded-lg border bg-background px-3 py-2 text-sm shadow-md">
-      <p className="font-medium">{roleLabel(entry.role)}</p>
-      <p className="text-muted-foreground">
-        {userCount(entry.count, entry.percentage.toFixed(1))}
-      </p>
-    </div>
-  );
+function weightFor(role: string): RoleVisualWeight {
+  return ROLE_WEIGHTS[role] ?? FALLBACK_WEIGHT;
 }
 
 interface RoleDistributionChartInnerProps {
@@ -61,20 +45,24 @@ interface RoleDistributionChartInnerProps {
   sampleSize: number;
 }
 
-export function RoleDistributionChartInner({ data, sampleSize }: RoleDistributionChartInnerProps) {
+export function RoleDistributionChartInner({
+  data,
+  sampleSize,
+}: RoleDistributionChartInnerProps) {
   const t = useTranslations("dashboardHub");
   const translateRole = useRoleLabel();
 
-  function roleLabel(role: string): string {
-    if (role === "sin_rol") return t("roleChart.noRolesFound");
-    return translateRole(role);
-  }
+  const { rows, unassigned } = useMemo(() => {
+    const sorted = [...data].sort((a, b) => b.count - a.count);
+    const unassignedEntry = sorted.find((e) => e.role === "sin_rol");
+    const visibleRows = sorted.filter((e) => e.role !== "sin_rol");
+    return {
+      rows: visibleRows,
+      unassigned: unassignedEntry ?? null,
+    };
+  }, [data]);
 
-  function userCount(count: number, percentage: string): string {
-    return t("roleChart.userCount", { count, percentage });
-  }
-
-  if (data.length === 0) {
+  if (rows.length === 0 && !unassigned) {
     return (
       <p className="text-sm text-muted-foreground">
         {t("roleChart.noRolesFound")}
@@ -82,38 +70,83 @@ export function RoleDistributionChartInner({ data, sampleSize }: RoleDistributio
     );
   }
 
+  const maxPct = rows.reduce((max, e) => Math.max(max, e.percentage), 0);
+
   return (
     <div className="space-y-3">
-      <ResponsiveContainer width="100%" height={160}>
-        <BarChart data={data} layout="vertical" margin={{ top: 0, right: 8, left: 0, bottom: 0 }}>
-          <XAxis type="number" hide />
-          <YAxis
-            type="category"
-            dataKey="role"
-            tickFormatter={roleLabel}
-            width={80}
-            tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
-            tickLine={false}
-            axisLine={false}
-          />
-          <Tooltip
-            content={
-              <CustomTooltip
-                roleLabel={roleLabel}
-                userCount={userCount}
-              />
-            }
-            cursor={{ fill: "color-mix(in oklch, var(--muted) 40%, transparent)" }}
-          />
-          <Bar dataKey="count" radius={[0, 4, 4, 0]} maxBarSize={18}>
-            {data.map((entry) => (
-              <Cell key={entry.role} fill={roleColor(entry.role)} />
-            ))}
-          </Bar>
-        </BarChart>
-      </ResponsiveContainer>
+      <ul role="list" className="space-y-1">
+        {rows.map((entry) => {
+          const label = translateRole(entry.role);
+          const weight = weightFor(entry.role);
+          const widthPct = maxPct > 0 ? (entry.percentage / maxPct) * 100 : 0;
+          return (
+            <Tooltip key={entry.role}>
+              <TooltipTrigger asChild>
+                <li
+                  role="listitem"
+                  tabIndex={0}
+                  className="group grid h-9 grid-cols-[minmax(0,2fr)_minmax(0,3fr)_auto] items-center gap-3 rounded-md px-2 transition-colors hover:bg-muted/50 focus-visible:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <span className="truncate text-sm font-medium text-foreground">
+                    {label}
+                  </span>
+                  <span
+                    className="relative h-2 overflow-hidden rounded-full bg-muted"
+                    aria-hidden="true"
+                  >
+                    <span
+                      className="block h-full rounded-full transition-[width] duration-300 ease-out"
+                      style={{
+                        width: `${widthPct}%`,
+                        backgroundColor: weight.fill,
+                        opacity: weight.opacity,
+                      }}
+                    />
+                  </span>
+                  <span className="flex items-baseline gap-1.5 tabular-nums">
+                    <span className="text-sm font-semibold text-foreground">
+                      {entry.count}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                      {entry.percentage.toFixed(0)}%
+                    </span>
+                  </span>
+                </li>
+              </TooltipTrigger>
+              <TooltipContent side="left" align="center">
+                <p className="font-medium">{label}</p>
+                <p className="text-muted-foreground">
+                  {t("roleChart.userCount", {
+                    count: entry.count,
+                    percentage: entry.percentage.toFixed(1),
+                  })}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          );
+        })}
+      </ul>
 
-      <p className="text-[11px] text-muted-foreground">
+      {unassigned && unassigned.count > 0 ? (
+        <div className="flex flex-wrap items-center gap-2 border-t pt-3">
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-2.5 py-1 text-xs text-muted-foreground">
+            <span
+              className="size-1.5 rounded-full"
+              style={{
+                backgroundColor: "var(--muted-foreground)",
+                opacity: 0.5,
+              }}
+              aria-hidden="true"
+            />
+            {t("roleChart.noRoleChip", {
+              count: unassigned.count,
+              percentage: unassigned.percentage.toFixed(0),
+            })}
+          </span>
+        </div>
+      ) : null}
+
+      <p className="text-xs text-muted-foreground">
         {t("roleChart.basedOn", { count: sampleSize })}
       </p>
     </div>

--- a/src/components/dashboard/role-distribution-chart.tsx
+++ b/src/components/dashboard/role-distribution-chart.tsx
@@ -9,6 +9,26 @@ export type RoleDistributionEntry = {
   percentage: number;
 };
 
+function RoleDistributionLoading() {
+  return (
+    <div className="space-y-3">
+      <ul className="space-y-1">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <li
+            key={i}
+            className="grid h-9 grid-cols-[minmax(0,2fr)_minmax(0,3fr)_auto] items-center gap-3 px-2"
+          >
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="h-2 w-full rounded-full" />
+            <Skeleton className="h-3 w-12" />
+          </li>
+        ))}
+      </ul>
+      <Skeleton className="h-3 w-48" />
+    </div>
+  );
+}
+
 const RoleDistributionChartInner = dynamic(
   () =>
     import("./role-distribution-chart-inner").then(
@@ -16,7 +36,7 @@ const RoleDistributionChartInner = dynamic(
     ),
   {
     ssr: false,
-    loading: () => <Skeleton className="h-[160px] w-full rounded-md" />,
+    loading: () => <RoleDistributionLoading />,
   }
 );
 

--- a/src/components/resources/resources-crud-page.tsx
+++ b/src/components/resources/resources-crud-page.tsx
@@ -75,6 +75,10 @@ import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { DataTablePagination } from "@/components/shared/data-table-pagination";
 import type { ResourceActionState } from "@/lib/resources/resource-actions";
+import {
+  createResourceFromUploadedAction,
+  requestUploadUrlAction,
+} from "@/lib/resources/resource-actions";
 import type { ResourceType, ClubTypeTarget, ScopeLevel } from "@/lib/api/resources";
 import { apiRequestFromClient } from "@/lib/api/client";
 import type { Union, LocalField } from "@/lib/api/geography";
@@ -119,6 +123,8 @@ interface ResourcesCrudPageProps {
   categories: CategoryRecord[];
   unions: Union[];
   localFields: LocalField[];
+  allowedScopeLevels: ScopeLevel[];
+  lockedScopeId: number | null;
   canCreate: boolean;
   canEdit: boolean;
   canDelete: boolean;
@@ -384,6 +390,8 @@ function ResourceFormFields({
   categories,
   unions,
   localFields,
+  allowedScopeLevels,
+  lockedScopeId,
   isEdit,
   onFileSizeError,
 }: {
@@ -391,6 +399,8 @@ function ResourceFormFields({
   categories: CategoryRecord[];
   unions: Union[];
   localFields: LocalField[];
+  allowedScopeLevels: ScopeLevel[];
+  lockedScopeId: number | null;
   isEdit?: boolean;
   onFileSizeError?: (error: string | null) => void;
 }) {
@@ -398,9 +408,15 @@ function ResourceFormFields({
   const [resourceType, setResourceType] = useState<ResourceType>(
     (item?.resource_type as ResourceType) ?? "document",
   );
-  const [scopeLevel, setScopeLevel] = useState<ScopeLevel>(
-    (item?.scope_level as ScopeLevel) ?? "system",
-  );
+  const initialScopeLevel: ScopeLevel = (() => {
+    if (item?.scope_level && allowedScopeLevels.includes(item.scope_level as ScopeLevel)) {
+      return item.scope_level as ScopeLevel;
+    }
+    return allowedScopeLevels[0] ?? "system";
+  })();
+  const [scopeLevel, setScopeLevel] = useState<ScopeLevel>(initialScopeLevel);
+  const scopeLevelLocked = allowedScopeLevels.length <= 1;
+  const scopeIdLocked = lockedScopeId !== null;
   const [fileSizeError, setFileSizeError] = useState<string | null>(null);
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -433,7 +449,10 @@ function ResourceFormFields({
     image: "JPG, PNG, WebP, GIF — máx. 50 MB",
   };
 
-  const currentScopeIdValue = toPositiveNumber(item?.scope_id)?.toString() ?? "";
+  const currentScopeIdValue =
+    (scopeIdLocked ? String(lockedScopeId) : null) ??
+    toPositiveNumber(item?.scope_id)?.toString() ??
+    "";
 
   return (
     <div className="space-y-4">
@@ -552,21 +571,26 @@ function ResourceFormFields({
             name="scope_level"
             value={scopeLevel}
             onValueChange={(v) => setScopeLevel(v as ScopeLevel)}
-            disabled={isEdit}
+            disabled={isEdit || scopeLevelLocked}
           >
             <SelectTrigger id="res-scope-level">
               <SelectValue placeholder={t("placeholders.selectScope")} />
             </SelectTrigger>
             <SelectContent>
-              {(Object.entries(SCOPE_LEVEL_LABELS) as [ScopeLevel, string][]).map(
-                ([value, label]) => (
+              {(Object.entries(SCOPE_LEVEL_LABELS) as [ScopeLevel, string][])
+                .filter(([value]) => allowedScopeLevels.includes(value))
+                .map(([value, label]) => (
                   <SelectItem key={value} value={value}>
                     {label}
                   </SelectItem>
-                ),
-              )}
+                ))}
             </SelectContent>
           </Select>
+          {scopeLevelLocked && allowedScopeLevels.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              Tu rol solo permite recursos de alcance {SCOPE_LEVEL_LABELS[allowedScopeLevels[0]]}.
+            </p>
+          )}
         </div>
       </div>
 
@@ -577,7 +601,25 @@ function ResourceFormFields({
             {scopeLevel === "union" ? "Unión" : "Campo local"}{" "}
             <span className="ml-0.5 text-destructive">*</span>
           </Label>
-          {scopeLevel === "union" ? (
+          {scopeIdLocked ? (
+            <>
+              <Input
+                id="res-scope-id-display"
+                value={
+                  scopeLevel === "union"
+                    ? unions.find((u) => u.union_id === lockedScopeId)?.name ?? `#${lockedScopeId}`
+                    : localFields.find((lf) => lf.local_field_id === lockedScopeId)?.name ??
+                      `#${lockedScopeId}`
+                }
+                readOnly
+                disabled
+              />
+              <input type="hidden" name="scope_id" value={String(lockedScopeId)} />
+              <p className="text-xs text-muted-foreground">
+                Tu rol está fijado a este alcance — no puede cambiarse.
+              </p>
+            </>
+          ) : scopeLevel === "union" ? (
             unions.length > 0 ? (
               <Select
                 name="scope_id"
@@ -712,6 +754,8 @@ export function ResourcesCrudPage({
   categories,
   unions,
   localFields,
+  allowedScopeLevels,
+  lockedScopeId,
   canCreate,
   canEdit,
   canDelete,
@@ -731,6 +775,11 @@ export function ResourcesCrudPage({
   const [editItem, setEditItem] = useState<ResourceRecord | null>(null);
   const [deleteItem, setDeleteItem] = useState<ResourceRecord | null>(null);
   const [createFileSizeError, setCreateFileSizeError] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [createSubmitting, setCreateSubmitting] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
+  const createFormRef = useRef<HTMLFormElement | null>(null);
+  const uploadXhrRef = useRef<XMLHttpRequest | null>(null);
 
   const [createState, createFormAction] = useActionState<ResourceActionState, FormData>(
     createAction,
@@ -744,6 +793,171 @@ export function ResourcesCrudPage({
     deleteAction,
     {},
   );
+
+  useEffect(() => {
+    return () => {
+      if (uploadXhrRef.current) {
+        uploadXhrRef.current.abort();
+        uploadXhrRef.current = null;
+      }
+    };
+  }, []);
+
+  function uploadToR2(
+    url: string,
+    file: File,
+    contentType: string,
+    onProgress: (pct: number) => void,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      uploadXhrRef.current = xhr;
+      xhr.open("PUT", url, true);
+      xhr.setRequestHeader("Content-Type", contentType);
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable && event.total > 0) {
+          onProgress(Math.round((event.loaded / event.total) * 100));
+        }
+      };
+      xhr.onload = () => {
+        uploadXhrRef.current = null;
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve();
+        } else {
+          reject(
+            new Error(
+              `R2 PUT respondió ${xhr.status}: ${xhr.statusText || "error"}`,
+            ),
+          );
+        }
+      };
+      xhr.onerror = () => {
+        uploadXhrRef.current = null;
+        reject(new Error("Error de red durante la subida a R2."));
+      };
+      xhr.onabort = () => {
+        uploadXhrRef.current = null;
+        reject(new Error("Subida cancelada."));
+      };
+      xhr.send(file);
+    });
+  }
+
+  async function handleCreateSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (createSubmitting) return;
+    setCreateError(null);
+    setUploadProgress(null);
+
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const resourceType = String(formData.get("resource_type") ?? "");
+
+    // text + video_link have no file → fallback to the legacy Server Action
+    if (resourceType === "text" || resourceType === "video_link") {
+      createFormAction(formData);
+      return;
+    }
+
+    if (!["document", "audio", "image"].includes(resourceType)) {
+      setCreateError("Tipo de recurso inválido.");
+      return;
+    }
+
+    const file = formData.get("file");
+    if (!(file instanceof File) || file.size === 0) {
+      setCreateError("Selecciona un archivo antes de subir.");
+      return;
+    }
+
+    const title = String(formData.get("title") ?? "").trim();
+    if (!title) {
+      setCreateError("El título es obligatorio.");
+      return;
+    }
+
+    const scopeLevel = String(formData.get("scope_level") ?? "") as ScopeLevel;
+    const scopeIdRaw = String(formData.get("scope_id") ?? "").trim();
+    const scopeId = scopeIdRaw ? Number(scopeIdRaw) : undefined;
+    if (scopeLevel !== "system" && (!scopeId || !Number.isFinite(scopeId))) {
+      setCreateError("Selecciona el alcance específico (unión o campo local).");
+      return;
+    }
+
+    const categoryIdRaw = String(formData.get("category_id") ?? "").trim();
+    const categoryId =
+      categoryIdRaw && categoryIdRaw !== "none" ? Number(categoryIdRaw) : undefined;
+    const description = String(formData.get("description") ?? "").trim() || undefined;
+
+    setCreateSubmitting(true);
+    try {
+      const uploadResp = await requestUploadUrlAction({
+        resource_type: resourceType as "document" | "audio" | "image",
+        scope_level: scopeLevel,
+        scope_id: scopeId,
+        file_name: file.name,
+        mime_type: file.type || "application/octet-stream",
+        file_size: file.size,
+      });
+
+      if (uploadResp.error || !uploadResp.data) {
+        setCreateError(uploadResp.error ?? "No se pudo iniciar la subida.");
+        return;
+      }
+
+      const { upload_url, file_key, required_headers } = uploadResp.data;
+      const contentType = required_headers["Content-Type"] ?? file.type;
+
+      setUploadProgress(0);
+      try {
+        await uploadToR2(upload_url, file, contentType, setUploadProgress);
+      } catch (uploadErr) {
+        setCreateError(
+          uploadErr instanceof Error ? uploadErr.message : "Subida fallida.",
+        );
+        return;
+      }
+
+      // Register the resource — server action will redirect on success.
+      const result = await createResourceFromUploadedAction(
+        {},
+        {
+          title,
+          description,
+          resource_type: resourceType as "document" | "audio" | "image",
+          resource_category_id: categoryId,
+          scope_level: scopeLevel,
+          scope_id: scopeId,
+          file_key,
+          file_name: file.name,
+          file_mime_type: contentType,
+          file_size: file.size,
+        },
+      );
+
+      if (result?.error) {
+        setCreateError(result.error);
+      }
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : "Error inesperado.");
+    } finally {
+      setCreateSubmitting(false);
+      setUploadProgress(null);
+    }
+  }
+
+  function handleCreateCancel() {
+    if (uploadXhrRef.current) {
+      uploadXhrRef.current.abort();
+      uploadXhrRef.current = null;
+    }
+    setCreateOpen(false);
+    setCreateFileSizeError(null);
+    setCreateError(null);
+    setUploadProgress(null);
+    setCreateSubmitting(false);
+  }
 
   useEffect(() => {
     latestParamsRef.current = searchParamsString;
@@ -1242,8 +1456,11 @@ export function ResourcesCrudPage({
         <Dialog
           open={createOpen}
           onOpenChange={(open) => {
-            setCreateOpen(open);
-            if (!open) setCreateFileSizeError(null);
+            if (!open) {
+              handleCreateCancel();
+            } else {
+              setCreateOpen(true);
+            }
           }}
         >
           <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
@@ -1253,23 +1470,54 @@ export function ResourcesCrudPage({
                 Completa los campos para registrar el nuevo recurso en el sistema.
               </DialogDescription>
             </DialogHeader>
-            <form action={createFormAction} className="space-y-4">
-              {createOpen && createState.error && (
+            <form
+              ref={createFormRef}
+              onSubmit={handleCreateSubmit}
+              className="space-y-4"
+            >
+              {createOpen && (createError || createState.error) && (
                 <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                  {createState.error}
+                  {createError ?? createState.error}
                 </div>
               )}
               <ResourceFormFields
                 categories={categories}
                 unions={unions}
                 localFields={localFields}
+                allowedScopeLevels={allowedScopeLevels}
+                lockedScopeId={lockedScopeId}
                 onFileSizeError={setCreateFileSizeError}
               />
+              {uploadProgress !== null && (
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>Subiendo archivo a R2…</span>
+                    <span>{uploadProgress}%</span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full bg-primary transition-all"
+                      style={{ width: `${uploadProgress}%` }}
+                    />
+                  </div>
+                </div>
+              )}
               <DialogFooter>
-                <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleCreateCancel}
+                  disabled={createSubmitting && uploadProgress === null}
+                >
                   Cancelar
                 </Button>
-                <SubmitButton label="Subir recurso" extraDisabled={!!createFileSizeError} />
+                <Button
+                  type="submit"
+                  disabled={createSubmitting || !!createFileSizeError}
+                >
+                  {createSubmitting && <Loader2 className="size-4 animate-spin" />}
+                  Subir recurso
+                </Button>
               </DialogFooter>
             </form>
           </DialogContent>
@@ -1307,6 +1555,8 @@ export function ResourcesCrudPage({
                 categories={categories}
                 unions={unions}
                 localFields={localFields}
+                allowedScopeLevels={allowedScopeLevels}
+                lockedScopeId={lockedScopeId}
                 isEdit
               />
               <DialogFooter>

--- a/src/components/users/bulk-upload-client.tsx
+++ b/src/components/users/bulk-upload-client.tsx
@@ -1,0 +1,599 @@
+"use client";
+
+import { useState, useRef, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { Upload, FileSpreadsheet, X, CheckCircle2, XCircle, Loader2, Download } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+import { ApiError } from "@/lib/api/client";
+import {
+  bulkUploadAdminUsersFromClient,
+  downloadAdminUsersBulkTemplate,
+  type BulkUserRowResult,
+  type BulkUsersResult,
+} from "@/lib/api/admin-users";
+
+// ─── Error code → human label map ─────────────────────────────────────────────
+
+const ERROR_CODE_LABELS: Record<string, string> = {
+  VALIDATION_FAILED: "Datos inválidos",
+  DUPLICATE_IN_FILE: "Email duplicado en el archivo",
+  EMAIL_ALREADY_IN_USE: "Email ya registrado",
+  INVALID_ROLE: "Rol inválido",
+  FORBIDDEN_ROLE_FOR_ACTOR: "No podés crear ese rol",
+  INTERNAL_ERROR: "Error interno",
+};
+
+function resolveErrorLabel(code: string | undefined, message: string | undefined): string {
+  if (code && ERROR_CODE_LABELS[code]) {
+    return ERROR_CODE_LABELS[code];
+  }
+  return message ?? code ?? "Error desconocido";
+}
+
+// ─── Preview row shape ─────────────────────────────────────────────────────────
+
+type PreviewRow = Record<string, unknown>;
+
+const REQUIRED_HEADERS = ["email"] as const;
+const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
+const MAX_ROWS = 500;
+const PREVIEW_ROWS = 5;
+const PREVIEW_COLS = ["email", "name", "paternal_last_name", "role"] as const;
+
+// ─── State machine ─────────────────────────────────────────────────────────────
+
+type IdleState = { phase: "idle" };
+type PreviewingState = { phase: "previewing"; file: File; rows: PreviewRow[]; total: number };
+type UploadingState = { phase: "uploading"; file: File };
+type ResultsState = { phase: "results"; data: BulkUsersResult };
+
+type UiState = IdleState | PreviewingState | UploadingState | ResultsState;
+
+type ResultFilter = "all" | "success" | "error";
+
+// ─── Download helper ───────────────────────────────────────────────────────────
+
+async function triggerTemplateDownload() {
+  const blob = await downloadAdminUsersBulkTemplate();
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "plantilla-usuarios.xlsx";
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+// ─── File validation ───────────────────────────────────────────────────────────
+
+function isValidExtension(file: File): boolean {
+  const name = file.name.toLowerCase();
+  return name.endsWith(".xlsx") || name.endsWith(".csv");
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function BulkUploadClient() {
+  const t = useTranslations("users.pages.bulk");
+
+  const [state, setState] = useState<UiState>({ phase: "idle" });
+  const [isDragging, setIsDragging] = useState(false);
+  const [resultFilter, setResultFilter] = useState<ResultFilter>("all");
+  const [isDownloading, setIsDownloading] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // ─── File processing ─────────────────────────────────────────────────────────
+
+  const processFile = useCallback(async (file: File) => {
+    if (!isValidExtension(file)) {
+      toast.error(t("toast.fileTypeInvalid"));
+      return;
+    }
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      toast.error(t("toast.fileTooLarge"));
+      return;
+    }
+
+    try {
+      const XLSX = await import("xlsx");
+      const buffer = await file.arrayBuffer();
+      const wb = XLSX.read(buffer, { type: "array", cellDates: false });
+      const sheet = wb.Sheets[wb.SheetNames[0]];
+      const json = XLSX.utils.sheet_to_json<PreviewRow>(sheet);
+
+      if (!Array.isArray(json) || json.length === 0) {
+        toast.error(t("toast.fileEmpty"));
+        return;
+      }
+
+      const firstRow = json[0];
+      const hasRequiredHeaders = REQUIRED_HEADERS.every((h) => h in firstRow);
+      if (!hasRequiredHeaders) {
+        toast.error(t("preview.headersInvalid"));
+        return;
+      }
+
+      if (json.length > MAX_ROWS) {
+        toast.error(t("toast.tooManyRows"));
+        return;
+      }
+
+      setState({
+        phase: "previewing",
+        file,
+        rows: json.slice(0, PREVIEW_ROWS),
+        total: json.length,
+      });
+    } catch {
+      toast.error(t("toast.generic"));
+    }
+  }, [t]);
+
+  // ─── Drag & drop ─────────────────────────────────────────────────────────────
+
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragging(false);
+  }, []);
+
+  const handleDrop = useCallback(
+    async (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setIsDragging(false);
+      const file = e.dataTransfer.files[0];
+      if (file) await processFile(file);
+    },
+    [processFile],
+  );
+
+  const handleInputChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) await processFile(file);
+      // Reset input so same file can be re-selected
+      e.target.value = "";
+    },
+    [processFile],
+  );
+
+  // ─── Submit ───────────────────────────────────────────────────────────────────
+
+  const handleSubmit = useCallback(async () => {
+    if (state.phase !== "previewing") return;
+    const { file } = state;
+
+    setState({ phase: "uploading", file });
+
+    try {
+      const data = await bulkUploadAdminUsersFromClient(file);
+
+      setState({ phase: "results", data });
+      setResultFilter("all");
+
+      if (data.failed === 0) {
+        toast.success(t("toast.success"));
+      } else if (data.succeeded === 0) {
+        toast.error(t("toast.allFailed"));
+      } else {
+        toast.warning(t("toast.partialSuccess"));
+      }
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 400) {
+          toast.error(err.message || t("toast.generic"));
+        } else if (err.status === 403) {
+          toast.error("No tenés permisos para esta operación");
+        } else if (err.status === 413) {
+          toast.error(t("toast.fileTooLarge"));
+        } else {
+          toast.error(t("toast.generic"));
+        }
+      } else {
+        toast.error(t("toast.generic"));
+      }
+
+      // Go back to previewing so user can retry or cancel
+      setState({ phase: "previewing", file, rows: state.rows ?? [], total: state.total ?? 0 });
+    }
+  }, [state, t]);
+
+  // ─── Template download ────────────────────────────────────────────────────────
+
+  const handleDownloadTemplate = useCallback(async () => {
+    setIsDownloading(true);
+    try {
+      await triggerTemplateDownload();
+    } catch {
+      toast.error(t("toast.generic"));
+    } finally {
+      setIsDownloading(false);
+    }
+  }, [t]);
+
+  // ─── Reset ────────────────────────────────────────────────────────────────────
+
+  const handleReset = useCallback(() => {
+    setState({ phase: "idle" });
+    setResultFilter("all");
+  }, []);
+
+  // ─── Render ───────────────────────────────────────────────────────────────────
+
+  if (state.phase === "idle") {
+    return <IdleView
+      isDragging={isDragging}
+      isDownloading={isDownloading}
+      inputRef={inputRef}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      onInputChange={handleInputChange}
+      onDownloadTemplate={handleDownloadTemplate}
+      t={t}
+    />;
+  }
+
+  if (state.phase === "previewing") {
+    return <PreviewView
+      file={state.file}
+      rows={state.rows}
+      total={state.total}
+      onSubmit={handleSubmit}
+      onCancel={handleReset}
+      t={t}
+    />;
+  }
+
+  if (state.phase === "uploading") {
+    return <UploadingView t={t} />;
+  }
+
+  // results
+  return <ResultsView
+    data={state.data}
+    filter={resultFilter}
+    onFilterChange={setResultFilter}
+    onReset={handleReset}
+    t={t}
+  />;
+}
+
+// ─── Idle view ────────────────────────────────────────────────────────────────
+
+interface IdleViewProps {
+  isDragging: boolean;
+  isDownloading: boolean;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  onDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDragLeave: (e: React.DragEvent<HTMLDivElement>) => void;
+  onDrop: (e: React.DragEvent<HTMLDivElement>) => Promise<void>;
+  onInputChange: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+  onDownloadTemplate: () => Promise<void>;
+  t: ReturnType<typeof useTranslations<"users.pages.bulk">>;
+}
+
+function IdleView({
+  isDragging,
+  isDownloading,
+  inputRef,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  onInputChange,
+  onDownloadTemplate,
+  t,
+}: IdleViewProps) {
+  return (
+    <div className="space-y-4">
+      <div
+        role="region"
+        aria-label={t("dropZone.title")}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        className={cn(
+          "relative flex flex-col items-center justify-center gap-4 rounded-xl border-2 border-dashed px-6 py-14 text-center transition-colors",
+          isDragging
+            ? "border-primary bg-primary/5"
+            : "border-border bg-muted/30 hover:border-primary/50 hover:bg-muted/50",
+        )}
+      >
+        <div className="flex size-14 items-center justify-center rounded-full bg-primary/10">
+          <Upload className="size-7 text-primary" aria-hidden="true" />
+        </div>
+
+        <div className="space-y-1">
+          <p className="text-sm font-medium text-foreground">{t("dropZone.title")}</p>
+          <p className="text-xs text-muted-foreground">{t("dropZone.subtitle")}</p>
+          <p className="text-xs text-muted-foreground">{t("dropZone.accept")}</p>
+        </div>
+
+        <label htmlFor="bulk-file-input">
+          <span className="cursor-pointer text-xs font-medium text-primary underline-offset-4 hover:underline">
+            {t("dropZone.browse")}
+          </span>
+          <input
+            ref={inputRef}
+            id="bulk-file-input"
+            type="file"
+            accept=".xlsx,.csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,text/csv"
+            className="sr-only"
+            onChange={onInputChange}
+          />
+        </label>
+      </div>
+
+      <div className="flex justify-center">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onDownloadTemplate}
+          disabled={isDownloading}
+          className="gap-2"
+        >
+          {isDownloading ? (
+            <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Download className="size-4" aria-hidden="true" />
+          )}
+          {t("downloadTemplate")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Preview view ─────────────────────────────────────────────────────────────
+
+interface PreviewViewProps {
+  file: File;
+  rows: PreviewRow[];
+  total: number;
+  onSubmit: () => Promise<void>;
+  onCancel: () => void;
+  t: ReturnType<typeof useTranslations<"users.pages.bulk">>;
+}
+
+function PreviewView({ file, rows, total, onSubmit, onCancel, t }: PreviewViewProps) {
+  const extraCols = Object.keys(rows[0] ?? {}).filter((k) => !PREVIEW_COLS.includes(k as typeof PREVIEW_COLS[number]));
+  const hasExtra = extraCols.length > 0;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3 rounded-lg border bg-muted/30 px-4 py-3">
+        <FileSpreadsheet className="size-5 text-primary shrink-0" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">{file.name}</p>
+          <p className="text-xs text-muted-foreground">
+            {t("preview.showingRowsOf", { shown: Math.min(rows.length, PREVIEW_ROWS), total })}
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {PREVIEW_COLS.map((col) => (
+                <TableHead key={col}>{col}</TableHead>
+              ))}
+              {hasExtra && (
+                <TableHead className="text-muted-foreground">
+                  +{extraCols.length} {t("preview.moreColumns")}
+                </TableHead>
+              )}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((row, idx) => (
+              <TableRow key={idx}>
+                {PREVIEW_COLS.map((col) => (
+                  <TableCell key={col} className="max-w-[180px] truncate">
+                    {row[col] != null ? String(row[col]) : (
+                      <span className="text-muted-foreground italic">—</span>
+                    )}
+                  </TableCell>
+                ))}
+                {hasExtra && <TableCell />}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {total > PREVIEW_ROWS && (
+        <p className="text-xs text-muted-foreground text-center">
+          {t("preview.subtitle")}
+        </p>
+      )}
+
+      <div className="flex items-center justify-end gap-3">
+        <Button variant="outline" size="sm" onClick={onCancel}>
+          {t("actions.cancel")}
+        </Button>
+        <Button size="sm" onClick={onSubmit}>
+          {t("actions.submit")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── Uploading view ───────────────────────────────────────────────────────────
+
+function UploadingView({ t }: { t: ReturnType<typeof useTranslations<"users.pages.bulk">> }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-4 rounded-xl border bg-muted/30 px-6 py-14">
+      <Loader2 className="size-10 animate-spin text-primary" aria-hidden="true" />
+      <p className="text-sm text-muted-foreground">{t("actions.submit")}…</p>
+    </div>
+  );
+}
+
+// ─── Results view ─────────────────────────────────────────────────────────────
+
+interface ResultsViewProps {
+  data: BulkUsersResult;
+  filter: ResultFilter;
+  onFilterChange: (f: ResultFilter) => void;
+  onReset: () => void;
+  t: ReturnType<typeof useTranslations<"users.pages.bulk">>;
+}
+
+function ResultsView({ data, filter, onFilterChange, onReset, t }: ResultsViewProps) {
+  const filteredRows: BulkUserRowResult[] =
+    filter === "all"
+      ? data.results
+      : data.results.filter((r) => r.status === filter);
+
+  return (
+    <div className="space-y-6">
+      {/* KPI cards */}
+      <div className="grid grid-cols-3 gap-4">
+        <KpiCard
+          label={t("results.totalLabel")}
+          value={data.total}
+          variant="neutral"
+        />
+        <KpiCard
+          label={t("results.succeededLabel")}
+          value={data.succeeded}
+          variant="success"
+        />
+        <KpiCard
+          label={t("results.failedLabel")}
+          value={data.failed}
+          variant={data.failed > 0 ? "error" : "neutral"}
+        />
+      </div>
+
+      {/* Filter tabs */}
+      <div className="flex items-center gap-2">
+        {(["all", "success", "error"] as const).map((f) => {
+          const labels: Record<ResultFilter, string> = {
+            all: t("actions.filterAll"),
+            success: t("actions.filterSuccess"),
+            error: t("actions.filterError"),
+          };
+          return (
+            <Button
+              key={f}
+              size="sm"
+              variant={filter === f ? "default" : "outline"}
+              onClick={() => onFilterChange(f)}
+            >
+              {labels[f]}
+            </Button>
+          );
+        })}
+      </div>
+
+      {/* Results table */}
+      <div className="rounded-lg border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>{t("results.rowHeader")}</TableHead>
+              <TableHead>{t("results.emailHeader")}</TableHead>
+              <TableHead>{t("results.statusHeader")}</TableHead>
+              <TableHead>{t("results.detailHeader")}</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filteredRows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="py-8 text-center text-sm text-muted-foreground">
+                  Sin resultados para este filtro.
+                </TableCell>
+              </TableRow>
+            ) : (
+              filteredRows.map((row) => (
+                <TableRow key={row.row}>
+                  <TableCell className="text-muted-foreground">{row.row}</TableCell>
+                  <TableCell className="max-w-[200px] truncate font-mono text-xs">
+                    {row.email ?? <span className="text-muted-foreground italic">—</span>}
+                  </TableCell>
+                  <TableCell>
+                    {row.status === "success" ? (
+                      <Badge variant="soft-success" className="gap-1">
+                        <CheckCircle2 className="size-3" aria-hidden="true" />
+                        {t("statusBadges.success")}
+                      </Badge>
+                    ) : (
+                      <Badge variant="destructive" className="gap-1">
+                        <XCircle className="size-3" aria-hidden="true" />
+                        {t("statusBadges.error")}
+                      </Badge>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-xs text-muted-foreground max-w-[260px]">
+                    {row.status === "success" ? (
+                      row.invite_email_sent
+                        ? t("results.inviteSent")
+                        : t("results.inviteNotSent")
+                    ) : (
+                      resolveErrorLabel(row.error_code, row.error_message)
+                    )}
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+
+      <div className="flex justify-end">
+        <Button size="sm" onClick={onReset}>
+          {t("actions.uploadAnother")}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── KPI card ─────────────────────────────────────────────────────────────────
+
+function KpiCard({
+  label,
+  value,
+  variant,
+}: {
+  label: string;
+  value: number;
+  variant: "neutral" | "success" | "error";
+}) {
+  return (
+    <div className="rounded-lg border bg-card px-5 py-4 space-y-1">
+      <p className="text-xs text-muted-foreground uppercase tracking-wider">{label}</p>
+      <p
+        className={cn(
+          "text-3xl font-semibold tracking-tight",
+          variant === "success" && "text-success",
+          variant === "error" && "text-destructive",
+          variant === "neutral" && "text-foreground",
+        )}
+      >
+        {value}
+      </p>
+    </div>
+  );
+}

--- a/src/components/users/new-user-form.tsx
+++ b/src/components/users/new-user-form.tsx
@@ -66,33 +66,25 @@ type NewUserTranslator = ReturnType<typeof useTranslations<"users.pages.new">>;
 
 function buildSchema(t: NewUserTranslator) {
   return z.object({
-    name: z
-      .string()
-      .min(1, t("validation.nameRequired"))
-      .max(50),
+    name: z.string().min(1, t("validation.nameRequired")).max(50),
     paternal_last_name: z
       .string()
       .min(1, t("validation.paternalRequired"))
       .max(50),
-    maternal_last_name: z
-      .string()
-      .max(50)
-      .optional(),
+    maternal_last_name: z.string().max(50).optional(),
     email: z
       .string()
       .min(1, t("validation.emailRequired"))
       .max(120)
       .email(t("validation.emailInvalid")),
-    role: z
-      .string()
-      .min(1, t("validation.roleRequired")) as z.ZodType<AdminCreatableRole>,
-    country_id: z.coerce
+    role: z.string().min(1, t("validation.roleRequired")),
+    country_id: z
       .number({ error: t("validation.countryRequired") })
       .min(1, t("validation.countryRequired")),
-    union_id: z.coerce
+    union_id: z
       .number({ error: t("validation.unionRequired") })
       .min(1, t("validation.unionRequired")),
-    local_field_id: z.coerce.number().min(1).optional(),
+    local_field_id: z.number().min(1).optional(),
   });
 }
 
@@ -101,7 +93,7 @@ type FormValues = {
   paternal_last_name: string;
   maternal_last_name?: string;
   email: string;
-  role: AdminCreatableRole;
+  role: string;
   country_id: number;
   union_id: number;
   local_field_id?: number;
@@ -207,7 +199,9 @@ export function NewUserForm({ allowedRoles }: NewUserFormProps) {
         paternal_last_name: values.paternal_last_name,
         maternal_last_name: values.maternal_last_name || undefined,
         email: values.email,
-        role: values.role,
+        // role is validated against `allowedRoles` in the UI and re-checked
+        // server-side; narrow here to satisfy the API client type.
+        role: values.role as AdminCreatableRole,
         country_id: values.country_id,
         union_id: values.union_id,
         local_field_id: values.local_field_id,

--- a/src/components/users/new-user-form.tsx
+++ b/src/components/users/new-user-form.tsx
@@ -1,0 +1,520 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  createAdminUserFromClient,
+  type AdminCreatableRole,
+} from "@/lib/api/admin-users";
+import {
+  listCountries,
+  listUnions,
+  listLocalFields,
+  type Country,
+  type Union,
+  type LocalField,
+} from "@/lib/api/geography";
+import { useRoleLabel } from "@/lib/auth/role-labels";
+import { ApiError } from "@/lib/api/client";
+
+// ─── Role ordering (highest to lowest) ───────────────────────────────────────
+
+const ALL_CREATABLE_ROLES: AdminCreatableRole[] = [
+  "admin",
+  "director-dia",
+  "assistant-dia",
+  "director-union",
+  "assistant-union",
+  "director-lf",
+  "assistant-lf",
+  "general-coordinator",
+  "zone-coordinator",
+  "coordinator",
+  "pastor",
+  "user",
+];
+
+// ─── Schema ───────────────────────────────────────────────────────────────────
+
+type NewUserTranslator = ReturnType<typeof useTranslations<"users.pages.new">>;
+
+function buildSchema(t: NewUserTranslator) {
+  return z.object({
+    name: z
+      .string()
+      .min(1, t("validation.nameRequired"))
+      .max(50),
+    paternal_last_name: z
+      .string()
+      .min(1, t("validation.paternalRequired"))
+      .max(50),
+    maternal_last_name: z
+      .string()
+      .max(50)
+      .optional(),
+    email: z
+      .string()
+      .min(1, t("validation.emailRequired"))
+      .max(120)
+      .email(t("validation.emailInvalid")),
+    role: z
+      .string()
+      .min(1, t("validation.roleRequired")) as z.ZodType<AdminCreatableRole>,
+    country_id: z.coerce
+      .number({ error: t("validation.countryRequired") })
+      .min(1, t("validation.countryRequired")),
+    union_id: z.coerce
+      .number({ error: t("validation.unionRequired") })
+      .min(1, t("validation.unionRequired")),
+    local_field_id: z.coerce.number().min(1).optional(),
+  });
+}
+
+type FormValues = {
+  name: string;
+  paternal_last_name: string;
+  maternal_last_name?: string;
+  email: string;
+  role: AdminCreatableRole;
+  country_id: number;
+  union_id: number;
+  local_field_id?: number;
+};
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface NewUserFormProps {
+  allowedRoles: AdminCreatableRole[];
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+const LIST_HREF = "/dashboard/users";
+
+export function NewUserForm({ allowedRoles }: NewUserFormProps) {
+  const t = useTranslations("users.pages.new");
+  const router = useRouter();
+  const getRoleLabel = useRoleLabel();
+
+  // Geography state
+  const [countries, setCountries] = useState<Country[]>([]);
+  const [unions, setUnions] = useState<Union[]>([]);
+  const [localFields, setLocalFields] = useState<LocalField[]>([]);
+  const [loadingCountries, setLoadingCountries] = useState(false);
+  const [loadingUnions, setLoadingUnions] = useState(false);
+  const [loadingLocalFields, setLoadingLocalFields] = useState(false);
+
+  // Schema is stable given t doesn't change after mount
+  const schema = useMemo(() => buildSchema(t), [t]);
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: "",
+      paternal_last_name: "",
+      maternal_last_name: "",
+      email: "",
+      role: undefined,
+      country_id: undefined,
+      union_id: undefined,
+      local_field_id: undefined,
+    },
+  });
+
+  const { formState: { isSubmitting } } = form;
+
+  // Load countries on mount
+  useEffect(() => {
+    setLoadingCountries(true);
+    listCountries()
+      .then((data) => setCountries(Array.isArray(data) ? data : []))
+      .catch(() => toast.error(t("toast.generic")))
+      .finally(() => setLoadingCountries(false));
+  }, [t]);
+
+  // Watch country_id and load unions when it changes
+  const watchedCountryId = form.watch("country_id");
+  useEffect(() => {
+    if (!watchedCountryId || watchedCountryId < 1) {
+      setUnions([]);
+      setLocalFields([]);
+      form.setValue("union_id", undefined as unknown as number);
+      form.setValue("local_field_id", undefined);
+      return;
+    }
+
+    setLoadingUnions(true);
+    setUnions([]);
+    setLocalFields([]);
+    form.setValue("union_id", undefined as unknown as number);
+    form.setValue("local_field_id", undefined);
+
+    listUnions(watchedCountryId)
+      .then((data) => setUnions(Array.isArray(data) ? data : []))
+      .catch(() => toast.error(t("toast.generic")))
+      .finally(() => setLoadingUnions(false));
+  }, [watchedCountryId, form, t]);
+
+  // Watch union_id and load local fields when it changes
+  const watchedUnionId = form.watch("union_id");
+  useEffect(() => {
+    if (!watchedUnionId || watchedUnionId < 1) {
+      setLocalFields([]);
+      form.setValue("local_field_id", undefined);
+      return;
+    }
+
+    setLoadingLocalFields(true);
+    setLocalFields([]);
+    form.setValue("local_field_id", undefined);
+
+    listLocalFields(watchedUnionId)
+      .then((data) => setLocalFields(Array.isArray(data) ? data : []))
+      .catch(() => toast.error(t("toast.generic")))
+      .finally(() => setLoadingLocalFields(false));
+  }, [watchedUnionId, form, t]);
+
+  async function onSubmit(values: FormValues) {
+    try {
+      const result = await createAdminUserFromClient({
+        name: values.name,
+        paternal_last_name: values.paternal_last_name,
+        maternal_last_name: values.maternal_last_name || undefined,
+        email: values.email,
+        role: values.role,
+        country_id: values.country_id,
+        union_id: values.union_id,
+        local_field_id: values.local_field_id,
+      });
+
+      toast.success(t("toast.success", { email: result.email }));
+
+      if (!result.invite_email_sent) {
+        toast.warning(t("toast.inviteNotSent"));
+      }
+
+      router.push(LIST_HREF);
+    } catch (error) {
+      if (error instanceof ApiError) {
+        if (error.status === 409) {
+          toast.error(t("toast.emailExists"));
+        } else if (error.status === 403) {
+          toast.error(t("toast.forbidden"));
+        } else if (error.status === 400) {
+          toast.error(t("toast.validationFailed"));
+        } else {
+          toast.error(t("toast.generic"));
+        }
+      } else {
+        toast.error(t("toast.generic"));
+      }
+    }
+  }
+
+  // Filter and order roles according to allowedRoles prop
+  const roleOptions = ALL_CREATABLE_ROLES.filter((r) => allowedRoles.includes(r));
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-8"
+        noValidate
+      >
+        {/* ── Grid fields ── */}
+        <div className="grid gap-6 md:grid-cols-2">
+          {/* Name */}
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t("fields.name")}{" "}
+                  <span aria-hidden="true" className="text-destructive">
+                    *
+                  </span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder={t("placeholders.name")}
+                    autoComplete="given-name"
+                    maxLength={50}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Paternal last name */}
+          <FormField
+            control={form.control}
+            name="paternal_last_name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t("fields.paternal_last_name")}{" "}
+                  <span aria-hidden="true" className="text-destructive">
+                    *
+                  </span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    placeholder={t("placeholders.paternal_last_name")}
+                    autoComplete="family-name"
+                    maxLength={50}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Maternal last name */}
+          <FormField
+            control={form.control}
+            name="maternal_last_name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("fields.maternal_last_name")}</FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    value={field.value ?? ""}
+                    placeholder={t("placeholders.maternal_last_name")}
+                    maxLength={50}
+                  />
+                </FormControl>
+                <FormDescription>{t("help.maternal_last_name")}</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Email */}
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t("fields.email")}{" "}
+                  <span aria-hidden="true" className="text-destructive">
+                    *
+                  </span>
+                </FormLabel>
+                <FormControl>
+                  <Input
+                    {...field}
+                    type="email"
+                    placeholder={t("placeholders.email")}
+                    autoComplete="email"
+                    maxLength={120}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Role */}
+          <FormField
+            control={form.control}
+            name="role"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t("fields.role")}{" "}
+                  <span aria-hidden="true" className="text-destructive">
+                    *
+                  </span>
+                </FormLabel>
+                <Select
+                  onValueChange={field.onChange}
+                  value={field.value ?? ""}
+                >
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder={t("placeholders.role")} />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {roleOptions.map((role) => (
+                      <SelectItem key={role} value={role}>
+                        {getRoleLabel(role)}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FormDescription>{t("help.role")}</FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Country */}
+          <FormField
+            control={form.control}
+            name="country_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t("fields.country")}{" "}
+                  <span aria-hidden="true" className="text-destructive">
+                    *
+                  </span>
+                </FormLabel>
+                {loadingCountries ? (
+                  <Skeleton className="h-9 w-full" />
+                ) : (
+                  <Select
+                    onValueChange={(val) => field.onChange(Number(val))}
+                    value={field.value ? String(field.value) : ""}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t("placeholders.country")} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {countries.map((c) => (
+                        <SelectItem key={c.country_id} value={String(c.country_id)}>
+                          {c.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Union */}
+          <FormField
+            control={form.control}
+            name="union_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  {t("fields.union")}{" "}
+                  <span aria-hidden="true" className="text-destructive">
+                    *
+                  </span>
+                </FormLabel>
+                {loadingUnions ? (
+                  <Skeleton className="h-9 w-full" />
+                ) : (
+                  <Select
+                    onValueChange={(val) => field.onChange(Number(val))}
+                    value={field.value ? String(field.value) : ""}
+                    disabled={!watchedCountryId || watchedCountryId < 1}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t("placeholders.union")} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {unions.map((u) => (
+                        <SelectItem key={u.union_id} value={String(u.union_id)}>
+                          {u.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                {!watchedCountryId && (
+                  <FormDescription>{t("help.union")}</FormDescription>
+                )}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Local field */}
+          <FormField
+            control={form.control}
+            name="local_field_id"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>{t("fields.local_field")}</FormLabel>
+                {loadingLocalFields ? (
+                  <Skeleton className="h-9 w-full" />
+                ) : (
+                  <Select
+                    onValueChange={(val) =>
+                      field.onChange(val ? Number(val) : undefined)
+                    }
+                    value={field.value ? String(field.value) : ""}
+                    disabled={!watchedUnionId || watchedUnionId < 1}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder={t("placeholders.local_field")} />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {localFields.map((lf) => (
+                        <SelectItem
+                          key={lf.local_field_id}
+                          value={String(lf.local_field_id)}
+                        >
+                          {lf.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                {!watchedUnionId && (
+                  <FormDescription>{t("help.local_field")}</FormDescription>
+                )}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </div>
+
+        {/* ── Footer ── */}
+        <div className="flex items-center justify-between gap-4 pt-2">
+          <Button variant="outline" asChild>
+            <Link href={LIST_HREF}>{t("actions.cancel")}</Link>
+          </Button>
+          <Button type="submit" disabled={isSubmitting}>
+            {isSubmitting && <Loader2 className="size-4 animate-spin" />}
+            {isSubmitting ? t("actions.submitting") : t("actions.submit")}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/components/users/users-toolbar-actions.tsx
+++ b/src/components/users/users-toolbar-actions.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { UserPlus, Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useCanManageUsers } from "@/lib/auth/use-can-manage-users";
+
+export function UsersToolbarActions() {
+  const canManage = useCanManageUsers();
+  const t = useTranslations("users.pages.list");
+
+  if (!canManage) return null;
+
+  return (
+    <div className="flex items-center gap-2">
+      <Button asChild size="sm" variant="outline">
+        <Link href="/dashboard/users/bulk-upload" className="inline-flex items-center gap-1.5">
+          <Upload className="size-4" aria-hidden="true" />
+          {t("actions.bulkUpload")}
+        </Link>
+      </Button>
+      <Button asChild size="sm">
+        <Link href="/dashboard/users/new" className="inline-flex items-center gap-1.5">
+          <UserPlus className="size-4" aria-hidden="true" />
+          {t("actions.addUser")}
+        </Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -936,6 +936,7 @@ export interface IntlMessages {
       noRolesFound: string;
       basedOn: string;
       userCount: string;
+      noRoleChip: string;
     };
     quickLinks: {
       title: string;
@@ -2819,6 +2820,63 @@ export interface IntlMessages {
         cannotShow: string;
         emptyTitle: string;
         emptyDescription: string;
+        actions: {
+          addUser: string;
+          bulkUpload: string;
+        };
+      };
+      new: {
+        title: string;
+        description: string;
+        breadcrumb: string;
+        fields: {
+          name: string;
+          paternal_last_name: string;
+          maternal_last_name: string;
+          email: string;
+          role: string;
+          country: string;
+          union: string;
+          local_field: string;
+        };
+        placeholders: {
+          name: string;
+          paternal_last_name: string;
+          maternal_last_name: string;
+          email: string;
+          role: string;
+          country: string;
+          union: string;
+          local_field: string;
+        };
+        help: {
+          maternal_last_name: string;
+          role: string;
+          union: string;
+          local_field: string;
+        };
+        actions: {
+          submit: string;
+          cancel: string;
+          submitting: string;
+        };
+        toast: {
+          success: string;
+          inviteNotSent: string;
+          emailExists: string;
+          forbidden: string;
+          validationFailed: string;
+          generic: string;
+        };
+        validation: {
+          nameRequired: string;
+          paternalRequired: string;
+          emailRequired: string;
+          emailInvalid: string;
+          roleRequired: string;
+          countryRequired: string;
+          unionRequired: string;
+        };
       };
       detail: {
         title: string;
@@ -2832,6 +2890,70 @@ export interface IntlMessages {
         tabSecurity: string;
         tabSessions: string;
         postRegistrationUnavailable: string;
+      };
+      bulk: {
+        title: string;
+        description: string;
+        breadcrumb: string;
+        downloadTemplate: string;
+        dropZone: {
+          title: string;
+          subtitle: string;
+          browse: string;
+          accept: string;
+        };
+        preview: {
+          title: string;
+          subtitle: string;
+          showingRowsOf: string;
+          moreColumns: string;
+          headersOk: string;
+          headersInvalid: string;
+          emptyFile: string;
+          tooManyRows: string;
+        };
+        actions: {
+          submit: string;
+          cancel: string;
+          uploadAnother: string;
+          filterAll: string;
+          filterSuccess: string;
+          filterError: string;
+        };
+        results: {
+          totalLabel: string;
+          succeededLabel: string;
+          failedLabel: string;
+          inviteSent: string;
+          inviteNotSent: string;
+          createdHeader: string;
+          emailHeader: string;
+          rowHeader: string;
+          detailHeader: string;
+          statusHeader: string;
+        };
+        statusBadges: {
+          success: string;
+          error: string;
+        };
+        errorCodes: {
+          validationFailed: string;
+          duplicateInFile: string;
+          emailAlreadyInUse: string;
+          invalidRole: string;
+          forbiddenRoleForActor: string;
+          internalError: string;
+        };
+        toast: {
+          success: string;
+          partialSuccess: string;
+          allFailed: string;
+          fileTooLarge: string;
+          fileTypeInvalid: string;
+          fileEmpty: string;
+          tooManyRows: string;
+          generic: string;
+        };
       };
     };
   };

--- a/src/lib/api/admin-users.ts
+++ b/src/lib/api/admin-users.ts
@@ -1,4 +1,4 @@
-import { ApiError, apiRequest, apiRequestFromClient } from "@/lib/api/client";
+import { ApiError, apiRequest, apiRequestFromClient, API_BASE_URL } from "@/lib/api/client";
 
 export type ScopeType = "ALL" | "UNION" | "LOCAL_FIELD";
 
@@ -925,3 +925,163 @@ export async function updateAdminUserApprovalFromClient(payload: UpdateAdminUser
 
   throw new Error("No se pudo actualizar la aprobación del usuario");
 }
+
+export type AdminCreatableRole =
+  | "user"
+  | "coordinator"
+  | "zone-coordinator"
+  | "general-coordinator"
+  | "pastor"
+  | "assistant-lf"
+  | "director-lf"
+  | "assistant-union"
+  | "director-union"
+  | "assistant-dia"
+  | "director-dia"
+  | "admin";
+
+export type CreateAdminUserPayload = {
+  name: string;
+  paternal_last_name: string;
+  maternal_last_name?: string | null;
+  email: string;
+  role: AdminCreatableRole;
+  country_id?: number | null;
+  union_id?: number | null;
+  local_field_id?: number | null;
+};
+
+export type CreateAdminUserResponse = {
+  user_id: string;
+  email: string;
+  invite_email_sent: boolean;
+};
+
+function buildCreateUserBody(payload: CreateAdminUserPayload): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    name: payload.name.trim(),
+    paternal_last_name: payload.paternal_last_name.trim(),
+    email: payload.email.trim().toLowerCase(),
+    role: payload.role,
+  };
+
+  const maternal = payload.maternal_last_name?.trim();
+  if (maternal) body.maternal_last_name = maternal;
+  if (typeof payload.country_id === "number") body.country_id = payload.country_id;
+  if (typeof payload.union_id === "number") body.union_id = payload.union_id;
+  if (typeof payload.local_field_id === "number") body.local_field_id = payload.local_field_id;
+
+  return body;
+}
+
+function unwrapCreateResponse(payload: unknown): CreateAdminUserResponse {
+  const obj = payload as { status?: string; data?: CreateAdminUserResponse } | null;
+  if (obj && obj.data && typeof obj.data === "object") {
+    return obj.data;
+  }
+  return payload as CreateAdminUserResponse;
+}
+
+export async function createAdminUser(
+  payload: CreateAdminUserPayload,
+): Promise<CreateAdminUserResponse> {
+  const raw = await apiRequest<unknown>("/admin/users", {
+    method: "POST",
+    body: buildCreateUserBody(payload),
+  });
+  return unwrapCreateResponse(raw);
+}
+
+export async function createAdminUserFromClient(
+  payload: CreateAdminUserPayload,
+): Promise<CreateAdminUserResponse> {
+  const raw = await apiRequestFromClient<unknown>("/admin/users", {
+    method: "POST",
+    body: buildCreateUserBody(payload),
+  });
+  return unwrapCreateResponse(raw);
+}
+
+// ─── Bulk upload ───────────────────────────────────────────────────────────────
+
+export type BulkUserRowResult = {
+  row: number;
+  email: string | null;
+  status: "success" | "error";
+  user_id?: string;
+  invite_email_sent?: boolean;
+  error_code?: string;
+  error_message?: string;
+};
+
+export type BulkUsersResult = {
+  total: number;
+  succeeded: number;
+  failed: number;
+  results: BulkUserRowResult[];
+};
+
+function unwrapBulkResponse(payload: unknown): BulkUsersResult {
+  const obj = payload as
+    | { status?: string; data?: BulkUsersResult }
+    | BulkUsersResult
+    | null;
+
+  if (obj && typeof obj === "object" && "data" in obj && obj.data && typeof obj.data === "object") {
+    return obj.data as BulkUsersResult;
+  }
+
+  return payload as BulkUsersResult;
+}
+
+/**
+ * Uploads an xlsx/csv file for bulk user creation.
+ * Uses FormData — axios sets the correct multipart Content-Type automatically.
+ */
+export async function bulkUploadAdminUsersFromClient(
+  file: File,
+): Promise<BulkUsersResult> {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const raw = await apiRequestFromClient<unknown>("/admin/users/bulk", {
+    method: "POST",
+    body: formData,
+  });
+
+  return unwrapBulkResponse(raw);
+}
+
+/**
+ * Fetches the xlsx template file for bulk uploads.
+ * Returns a Blob — the caller triggers the browser download.
+ * Must be called from the browser only.
+ */
+export async function downloadAdminUsersBulkTemplate(): Promise<Blob> {
+  // Fetch the token from the httpOnly relay first
+  let token: string | null = null;
+  try {
+    const res = await fetch("/api/auth/token");
+    if (res.ok) {
+      const json = (await res.json()) as { token: string | null };
+      token = json.token;
+    }
+  } catch {
+    // Proceed without token — backend will 401
+  }
+
+  const url = `${API_BASE_URL}/admin/users/bulk-template`;
+  const headers: HeadersInit = { Accept: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, */*" };
+  if (token) {
+    (headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
+  }
+
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    throw new Error(`Template download failed: ${response.status}`);
+  }
+
+  return response.blob();
+}
+

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -57,19 +57,52 @@ function toRecord(headers?: HeadersInit) {
   return headers;
 }
 
+function flattenValidationMessages(value: unknown): string[] {
+  if (value == null) return [];
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap(flattenValidationMessages);
+  }
+  if (typeof value === "object") {
+    const node = value as {
+      constraints?: Record<string, unknown>;
+      children?: unknown;
+      message?: unknown;
+      property?: unknown;
+    };
+    const out: string[] = [];
+    if (node.constraints && typeof node.constraints === "object") {
+      for (const v of Object.values(node.constraints)) {
+        if (typeof v === "string" && v.trim()) out.push(v.trim());
+      }
+    }
+    if (node.children) out.push(...flattenValidationMessages(node.children));
+    if (typeof node.message === "string" && node.message.trim()) {
+      out.push(node.message.trim());
+    }
+    return out;
+  }
+  return [];
+}
+
 function extractMessage(payload: unknown, status: number): string {
   if (typeof payload === "string" && payload.trim().length > 0) {
     return payload.trim();
   }
 
-  if (payload && typeof payload === "object" && "message" in payload) {
-    const message = (payload as { message?: unknown }).message;
-    if (typeof message === "string") {
-      return message;
-    }
+  if (payload && typeof payload === "object") {
+    const obj = payload as { message?: unknown; errors?: unknown };
+    const fromMessage = flattenValidationMessages(obj.message);
+    if (fromMessage.length > 0) return fromMessage.join(", ");
 
-    if (Array.isArray(message)) {
-      return message.map(String).join(", ");
+    const fromErrors = flattenValidationMessages(obj.errors);
+    if (fromErrors.length > 0) return fromErrors.join(", ");
+
+    if (typeof obj.message === "string" && obj.message.trim()) {
+      return obj.message.trim();
     }
   }
 

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -127,6 +127,54 @@ export async function createResource(formData: FormData) {
   return apiRequest("/resources", { method: "POST", body: formData });
 }
 
+// Presigned upload flow ----------------------------------------------------
+
+export type UploadUrlRequest = {
+  resource_type: "document" | "audio" | "image";
+  scope_level: ScopeLevel;
+  scope_id?: number;
+  file_name: string;
+  mime_type: string;
+  file_size: number;
+};
+
+export type UploadUrlResponse = {
+  upload_url: string;
+  file_key: string;
+  expires_in: number;
+  required_headers: Record<string, string>;
+};
+
+export type CreateFromUploadedPayload = {
+  title: string;
+  description?: string;
+  resource_type: "document" | "audio" | "image";
+  resource_category_id?: number;
+  club_type_id?: number;
+  scope_level: ScopeLevel;
+  scope_id?: number;
+  file_key: string;
+  file_name: string;
+  file_mime_type: string;
+  file_size: number;
+};
+
+export async function requestResourceUploadUrl(payload: UploadUrlRequest) {
+  return apiRequest<{ status: string; data: UploadUrlResponse }>(
+    "/resources/upload-url",
+    { method: "POST", body: payload },
+  );
+}
+
+export async function createResourceFromUploaded(
+  payload: CreateFromUploadedPayload,
+) {
+  return apiRequest("/resources/from-uploaded", {
+    method: "POST",
+    body: payload,
+  });
+}
+
 export async function updateResource(id: number, payload: Partial<ResourcePayload>) {
   return apiRequest(`/resources/${id}`, { method: "PATCH", body: payload });
 }

--- a/src/lib/auth/use-can-manage-users.ts
+++ b/src/lib/auth/use-can-manage-users.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useMemo } from "react";
+import { usePermissions } from "@/lib/auth/use-permissions";
+
+const USERS_CREATE_PERMISSION = "users:create";
+
+const ROLES_ALLOWED_TO_CREATE_USERS = [
+  "super-admin",
+  "admin",
+  "director-dia",
+  "assistant-dia",
+  "director-union",
+  "assistant-union",
+  "director-lf",
+  "assistant-lf",
+] as const;
+
+export function useCanManageUsers(): boolean {
+  const { can, hasRole, isSuperAdmin } = usePermissions();
+
+  return useMemo(() => {
+    if (isSuperAdmin) return true;
+    if (can(USERS_CREATE_PERMISSION)) return true;
+    return ROLES_ALLOWED_TO_CREATE_USERS.some((r) => hasRole(r));
+  }, [can, hasRole, isSuperAdmin]);
+}

--- a/src/lib/resources/resource-actions.ts
+++ b/src/lib/resources/resource-actions.ts
@@ -5,12 +5,17 @@ import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import {
   createResource,
+  createResourceFromUploaded,
   deleteResource,
+  requestResourceUploadUrl,
   updateResource,
+  type CreateFromUploadedPayload,
   type ResourcePayload,
   type ResourceType,
   type ClubTypeTarget,
   type ScopeLevel,
+  type UploadUrlRequest,
+  type UploadUrlResponse,
 } from "@/lib/api/resources";
 import { hasAnyPermission } from "@/lib/auth/permission-utils";
 import {
@@ -149,6 +154,56 @@ export async function createResourceAction(
     await createResource(outFormData);
   } catch (error) {
     return { error: error instanceof Error ? error.message : t("errors.create_failed") };
+  }
+  revalidatePath(RESOURCES_PATH);
+  redirect(RESOURCES_PATH);
+}
+
+/**
+ * Server Action wrapper that requests a presigned PUT URL from the backend.
+ * Called from the client BEFORE the browser uploads to R2. Returns null on
+ * permission/validation errors so the client can surface them.
+ */
+export async function requestUploadUrlAction(
+  payload: UploadUrlRequest,
+): Promise<{ data?: UploadUrlResponse; error?: string }> {
+  const user = await requireAdminUser();
+  const t = await getTranslations("resources");
+  if (!hasAnyPermission(user, [RESOURCES_CREATE])) {
+    return { error: t("errors.create_permission_denied") };
+  }
+  try {
+    const response = await requestResourceUploadUrl(payload);
+    return { data: response.data };
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : t("errors.create_failed"),
+    };
+  }
+}
+
+/**
+ * Server Action that registers a resource AFTER the client uploaded the file
+ * directly to R2. Backend HEAD-checks the key before persisting.
+ */
+export async function createResourceFromUploadedAction(
+  _: ResourceActionState,
+  payload: CreateFromUploadedPayload,
+): Promise<ResourceActionState> {
+  const user = await requireAdminUser();
+  const t = await getTranslations("resources");
+  if (!hasAnyPermission(user, [RESOURCES_CREATE])) {
+    return { error: t("errors.create_permission_denied") };
+  }
+  try {
+    await createResourceFromUploaded(payload);
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : t("errors.create_failed"),
+    };
   }
   revalidatePath(RESOURCES_PATH);
   redirect(RESOURCES_PATH);


### PR DESCRIPTION
## Summary
- Redesigns the "Distribución de roles" card on `/dashboard` to fix overlapping labels, the broken `sin_rol` empty-state tick, and alarming destructive red on `super-admin`.
- Adds the toolbar on `/dashboard/users` with "Agregar usuario" and "Carga masiva", gated to 8 field-admin roles via a new `useCanManageUsers()` hook.
- Adds dedicated pages `/dashboard/users/new` (single-user form) and `/dashboard/users/bulk-upload` (xlsx/csv upload + per-row results).

Pairs with backend PR https://github.com/abn-r/sacdia-backend/pull/127.

## Dashboard chart
Replaces Recharts with a pure-CSS ranked list (label / data bar / count+% in `tabular-nums`). `sin_rol` moves out of the chart into a footer chip. Color map now uses `--chart-1..5` and `--primary` at opacity — no destructive red. Rows are focusable; tooltip on hover/focus shows the full untruncated label.

## Manual user creation (`/dashboard/users/new`)
- Server component checks role membership against the 8 allowed slugs and `notFound()`s otherwise.
- Client form is RHF + Zod with cascading country → union → local-field selectors.
- Role dropdown is filtered to the actor's tier via `resolveAllowedRoles` (mirrors the backend `ROLE_HIERARCHY`):
  - super-admin → any role, including admin
  - admin → everything below admin
  - DIA tier → UNION + LF + base
  - UNION tier → LF + base
  - LF tier → base only

## Bulk upload (`/dashboard/users/bulk-upload`)
- State machine `idle → previewing → uploading → results`.
- Drag-drop zone with client-side xlsx preview (first 5 rows) for confirmation. Backend is the authoritative parser.
- KPI cards (total / succeeded / failed) + filterable results table mapping `error_code` to a human label.
- "Descargar plantilla" pulls the actor-scoped template from the backend (uses `/api/auth/token` relay for the JWT and `fetch` directly).

## API client
`src/lib/api/admin-users.ts` adds:
- `createAdminUser` / `createAdminUserFromClient`
- `bulkUploadAdminUsersFromClient`
- `downloadAdminUsersBulkTemplate`

Types: `AdminCreatableRole`, `CreateAdminUserPayload`, `CreateAdminUserResponse`, `BulkUserRowResult`, `BulkUsersResult`.

## Other changes
- `xlsx@0.18.5` installed for client-side preview.
- New i18n keys under `users.pages.new` and `users.pages.bulk` (es / en) plus `roleChart.noRoleChip`. Mirrored in `src/i18n/messages.d.ts`.

## Test plan
- [ ] Backend PR merged or its branch deployed to the dev API; seeds applied.
- [ ] Refresh `/dashboard` — chart shows ranked list with `sin_rol` chip in the footer (or hidden if no entries). No overlap, no destructive red.
- [ ] As `super-admin`: open `/dashboard/users` → both toolbar buttons visible → `/dashboard/users/new` → submit creates user → toast confirms invite sent.
- [ ] As `assistant-lf`: role dropdown contains only base roles. Submitting `admin` or higher is impossible from the UI; backend rejects it too.
- [ ] As `director-union`: dropdown includes `assistant-lf` / `director-lf` but not UNION peers.
- [ ] Bulk: download template, fill 3 valid + 1 duplicate-in-file + 1 invalid email → preview shows first 5 → submit → results table has 3 success + 2 error rows with correct labels.