### PR TITLE
feat(clubs): bulk Excel import + Google Maps location picker

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -753,7 +753,8 @@
       "ecclesiastical_year_invalid": "Invalid ecclesiastical year",
       "member_not_identified": "The member could not be identified",
       "assignment_not_identified": "The assignment to update could not be identified",
-      "assignment_remove_not_identified": "The assignment to remove could not be identified"
+      "assignment_remove_not_identified": "The assignment to remove could not be identified",
+      "bulk_row_invalid": "Invalid row: missing required fields"
     },
     "success": {
       "section_created": "Section created successfully",
@@ -769,6 +770,14 @@
       "district": "District",
       "church": "Church",
       "ecclesiastical_year": "Ecclesiastical year"
+    },
+    "locationPicker": {
+      "searchLabel": "Search address",
+      "searchPlaceholder": "Type the address or place...",
+      "hint": "Search, click on the map, or drag the pin to set the location.",
+      "noPin": "No location selected",
+      "clear": "Remove pin",
+      "missingApiKey": "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY is not configured."
     },
     "form": {
       "labelName": "Name",
@@ -830,11 +839,57 @@
         "cannotShow": "Cannot display clubs",
         "emptyTitle": "No clubs registered",
         "emptyDescription": "Create the first club to get started.",
-        "emptyCreateButton": "Create club"
+        "emptyCreateButton": "Create club",
+        "createMenuManual": "Create manually",
+        "createMenuBulk": "Import from Excel"
       },
       "new": {
         "title": "Create club",
         "back": "Back"
+      },
+      "import": {
+        "title": "Import clubs from Excel",
+        "description": "Bulk-create clubs from an .xlsx file. Local field, district and church names must match existing catalogs.",
+        "back": "Back",
+        "uploadCardTitle": "Excel file",
+        "uploadCardDescription": "Upload an .xlsx or .csv file with clubs to create.",
+        "downloadTemplate": "Download template",
+        "chooseFile": "Choose file",
+        "reset": "Reset",
+        "expectedHeadersTitle": "Expected columns (free order, required headers):",
+        "matchHint": "Columns local_field, district and church are resolved by exact name against the catalogs.",
+        "previewTitle": "Preview ({total} rows)",
+        "previewSummary": "{valid} valid · {invalid} with errors",
+        "colName": "Name",
+        "colLocalField": "Local field",
+        "colDistrict": "District",
+        "colChurch": "Church",
+        "colStatus": "Status",
+        "colMessage": "Message",
+        "rowValid": "Valid",
+        "rowInvalid": "Error",
+        "rowCreated": "Created",
+        "rowFailed": "Failed",
+        "submitButton": "Import {count} clubs",
+        "resultTitle": "Import result",
+        "resultSummary": "{created} created · {failed} failed",
+        "resultForbidden": "You don't have permission to import clubs",
+        "validation": {
+          "missingName": "Name required",
+          "missingLocalField": "Local field required",
+          "missingDistrict": "District required",
+          "missingChurch": "Church required",
+          "unknownLocalField": "Unknown local field: {value}",
+          "unknownDistrict": "Unknown district: {value}",
+          "unknownChurch": "Unknown church: {value}",
+          "coordinatesInvalid": "Invalid coordinates"
+        },
+        "errors": {
+          "emptyWorkbook": "The file has no sheets",
+          "noRows": "The file has no rows",
+          "missingHeaders": "Missing required columns: {headers}",
+          "parseFailed": "Could not read the file"
+        }
       },
       "detail": {
         "back": "Back",

--- a/messages/es.json
+++ b/messages/es.json
@@ -753,7 +753,8 @@
       "ecclesiastical_year_invalid": "Año eclesiástico no válido",
       "member_not_identified": "No se pudo identificar al miembro",
       "assignment_not_identified": "No se pudo identificar la asignación a actualizar",
-      "assignment_remove_not_identified": "No se pudo identificar la asignación a remover"
+      "assignment_remove_not_identified": "No se pudo identificar la asignación a remover",
+      "bulk_row_invalid": "Fila inválida: faltan campos requeridos"
     },
     "success": {
       "section_created": "Sección creada correctamente",
@@ -769,6 +770,14 @@
       "district": "Distrito",
       "church": "Iglesia",
       "ecclesiastical_year": "Año eclesiástico"
+    },
+    "locationPicker": {
+      "searchLabel": "Buscar dirección",
+      "searchPlaceholder": "Escribe la dirección o lugar...",
+      "hint": "Busca, haz clic en el mapa o arrastra el pin para fijar la ubicación.",
+      "noPin": "Sin ubicación seleccionada",
+      "clear": "Quitar pin",
+      "missingApiKey": "Falta configurar NEXT_PUBLIC_GOOGLE_MAPS_API_KEY en el entorno."
     },
     "form": {
       "labelName": "Nombre",
@@ -830,11 +839,57 @@
         "cannotShow": "No se pueden mostrar clubes",
         "emptyTitle": "No hay clubes registrados",
         "emptyDescription": "Crea el primer club para comenzar.",
-        "emptyCreateButton": "Crear club"
+        "emptyCreateButton": "Crear club",
+        "createMenuManual": "Crear manualmente",
+        "createMenuBulk": "Importar desde Excel"
       },
       "new": {
         "title": "Crear club",
         "back": "Volver"
+      },
+      "import": {
+        "title": "Importar clubes desde Excel",
+        "description": "Carga masiva de clubes desde un archivo .xlsx. Los nombres de campo local, distrito e iglesia deben coincidir con los catálogos existentes.",
+        "back": "Volver",
+        "uploadCardTitle": "Archivo Excel",
+        "uploadCardDescription": "Sube un archivo .xlsx o .csv con los clubes a crear.",
+        "downloadTemplate": "Descargar plantilla",
+        "chooseFile": "Elegir archivo",
+        "reset": "Limpiar",
+        "expectedHeadersTitle": "Columnas esperadas (orden libre, encabezados obligatorios):",
+        "matchHint": "Las columnas local_field, district y church se resuelven por nombre exacto contra los catálogos.",
+        "previewTitle": "Vista previa ({total} filas)",
+        "previewSummary": "{valid} válidas · {invalid} con errores",
+        "colName": "Nombre",
+        "colLocalField": "Campo local",
+        "colDistrict": "Distrito",
+        "colChurch": "Iglesia",
+        "colStatus": "Estado",
+        "colMessage": "Mensaje",
+        "rowValid": "Válida",
+        "rowInvalid": "Error",
+        "rowCreated": "Creado",
+        "rowFailed": "Falló",
+        "submitButton": "Importar {count} clubes",
+        "resultTitle": "Resultado de importación",
+        "resultSummary": "{created} creados · {failed} fallaron",
+        "resultForbidden": "No tienes permisos para importar clubes",
+        "validation": {
+          "missingName": "Nombre requerido",
+          "missingLocalField": "Campo local requerido",
+          "missingDistrict": "Distrito requerido",
+          "missingChurch": "Iglesia requerida",
+          "unknownLocalField": "Campo local desconocido: {value}",
+          "unknownDistrict": "Distrito desconocido: {value}",
+          "unknownChurch": "Iglesia desconocida: {value}",
+          "coordinatesInvalid": "Coordenadas inválidas"
+        },
+        "errors": {
+          "emptyWorkbook": "El archivo no contiene hojas",
+          "noRows": "El archivo no tiene filas",
+          "missingHeaders": "Faltan columnas obligatorias: {headers}",
+          "parseFailed": "No se pudo leer el archivo"
+        }
       },
       "detail": {
         "back": "Volver",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -753,7 +753,8 @@
       "ecclesiastical_year_invalid": "Année ecclésiastique non valide",
       "member_not_identified": "Impossible d'identifier le membre",
       "assignment_not_identified": "Impossible d'identifier l'affectation à mettre à jour",
-      "assignment_remove_not_identified": "Impossible d'identifier l'affectation à supprimer"
+      "assignment_remove_not_identified": "Impossible d'identifier l'affectation à supprimer",
+      "bulk_row_invalid": "Ligne invalide : champs obligatoires manquants"
     },
     "success": {
       "section_created": "Section créée avec succès",
@@ -769,6 +770,14 @@
       "district": "District",
       "church": "Église",
       "ecclesiastical_year": "Année ecclésiastique"
+    },
+    "locationPicker": {
+      "searchLabel": "Rechercher une adresse",
+      "searchPlaceholder": "Saisissez l'adresse ou le lieu...",
+      "hint": "Recherchez, cliquez sur la carte ou faites glisser l'épingle pour définir l'emplacement.",
+      "noPin": "Aucun emplacement sélectionné",
+      "clear": "Retirer l'épingle",
+      "missingApiKey": "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY n'est pas configurée."
     },
     "form": {
       "labelName": "Nom",
@@ -830,11 +839,57 @@
         "cannotShow": "Impossible d’afficher les clubs",
         "emptyTitle": "Aucun club enregistré",
         "emptyDescription": "Créez le premier club pour commencer.",
-        "emptyCreateButton": "Créer un club"
+        "emptyCreateButton": "Créer un club",
+        "createMenuManual": "Créer manuellement",
+        "createMenuBulk": "Importer depuis Excel"
       },
       "new": {
         "title": "Créer un club",
         "back": "Retour"
+      },
+      "import": {
+        "title": "Importer des clubs depuis Excel",
+        "description": "Création en masse de clubs à partir d'un fichier .xlsx. Les noms du champ local, du district et de l'église doivent correspondre aux catalogues existants.",
+        "back": "Retour",
+        "uploadCardTitle": "Fichier Excel",
+        "uploadCardDescription": "Téléversez un fichier .xlsx ou .csv avec les clubs à créer.",
+        "downloadTemplate": "Télécharger le modèle",
+        "chooseFile": "Choisir un fichier",
+        "reset": "Réinitialiser",
+        "expectedHeadersTitle": "Colonnes attendues (ordre libre, en-têtes obligatoires) :",
+        "matchHint": "Les colonnes local_field, district et church sont résolues par nom exact contre les catalogues.",
+        "previewTitle": "Aperçu ({total} lignes)",
+        "previewSummary": "{valid} valides · {invalid} avec erreurs",
+        "colName": "Nom",
+        "colLocalField": "Champ local",
+        "colDistrict": "District",
+        "colChurch": "Église",
+        "colStatus": "Statut",
+        "colMessage": "Message",
+        "rowValid": "Valide",
+        "rowInvalid": "Erreur",
+        "rowCreated": "Créé",
+        "rowFailed": "Échec",
+        "submitButton": "Importer {count} clubs",
+        "resultTitle": "Résultat de l'importation",
+        "resultSummary": "{created} créés · {failed} en échec",
+        "resultForbidden": "Vous n'avez pas la permission d'importer des clubs",
+        "validation": {
+          "missingName": "Nom requis",
+          "missingLocalField": "Champ local requis",
+          "missingDistrict": "District requis",
+          "missingChurch": "Église requise",
+          "unknownLocalField": "Champ local inconnu : {value}",
+          "unknownDistrict": "District inconnu : {value}",
+          "unknownChurch": "Église inconnue : {value}",
+          "coordinatesInvalid": "Coordonnées invalides"
+        },
+        "errors": {
+          "emptyWorkbook": "Le fichier ne contient pas de feuilles",
+          "noRows": "Le fichier ne contient pas de lignes",
+          "missingHeaders": "Colonnes obligatoires manquantes : {headers}",
+          "parseFailed": "Impossible de lire le fichier"
+        }
       },
       "detail": {
         "back": "Retour",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -753,7 +753,8 @@
       "ecclesiastical_year_invalid": "Ano eclesiástico inválido",
       "member_not_identified": "Não foi possível identificar o membro",
       "assignment_not_identified": "Não foi possível identificar a atribuição a atualizar",
-      "assignment_remove_not_identified": "Não foi possível identificar a atribuição a remover"
+      "assignment_remove_not_identified": "Não foi possível identificar a atribuição a remover",
+      "bulk_row_invalid": "Linha inválida: faltam campos obrigatórios"
     },
     "success": {
       "section_created": "Seção criada com sucesso",
@@ -769,6 +770,14 @@
       "district": "Distrito",
       "church": "Igreja",
       "ecclesiastical_year": "Ano eclesiástico"
+    },
+    "locationPicker": {
+      "searchLabel": "Buscar endereço",
+      "searchPlaceholder": "Digite o endereço ou local...",
+      "hint": "Busque, clique no mapa ou arraste o pino para definir a localização.",
+      "noPin": "Nenhuma localização selecionada",
+      "clear": "Remover pino",
+      "missingApiKey": "NEXT_PUBLIC_GOOGLE_MAPS_API_KEY não está configurada."
     },
     "form": {
       "labelName": "Nome",
@@ -830,11 +839,57 @@
         "cannotShow": "Não é possível exibir clubes",
         "emptyTitle": "Nenhum clube registrado",
         "emptyDescription": "Crie o primeiro clube para começar.",
-        "emptyCreateButton": "Criar clube"
+        "emptyCreateButton": "Criar clube",
+        "createMenuManual": "Criar manualmente",
+        "createMenuBulk": "Importar do Excel"
       },
       "new": {
         "title": "Criar clube",
         "back": "Voltar"
+      },
+      "import": {
+        "title": "Importar clubes do Excel",
+        "description": "Criação em massa de clubes a partir de um arquivo .xlsx. Os nomes de campo local, distrito e igreja devem corresponder aos catálogos existentes.",
+        "back": "Voltar",
+        "uploadCardTitle": "Arquivo Excel",
+        "uploadCardDescription": "Envie um arquivo .xlsx ou .csv com os clubes a criar.",
+        "downloadTemplate": "Baixar modelo",
+        "chooseFile": "Escolher arquivo",
+        "reset": "Limpar",
+        "expectedHeadersTitle": "Colunas esperadas (ordem livre, cabeçalhos obrigatórios):",
+        "matchHint": "As colunas local_field, district e church são resolvidas por nome exato contra os catálogos.",
+        "previewTitle": "Pré-visualização ({total} linhas)",
+        "previewSummary": "{valid} válidas · {invalid} com erros",
+        "colName": "Nome",
+        "colLocalField": "Campo local",
+        "colDistrict": "Distrito",
+        "colChurch": "Igreja",
+        "colStatus": "Status",
+        "colMessage": "Mensagem",
+        "rowValid": "Válida",
+        "rowInvalid": "Erro",
+        "rowCreated": "Criado",
+        "rowFailed": "Falhou",
+        "submitButton": "Importar {count} clubes",
+        "resultTitle": "Resultado da importação",
+        "resultSummary": "{created} criados · {failed} falharam",
+        "resultForbidden": "Você não tem permissão para importar clubes",
+        "validation": {
+          "missingName": "Nome obrigatório",
+          "missingLocalField": "Campo local obrigatório",
+          "missingDistrict": "Distrito obrigatório",
+          "missingChurch": "Igreja obrigatória",
+          "unknownLocalField": "Campo local desconhecido: {value}",
+          "unknownDistrict": "Distrito desconhecido: {value}",
+          "unknownChurch": "Igreja desconhecida: {value}",
+          "coordinatesInvalid": "Coordenadas inválidas"
+        },
+        "errors": {
+          "emptyWorkbook": "O arquivo não contém planilhas",
+          "noRows": "O arquivo não tem linhas",
+          "missingHeaders": "Colunas obrigatórias ausentes: {headers}",
+          "parseFailed": "Não foi possível ler o arquivo"
+        }
       },
       "detail": {
         "back": "Voltar",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@sentry/nextjs": "^10",
     "@tanstack/react-query": "^5.90.20",
+    "@vis.gl/react-google-maps": "^1.8.3",
     "axios": "^1.16.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -36,6 +37,7 @@
     "recharts": "^3.7.0",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
+    "xlsx": "^0.18.5",
     "zod": "^4.3.6"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.20
         version: 5.90.20(react@19.2.3)
+      '@vis.gl/react-google-maps':
+        specifier: ^1.8.3
+        version: 1.8.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       axios:
         specifier: ^1.16.0
         version: 1.16.0
@@ -77,6 +80,9 @@ importers:
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
+      xlsx:
+        specifier: ^0.18.5
+        version: 0.18.5
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -494,6 +500,9 @@ packages:
 
   '@formatjs/intl-localematcher@0.8.3':
     resolution: {integrity: sha512-pHUjWb9NuhnMs8+PxQdzBtZRFJHlGhrURGAbm6Ltwl82BFajeuiIR3jblSa7ia3r62rXe/0YtVpUG3xWr5bFCA==}
+
+  '@googlemaps/js-api-loader@2.0.2':
+    resolution: {integrity: sha512-bKVuTqatS8Jven5aFqVB7rCHF1VFEzpzyi0ruzO0GUR+A7m9oMqMgtnmpANj7kMYEvvhty8Fk7TnJ1MKjWHu+Q==}
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -2410,6 +2419,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/google.maps@3.64.0':
+    resolution: {integrity: sha512-dN0H6tB4lgLQLovcbPXFYYOEV41TpyyJghzb5jrzjB96FZmjeOghevVdC+BMGd6YqyCqXaggyEtqRXLRjzCBZA==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -2610,6 +2622,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vis.gl/react-google-maps@1.8.3':
+    resolution: {integrity: sha512-DW7nEuvOJ299DmdBnvGiUARrgS/+sTEO1iJgG9J8YaErZqLoq7S4TJ22f3EjJvR4dti4L4gft43JEK77nnKXDw==}
+    peerDependencies:
+      react: '>=16.8.0 || ^19.0 || ^19.0.0-rc'
+      react-dom: '>=16.8.0 || ^19.0 || ^19.0.0-rc'
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -2721,6 +2739,10 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adler-32@1.3.1:
+    resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
+    engines: {node: '>=0.8'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -2892,6 +2914,10 @@ packages:
   caniuse-lite@1.0.30001766:
     resolution: {integrity: sha512-4C0lfJ0/YPjJQHagaE9x2Elb69CIqEPZeG0anQt9SIvIoOH4a4uaRl73IavyO+0qZh6MDLH//DrXThEYKHkmYA==}
 
+  cfb@1.2.2:
+    resolution: {integrity: sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==}
+    engines: {node: '>=0.8'}
+
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
@@ -2935,6 +2961,10 @@ packages:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
 
+  codepage@1.15.0:
+    resolution: {integrity: sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==}
+    engines: {node: '>=0.8'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2961,6 +2991,11 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -3407,6 +3442,10 @@ packages:
 
   forwarded-parse@2.1.2:
     resolution: {integrity: sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw==}
+
+  frac@1.1.2:
+    resolution: {integrity: sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==}
+    engines: {node: '>=0.8'}
 
   framer-motion@12.38.0:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
@@ -4509,6 +4548,10 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  ssf@0.11.2:
+    resolution: {integrity: sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==}
+    engines: {node: '>=0.8'}
+
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
@@ -4954,9 +4997,17 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wmf@1.0.2:
+    resolution: {integrity: sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==}
+    engines: {node: '>=0.8'}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  word@0.3.0:
+    resolution: {integrity: sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==}
+    engines: {node: '>=0.8'}
 
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
@@ -4973,6 +5024,11 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xlsx@0.18.5:
+    resolution: {integrity: sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
 
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
@@ -5341,6 +5397,10 @@ snapshots:
   '@formatjs/intl-localematcher@0.8.3':
     dependencies:
       '@formatjs/fast-memoize': 3.1.2
+
+  '@googlemaps/js-api-loader@2.0.2':
+    dependencies:
+      '@types/google.maps': 3.64.0
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.3))':
     dependencies:
@@ -7202,6 +7262,8 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/google.maps@3.64.0': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -7394,6 +7456,14 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vis.gl/react-google-maps@1.8.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@googlemaps/js-api-loader': 2.0.2
+      '@types/google.maps': 3.64.0
+      fast-deep-equal: 3.1.3
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
   '@vitejs/plugin-react@4.7.0(vite@7.3.3(@types/node@20.19.30)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.1))':
     dependencies:
       '@babel/core': 7.28.6
@@ -7548,6 +7618,8 @@ snapshots:
   acorn@8.15.0: {}
 
   acorn@8.16.0: {}
+
+  adler-32@1.3.1: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -7747,6 +7819,11 @@ snapshots:
 
   caniuse-lite@1.0.30001766: {}
 
+  cfb@1.2.2:
+    dependencies:
+      adler-32: 1.3.1
+      crc-32: 1.2.2
+
   chai@5.3.3:
     dependencies:
       assertion-error: 2.0.1
@@ -7794,6 +7871,8 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  codepage@1.15.0: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -7813,6 +7892,8 @@ snapshots:
   convert-source-map@2.0.0: {}
 
   cookie@1.1.1: {}
+
+  crc-32@1.2.2: {}
 
   cross-spawn@7.0.6:
     dependencies:
@@ -8397,6 +8478,8 @@ snapshots:
       mime-types: 2.1.35
 
   forwarded-parse@2.1.2: {}
+
+  frac@1.1.2: {}
 
   framer-motion@12.38.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
@@ -9595,6 +9678,10 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  ssf@0.11.2:
+    dependencies:
+      frac: 1.1.2
+
   stable-hash@0.0.5: {}
 
   stackback@0.0.2: {}
@@ -10125,7 +10212,11 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wmf@1.0.2: {}
+
   word-wrap@1.2.5: {}
+
+  word@0.3.0: {}
 
   wrap-ansi@7.0.0:
     dependencies:
@@ -10134,6 +10225,16 @@ snapshots:
       strip-ansi: 6.0.1
 
   ws@8.20.0: {}
+
+  xlsx@0.18.5:
+    dependencies:
+      adler-32: 1.3.1
+      cfb: 1.2.2
+      codepage: 1.15.0
+      crc-32: 1.2.2
+      ssf: 0.11.2
+      wmf: 1.0.2
+      word: 0.3.0
 
   xml-name-validator@5.0.0: {}
 

--- a/src/app/(dashboard)/dashboard/clubs/import/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/import/page.tsx
@@ -1,16 +1,22 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/shared/page-header";
 import { requireAdminUser } from "@/lib/auth/session";
+import { canManageClubsByRole } from "@/lib/auth/permission-utils";
 import { getSelectOptions } from "@/lib/catalogs/service";
-import { CreateClubForm } from "@/components/clubs/create-club-form";
-import { createClubAction } from "@/lib/clubs/actions";
+import { ClubsBulkImport } from "@/components/clubs/clubs-bulk-import";
+import { bulkCreateClubsAction } from "@/lib/clubs/actions";
 
-export default async function NewClubPage() {
-  await requireAdminUser();
-  const t = await getTranslations("clubs.pages.new");
+export default async function ImportClubsPage() {
+  const user = await requireAdminUser();
+  if (!canManageClubsByRole(user)) {
+    redirect("/dashboard/clubs");
+  }
+
+  const t = await getTranslations("clubs.pages.import");
 
   const [localFields, districts, churches] = await Promise.all([
     getSelectOptions("local-fields").catch(() => []),
@@ -20,7 +26,7 @@ export default async function NewClubPage() {
 
   return (
     <div className="space-y-6">
-      <PageHeader title={t("title")}>
+      <PageHeader title={t("title")} description={t("description")}>
         <Button variant="outline" size="sm" asChild>
           <Link href="/dashboard/clubs">
             <ArrowLeft className="size-4" />
@@ -29,12 +35,11 @@ export default async function NewClubPage() {
         </Button>
       </PageHeader>
 
-      <CreateClubForm
+      <ClubsBulkImport
         localFields={localFields}
         districts={districts}
         churches={churches}
-        formAction={createClubAction}
-        googleMapsApiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? ""}
+        submitAction={bulkCreateClubsAction}
       />
     </div>
   );

--- a/src/app/(dashboard)/dashboard/clubs/page.tsx
+++ b/src/app/(dashboard)/dashboard/clubs/page.tsx
@@ -19,9 +19,13 @@ import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 import { DataTableShell } from "@/components/shared/data-table-shell";
 import { DataTablePagination } from "@/components/shared/data-table-pagination";
 import { ClubsTableActionsCell } from "@/components/clubs/clubs-table-actions-cell";
+import { ClubsCreateMenu } from "@/components/clubs/clubs-create-menu";
 import { apiRequest, ApiError } from "@/lib/api/client";
 import { requireAdminUser } from "@/lib/auth/session";
-import { hasPermission } from "@/lib/auth/permission-utils";
+import {
+  canManageClubsByRole,
+  hasPermission,
+} from "@/lib/auth/permission-utils";
 import { CLUBS_UPDATE, CLUBS_DELETE } from "@/lib/auth/permissions";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -162,7 +166,8 @@ async function ClubsContent({
 }) {
   const user = await requireAdminUser();
   const t = await getTranslations("clubs.pages.list");
-  const canCreate = hasPermission(user, "clubs:create");
+  const canCreate =
+    hasPermission(user, "clubs:create") && canManageClubsByRole(user);
   const canEdit = hasPermission(user, CLUBS_UPDATE);
   const canDelete = hasPermission(user, CLUBS_DELETE);
   const result = await fetchClubs(query);
@@ -365,21 +370,15 @@ export default async function ClubsPage({
 }) {
   const user = await requireAdminUser();
   const t = await getTranslations("clubs.pages.list");
-  const canCreate = hasPermission(user, "clubs:create");
+  const canCreate =
+    hasPermission(user, "clubs:create") && canManageClubsByRole(user);
   const rawParams = await searchParams;
   const query = parseSearchParams(rawParams);
 
   return (
     <div className="space-y-6">
       <PageHeader title={t("title")} description={t("description")}>
-        {canCreate && (
-          <Button asChild>
-            <Link href="/dashboard/clubs/new">
-              <Plus className="size-4" />
-              {t("createButton")}
-            </Link>
-          </Button>
-        )}
+        {canCreate && <ClubsCreateMenu />}
       </PageHeader>
 
       <Suspense fallback={<ClubsSkeleton />}>

--- a/src/components/clubs/clubs-bulk-import.tsx
+++ b/src/components/clubs/clubs-bulk-import.tsx
@@ -1,0 +1,498 @@
+"use client";
+
+import { useMemo, useRef, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  Download,
+  FileSpreadsheet,
+  Loader2,
+  Upload,
+  XCircle,
+} from "lucide-react";
+import * as XLSX from "xlsx";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { DataTableShell } from "@/components/shared/data-table-shell";
+import type {
+  BulkClubRow,
+  BulkClubsImportResult,
+} from "@/lib/clubs/actions";
+
+type SelectOption = { label: string; value: number };
+
+type ParsedRow = {
+  rowNumber: number;
+  name: string;
+  localFieldRaw: string;
+  districtRaw: string;
+  churchRaw: string;
+  description?: string;
+  address?: string;
+  latitudeRaw?: string;
+  longitudeRaw?: string;
+  local_field_id?: number;
+  district_id?: number;
+  church_id?: number;
+  coordinates?: { lat: number; lng: number };
+  errors: string[];
+};
+
+type Props = {
+  localFields: SelectOption[];
+  districts: SelectOption[];
+  churches: SelectOption[];
+  submitAction: (rows: BulkClubRow[]) => Promise<BulkClubsImportResult>;
+};
+
+const EXPECTED_HEADERS = [
+  "name",
+  "local_field",
+  "district",
+  "church",
+  "description",
+  "address",
+  "latitude",
+  "longitude",
+] as const;
+
+function normalize(value: unknown): string {
+  return String(value ?? "")
+    .trim()
+    .toLowerCase();
+}
+
+function buildLookup(options: SelectOption[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const opt of options) {
+    map.set(normalize(opt.label), opt.value);
+  }
+  return map;
+}
+
+function parseCoord(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+export function ClubsBulkImport({
+  localFields,
+  districts,
+  churches,
+  submitAction,
+}: Props) {
+  const t = useTranslations("clubs.pages.import");
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [fileName, setFileName] = useState<string | null>(null);
+  const [rows, setRows] = useState<ParsedRow[]>([]);
+  const [parseError, setParseError] = useState<string | null>(null);
+  const [result, setResult] = useState<BulkClubsImportResult | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const localFieldsLookup = useMemo(() => buildLookup(localFields), [localFields]);
+  const districtsLookup = useMemo(() => buildLookup(districts), [districts]);
+  const churchesLookup = useMemo(() => buildLookup(churches), [churches]);
+
+  const validRows = useMemo(
+    () => rows.filter((row) => row.errors.length === 0),
+    [rows],
+  );
+  const invalidRows = useMemo(
+    () => rows.filter((row) => row.errors.length > 0),
+    [rows],
+  );
+
+  function resetState() {
+    setRows([]);
+    setParseError(null);
+    setResult(null);
+    setFileName(null);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  }
+
+  function validateRow(row: ParsedRow): string[] {
+    const errors: string[] = [];
+
+    if (!row.name) errors.push(t("validation.missingName"));
+
+    const localFieldId = localFieldsLookup.get(normalize(row.localFieldRaw));
+    if (!row.localFieldRaw) {
+      errors.push(t("validation.missingLocalField"));
+    } else if (!localFieldId) {
+      errors.push(t("validation.unknownLocalField", { value: row.localFieldRaw }));
+    } else {
+      row.local_field_id = localFieldId;
+    }
+
+    const districtId = districtsLookup.get(normalize(row.districtRaw));
+    if (!row.districtRaw) {
+      errors.push(t("validation.missingDistrict"));
+    } else if (!districtId) {
+      errors.push(t("validation.unknownDistrict", { value: row.districtRaw }));
+    } else {
+      row.district_id = districtId;
+    }
+
+    const churchId = churchesLookup.get(normalize(row.churchRaw));
+    if (!row.churchRaw) {
+      errors.push(t("validation.missingChurch"));
+    } else if (!churchId) {
+      errors.push(t("validation.unknownChurch", { value: row.churchRaw }));
+    } else {
+      row.church_id = churchId;
+    }
+
+    const lat = parseCoord(row.latitudeRaw);
+    const lng = parseCoord(row.longitudeRaw);
+    if ((row.latitudeRaw || row.longitudeRaw) && (lat === undefined || lng === undefined)) {
+      errors.push(t("validation.coordinatesInvalid"));
+    } else if (lat !== undefined && lng !== undefined) {
+      row.coordinates = { lat, lng };
+    }
+
+    return errors;
+  }
+
+  async function handleFile(file: File) {
+    setResult(null);
+    setParseError(null);
+    setRows([]);
+    setFileName(file.name);
+
+    try {
+      const buffer = await file.arrayBuffer();
+      const workbook = XLSX.read(buffer, { type: "array" });
+      const firstSheetName = workbook.SheetNames[0];
+      if (!firstSheetName) {
+        setParseError(t("errors.emptyWorkbook"));
+        return;
+      }
+      const sheet = workbook.Sheets[firstSheetName];
+      const json = XLSX.utils.sheet_to_json<Record<string, unknown>>(sheet, {
+        defval: "",
+        raw: false,
+      });
+
+      if (json.length === 0) {
+        setParseError(t("errors.noRows"));
+        return;
+      }
+
+      const headerCheck = Object.keys(json[0] ?? {}).map((h) => normalize(h));
+      const required = ["name", "local_field", "district", "church"];
+      const missing = required.filter((h) => !headerCheck.includes(h));
+      if (missing.length > 0) {
+        setParseError(t("errors.missingHeaders", { headers: missing.join(", ") }));
+        return;
+      }
+
+      const parsed: ParsedRow[] = json.map((raw, idx) => {
+        const getValue = (key: string) => {
+          const found = Object.entries(raw).find(
+            ([k]) => normalize(k) === key,
+          );
+          return found ? String(found[1] ?? "").trim() : "";
+        };
+
+        const row: ParsedRow = {
+          rowNumber: idx + 2,
+          name: getValue("name"),
+          localFieldRaw: getValue("local_field"),
+          districtRaw: getValue("district"),
+          churchRaw: getValue("church"),
+          description: getValue("description") || undefined,
+          address: getValue("address") || undefined,
+          latitudeRaw: getValue("latitude") || undefined,
+          longitudeRaw: getValue("longitude") || undefined,
+          errors: [],
+        };
+        row.errors = validateRow(row);
+        return row;
+      });
+
+      setRows(parsed);
+    } catch (error) {
+      setParseError(
+        error instanceof Error ? error.message : t("errors.parseFailed"),
+      );
+    }
+  }
+
+  function handleSubmit() {
+    if (validRows.length === 0) return;
+
+    const payload: BulkClubRow[] = validRows.map((row) => ({
+      rowNumber: row.rowNumber,
+      name: row.name,
+      local_field_id: row.local_field_id!,
+      district_id: row.district_id!,
+      church_id: row.church_id!,
+      description: row.description,
+      address: row.address,
+      coordinates: row.coordinates,
+    }));
+
+    startTransition(async () => {
+      const res = await submitAction(payload);
+      setResult(res);
+      if (res.created > 0) {
+        router.refresh();
+      }
+    });
+  }
+
+  function downloadTemplate() {
+    const sample: Record<string, string> = {
+      name: "Club Ejemplo",
+      local_field: localFields[0]?.label ?? "",
+      district: districts[0]?.label ?? "",
+      church: churches[0]?.label ?? "",
+      description: "",
+      address: "",
+      latitude: "",
+      longitude: "",
+    };
+    const ws = XLSX.utils.json_to_sheet([sample], { header: [...EXPECTED_HEADERS] });
+    const wb = XLSX.utils.book_new();
+    XLSX.utils.book_append_sheet(wb, ws, "clubs");
+    XLSX.writeFile(wb, "clubs-template.xlsx");
+  }
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{t("uploadCardTitle")}</CardTitle>
+          <CardDescription>{t("uploadCardDescription")}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              variant="outline"
+              size="sm"
+              type="button"
+              onClick={downloadTemplate}
+            >
+              <Download className="size-4" />
+              {t("downloadTemplate")}
+            </Button>
+            <Button
+              size="sm"
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isPending}
+            >
+              <Upload className="size-4" />
+              {t("chooseFile")}
+            </Button>
+            {fileName && (
+              <span className="inline-flex items-center gap-1.5 text-sm text-muted-foreground">
+                <FileSpreadsheet className="size-4" />
+                {fileName}
+              </span>
+            )}
+            {rows.length > 0 && (
+              <Button
+                variant="ghost"
+                size="sm"
+                type="button"
+                onClick={resetState}
+                disabled={isPending}
+              >
+                {t("reset")}
+              </Button>
+            )}
+          </div>
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".xlsx,.xls,.csv"
+            className="hidden"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) void handleFile(file);
+            }}
+          />
+
+          <div className="rounded-md border border-border/60 bg-muted/30 p-3 text-xs text-muted-foreground">
+            <p className="font-medium text-foreground">{t("expectedHeadersTitle")}</p>
+            <p className="mt-1">
+              <code className="rounded bg-background px-1.5 py-0.5">
+                name, local_field, district, church, description, address, latitude, longitude
+              </code>
+            </p>
+            <p className="mt-2">{t("matchHint")}</p>
+          </div>
+
+          {parseError && (
+            <div
+              role="alert"
+              className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            >
+              {parseError}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {rows.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              {t("previewTitle", { total: rows.length })}
+            </CardTitle>
+            <CardDescription>
+              {t("previewSummary", {
+                valid: validRows.length,
+                invalid: invalidRows.length,
+              })}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <DataTableShell>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead className="w-[60px]">#</TableHead>
+                    <TableHead>{t("colName")}</TableHead>
+                    <TableHead>{t("colLocalField")}</TableHead>
+                    <TableHead>{t("colDistrict")}</TableHead>
+                    <TableHead>{t("colChurch")}</TableHead>
+                    <TableHead>{t("colStatus")}</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((row) => {
+                    const isValid = row.errors.length === 0;
+                    return (
+                      <TableRow key={row.rowNumber}>
+                        <TableCell className="text-muted-foreground">
+                          {row.rowNumber}
+                        </TableCell>
+                        <TableCell className="font-medium">{row.name || "—"}</TableCell>
+                        <TableCell className="text-sm">{row.localFieldRaw || "—"}</TableCell>
+                        <TableCell className="text-sm">{row.districtRaw || "—"}</TableCell>
+                        <TableCell className="text-sm">{row.churchRaw || "—"}</TableCell>
+                        <TableCell>
+                          {isValid ? (
+                            <Badge variant="soft-success" className="text-xs">
+                              <CheckCircle2 className="size-3" />
+                              {t("rowValid")}
+                            </Badge>
+                          ) : (
+                            <div className="space-y-1">
+                              <Badge variant="destructive" className="text-xs">
+                                <AlertTriangle className="size-3" />
+                                {t("rowInvalid")}
+                              </Badge>
+                              <ul className="text-xs text-destructive">
+                                {row.errors.map((err, i) => (
+                                  <li key={i}>• {err}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </DataTableShell>
+
+            <div className="flex items-center justify-end gap-2">
+              <Button
+                onClick={handleSubmit}
+                disabled={validRows.length === 0 || isPending}
+              >
+                {isPending && (
+                  <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+                )}
+                {t("submitButton", { count: validRows.length })}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {result && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">{t("resultTitle")}</CardTitle>
+            <CardDescription>
+              {result.forbidden
+                ? t("resultForbidden")
+                : t("resultSummary", {
+                    created: result.created,
+                    failed: result.failed,
+                  })}
+            </CardDescription>
+          </CardHeader>
+          {result.results.length > 0 && (
+            <CardContent>
+              <DataTableShell>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[60px]">#</TableHead>
+                      <TableHead>{t("colName")}</TableHead>
+                      <TableHead>{t("colStatus")}</TableHead>
+                      <TableHead>{t("colMessage")}</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {result.results.map((res) => (
+                      <TableRow key={res.rowNumber}>
+                        <TableCell className="text-muted-foreground">
+                          {res.rowNumber}
+                        </TableCell>
+                        <TableCell className="font-medium">{res.name || "—"}</TableCell>
+                        <TableCell>
+                          {res.ok ? (
+                            <Badge variant="soft-success" className="text-xs">
+                              <CheckCircle2 className="size-3" />
+                              {t("rowCreated")}
+                            </Badge>
+                          ) : (
+                            <Badge variant="destructive" className="text-xs">
+                              <XCircle className="size-3" />
+                              {t("rowFailed")}
+                            </Badge>
+                          )}
+                        </TableCell>
+                        <TableCell className="text-sm text-muted-foreground">
+                          {res.message ?? (res.clubId ? `#${res.clubId}` : "—")}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </DataTableShell>
+            </CardContent>
+          )}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/components/clubs/clubs-create-menu.tsx
+++ b/src/components/clubs/clubs-create-menu.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronDown, FileSpreadsheet, Plus, UserPlus } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+export function ClubsCreateMenu() {
+  const t = useTranslations("clubs.pages.list");
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button>
+          <Plus className="size-4" />
+          {t("createButton")}
+          <ChevronDown className="size-4 opacity-70" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuItem asChild>
+          <Link href="/dashboard/clubs/new">
+            <UserPlus className="size-4" />
+            {t("createMenuManual")}
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <Link href="/dashboard/clubs/import">
+            <FileSpreadsheet className="size-4" />
+            {t("createMenuBulk")}
+          </Link>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/clubs/create-club-form.tsx
+++ b/src/components/clubs/create-club-form.tsx
@@ -17,6 +17,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { ClubActionState } from "@/lib/clubs/actions";
+import { LocationPicker } from "@/components/shared/location-picker";
 
 type SelectOption = { label: string; value: number };
 
@@ -36,11 +37,18 @@ interface CreateClubFormProps {
   districts: SelectOption[];
   churches: SelectOption[];
   formAction: (prev: ClubActionState, formData: FormData) => Promise<ClubActionState>;
+  googleMapsApiKey: string;
 }
 
 const initialState: ClubActionState = {};
 
-export function CreateClubForm({ localFields, districts, churches, formAction }: CreateClubFormProps) {
+export function CreateClubForm({
+  localFields,
+  districts,
+  churches,
+  formAction,
+  googleMapsApiKey,
+}: CreateClubFormProps) {
   const [state, action] = useActionState(formAction, initialState);
   const t = useTranslations("clubs");
 
@@ -165,27 +173,8 @@ export function CreateClubForm({ localFields, districts, churches, formAction }:
         <CardHeader>
           <CardTitle className="text-base">{t("form.coordinatesTitle")}</CardTitle>
         </CardHeader>
-        <CardContent className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="coordinates_lat">{t("form.labelLatitude")}</Label>
-            <Input
-              id="coordinates_lat"
-              name="coordinates_lat"
-              type="number"
-              step="any"
-              placeholder="19.4326"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="coordinates_lng">{t("form.labelLongitude")}</Label>
-            <Input
-              id="coordinates_lng"
-              name="coordinates_lng"
-              type="number"
-              step="any"
-              placeholder="-99.1332"
-            />
-          </div>
+        <CardContent>
+          <LocationPicker apiKey={googleMapsApiKey} />
         </CardContent>
       </Card>
 

--- a/src/components/clubs/detail/view.tsx
+++ b/src/components/clubs/detail/view.tsx
@@ -266,6 +266,9 @@ export function ClubDetailView({
                 districts={districtOptions}
                 churches={churchOptions}
                 formAction={updateAction}
+                googleMapsApiKey={
+                  process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY ?? ""
+                }
               />
             </section>
           )}

--- a/src/components/clubs/edit-club-form.tsx
+++ b/src/components/clubs/edit-club-form.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/select";
 import { Checkbox } from "@/components/ui/checkbox";
 import type { ClubActionState } from "@/lib/clubs/actions";
+import { LocationPicker } from "@/components/shared/location-picker";
 
 type SelectOption = { label: string; value: number };
 
@@ -49,11 +50,19 @@ interface EditClubFormProps {
   districts: SelectOption[];
   churches: SelectOption[];
   formAction: (prev: ClubActionState, formData: FormData) => Promise<ClubActionState>;
+  googleMapsApiKey: string;
 }
 
 const initialState: ClubActionState = {};
 
-export function EditClubForm({ club, localFields, districts, churches, formAction }: EditClubFormProps) {
+export function EditClubForm({
+  club,
+  localFields,
+  districts,
+  churches,
+  formAction,
+  googleMapsApiKey,
+}: EditClubFormProps) {
   const [state, action] = useActionState(formAction, initialState);
   const t = useTranslations("clubs");
 
@@ -154,15 +163,13 @@ export function EditClubForm({ club, localFields, districts, churches, formActio
         <CardHeader>
           <CardTitle className="text-base">{t("form.coordinatesTitle")}</CardTitle>
         </CardHeader>
-        <CardContent className="grid gap-4 sm:grid-cols-2">
-          <div className="space-y-2">
-            <Label htmlFor="coordinates_lat">{t("form.labelLatitude")}</Label>
-            <Input id="coordinates_lat" name="coordinates_lat" type="number" step="any" defaultValue={lat ?? ""} />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="coordinates_lng">{t("form.labelLongitude")}</Label>
-            <Input id="coordinates_lng" name="coordinates_lng" type="number" step="any" defaultValue={lng ?? ""} />
-          </div>
+        <CardContent>
+          <LocationPicker
+            apiKey={googleMapsApiKey}
+            initialLat={lat ?? null}
+            initialLng={lng ?? null}
+            initialAddress={club.address ?? null}
+          />
         </CardContent>
       </Card>
 

--- a/src/components/shared/location-picker.tsx
+++ b/src/components/shared/location-picker.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  APIProvider,
+  Map,
+  AdvancedMarker,
+  useMap,
+  useMapsLibrary,
+} from "@vis.gl/react-google-maps";
+import { MapPin, Search, X } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+
+type LatLng = { lat: number; lng: number };
+
+const DEFAULT_CENTER: LatLng = { lat: 19.4326, lng: -99.1332 }; // CDMX
+const DEFAULT_ZOOM = 12;
+const PINNED_ZOOM = 16;
+
+type LocationPickerProps = {
+  apiKey: string;
+  latFieldName?: string;
+  lngFieldName?: string;
+  addressFieldName?: string;
+  initialLat?: number | null;
+  initialLng?: number | null;
+  initialAddress?: string | null;
+  mapId?: string;
+};
+
+function PlaceAutocomplete({
+  onPlaceSelect,
+  placeholder,
+}: {
+  onPlaceSelect: (place: { lat: number; lng: number; address: string }) => void;
+  placeholder: string;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const places = useMapsLibrary("places");
+  const [autocomplete, setAutocomplete] =
+    useState<google.maps.places.Autocomplete | null>(null);
+
+  useEffect(() => {
+    if (!places || !inputRef.current) return;
+    const instance = new places.Autocomplete(inputRef.current, {
+      fields: ["geometry", "formatted_address", "name"],
+    });
+    setAutocomplete(instance);
+  }, [places]);
+
+  useEffect(() => {
+    if (!autocomplete) return;
+    const listener = autocomplete.addListener("place_changed", () => {
+      const place = autocomplete.getPlace();
+      const loc = place.geometry?.location;
+      if (!loc) return;
+      onPlaceSelect({
+        lat: loc.lat(),
+        lng: loc.lng(),
+        address: place.formatted_address ?? place.name ?? "",
+      });
+    });
+    return () => listener.remove();
+  }, [autocomplete, onPlaceSelect]);
+
+  return (
+    <div className="relative">
+      <Search
+        className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+        aria-hidden="true"
+      />
+      <Input
+        ref={inputRef}
+        type="text"
+        placeholder={placeholder}
+        className="pl-9"
+        autoComplete="off"
+      />
+    </div>
+  );
+}
+
+function MapController({
+  position,
+  zoom,
+}: {
+  position: LatLng | null;
+  zoom: number;
+}) {
+  const map = useMap();
+  useEffect(() => {
+    if (!map || !position) return;
+    map.panTo(position);
+    map.setZoom(zoom);
+  }, [map, position, zoom]);
+  return null;
+}
+
+export function LocationPicker({
+  apiKey,
+  latFieldName = "coordinates_lat",
+  lngFieldName = "coordinates_lng",
+  addressFieldName,
+  initialLat,
+  initialLng,
+  initialAddress,
+  mapId = "club-location-picker",
+}: LocationPickerProps) {
+  const t = useTranslations("clubs.locationPicker");
+  const hasInitial =
+    typeof initialLat === "number" &&
+    typeof initialLng === "number" &&
+    Number.isFinite(initialLat) &&
+    Number.isFinite(initialLng);
+
+  const [position, setPosition] = useState<LatLng | null>(
+    hasInitial ? { lat: initialLat!, lng: initialLng! } : null,
+  );
+  const [address, setAddress] = useState<string>(initialAddress ?? "");
+  const [center, setCenter] = useState<LatLng>(
+    hasInitial ? { lat: initialLat!, lng: initialLng! } : DEFAULT_CENTER,
+  );
+  const [zoom, setZoom] = useState<number>(hasInitial ? PINNED_ZOOM : DEFAULT_ZOOM);
+
+  const handlePlaceSelect = useCallback(
+    (place: { lat: number; lng: number; address: string }) => {
+      const next = { lat: place.lat, lng: place.lng };
+      setPosition(next);
+      setCenter(next);
+      setZoom(PINNED_ZOOM);
+      if (place.address) setAddress(place.address);
+    },
+    [],
+  );
+
+  const handleMarkerDrag = useCallback(
+    (event: google.maps.MapMouseEvent) => {
+      if (!event.latLng) return;
+      setPosition({ lat: event.latLng.lat(), lng: event.latLng.lng() });
+    },
+    [],
+  );
+
+  const handleMapClick = useCallback((event: google.maps.MapMouseEvent) => {
+    if (!event.detail.latLng) return;
+    setPosition({
+      lat: event.detail.latLng.lat,
+      lng: event.detail.latLng.lng,
+    });
+  }, []);
+
+  function clear() {
+    setPosition(null);
+    setAddress("");
+  }
+
+  if (!apiKey) {
+    return (
+      <div className="rounded-md border border-dashed border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+        {t("missingApiKey")}
+      </div>
+    );
+  }
+
+  return (
+    <APIProvider apiKey={apiKey} libraries={["places"]}>
+      <div className="space-y-3">
+        <div className="space-y-2">
+          <Label htmlFor="location-search">{t("searchLabel")}</Label>
+          <PlaceAutocomplete
+            placeholder={t("searchPlaceholder")}
+            onPlaceSelect={handlePlaceSelect}
+          />
+          <p className="text-xs text-muted-foreground">{t("hint")}</p>
+        </div>
+
+        <div className="h-[320px] w-full overflow-hidden rounded-md border border-border">
+          <Map
+            mapId={mapId}
+            defaultCenter={center}
+            defaultZoom={zoom}
+            gestureHandling="greedy"
+            disableDefaultUI={false}
+            onClick={handleMapClick}
+          >
+            <MapController position={position} zoom={zoom} />
+            {position && (
+              <AdvancedMarker
+                position={position}
+                draggable
+                onDragEnd={handleMarkerDrag}
+              />
+            )}
+          </Map>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-between gap-2 text-xs text-muted-foreground">
+          {position ? (
+            <span className="inline-flex items-center gap-1.5">
+              <MapPin className="size-3.5" aria-hidden="true" />
+              {position.lat.toFixed(6)}, {position.lng.toFixed(6)}
+            </span>
+          ) : (
+            <span>{t("noPin")}</span>
+          )}
+          {position && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={clear}
+              className="text-xs"
+            >
+              <X className="size-3" />
+              {t("clear")}
+            </Button>
+          )}
+        </div>
+
+        {/* Hidden inputs sync to host form */}
+        <input
+          type="hidden"
+          name={latFieldName}
+          value={position?.lat.toString() ?? ""}
+        />
+        <input
+          type="hidden"
+          name={lngFieldName}
+          value={position?.lng.toString() ?? ""}
+        />
+        {addressFieldName && (
+          <input type="hidden" name={addressFieldName} value={address} />
+        )}
+      </div>
+    </APIProvider>
+  );
+}

--- a/src/lib/auth/permission-utils.ts
+++ b/src/lib/auth/permission-utils.ts
@@ -339,6 +339,22 @@ export function canByPermissionOrRole(
   return false;
 }
 
+/**
+ * Roles allowed to create clubs (manual or bulk import).
+ * Restricted set per business rule: only org-level admins + local-field leadership.
+ */
+export const CLUB_CREATE_ROLES = [
+  "super-admin",
+  "admin",
+  "director-lf",
+  "assistant-lf",
+] as const;
+
+export function canManageClubsByRole(user: AuthUser | null | undefined): boolean {
+  const roles = new Set(extractRoles(user));
+  return CLUB_CREATE_ROLES.some((role) => roles.has(role));
+}
+
 export function canReadClubs(user: AuthUser | null | undefined) {
   return canByPermissionOrRole(user, CLUBS_READ_KEYS, {
     allowAdminFallback: true,

--- a/src/lib/clubs/actions.ts
+++ b/src/lib/clubs/actions.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/api/clubs";
 import { unwrapList, unwrapObject } from "@/lib/api/response";
 import { requireAdminUser } from "@/lib/auth/session";
+import { canManageClubsByRole } from "@/lib/auth/permission-utils";
 
 type ClubsTranslator = Awaited<ReturnType<typeof getTranslations<"clubs">>>;
 
@@ -657,4 +658,111 @@ export async function removeClubSectionMemberAction(
   revalidatePath(`/dashboard/clubs/${clubId}`);
   revalidatePath(buildClubSectionPath(clubId, sectionId));
   return { success: t("success.assignment_removed") };
+}
+
+// ─── Bulk import ──────────────────────────────────────────────────────────────
+
+export type BulkClubRow = {
+  rowNumber: number;
+  name: string;
+  local_field_id: number;
+  district_id: number;
+  church_id: number;
+  description?: string;
+  address?: string;
+  coordinates?: { lat: number; lng: number };
+};
+
+export type BulkClubRowResult = {
+  rowNumber: number;
+  name: string;
+  ok: boolean;
+  message?: string;
+  clubId?: number;
+};
+
+export type BulkClubsImportResult = {
+  results: BulkClubRowResult[];
+  created: number;
+  failed: number;
+  forbidden?: boolean;
+};
+
+export async function bulkCreateClubsAction(
+  rows: BulkClubRow[],
+): Promise<BulkClubsImportResult> {
+  const user = await requireAdminUser();
+  const t = await getTranslations("clubs");
+
+  if (!canManageClubsByRole(user)) {
+    return {
+      results: [],
+      created: 0,
+      failed: 0,
+      forbidden: true,
+    };
+  }
+
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return { results: [], created: 0, failed: 0 };
+  }
+
+  const results: BulkClubRowResult[] = [];
+  let created = 0;
+  let failed = 0;
+
+  for (const row of rows) {
+    if (
+      !row.name ||
+      !Number.isFinite(row.local_field_id) ||
+      !Number.isFinite(row.district_id) ||
+      !Number.isFinite(row.church_id)
+    ) {
+      failed++;
+      results.push({
+        rowNumber: row.rowNumber,
+        name: row.name ?? "",
+        ok: false,
+        message: t("validation.bulk_row_invalid"),
+      });
+      continue;
+    }
+
+    try {
+      const payload = {
+        name: row.name,
+        description: row.description,
+        local_field_id: row.local_field_id,
+        district_id: row.district_id,
+        church_id: row.church_id,
+        address: row.address,
+        coordinates: row.coordinates,
+      };
+      const createdPayload = await createClub(payload);
+      const clubId = normalizeCreatedClubId(createdPayload) ?? undefined;
+      created++;
+      results.push({
+        rowNumber: row.rowNumber,
+        name: row.name,
+        ok: true,
+        clubId,
+      });
+    } catch (error) {
+      failed++;
+      results.push({
+        rowNumber: row.rowNumber,
+        name: row.name,
+        ok: false,
+        message: getActionErrorMessage(error, t("errors.create_club_failed"), {
+          endpointLabel: "/clubs",
+        }),
+      });
+    }
+  }
+
+  if (created > 0) {
+    revalidatePath("/dashboard/clubs");
+  }
+
+  return { results, created, failed };
 }


### PR DESCRIPTION
## Summary
- Importación masiva de clubes desde Excel en `/dashboard/clubs/import` (parseo cliente con `xlsx`, resolución de catálogos por nombre, preview por fila con validación, ejecución por lote contra `POST /clubs`, reporte por fila).
- DropdownMenu en `/dashboard/clubs` con opciones Manual / Importar Excel.
- Restricción de acceso (lectura del menú, página `/import` y `bulkCreateClubsAction`) a roles: `super-admin`, `admin`, `director-lf`, `assistant-lf` vía nuevo helper `canManageClubsByRole`.
- Nuevo componente compartido `LocationPicker` (Places Autocomplete + marker draggable + click en mapa) reemplaza inputs lat/lng en formularios de crear/editar club.
- Soporte i18n para ambos flujos en `es`, `en`, `pt-BR`, `fr`.

## Required setup
Agregar en `.env.local` del proyecto admin:

```
NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=...
```

APIs requeridas en Google Cloud: **Maps JavaScript API** + **Places API**. Restringir la key por HTTP referrer.

## New dependencies
- `xlsx@^0.18.5`
- `@vis.gl/react-google-maps@^1.8.3`

## Test plan
- [ ] Visitar `/dashboard/clubs` como `super-admin`/`admin`/`director-lf`/`assistant-lf` → ver botón "Crear club" con dropdown (Manual + Importar Excel).
- [ ] Visitar `/dashboard/clubs` como cualquier otro rol con `clubs:read` → no aparece el botón.
- [ ] Acceder directamente a `/dashboard/clubs/import` sin rol permitido → redirige a `/dashboard/clubs`.
- [ ] Descargar plantilla → archivo `clubs-template.xlsx` con headers correctos.
- [ ] Subir Excel con clubes válidos → preview muestra filas válidas, submit crea clubes y reporta IDs.
- [ ] Subir Excel con nombres de campo local/distrito/iglesia que no existen → filas marcadas como inválidas con mensaje.
- [ ] Subir Excel faltante de columnas requeridas → mensaje de error claro.
- [ ] En `/dashboard/clubs/new` el card "Coordenadas" muestra el mapa. Buscar dirección → centra y coloca pin. Arrastrar pin → actualiza lat/lng. Submit → club creado con coords.
- [ ] En detalle de club, tab "Editar", el mapa carga con coords existentes. Modificar y guardar.
- [ ] Variar el idioma (es/en/pt-BR/fr) → todos los textos del flujo localizados.