### PR TITLE
feat(resources): presigned R2 upload + scope RBAC + body limit fixes

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -71,7 +71,7 @@ const cspValue = [
   `style-src 'self' 'unsafe-inline'`,
   `img-src 'self' data: blob: https://lh3.googleusercontent.com https://avatars.githubusercontent.com https://pub-c8aa231ae66c46ff96fc5e811994d9d2.r2.dev https://pub-c0e79f5fa4634581867fab5b0fed605c.r2.dev https://5da196c051c48c7a4ebeea275a2b23d1.r2.cloudflarestorage.com`,
   `font-src 'self' data:`,
-  `connect-src 'self' ${backendOrigin} https://*.sentry.io https://*.ingest.sentry.io https://*.ingest.us.sentry.io`,
+  `connect-src 'self' ${backendOrigin} https://*.r2.cloudflarestorage.com https://*.sentry.io https://*.ingest.sentry.io https://*.ingest.us.sentry.io`,
   `frame-ancestors 'none'`,
   `base-uri 'self'`,
   `form-action 'self'`,
@@ -80,6 +80,14 @@ const cspValue = [
   .concat(";");
 
 const nextConfig: NextConfig = {
+  // Bumping default 1MB so Server Actions still work as a fallback path. Large
+  // files (>25MB) MUST go through the presigned R2 PUT flow — see
+  // /resources/upload-url and createResourceFromUploadedAction.
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "25mb",
+    },
+  },
   async headers() {
     return [
       {

--- a/src/app/(dashboard)/dashboard/resources/page.tsx
+++ b/src/app/(dashboard)/dashboard/resources/page.tsx
@@ -268,6 +268,42 @@ export default async function ResourcesPage({
   const canEdit = hasAnyPermission(user, [RESOURCES_UPDATE]);
   const canDelete = hasAnyPermission(user, [RESOURCES_DELETE]);
 
+  // Resolve user's effective global scope to limit available scope levels and
+  // pre-select / lock the scope_id in the create form per RBAC hierarchy.
+  const globalScope = (user.authorization?.effective as { scope?: { global?: unknown } } | undefined)
+    ?.scope?.global as
+    | {
+        country?: { id?: unknown } | null;
+        union?: { id?: unknown } | null;
+        local_field?: { id?: unknown } | null;
+      }
+    | undefined;
+
+  const userCountryId = toPositiveNumber(globalScope?.country?.id);
+  const userUnionId = toPositiveNumber(globalScope?.union?.id);
+  const userLocalFieldId = toPositiveNumber(globalScope?.local_field?.id);
+
+  let allowedScopeLevels: ScopeLevel[];
+  let lockedScopeId: number | null = null;
+  let scopedUnions = unions;
+  let scopedLocalFields = localFields;
+
+  if (userCountryId) {
+    allowedScopeLevels = ["system", "union", "local_field"];
+  } else if (userUnionId) {
+    allowedScopeLevels = ["union"];
+    lockedScopeId = userUnionId;
+    scopedUnions = unions.filter((u) => u.union_id === userUnionId);
+    scopedLocalFields = [];
+  } else if (userLocalFieldId) {
+    allowedScopeLevels = ["local_field"];
+    lockedScopeId = userLocalFieldId;
+    scopedUnions = [];
+    scopedLocalFields = localFields.filter((lf) => lf.local_field_id === userLocalFieldId);
+  } else {
+    allowedScopeLevels = [];
+  }
+
   return (
     <div className="space-y-6">
       {loadError && <EndpointErrorBanner state="missing" detail={loadError} />}
@@ -276,8 +312,10 @@ export default async function ResourcesPage({
         items={items}
         meta={meta}
         categories={categories}
-        unions={unions}
-        localFields={localFields}
+        unions={scopedUnions}
+        localFields={scopedLocalFields}
+        allowedScopeLevels={allowedScopeLevels}
+        lockedScopeId={lockedScopeId}
         canCreate={canCreate}
         canEdit={canEdit}
         canDelete={canDelete}

--- a/src/components/resources/resources-crud-page.tsx
+++ b/src/components/resources/resources-crud-page.tsx
@@ -75,6 +75,10 @@ import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { DataTablePagination } from "@/components/shared/data-table-pagination";
 import type { ResourceActionState } from "@/lib/resources/resource-actions";
+import {
+  createResourceFromUploadedAction,
+  requestUploadUrlAction,
+} from "@/lib/resources/resource-actions";
 import type { ResourceType, ClubTypeTarget, ScopeLevel } from "@/lib/api/resources";
 import { apiRequestFromClient } from "@/lib/api/client";
 import type { Union, LocalField } from "@/lib/api/geography";
@@ -119,6 +123,8 @@ interface ResourcesCrudPageProps {
   categories: CategoryRecord[];
   unions: Union[];
   localFields: LocalField[];
+  allowedScopeLevels: ScopeLevel[];
+  lockedScopeId: number | null;
   canCreate: boolean;
   canEdit: boolean;
   canDelete: boolean;
@@ -384,6 +390,8 @@ function ResourceFormFields({
   categories,
   unions,
   localFields,
+  allowedScopeLevels,
+  lockedScopeId,
   isEdit,
   onFileSizeError,
 }: {
@@ -391,6 +399,8 @@ function ResourceFormFields({
   categories: CategoryRecord[];
   unions: Union[];
   localFields: LocalField[];
+  allowedScopeLevels: ScopeLevel[];
+  lockedScopeId: number | null;
   isEdit?: boolean;
   onFileSizeError?: (error: string | null) => void;
 }) {
@@ -398,9 +408,15 @@ function ResourceFormFields({
   const [resourceType, setResourceType] = useState<ResourceType>(
     (item?.resource_type as ResourceType) ?? "document",
   );
-  const [scopeLevel, setScopeLevel] = useState<ScopeLevel>(
-    (item?.scope_level as ScopeLevel) ?? "system",
-  );
+  const initialScopeLevel: ScopeLevel = (() => {
+    if (item?.scope_level && allowedScopeLevels.includes(item.scope_level as ScopeLevel)) {
+      return item.scope_level as ScopeLevel;
+    }
+    return allowedScopeLevels[0] ?? "system";
+  })();
+  const [scopeLevel, setScopeLevel] = useState<ScopeLevel>(initialScopeLevel);
+  const scopeLevelLocked = allowedScopeLevels.length <= 1;
+  const scopeIdLocked = lockedScopeId !== null;
   const [fileSizeError, setFileSizeError] = useState<string | null>(null);
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
@@ -433,7 +449,10 @@ function ResourceFormFields({
     image: "JPG, PNG, WebP, GIF — máx. 50 MB",
   };
 
-  const currentScopeIdValue = toPositiveNumber(item?.scope_id)?.toString() ?? "";
+  const currentScopeIdValue =
+    (scopeIdLocked ? String(lockedScopeId) : null) ??
+    toPositiveNumber(item?.scope_id)?.toString() ??
+    "";
 
   return (
     <div className="space-y-4">
@@ -552,21 +571,26 @@ function ResourceFormFields({
             name="scope_level"
             value={scopeLevel}
             onValueChange={(v) => setScopeLevel(v as ScopeLevel)}
-            disabled={isEdit}
+            disabled={isEdit || scopeLevelLocked}
           >
             <SelectTrigger id="res-scope-level">
               <SelectValue placeholder={t("placeholders.selectScope")} />
             </SelectTrigger>
             <SelectContent>
-              {(Object.entries(SCOPE_LEVEL_LABELS) as [ScopeLevel, string][]).map(
-                ([value, label]) => (
+              {(Object.entries(SCOPE_LEVEL_LABELS) as [ScopeLevel, string][])
+                .filter(([value]) => allowedScopeLevels.includes(value))
+                .map(([value, label]) => (
                   <SelectItem key={value} value={value}>
                     {label}
                   </SelectItem>
-                ),
-              )}
+                ))}
             </SelectContent>
           </Select>
+          {scopeLevelLocked && allowedScopeLevels.length > 0 && (
+            <p className="text-xs text-muted-foreground">
+              Tu rol solo permite recursos de alcance {SCOPE_LEVEL_LABELS[allowedScopeLevels[0]]}.
+            </p>
+          )}
         </div>
       </div>
 
@@ -577,7 +601,25 @@ function ResourceFormFields({
             {scopeLevel === "union" ? "Unión" : "Campo local"}{" "}
             <span className="ml-0.5 text-destructive">*</span>
           </Label>
-          {scopeLevel === "union" ? (
+          {scopeIdLocked ? (
+            <>
+              <Input
+                id="res-scope-id-display"
+                value={
+                  scopeLevel === "union"
+                    ? unions.find((u) => u.union_id === lockedScopeId)?.name ?? `#${lockedScopeId}`
+                    : localFields.find((lf) => lf.local_field_id === lockedScopeId)?.name ??
+                      `#${lockedScopeId}`
+                }
+                readOnly
+                disabled
+              />
+              <input type="hidden" name="scope_id" value={String(lockedScopeId)} />
+              <p className="text-xs text-muted-foreground">
+                Tu rol está fijado a este alcance — no puede cambiarse.
+              </p>
+            </>
+          ) : scopeLevel === "union" ? (
             unions.length > 0 ? (
               <Select
                 name="scope_id"
@@ -712,6 +754,8 @@ export function ResourcesCrudPage({
   categories,
   unions,
   localFields,
+  allowedScopeLevels,
+  lockedScopeId,
   canCreate,
   canEdit,
   canDelete,
@@ -731,6 +775,11 @@ export function ResourcesCrudPage({
   const [editItem, setEditItem] = useState<ResourceRecord | null>(null);
   const [deleteItem, setDeleteItem] = useState<ResourceRecord | null>(null);
   const [createFileSizeError, setCreateFileSizeError] = useState<string | null>(null);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [createSubmitting, setCreateSubmitting] = useState(false);
+  const [uploadProgress, setUploadProgress] = useState<number | null>(null);
+  const createFormRef = useRef<HTMLFormElement | null>(null);
+  const uploadXhrRef = useRef<XMLHttpRequest | null>(null);
 
   const [createState, createFormAction] = useActionState<ResourceActionState, FormData>(
     createAction,
@@ -744,6 +793,171 @@ export function ResourcesCrudPage({
     deleteAction,
     {},
   );
+
+  useEffect(() => {
+    return () => {
+      if (uploadXhrRef.current) {
+        uploadXhrRef.current.abort();
+        uploadXhrRef.current = null;
+      }
+    };
+  }, []);
+
+  function uploadToR2(
+    url: string,
+    file: File,
+    contentType: string,
+    onProgress: (pct: number) => void,
+  ): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      uploadXhrRef.current = xhr;
+      xhr.open("PUT", url, true);
+      xhr.setRequestHeader("Content-Type", contentType);
+      xhr.upload.onprogress = (event) => {
+        if (event.lengthComputable && event.total > 0) {
+          onProgress(Math.round((event.loaded / event.total) * 100));
+        }
+      };
+      xhr.onload = () => {
+        uploadXhrRef.current = null;
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve();
+        } else {
+          reject(
+            new Error(
+              `R2 PUT respondió ${xhr.status}: ${xhr.statusText || "error"}`,
+            ),
+          );
+        }
+      };
+      xhr.onerror = () => {
+        uploadXhrRef.current = null;
+        reject(new Error("Error de red durante la subida a R2."));
+      };
+      xhr.onabort = () => {
+        uploadXhrRef.current = null;
+        reject(new Error("Subida cancelada."));
+      };
+      xhr.send(file);
+    });
+  }
+
+  async function handleCreateSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (createSubmitting) return;
+    setCreateError(null);
+    setUploadProgress(null);
+
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    const resourceType = String(formData.get("resource_type") ?? "");
+
+    // text + video_link have no file → fallback to the legacy Server Action
+    if (resourceType === "text" || resourceType === "video_link") {
+      createFormAction(formData);
+      return;
+    }
+
+    if (!["document", "audio", "image"].includes(resourceType)) {
+      setCreateError("Tipo de recurso inválido.");
+      return;
+    }
+
+    const file = formData.get("file");
+    if (!(file instanceof File) || file.size === 0) {
+      setCreateError("Selecciona un archivo antes de subir.");
+      return;
+    }
+
+    const title = String(formData.get("title") ?? "").trim();
+    if (!title) {
+      setCreateError("El título es obligatorio.");
+      return;
+    }
+
+    const scopeLevel = String(formData.get("scope_level") ?? "") as ScopeLevel;
+    const scopeIdRaw = String(formData.get("scope_id") ?? "").trim();
+    const scopeId = scopeIdRaw ? Number(scopeIdRaw) : undefined;
+    if (scopeLevel !== "system" && (!scopeId || !Number.isFinite(scopeId))) {
+      setCreateError("Selecciona el alcance específico (unión o campo local).");
+      return;
+    }
+
+    const categoryIdRaw = String(formData.get("category_id") ?? "").trim();
+    const categoryId =
+      categoryIdRaw && categoryIdRaw !== "none" ? Number(categoryIdRaw) : undefined;
+    const description = String(formData.get("description") ?? "").trim() || undefined;
+
+    setCreateSubmitting(true);
+    try {
+      const uploadResp = await requestUploadUrlAction({
+        resource_type: resourceType as "document" | "audio" | "image",
+        scope_level: scopeLevel,
+        scope_id: scopeId,
+        file_name: file.name,
+        mime_type: file.type || "application/octet-stream",
+        file_size: file.size,
+      });
+
+      if (uploadResp.error || !uploadResp.data) {
+        setCreateError(uploadResp.error ?? "No se pudo iniciar la subida.");
+        return;
+      }
+
+      const { upload_url, file_key, required_headers } = uploadResp.data;
+      const contentType = required_headers["Content-Type"] ?? file.type;
+
+      setUploadProgress(0);
+      try {
+        await uploadToR2(upload_url, file, contentType, setUploadProgress);
+      } catch (uploadErr) {
+        setCreateError(
+          uploadErr instanceof Error ? uploadErr.message : "Subida fallida.",
+        );
+        return;
+      }
+
+      // Register the resource — server action will redirect on success.
+      const result = await createResourceFromUploadedAction(
+        {},
+        {
+          title,
+          description,
+          resource_type: resourceType as "document" | "audio" | "image",
+          resource_category_id: categoryId,
+          scope_level: scopeLevel,
+          scope_id: scopeId,
+          file_key,
+          file_name: file.name,
+          file_mime_type: contentType,
+          file_size: file.size,
+        },
+      );
+
+      if (result?.error) {
+        setCreateError(result.error);
+      }
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : "Error inesperado.");
+    } finally {
+      setCreateSubmitting(false);
+      setUploadProgress(null);
+    }
+  }
+
+  function handleCreateCancel() {
+    if (uploadXhrRef.current) {
+      uploadXhrRef.current.abort();
+      uploadXhrRef.current = null;
+    }
+    setCreateOpen(false);
+    setCreateFileSizeError(null);
+    setCreateError(null);
+    setUploadProgress(null);
+    setCreateSubmitting(false);
+  }
 
   useEffect(() => {
     latestParamsRef.current = searchParamsString;
@@ -1242,8 +1456,11 @@ export function ResourcesCrudPage({
         <Dialog
           open={createOpen}
           onOpenChange={(open) => {
-            setCreateOpen(open);
-            if (!open) setCreateFileSizeError(null);
+            if (!open) {
+              handleCreateCancel();
+            } else {
+              setCreateOpen(true);
+            }
           }}
         >
           <DialogContent className="max-h-[90vh] max-w-2xl overflow-y-auto">
@@ -1253,23 +1470,54 @@ export function ResourcesCrudPage({
                 Completa los campos para registrar el nuevo recurso en el sistema.
               </DialogDescription>
             </DialogHeader>
-            <form action={createFormAction} className="space-y-4">
-              {createOpen && createState.error && (
+            <form
+              ref={createFormRef}
+              onSubmit={handleCreateSubmit}
+              className="space-y-4"
+            >
+              {createOpen && (createError || createState.error) && (
                 <div className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
-                  {createState.error}
+                  {createError ?? createState.error}
                 </div>
               )}
               <ResourceFormFields
                 categories={categories}
                 unions={unions}
                 localFields={localFields}
+                allowedScopeLevels={allowedScopeLevels}
+                lockedScopeId={lockedScopeId}
                 onFileSizeError={setCreateFileSizeError}
               />
+              {uploadProgress !== null && (
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between text-xs text-muted-foreground">
+                    <span>Subiendo archivo a R2…</span>
+                    <span>{uploadProgress}%</span>
+                  </div>
+                  <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                    <div
+                      className="h-full bg-primary transition-all"
+                      style={{ width: `${uploadProgress}%` }}
+                    />
+                  </div>
+                </div>
+              )}
               <DialogFooter>
-                <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleCreateCancel}
+                  disabled={createSubmitting && uploadProgress === null}
+                >
                   Cancelar
                 </Button>
-                <SubmitButton label="Subir recurso" extraDisabled={!!createFileSizeError} />
+                <Button
+                  type="submit"
+                  disabled={createSubmitting || !!createFileSizeError}
+                >
+                  {createSubmitting && <Loader2 className="size-4 animate-spin" />}
+                  Subir recurso
+                </Button>
               </DialogFooter>
             </form>
           </DialogContent>
@@ -1307,6 +1555,8 @@ export function ResourcesCrudPage({
                 categories={categories}
                 unions={unions}
                 localFields={localFields}
+                allowedScopeLevels={allowedScopeLevels}
+                lockedScopeId={lockedScopeId}
                 isEdit
               />
               <DialogFooter>

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -57,19 +57,52 @@ function toRecord(headers?: HeadersInit) {
   return headers;
 }
 
+function flattenValidationMessages(value: unknown): string[] {
+  if (value == null) return [];
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed ? [trimmed] : [];
+  }
+  if (Array.isArray(value)) {
+    return value.flatMap(flattenValidationMessages);
+  }
+  if (typeof value === "object") {
+    const node = value as {
+      constraints?: Record<string, unknown>;
+      children?: unknown;
+      message?: unknown;
+      property?: unknown;
+    };
+    const out: string[] = [];
+    if (node.constraints && typeof node.constraints === "object") {
+      for (const v of Object.values(node.constraints)) {
+        if (typeof v === "string" && v.trim()) out.push(v.trim());
+      }
+    }
+    if (node.children) out.push(...flattenValidationMessages(node.children));
+    if (typeof node.message === "string" && node.message.trim()) {
+      out.push(node.message.trim());
+    }
+    return out;
+  }
+  return [];
+}
+
 function extractMessage(payload: unknown, status: number): string {
   if (typeof payload === "string" && payload.trim().length > 0) {
     return payload.trim();
   }
 
-  if (payload && typeof payload === "object" && "message" in payload) {
-    const message = (payload as { message?: unknown }).message;
-    if (typeof message === "string") {
-      return message;
-    }
+  if (payload && typeof payload === "object") {
+    const obj = payload as { message?: unknown; errors?: unknown };
+    const fromMessage = flattenValidationMessages(obj.message);
+    if (fromMessage.length > 0) return fromMessage.join(", ");
 
-    if (Array.isArray(message)) {
-      return message.map(String).join(", ");
+    const fromErrors = flattenValidationMessages(obj.errors);
+    if (fromErrors.length > 0) return fromErrors.join(", ");
+
+    if (typeof obj.message === "string" && obj.message.trim()) {
+      return obj.message.trim();
     }
   }
 

--- a/src/lib/api/resources.ts
+++ b/src/lib/api/resources.ts
@@ -127,6 +127,54 @@ export async function createResource(formData: FormData) {
   return apiRequest("/resources", { method: "POST", body: formData });
 }
 
+// Presigned upload flow ----------------------------------------------------
+
+export type UploadUrlRequest = {
+  resource_type: "document" | "audio" | "image";
+  scope_level: ScopeLevel;
+  scope_id?: number;
+  file_name: string;
+  mime_type: string;
+  file_size: number;
+};
+
+export type UploadUrlResponse = {
+  upload_url: string;
+  file_key: string;
+  expires_in: number;
+  required_headers: Record<string, string>;
+};
+
+export type CreateFromUploadedPayload = {
+  title: string;
+  description?: string;
+  resource_type: "document" | "audio" | "image";
+  resource_category_id?: number;
+  club_type_id?: number;
+  scope_level: ScopeLevel;
+  scope_id?: number;
+  file_key: string;
+  file_name: string;
+  file_mime_type: string;
+  file_size: number;
+};
+
+export async function requestResourceUploadUrl(payload: UploadUrlRequest) {
+  return apiRequest<{ status: string; data: UploadUrlResponse }>(
+    "/resources/upload-url",
+    { method: "POST", body: payload },
+  );
+}
+
+export async function createResourceFromUploaded(
+  payload: CreateFromUploadedPayload,
+) {
+  return apiRequest("/resources/from-uploaded", {
+    method: "POST",
+    body: payload,
+  });
+}
+
 export async function updateResource(id: number, payload: Partial<ResourcePayload>) {
   return apiRequest(`/resources/${id}`, { method: "PATCH", body: payload });
 }

--- a/src/lib/resources/resource-actions.ts
+++ b/src/lib/resources/resource-actions.ts
@@ -5,12 +5,17 @@ import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import {
   createResource,
+  createResourceFromUploaded,
   deleteResource,
+  requestResourceUploadUrl,
   updateResource,
+  type CreateFromUploadedPayload,
   type ResourcePayload,
   type ResourceType,
   type ClubTypeTarget,
   type ScopeLevel,
+  type UploadUrlRequest,
+  type UploadUrlResponse,
 } from "@/lib/api/resources";
 import { hasAnyPermission } from "@/lib/auth/permission-utils";
 import {
@@ -149,6 +154,56 @@ export async function createResourceAction(
     await createResource(outFormData);
   } catch (error) {
     return { error: error instanceof Error ? error.message : t("errors.create_failed") };
+  }
+  revalidatePath(RESOURCES_PATH);
+  redirect(RESOURCES_PATH);
+}
+
+/**
+ * Server Action wrapper that requests a presigned PUT URL from the backend.
+ * Called from the client BEFORE the browser uploads to R2. Returns null on
+ * permission/validation errors so the client can surface them.
+ */
+export async function requestUploadUrlAction(
+  payload: UploadUrlRequest,
+): Promise<{ data?: UploadUrlResponse; error?: string }> {
+  const user = await requireAdminUser();
+  const t = await getTranslations("resources");
+  if (!hasAnyPermission(user, [RESOURCES_CREATE])) {
+    return { error: t("errors.create_permission_denied") };
+  }
+  try {
+    const response = await requestResourceUploadUrl(payload);
+    return { data: response.data };
+  } catch (error) {
+    return {
+      error:
+        error instanceof Error
+          ? error.message
+          : t("errors.create_failed"),
+    };
+  }
+}
+
+/**
+ * Server Action that registers a resource AFTER the client uploaded the file
+ * directly to R2. Backend HEAD-checks the key before persisting.
+ */
+export async function createResourceFromUploadedAction(
+  _: ResourceActionState,
+  payload: CreateFromUploadedPayload,
+): Promise<ResourceActionState> {
+  const user = await requireAdminUser();
+  const t = await getTranslations("resources");
+  if (!hasAnyPermission(user, [RESOURCES_CREATE])) {
+    return { error: t("errors.create_permission_denied") };
+  }
+  try {
+    await createResourceFromUploaded(payload);
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : t("errors.create_failed"),
+    };
   }
   revalidatePath(RESOURCES_PATH);
   redirect(RESOURCES_PATH);


### PR DESCRIPTION
## Summary
- Direct-to-R2 presigned PUT flow for resource file uploads — bypasses the Next.js Server Action 1MB body limit and the NestJS Multer 50MB cap. Browser uploads directly to R2 with progress, then registers metadata.
- Scope RBAC hardened in the resources module so Director/Asistente Unión only create resources for their own union and Director/Asistente Local only for their own campo local. Fixes a latent bug where admin de unión could create `local_field` resources for fields of other unions.
- `[object Object]` rendering fix in the admin api client error path (covers any backend module emitting nested `ValidationError` trees).
- `experimental.serverActions.bodySizeLimit = 25mb` so the legacy Server Action path keeps working for `text` / `video_link` (no-file) resources without hitting the 1MB default.
- CSP `connect-src` extended to `https://*.r2.cloudflarestorage.com` so the browser can PUT directly.

## Architecture
End-to-end flow for `document` / `audio` / `image`:
1. Browser → `POST /resources/upload-url` (JSON) with `{resource_type, scope_level, scope_id?, file_name, mime_type, file_size}`.
2. Backend validates scope auth + MIME + size, returns a presigned PUT URL (TTL 15 min) and a deterministic `file_key` under `resources/{scope_level}/{scope_id}/{uuid}.{ext}`.
3. Browser PUTs directly to R2 with the signed URL (Content-Type matches).
4. Browser → `POST /resources/from-uploaded` (JSON) with `file_key` + metadata.
5. Backend HEAD-checks R2, asserts the `file_key` belongs to the requested scope path, persists the row.

For `text` / `video_link` the legacy Server Action multipart endpoint is preserved (no file involved).

## RBAC rules (resources.service.validateScopeAuthorization)
| Role (`effective.scope.global`) | `system` | `union` | `local_field` |
|---|---|---|---|
| `country.id` set (admin país) | ✅ | ✅ any | ✅ any |
| `union.id` set (no country) | ❌ | ✅ only own union | ❌ |
| `local_field.id` set (no union, no country) | ❌ | ❌ | ✅ only own campo |

UI mirrors this: scope_level select is filtered to allowed levels, and scope_id is displayed read-only with a hidden input when the role is locked to a single scope.

## Test plan
- [ ] Backend PR merged or its branch deployed; `R2_BUCKET_RESOURCES_FILES` / `R2_PUBLIC_URL_RESOURCES_FILES` / `R2_KEY_PREFIX_RESOURCES_FILES` set in the API env (usually pointing at the shared `secure-documents` bucket).
- [ ] R2 bucket CORS allows `PUT GET HEAD` from the admin origin with `Content-Type` + `Range` headers.
- [ ] As `super-admin`: create a `document` resource with a 30 MB PDF → progress bar advances → record appears in list, signed URL opens correctly.
- [ ] As `director-union`: open the create dialog → Alcance shows only `Unión`, Unión field is locked to their union → submission succeeds for their union and is rejected for any other.
- [ ] As `director-lf`: Alcance shows only `Campo local`, scope_id locked to their campo → upload succeeds.
- [ ] Create a `text` resource → still uses the legacy Server Action path, succeeds without going through R2.
- [ ] Create a resource category from `/dashboard/resources/categories` → the "[object Object]" error no longer appears; backend validation errors render their actual messages.

## Notes
- This is the admin side of the change. The backend companion is in `sacdia-backend` PR (feat/admin-fixes → development) and must merge first or the upload endpoints will 404.