### PR TITLE
feat(materiales): admin panel para módulo pedidos/materiales

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -10,7 +10,8 @@
       "requests_reports": "Requests and reports",
       "members": "Members",
       "operations": "Operations",
-      "rankings_analytics": "Rankings & Analytics"
+      "rankings_analytics": "Rankings & Analytics",
+      "materiales": "Materials"
     },
     "items": {
       "dashboard": "Dashboard",
@@ -102,7 +103,11 @@
       "subgroup_academics": "Academics",
       "subgroup_business": "Business",
       "subgroup_honors_cat": "Honors",
-      "ranking_weights_root": "Weights configuration"
+      "ranking_weights_root": "Weights configuration",
+      "materiales_bandeja": "Inbox",
+      "materiales_comprobantes": "Receipts",
+      "materiales_inventario": "Inventory",
+      "materiales_configuracion": "Settings"
     },
     "breadcrumbs": {
       "dashboard": "Dashboard",

--- a/messages/es.json
+++ b/messages/es.json
@@ -10,7 +10,8 @@
       "requests_reports": "Solicitudes y reportes",
       "members": "Miembros",
       "operations": "Operaciones",
-      "rankings_analytics": "Rankings y análisis"
+      "rankings_analytics": "Rankings y análisis",
+      "materiales": "Materiales"
     },
     "items": {
       "dashboard": "Dashboard",
@@ -102,7 +103,11 @@
       "subgroup_academics": "Académicos",
       "subgroup_business": "Negocio",
       "subgroup_honors_cat": "Honores",
-      "ranking_weights_root": "Configuración de pesos"
+      "ranking_weights_root": "Configuración de pesos",
+      "materiales_bandeja": "Bandeja",
+      "materiales_comprobantes": "Comprobantes",
+      "materiales_inventario": "Inventario",
+      "materiales_configuracion": "Configuración"
     },
     "breadcrumbs": {
       "dashboard": "Dashboard",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -10,7 +10,8 @@
       "requests_reports": "Demandes et rapports",
       "members": "Membres",
       "operations": "Opérations",
-      "rankings_analytics": "Classements & Analytique"
+      "rankings_analytics": "Classements & Analytique",
+      "materiales": "Matériaux"
     },
     "items": {
       "dashboard": "Tableau de bord",
@@ -102,7 +103,11 @@
       "subgroup_academics": "Académiques",
       "subgroup_business": "Affaires",
       "subgroup_honors_cat": "Honneurs",
-      "ranking_weights_root": "Configuration des poids"
+      "ranking_weights_root": "Configuration des poids",
+      "materiales_bandeja": "Boîte de réception",
+      "materiales_comprobantes": "Reçus",
+      "materiales_inventario": "Inventaire",
+      "materiales_configuracion": "Paramètres"
     },
     "breadcrumbs": {
       "dashboard": "Tableau de bord",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -10,7 +10,8 @@
       "requests_reports": "Solicitações e relatórios",
       "members": "Membros",
       "operations": "Operações",
-      "rankings_analytics": "Rankings e análises"
+      "rankings_analytics": "Rankings e análises",
+      "materiales": "Materiais"
     },
     "items": {
       "dashboard": "Dashboard",
@@ -102,7 +103,11 @@
       "subgroup_academics": "Acadêmicos",
       "subgroup_business": "Negócio",
       "subgroup_honors_cat": "Honras",
-      "ranking_weights_root": "Configuração de pesos"
+      "ranking_weights_root": "Configuração de pesos",
+      "materiales_bandeja": "Caixa de entrada",
+      "materiales_comprobantes": "Comprovantes",
+      "materiales_inventario": "Inventário",
+      "materiales_configuracion": "Configurações"
     },
     "breadcrumbs": {
       "dashboard": "Painel",

--- a/src/app/(dashboard)/dashboard/materiales/bandeja/_components/bandeja-filters.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/bandeja/_components/bandeja-filters.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useCallback, useTransition } from "react";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { MaterialEstado } from "@/lib/types/materiales";
+
+const ESTADO_OPTIONS: { value: MaterialEstado | "all"; label: string }[] = [
+  { value: "all", label: "Todos los estados" },
+  { value: "en_revision", label: "En revisión" },
+  { value: "aprobada", label: "Aprobada" },
+  { value: "pagada", label: "Pagada" },
+  { value: "entregada", label: "Entregada" },
+  { value: "cancelada", label: "Cancelada" },
+];
+
+interface BandejaFiltersProps {
+  currentEstado: MaterialEstado | "all";
+  currentQ: string;
+}
+
+export function BandejaFilters({ currentEstado, currentQ }: BandejaFiltersProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
+  const updateParam = useCallback(
+    (key: string, value: string | undefined) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value && value !== "all") {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      // Reset to page 1 on filter change
+      params.delete("page");
+      startTransition(() => {
+        router.push(`${pathname}?${params.toString()}`);
+      });
+    },
+    [router, pathname, searchParams],
+  );
+
+  function handleEstadoChange(value: string) {
+    updateParam("estado", value);
+  }
+
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value.trim();
+    updateParam("q", value || undefined);
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {/* Estado filter */}
+      <Select
+        value={currentEstado}
+        onValueChange={handleEstadoChange}
+      >
+        <SelectTrigger className="h-9 w-[180px]">
+          <SelectValue placeholder="Estado" />
+        </SelectTrigger>
+        <SelectContent>
+          {ESTADO_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Search input */}
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          className="h-9 w-[220px] pl-8"
+          placeholder="Buscar folio o director..."
+          defaultValue={currentQ}
+          onChange={handleSearchChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/bandeja/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/bandeja/page.tsx
@@ -1,0 +1,237 @@
+import Link from "next/link";
+import { Inbox } from "lucide-react";
+import { PageHeader } from "@/components/shared/page-header";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { EmptyState } from "@/components/shared/empty-state";
+import { DataTablePagination } from "@/components/shared/data-table-pagination";
+import { EstadoBadge } from "@/components/materiales/estado-badge";
+import { MoneyFormat } from "@/components/materiales/money-format";
+import { FolioPill } from "@/components/materiales/folio-pill";
+import { BandejaFilters } from "./_components/bandeja-filters";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { listOrdenes } from "@/lib/api/materiales";
+import { ApiError } from "@/lib/api/client";
+import type { MaterialEstado } from "@/lib/types/materiales";
+import type { OrdenSummary } from "@/lib/types/materiales";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+const PAGE_SIZE = 20;
+
+const VALID_ESTADOS: Array<MaterialEstado | "all"> = [
+  "all",
+  "en_revision",
+  "aprobada",
+  "pagada",
+  "entregada",
+  "cancelada",
+];
+
+function resolveEstado(raw: unknown): MaterialEstado | "all" {
+  if (typeof raw === "string" && VALID_ESTADOS.includes(raw as MaterialEstado)) {
+    return raw as MaterialEstado | "all";
+  }
+  return "en_revision";
+}
+
+function resolveQ(raw: unknown): string {
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function resolvePage(raw: unknown): number {
+  const n = typeof raw === "string" ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+}
+
+/**
+ * Builds the href for the row detail link.
+ * Uses folio_referencia when available (approved+), falls back to UUID.
+ */
+function resolveDetailHref(orden: OrdenSummary): string {
+  const slug = orden.folio_referencia ?? orden.id;
+  return `/dashboard/materiales/solicitud/${slug}`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat("es-MX", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function BandejaPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const raw = await searchParams;
+
+  const estado = resolveEstado(raw["estado"]);
+  const q = resolveQ(raw["q"]);
+  const page = resolvePage(raw["page"]);
+
+  let ordenes: OrdenSummary[] = [];
+  let total = 0;
+  let loadError: string | null = null;
+  let loadErrorStatus: number | null = null;
+
+  try {
+    const result = await listOrdenes({
+      estado,
+      q: q || undefined,
+      page,
+      pageSize: PAGE_SIZE,
+    });
+    ordenes = result.data;
+    total = result.total;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      loadError = error.message;
+      loadErrorStatus = error.status;
+    } else {
+      loadError = "Error al cargar las solicitudes.";
+    }
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Bandeja de solicitudes"
+        description="Gestión de pedidos de materiales enviados por directores de club."
+      />
+
+      {/* Filters */}
+      <BandejaFilters currentEstado={estado} currentQ={q} />
+
+      {/* Error state */}
+      {loadError && (
+        <EndpointErrorBanner
+          state={loadErrorStatus === 403 ? "forbidden" : "missing"}
+          detail={loadError}
+        />
+      )}
+
+      {/* Empty state */}
+      {!loadError && ordenes.length === 0 && (
+        <EmptyState
+          icon={Inbox}
+          title="Sin solicitudes"
+          description={
+            estado === "all" || estado === "en_revision"
+              ? "No hay solicitudes pendientes de revisión."
+              : "No hay solicitudes con el estado y filtros seleccionados."
+          }
+          variant={q ? "no-results" : "default"}
+        />
+      )}
+
+      {/* Table */}
+      {!loadError && ordenes.length > 0 && (
+        <div className="space-y-4">
+          <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Folio
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Director / Club
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Estado
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+                    Total
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Fecha
+                  </TableHead>
+                  <TableHead className="h-9 w-20 px-3" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {ordenes.map((orden) => (
+                  <TableRow key={orden.id} className="hover:bg-muted/30">
+                    <TableCell className="px-3 py-2.5 align-middle">
+                      <FolioPill folio={orden.folio_referencia} />
+                    </TableCell>
+                    <TableCell className="px-3 py-2.5 align-middle">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">
+                          {orden.director.nombre}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {orden.director.club}
+                        </p>
+                      </div>
+                    </TableCell>
+                    <TableCell className="px-3 py-2.5 align-middle">
+                      <EstadoBadge estado={orden.estado} />
+                    </TableCell>
+                    <TableCell className="px-3 py-2.5 align-middle text-right tabular-nums">
+                      <MoneyFormat centavos={orden.total_centavos} />
+                    </TableCell>
+                    <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                      {formatDate(orden.created_at)}
+                    </TableCell>
+                    <TableCell className="px-3 py-2.5 align-middle">
+                      <Button variant="ghost" size="icon-sm" asChild>
+                        <Link href={resolveDetailHref(orden)}>
+                          <span className="sr-only">Ver solicitud</span>
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            aria-hidden="true"
+                          >
+                            <path d="m9 18 6-6-6-6" />
+                          </svg>
+                        </Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <DataTablePagination
+              page={page}
+              totalPages={totalPages}
+              total={total}
+              limit={PAGE_SIZE}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/comprobantes/[folio]/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/comprobantes/[folio]/page.tsx
@@ -1,0 +1,170 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import {
+  Building2,
+  Banknote,
+  ShoppingBag,
+  ChevronLeft,
+} from "lucide-react";
+import { PageHeader } from "@/components/shared/page-header";
+import { EstadoBadge } from "@/components/materiales/estado-badge";
+import { MoneyFormat } from "@/components/materiales/money-format";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { getOrden, listComprobantes } from "@/lib/api/materiales";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasPermission } from "@/lib/auth/permission-utils";
+import { ApiError } from "@/lib/api/client";
+// Direct cross-route import — component lives co-located with solicitud detail;
+// no duplication. Next.js allows importing from any route's _components folder.
+import { ComprobantesSection } from "@/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/comprobantes-section";
+import type { Comprobante } from "@/lib/types/materiales";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type Params = Promise<{ folio: string }>;
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function ComprobantesDetailPage({
+  params,
+}: {
+  params: Params;
+}) {
+  const { folio } = await params;
+  const user = await requireAdminUser();
+
+  // Guard: only users with validate-receipt permission can access this route
+  if (!hasPermission(user, "materiales:validate-receipt")) {
+    redirect("/dashboard");
+  }
+
+  const canReview = true; // already gated above — any user reaching this page can review
+
+  // Fetch order and comprobantes in parallel
+  let orden;
+  let comprobantes: Comprobante[] = [];
+
+  try {
+    [orden, comprobantes] = await Promise.all([
+      getOrden(folio),
+      listComprobantes(folio),
+    ]);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Back link */}
+      <Button variant="ghost" size="sm" className="-ml-1" asChild>
+        <Link href="/dashboard/materiales/comprobantes">
+          <ChevronLeft className="mr-1 size-4" />
+          Volver a comprobantes
+        </Link>
+      </Button>
+
+      {/* Page header */}
+      <PageHeader
+        title={`Comprobantes — ${orden.folio_referencia ?? folio}`}
+        description="Revisá y validá los comprobantes de pago adjuntos a esta solicitud."
+        actions={<EstadoBadge estado={orden.estado} />}
+      />
+
+      {/* ── Order summary card ────────────────────────────────────────────── */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <Card className="gap-3 py-4">
+          <CardContent className="flex items-start gap-3">
+            <Building2 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div>
+              <p className="text-xs text-muted-foreground">Director / Club</p>
+              <p className="text-sm font-medium">
+                {orden.director?.nombre ?? orden.created_by}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {orden.director?.club}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="gap-3 py-4">
+          <CardContent className="flex items-start gap-3">
+            <ShoppingBag className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div>
+              <p className="text-xs text-muted-foreground">Totales</p>
+              <p className="text-xs">
+                Subtotal:{" "}
+                <span className="tabular-nums text-foreground">
+                  <MoneyFormat centavos={orden.subtotal_centavos} />
+                </span>
+              </p>
+              <p className="text-xs">
+                Envío:{" "}
+                <span className="tabular-nums text-foreground">
+                  <MoneyFormat centavos={orden.envio_centavos} />
+                </span>
+              </p>
+              <p className="text-sm font-semibold">
+                Total:{" "}
+                <span className="tabular-nums">
+                  <MoneyFormat centavos={orden.total_centavos} />
+                </span>
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Bank snapshot — only present after approval */}
+        {orden.bank_account_clabe && (
+          <Card className="gap-3 py-4">
+            <CardContent className="flex items-start gap-3">
+              <Banknote className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+              <div>
+                <p className="text-xs text-muted-foreground">Datos bancarios</p>
+                {orden.bank_name && (
+                  <p className="text-xs">
+                    <span className="text-muted-foreground">Banco: </span>
+                    {orden.bank_name}
+                  </p>
+                )}
+                <p className="font-mono text-xs tabular-nums">
+                  {orden.bank_account_clabe}
+                </p>
+                {orden.account_holder && (
+                  <p className="text-xs text-muted-foreground">
+                    {orden.account_holder}
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+
+      {/* ── Comprobantes list ─────────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm">
+            Comprobantes de pago ({comprobantes.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ComprobantesSection
+            folio={folio}
+            comprobantes={comprobantes}
+            canReview={canReview}
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/comprobantes/_components/comprobantes-filters.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/comprobantes/_components/comprobantes-filters.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useCallback, useTransition } from "react";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+
+interface ComprobantesFiltersProps {
+  currentQ: string;
+}
+
+export function ComprobantesFilters({ currentQ }: ComprobantesFiltersProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
+  const updateParam = useCallback(
+    (key: string, value: string | undefined) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value) {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      // Reset to page 1 on filter change
+      params.delete("page");
+      startTransition(() => {
+        router.push(`${pathname}?${params.toString()}`);
+      });
+    },
+    [router, pathname, searchParams],
+  );
+
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value.trim();
+    updateParam("q", value || undefined);
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {/* Search input */}
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          className="h-9 w-[260px] pl-8"
+          placeholder="Buscar folio o director..."
+          defaultValue={currentQ}
+          onChange={handleSearchChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/comprobantes/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/comprobantes/page.tsx
@@ -1,0 +1,217 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { Receipt, ArrowRight } from "lucide-react";
+import { PageHeader } from "@/components/shared/page-header";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { EmptyState } from "@/components/shared/empty-state";
+import { DataTablePagination } from "@/components/shared/data-table-pagination";
+import { FolioPill } from "@/components/materiales/folio-pill";
+import { MoneyFormat } from "@/components/materiales/money-format";
+import { ComprobantesFilters } from "./_components/comprobantes-filters";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { listOrdenes } from "@/lib/api/materiales";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasPermission } from "@/lib/auth/permission-utils";
+import { ApiError } from "@/lib/api/client";
+import type { OrdenSummary } from "@/lib/types/materiales";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+const PAGE_SIZE = 20;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function resolveQ(raw: unknown): string {
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function resolvePage(raw: unknown): number {
+  const n = typeof raw === "string" ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Intl.DateTimeFormat("es-MX", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+/** Client-side filter: narrow by folio or director name. */
+function matchesQ(orden: OrdenSummary, q: string): boolean {
+  if (!q) return true;
+  const needle = q.toLowerCase();
+  const folio = orden.folio_referencia?.toLowerCase() ?? "";
+  const director = orden.director?.nombre?.toLowerCase() ?? "";
+  return folio.includes(needle) || director.includes(needle);
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function ComprobantesPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const user = await requireAdminUser();
+
+  // Guard: only users with validate-receipt permission can access this route
+  if (!hasPermission(user, "materiales:validate-receipt")) {
+    redirect("/dashboard");
+  }
+
+  const raw = await searchParams;
+  const q = resolveQ(raw["q"]);
+  const page = resolvePage(raw["page"]);
+
+  let ordenes: OrdenSummary[] = [];
+  let total = 0;
+  let loadError: string | null = null;
+  let loadErrorStatus: number | null = null;
+
+  try {
+    // Only aprobada orders can have pending comprobantes awaiting validation
+    const result = await listOrdenes({
+      estado: "aprobada",
+      page,
+      pageSize: PAGE_SIZE,
+    });
+    // Client-side filter by folio/director (backend /ordenes supports q but
+    // we apply it here to avoid a round-trip since the dataset is small)
+    const filtered = result.data.filter((o) => matchesQ(o, q));
+    ordenes = filtered;
+    total = q ? filtered.length : result.total;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      loadError = error.message;
+      loadErrorStatus = error.status;
+    } else {
+      loadError = "Error al cargar las órdenes.";
+    }
+  }
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Validación de comprobantes"
+        description="Órdenes aprobadas en espera de confirmación de pago."
+      />
+
+      {/* Filters */}
+      <ComprobantesFilters currentQ={q} />
+
+      {/* Error state */}
+      {loadError && (
+        <EndpointErrorBanner
+          state={loadErrorStatus === 403 ? "forbidden" : "missing"}
+          detail={loadError}
+        />
+      )}
+
+      {/* Empty state */}
+      {!loadError && ordenes.length === 0 && (
+        <EmptyState
+          icon={Receipt}
+          title="Sin órdenes pendientes"
+          description={
+            q
+              ? "Ninguna orden aprobada coincide con la búsqueda."
+              : "No hay órdenes pendientes de validación de pago."
+          }
+          variant={q ? "no-results" : "default"}
+        />
+      )}
+
+      {/* Table */}
+      {!loadError && ordenes.length > 0 && (
+        <div className="space-y-4">
+          <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Folio
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Director / Club
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+                    Total
+                  </TableHead>
+                  <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                    Fecha aprobación
+                  </TableHead>
+                  <TableHead className="h-9 w-40 px-3" />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {ordenes.map((orden) => (
+                  <TableRow key={orden.id} className="hover:bg-muted/30">
+                    <TableCell className="px-3 py-2.5 align-middle">
+                      <FolioPill folio={orden.folio_referencia} />
+                    </TableCell>
+                    <TableCell className="px-3 py-2.5 align-middle">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium">
+                          {orden.director?.nombre ?? "—"}
+                        </p>
+                        <p className="truncate text-xs text-muted-foreground">
+                          {orden.director?.club ?? "—"}
+                        </p>
+                      </div>
+                    </TableCell>
+                    <TableCell className="px-3 py-2.5 align-middle text-right tabular-nums">
+                      <MoneyFormat centavos={orden.total_centavos} />
+                    </TableCell>
+                    <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                      {/* OrdenSummary doesn't include approved_at; show created_at as proxy */}
+                      {formatDate(orden.created_at)}
+                    </TableCell>
+                    <TableCell className="px-3 py-2.5 align-middle">
+                      <Button variant="ghost" size="sm" asChild>
+                        <Link
+                          href={`/dashboard/materiales/comprobantes/${orden.folio_referencia ?? orden.id}`}
+                        >
+                          Revisar comprobantes
+                          <ArrowRight className="ml-1.5 size-3.5" />
+                        </Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Pagination — only when not filtered (q bypasses server pagination) */}
+          {!q && totalPages > 1 && (
+            <DataTablePagination
+              page={page}
+              totalPages={totalPages}
+              total={total}
+              limit={PAGE_SIZE}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/configuracion/_components/configuracion-form.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/configuracion/_components/configuracion-form.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useForm, Controller } from "react-hook-form";
+import type { Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { PriceInput } from "../../inventario/_components/price-input";
+import { updateConfiguracion } from "@/lib/api/materiales";
+import { ApiError } from "@/lib/api/client";
+import type { MaterialConfig } from "@/lib/types/materiales";
+
+// ─── Schema ───────────────────────────────────────────────────────────────────
+
+const schema = z.object({
+  bank_name: z.string().min(1, "El nombre del banco es requerido").max(200),
+  account_holder: z.string().min(1, "El titular de la cuenta es requerido").max(200),
+  bank_account_clabe: z
+    .string()
+    .regex(/^\d{18}$/, "La CLABE debe tener exactamente 18 dígitos"),
+  envio_centavos_default: z
+    .number()
+    .int()
+    .min(0, "El costo de envío no puede ser negativo"),
+  pickup_address: z.string().optional(),
+});
+
+type FormValues = z.infer<typeof schema>;
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface ConfiguracionFormProps {
+  config: MaterialConfig;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ConfiguracionForm({ config }: ConfiguracionFormProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema) as unknown as Resolver<FormValues>,
+    defaultValues: {
+      bank_name: config.bank_name ?? "",
+      account_holder: config.account_holder ?? "",
+      bank_account_clabe: config.bank_account_clabe ?? "",
+      envio_centavos_default: config.envio_centavos_default ?? 0,
+      pickup_address: config.pickup_address ?? "",
+    },
+  });
+
+  async function onSubmit(values: FormValues) {
+    try {
+      await updateConfiguracion({
+        bank_name: values.bank_name,
+        account_holder: values.account_holder,
+        bank_account_clabe: values.bank_account_clabe,
+        envio_centavos_default: values.envio_centavos_default,
+        pickup_address: values.pickup_address || undefined,
+      });
+      toast.success("Configuración actualizada correctamente.");
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : "Error al actualizar la configuración.";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {/* Bank section */}
+        <fieldset className="space-y-4 rounded-lg border p-4">
+          <legend className="px-1 text-sm font-semibold tracking-tight">
+            Datos bancarios
+          </legend>
+
+          {/* Bank name */}
+          <FormField
+            control={form.control}
+            name="bank_name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Banco</FormLabel>
+                <FormControl>
+                  <Input placeholder="ej. BBVA Bancomer" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* Account holder */}
+          <FormField
+            control={form.control}
+            name="account_holder"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Titular de la cuenta</FormLabel>
+                <FormControl>
+                  <Input placeholder="Nombre completo del titular" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          {/* CLABE */}
+          <FormField
+            control={form.control}
+            name="bank_account_clabe"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>CLABE interbancaria</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="18 dígitos"
+                    maxLength={18}
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </fieldset>
+
+        {/* Delivery section */}
+        <fieldset className="space-y-4 rounded-lg border p-4">
+          <legend className="px-1 text-sm font-semibold tracking-tight">
+            Opciones de entrega
+          </legend>
+
+          {/* Envío default */}
+          <Controller
+            control={form.control}
+            name="envio_centavos_default"
+            render={({ field, fieldState }) => (
+              <div className="space-y-1.5">
+                <Label htmlFor="envio_centavos_default">
+                  Costo de envío predeterminado
+                </Label>
+                <PriceInput
+                  id="envio_centavos_default"
+                  valueCentavos={field.value}
+                  onChange={field.onChange}
+                  disabled={isPending}
+                  placeholder="0.00"
+                />
+                {fieldState.error && (
+                  <p className="text-sm font-medium text-destructive">
+                    {fieldState.error.message}
+                  </p>
+                )}
+              </div>
+            )}
+          />
+
+          {/* Pickup address */}
+          <FormField
+            control={form.control}
+            name="pickup_address"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>
+                  Dirección de recoger{" "}
+                  <span className="text-xs text-muted-foreground">(opcional)</span>
+                </FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Dirección completa para retiro en persona..."
+                    className="resize-none"
+                    rows={3}
+                    {...field}
+                    value={field.value ?? ""}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+        </fieldset>
+
+        <div className="flex justify-end">
+          <Button type="submit" disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+            Guardar cambios
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/configuracion/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/configuracion/page.tsx
@@ -1,0 +1,55 @@
+import { redirect } from "next/navigation";
+import { Settings } from "lucide-react";
+import { PageHeader } from "@/components/shared/page-header";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { ConfiguracionForm } from "./_components/configuracion-form";
+import { getConfiguracion } from "@/lib/api/materiales";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasPermission } from "@/lib/auth/permission-utils";
+import { ApiError } from "@/lib/api/client";
+import type { MaterialConfig } from "@/lib/types/materiales";
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function ConfiguracionPage() {
+  const user = await requireAdminUser();
+
+  if (!hasPermission(user, "materiales:configure")) {
+    redirect("/dashboard");
+  }
+
+  let config: MaterialConfig | null = null;
+  let loadError: string | null = null;
+  let loadErrorStatus: number | null = null;
+
+  try {
+    config = await getConfiguracion();
+  } catch (error) {
+    if (error instanceof ApiError) {
+      loadError = error.message;
+      loadErrorStatus = error.status;
+    } else {
+      loadError = "Error al cargar la configuración.";
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Configuración de materiales"
+        description="Datos bancarios y opciones de entrega para las solicitudes de materiales."
+      />
+
+      {/* Error state */}
+      {loadError && (
+        <EndpointErrorBanner
+          state={loadErrorStatus === 403 ? "forbidden" : "missing"}
+          detail={loadError}
+        />
+      )}
+
+      {/* Form */}
+      {config && <ConfiguracionForm config={config} />}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/inventario/_components/delete-product-dialog.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/inventario/_components/delete-product-dialog.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Loader2, Trash2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { deleteProduct } from "@/lib/api/materiales";
+import { ApiError } from "@/lib/api/client";
+import type { MaterialProduct } from "@/lib/types/materiales";
+
+interface DeleteProductDialogProps {
+  product: MaterialProduct | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeleteProductDialog({
+  product,
+  open,
+  onOpenChange,
+}: DeleteProductDialogProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  async function handleConfirm() {
+    if (!product) return;
+    try {
+      await deleteProduct(product.id);
+      toast.success(`Producto "${product.title}" desactivado.`);
+      onOpenChange(false);
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        toast.error(
+          "No se puede eliminar: el producto tiene órdenes abiertas.",
+        );
+      } else {
+        const message =
+          err instanceof ApiError
+            ? err.message
+            : "Error al eliminar el producto.";
+        toast.error(message);
+      }
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>¿Desactivar producto?</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-2">
+              <p>
+                El producto{" "}
+                <span className="font-medium text-foreground">
+                  {product?.title}
+                </span>{" "}
+                (SKU: <span className="font-mono text-xs">{product?.sku}</span>)
+                será marcado como inactivo y no aparecerá en el catálogo.
+              </p>
+              <p className="text-destructive/90 text-sm">
+                Si el producto tiene órdenes abiertas, no podrá desactivarse.
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancelar</AlertDialogCancel>
+          <Button
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isPending}
+          >
+            {isPending ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <Trash2 className="size-4" />
+            )}
+            Desactivar
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/inventario/_components/inventario-filters.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/inventario/_components/inventario-filters.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import { useCallback, useTransition } from "react";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type { MaterialCategory } from "@/lib/types/materiales";
+
+interface InventarioFiltersProps {
+  currentQ: string;
+  currentCat: string;
+  categories: MaterialCategory[];
+}
+
+export function InventarioFilters({
+  currentQ,
+  currentCat,
+  categories,
+}: InventarioFiltersProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
+  const updateParam = useCallback(
+    (key: string, value: string | undefined) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value && value !== "all") {
+        params.set(key, value);
+      } else {
+        params.delete(key);
+      }
+      params.delete("page");
+      startTransition(() => {
+        router.push(`${pathname}?${params.toString()}`);
+      });
+    },
+    [router, pathname, searchParams],
+  );
+
+  function handleCatChange(value: string) {
+    updateParam("cat", value);
+  }
+
+  function handleSearchChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const value = e.target.value.trim();
+    updateParam("q", value || undefined);
+  }
+
+  return (
+    <div className="flex flex-wrap items-center gap-3">
+      {/* Category filter */}
+      <Select value={currentCat || "all"} onValueChange={handleCatChange}>
+        <SelectTrigger className="h-9 w-[200px]">
+          <SelectValue placeholder="Categoría" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Todas las categorías</SelectItem>
+          {categories.map((cat) => (
+            <SelectItem key={cat.id} value={cat.slug}>
+              {cat.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {/* Search input */}
+      <div className="relative">
+        <Search className="absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          className="h-9 w-[240px] pl-8"
+          placeholder="Buscar por nombre o SKU..."
+          defaultValue={currentQ}
+          onChange={handleSearchChange}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/inventario/_components/inventario-table.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/inventario/_components/inventario-table.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { Pencil, Trash2 } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { MoneyFormat } from "@/components/materiales/money-format";
+import { ProductFormSheet } from "./product-form-sheet";
+import { DeleteProductDialog } from "./delete-product-dialog";
+import type { MaterialProduct, MaterialCategory } from "@/lib/types/materiales";
+
+interface InventarioTableProps {
+  products: MaterialProduct[];
+  categories: MaterialCategory[];
+}
+
+export function InventarioTable({ products, categories }: InventarioTableProps) {
+  const [editTarget, setEditTarget] = useState<MaterialProduct | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<MaterialProduct | null>(null);
+
+  return (
+    <>
+      <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                SKU
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Producto
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Programa
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Categoría
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+                Precio
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+                Stock
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Estado
+              </TableHead>
+              <TableHead className="h-9 w-24 px-3" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {products.map((product) => (
+              <TableRow key={product.id} className="hover:bg-muted/30">
+                {/* SKU */}
+                <TableCell className="px-3 py-2.5 align-middle">
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {product.sku}
+                  </span>
+                </TableCell>
+
+                {/* Product name */}
+                <TableCell className="px-3 py-2.5 align-middle">
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">{product.title}</p>
+                    {product.description && (
+                      <p className="truncate text-xs text-muted-foreground">
+                        {product.description}
+                      </p>
+                    )}
+                  </div>
+                </TableCell>
+
+                {/* Programa */}
+                <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                  {product.programa?.label ?? "—"}
+                </TableCell>
+
+                {/* Categoría */}
+                <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                  {product.cat?.label ?? "—"}
+                </TableCell>
+
+                {/* Precio */}
+                <TableCell className="px-3 py-2.5 align-middle text-right tabular-nums">
+                  <MoneyFormat centavos={product.price_centavos} />
+                </TableCell>
+
+                {/* Stock */}
+                <TableCell className="px-3 py-2.5 align-middle text-right tabular-nums">
+                  <span
+                    className={
+                      product.stock === 0 ? "text-destructive font-medium" : ""
+                    }
+                  >
+                    {product.stock}
+                  </span>
+                </TableCell>
+
+                {/* Estado */}
+                <TableCell className="px-3 py-2.5 align-middle">
+                  {product.active ? (
+                    <Badge variant="success">Activo</Badge>
+                  ) : (
+                    <Badge variant="secondary">Inactivo</Badge>
+                  )}
+                </TableCell>
+
+                {/* Acciones */}
+                <TableCell className="px-3 py-2.5 align-middle">
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="Editar producto"
+                      onClick={() => setEditTarget(product)}
+                    >
+                      <Pencil className="size-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className="text-destructive hover:text-destructive"
+                      aria-label="Desactivar producto"
+                      onClick={() => setDeleteTarget(product)}
+                    >
+                      <Trash2 className="size-3.5" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Edit sheet */}
+      <ProductFormSheet
+        open={!!editTarget}
+        onOpenChange={(open) => {
+          if (!open) setEditTarget(null);
+        }}
+        mode="edit"
+        product={editTarget}
+        categories={categories}
+      />
+
+      {/* Delete dialog */}
+      <DeleteProductDialog
+        product={deleteTarget}
+        open={!!deleteTarget}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      />
+    </>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/inventario/_components/nuevo-producto-button.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/inventario/_components/nuevo-producto-button.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ProductFormSheet } from "./product-form-sheet";
+import type { MaterialCategory } from "@/lib/types/materiales";
+
+interface NuevoProductoButtonProps {
+  categories: MaterialCategory[];
+}
+
+export function NuevoProductoButton({ categories }: NuevoProductoButtonProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        <Plus className="mr-1.5 size-4" />
+        Nuevo producto
+      </Button>
+
+      <ProductFormSheet
+        open={open}
+        onOpenChange={setOpen}
+        mode="create"
+        categories={categories}
+      />
+    </>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/inventario/_components/price-input.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/inventario/_components/price-input.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useRef } from "react";
+import { Input } from "@/components/ui/input";
+
+interface PriceInputProps {
+  /** Current value in centavos (integer) */
+  valueCentavos: number;
+  onChange: (centavos: number) => void;
+  disabled?: boolean;
+  id?: string;
+  placeholder?: string;
+}
+
+/**
+ * Converts a peso string (e.g. "123.45") input to centavos integer.
+ * Display: pesos with 2 decimal places. Submit: integer centavos.
+ */
+export function PriceInput({
+  valueCentavos,
+  onChange,
+  disabled,
+  id,
+  placeholder = "0.00",
+}: PriceInputProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const displayValue =
+    valueCentavos > 0 ? (valueCentavos / 100).toFixed(2) : "";
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const raw = e.target.value;
+    // Allow only digits and at most one decimal point with up to 2 decimal places
+    if (raw === "" || raw === ".") {
+      onChange(0);
+      return;
+    }
+    const parsed = parseFloat(raw);
+    if (!isNaN(parsed) && parsed >= 0) {
+      // Round to 2 decimal places to avoid floating-point drift
+      onChange(Math.round(parsed * 100));
+    }
+  }
+
+  return (
+    <div className="relative">
+      <span className="absolute left-2.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground pointer-events-none">
+        $
+      </span>
+      <Input
+        ref={inputRef}
+        id={id}
+        type="number"
+        step="0.01"
+        min="0"
+        defaultValue={displayValue}
+        onChange={handleChange}
+        disabled={disabled}
+        placeholder={placeholder}
+        className="pl-6"
+      />
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/inventario/_components/product-form-sheet.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/inventario/_components/product-form-sheet.tsx
@@ -1,0 +1,508 @@
+"use client";
+
+import { useEffect, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useForm, Controller } from "react-hook-form";
+import type { Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { PriceInput } from "./price-input";
+import { createProduct, updateProduct } from "@/lib/api/materiales";
+import { ApiError } from "@/lib/api/client";
+import type { MaterialProduct, MaterialCategory } from "@/lib/types/materiales";
+
+// ─── TODO: Replace hardcoded club_type_id options with API call when
+// a dedicated programas endpoint is available in the admin context. For v1,
+// these values match club_types seed data (1=Aventureros, 2=Conquistadores,
+// 3=Guías Mayores). ─────────────────────────────────────────────────────────
+const CLUB_TYPES = [
+  { id: 1, label: "Aventureros" },
+  { id: 2, label: "Conquistadores" },
+  { id: 3, label: "Guías Mayores" },
+] as const;
+
+// ─── Schemas ──────────────────────────────────────────────────────────────────
+
+// z.coerce.number() splits input/output types → needs resolver cast (same pattern
+// as weights-form.tsx). See that file for the full explanation.
+const createSchema = z.object({
+  sku: z.string().min(1, "El SKU es requerido").max(64),
+  title: z.string().min(1, "El nombre es requerido").max(200),
+  description: z.string().optional(),
+  club_type_id: z.coerce.number().int().min(1, "Seleccioná un programa"),
+  material_category_id: z.string().min(1, "Seleccioná una categoría"),
+  price_centavos: z.number().int().min(1, "El precio debe ser mayor a 0"),
+  stock: z.coerce.number().int().min(0).optional(),
+});
+
+const editSchema = z.object({
+  title: z.string().min(1, "El nombre es requerido").max(200),
+  description: z.string().optional(),
+  price_centavos: z.number().int().min(1, "El precio debe ser mayor a 0"),
+  active: z.boolean(),
+});
+
+type CreateFormValues = z.infer<typeof createSchema>;
+type EditFormValues = z.infer<typeof editSchema>;
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface ProductFormSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  product?: MaterialProduct | null;
+  categories: MaterialCategory[];
+}
+
+// ─── Create Form ──────────────────────────────────────────────────────────────
+
+function CreateForm({
+  categories,
+  onSuccess,
+}: {
+  categories: MaterialCategory[];
+  onSuccess: () => void;
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<CreateFormValues>({
+    resolver: zodResolver(createSchema) as unknown as Resolver<CreateFormValues>,
+    defaultValues: {
+      sku: "",
+      title: "",
+      description: "",
+      club_type_id: undefined,
+      material_category_id: "",
+      price_centavos: 0,
+      stock: 0,
+    },
+  });
+
+  async function onSubmit(values: CreateFormValues) {
+    try {
+      await createProduct({
+        sku: values.sku,
+        title: values.title,
+        description: values.description || undefined,
+        club_type_id: values.club_type_id,
+        material_category_id: values.material_category_id,
+        price_centavos: values.price_centavos,
+        stock: values.stock ?? 0,
+      });
+      toast.success("Producto creado correctamente.");
+      form.reset();
+      startTransition(() => onSuccess());
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        form.setError("sku", {
+          message: "Este SKU ya está en uso. Usá uno diferente.",
+        });
+      } else {
+        const message =
+          err instanceof ApiError ? err.message : "Error al crear el producto.";
+        toast.error(message);
+      }
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        id="product-form"
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4"
+      >
+        {/* SKU */}
+        <FormField
+          control={form.control}
+          name="sku"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>SKU</FormLabel>
+              <FormControl>
+                <Input placeholder="ej. PAÑUELO-CON-001" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Title */}
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nombre del producto</FormLabel>
+              <FormControl>
+                <Input placeholder="ej. Pañuelo Conquistadores" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Description */}
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Descripción{" "}
+                <span className="text-xs text-muted-foreground">(opcional)</span>
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  placeholder="Descripción del producto..."
+                  className="resize-none"
+                  rows={3}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Programa */}
+        <FormField
+          control={form.control}
+          name="club_type_id"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Programa</FormLabel>
+              <Select
+                value={field.value ? String(field.value) : ""}
+                onValueChange={(v) => field.onChange(v)}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Seleccioná un programa" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {CLUB_TYPES.map((ct) => (
+                    <SelectItem key={ct.id} value={String(ct.id)}>
+                      {ct.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Category */}
+        <FormField
+          control={form.control}
+          name="material_category_id"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Categoría</FormLabel>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Seleccioná una categoría" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {categories.map((cat) => (
+                    <SelectItem key={cat.id} value={cat.id}>
+                      {cat.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Price */}
+        <Controller
+          control={form.control}
+          name="price_centavos"
+          render={({ field, fieldState }) => (
+            <div className="space-y-1.5">
+              <Label htmlFor="price_centavos">Precio</Label>
+              <PriceInput
+                id="price_centavos"
+                valueCentavos={field.value}
+                onChange={field.onChange}
+                disabled={isPending}
+              />
+              {fieldState.error && (
+                <p className="text-sm font-medium text-destructive">
+                  {fieldState.error.message}
+                </p>
+              )}
+            </div>
+          )}
+        />
+
+        {/* Stock (create only) */}
+        <FormField
+          control={form.control}
+          name="stock"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Stock inicial{" "}
+                <span className="text-xs text-muted-foreground">(opcional)</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  min={0}
+                  placeholder="0"
+                  {...field}
+                  value={field.value ?? 0}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <SheetFooter className="pt-2">
+          <Button type="submit" disabled={isPending} form="product-form">
+            {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+            Crear producto
+          </Button>
+        </SheetFooter>
+      </form>
+    </Form>
+  );
+}
+
+// ─── Edit Form ────────────────────────────────────────────────────────────────
+
+function EditForm({
+  product,
+  onSuccess,
+}: {
+  product: MaterialProduct;
+  onSuccess: () => void;
+}) {
+  const [isPending, startTransition] = useTransition();
+
+  const form = useForm<EditFormValues>({
+    resolver: zodResolver(editSchema) as unknown as Resolver<EditFormValues>,
+    defaultValues: {
+      title: product.title,
+      description: product.description ?? "",
+      price_centavos: product.price_centavos,
+      active: product.active,
+    },
+  });
+
+  // Sync form when product changes (sheet re-opened with different product)
+  useEffect(() => {
+    form.reset({
+      title: product.title,
+      description: product.description ?? "",
+      price_centavos: product.price_centavos,
+      active: product.active,
+    });
+  }, [product.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function onSubmit(values: EditFormValues) {
+    try {
+      await updateProduct(product.id, {
+        title: values.title,
+        description: values.description || undefined,
+        price_centavos: values.price_centavos,
+        active: values.active,
+      });
+      toast.success("Producto actualizado correctamente.");
+      startTransition(() => onSuccess());
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : "Error al actualizar el producto.";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        id="product-form"
+        onSubmit={form.handleSubmit(onSubmit)}
+        className="space-y-4"
+      >
+        {/* SKU — read-only in edit mode */}
+        <div className="space-y-1.5">
+          <Label className="text-sm font-medium">SKU</Label>
+          <p className="rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm text-muted-foreground">
+            {product.sku}
+          </p>
+        </div>
+
+        {/* Title */}
+        <FormField
+          control={form.control}
+          name="title"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nombre del producto</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Description */}
+        <FormField
+          control={form.control}
+          name="description"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Descripción{" "}
+                <span className="text-xs text-muted-foreground">(opcional)</span>
+              </FormLabel>
+              <FormControl>
+                <Textarea
+                  className="resize-none"
+                  rows={3}
+                  {...field}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {/* Price */}
+        <Controller
+          control={form.control}
+          name="price_centavos"
+          render={({ field, fieldState }) => (
+            <div className="space-y-1.5">
+              <Label htmlFor="edit_price_centavos">Precio</Label>
+              <PriceInput
+                id="edit_price_centavos"
+                valueCentavos={field.value}
+                onChange={field.onChange}
+                disabled={isPending}
+              />
+              {fieldState.error && (
+                <p className="text-sm font-medium text-destructive">
+                  {fieldState.error.message}
+                </p>
+              )}
+            </div>
+          )}
+        />
+
+        {/* Active (edit only) */}
+        <FormField
+          control={form.control}
+          name="active"
+          render={({ field }) => (
+            <FormItem className="flex items-center justify-between rounded-lg border p-3">
+              <div className="space-y-0.5">
+                <FormLabel className="text-base">Activo</FormLabel>
+                <p className="text-sm text-muted-foreground">
+                  Los productos inactivos no aparecen en el catálogo.
+                </p>
+              </div>
+              <FormControl>
+                <Switch
+                  checked={field.value}
+                  onCheckedChange={field.onChange}
+                />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <SheetFooter className="pt-2">
+          <Button type="submit" disabled={isPending} form="product-form">
+            {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+            Guardar cambios
+          </Button>
+        </SheetFooter>
+      </form>
+    </Form>
+  );
+}
+
+// ─── Shell ────────────────────────────────────────────────────────────────────
+
+export function ProductFormSheet({
+  open,
+  onOpenChange,
+  mode,
+  product,
+  categories,
+}: ProductFormSheetProps) {
+  const router = useRouter();
+
+  function handleSuccess() {
+    onOpenChange(false);
+    router.refresh();
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="overflow-y-auto sm:max-w-lg">
+        <SheetHeader>
+          <SheetTitle>
+            {mode === "create" ? "Nuevo producto" : "Editar producto"}
+          </SheetTitle>
+          <SheetDescription>
+            {mode === "create"
+              ? "Completá los datos para agregar un nuevo producto al inventario."
+              : "Modificá los campos del producto. El SKU no puede cambiarse."}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-6">
+          {mode === "create" ? (
+            <CreateForm categories={categories} onSuccess={handleSuccess} />
+          ) : product ? (
+            <EditForm product={product} onSuccess={handleSuccess} />
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/inventario/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/inventario/page.tsx
@@ -1,0 +1,148 @@
+import { redirect } from "next/navigation";
+import { Package } from "lucide-react";
+import { PageHeader } from "@/components/shared/page-header";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { EmptyState } from "@/components/shared/empty-state";
+import { DataTablePagination } from "@/components/shared/data-table-pagination";
+import { InventarioFilters } from "./_components/inventario-filters";
+import { InventarioTable } from "./_components/inventario-table";
+import { NuevoProductoButton } from "./_components/nuevo-producto-button";
+import { listInventario } from "@/lib/api/materiales";
+import { apiRequest } from "@/lib/api/client";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasPermission } from "@/lib/auth/permission-utils";
+import { ApiError } from "@/lib/api/client";
+import type { MaterialProduct, MaterialCategory } from "@/lib/types/materiales";
+import type { Paginated } from "@/lib/types/materiales";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+const PAGE_SIZE = 20;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function resolveQ(raw: unknown): string {
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function resolveCat(raw: unknown): string {
+  return typeof raw === "string" ? raw.trim() : "";
+}
+
+function resolvePage(raw: unknown): number {
+  const n = typeof raw === "string" ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) && n >= 1 ? n : 1;
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function InventarioPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const user = await requireAdminUser();
+
+  if (!hasPermission(user, "materiales:manage-inventory")) {
+    redirect("/dashboard");
+  }
+
+  const raw = await searchParams;
+  const q = resolveQ(raw["q"]);
+  const cat = resolveCat(raw["cat"]);
+  const page = resolvePage(raw["page"]);
+
+  let products: MaterialProduct[] = [];
+  let total = 0;
+  let categories: MaterialCategory[] = [];
+  let loadError: string | null = null;
+  let loadErrorStatus: number | null = null;
+
+  // Parallel fetch: inventario + categories
+  const [inventarioResult, catResult] = await Promise.allSettled([
+    listInventario({
+      cat: cat || undefined,
+      q: q || undefined,
+      page,
+      pageSize: PAGE_SIZE,
+    }),
+    apiRequest<{ data: MaterialCategory[] }>("/materiales/catalogo/categorias"),
+  ]);
+
+  if (inventarioResult.status === "fulfilled") {
+    const result = inventarioResult.value as Paginated<MaterialProduct>;
+    products = result.data;
+    total = result.total;
+  } else {
+    const error = inventarioResult.reason;
+    if (error instanceof ApiError) {
+      loadError = error.message;
+      loadErrorStatus = error.status;
+    } else {
+      loadError = "Error al cargar el inventario.";
+    }
+  }
+
+  if (catResult.status === "fulfilled") {
+    categories = catResult.value.data;
+  }
+  // If categories fail, filters degrade gracefully (empty list)
+
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <PageHeader
+          title="Inventario"
+          description="Administrá el catálogo de productos, precios y stock."
+        />
+        <NuevoProductoButton categories={categories} />
+      </div>
+
+      {/* Filters */}
+      <InventarioFilters currentQ={q} currentCat={cat} categories={categories} />
+
+      {/* Error state */}
+      {loadError && (
+        <EndpointErrorBanner
+          state={loadErrorStatus === 403 ? "forbidden" : "missing"}
+          detail={loadError}
+        />
+      )}
+
+      {/* Empty state */}
+      {!loadError && products.length === 0 && (
+        <EmptyState
+          icon={Package}
+          title="Sin productos"
+          description={
+            q || cat
+              ? "Ningún producto coincide con los filtros seleccionados."
+              : "No hay productos en el inventario todavía. Creá el primero."
+          }
+          variant={q || cat ? "no-results" : "default"}
+        />
+      )}
+
+      {/* Table */}
+      {!loadError && products.length > 0 && (
+        <div className="space-y-4">
+          <InventarioTable products={products} categories={categories} />
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <DataTablePagination
+              page={page}
+              totalPages={totalPages}
+              total={total}
+              limit={PAGE_SIZE}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/layout.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/layout.tsx
@@ -1,0 +1,10 @@
+import { requireAdminUser } from "@/lib/auth/session";
+
+export default async function MaterialesLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  await requireAdminUser();
+  return <>{children}</>;
+}

--- a/src/app/(dashboard)/dashboard/materiales/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function MaterialesIndexPage() {
+  redirect("/dashboard/materiales/bandeja");
+}

--- a/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/approve-button.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/approve-button.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { CheckCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { aprobarOrden } from "@/lib/api/materiales";
+import { ApiError } from "@/lib/api/client";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface ApproveButtonProps {
+  folio: string;
+  allLinesResolved: boolean;
+  canApprove: boolean;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ApproveButton({
+  folio,
+  allLinesResolved,
+  canApprove,
+}: ApproveButtonProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  const isDisabled = !allLinesResolved || !canApprove || isPending;
+
+  async function handleApprove() {
+    try {
+      await aprobarOrden(folio);
+      toast.success("Solicitud aprobada correctamente.");
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      if (err instanceof ApiError) {
+        // Surface 409 insufficient_stock details if present
+        const details = (err as ApiError & { details?: unknown }).details;
+        if (err.status === 409 && details) {
+          const affected = Array.isArray(details)
+            ? details
+                .map(
+                  (d: { product_id?: string; required?: number; available?: number }) =>
+                    `Producto ${d.product_id}: requiere ${d.required}, disponible ${d.available}`,
+                )
+                .join("; ")
+            : String(details);
+          toast.error(`Stock insuficiente: ${affected}`);
+        } else {
+          toast.error(err.message || "Error al aprobar la solicitud.");
+        }
+      } else {
+        toast.error("Error al aprobar la solicitud.");
+      }
+    }
+  }
+
+  return (
+    <Button
+      variant="default"
+      size="sm"
+      disabled={isDisabled}
+      onClick={handleApprove}
+    >
+      {isPending ? (
+        <>
+          <Loader2 className="mr-1.5 size-4 animate-spin" />
+          Aprobando...
+        </>
+      ) : (
+        <>
+          <CheckCircle className="mr-1.5 size-4" />
+          Aprobar solicitud
+        </>
+      )}
+    </Button>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/cancel-dialog.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/cancel-dialog.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { XCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { cancelarOrden } from "@/lib/api/materiales";
+import { ApiError } from "@/lib/api/client";
+import type { MaterialEstado } from "@/lib/types/materiales";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface CancelDialogProps {
+  folio: string;
+  estado: MaterialEstado;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function CancelDialog({ folio, estado }: CancelDialogProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const isStockAffected = estado === "aprobada" || estado === "pagada";
+
+  async function handleConfirm() {
+    const trimmed = reason.trim();
+    if (!trimmed) {
+      toast.error("El motivo de cancelación es obligatorio.");
+      return;
+    }
+
+    try {
+      await cancelarOrden(folio, trimmed);
+      toast.success("Solicitud cancelada.");
+      setOpen(false);
+      setReason("");
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : "Error al cancelar la solicitud.";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+        onClick={() => setOpen(true)}
+        disabled={isPending}
+      >
+        <XCircle className="mr-1.5 size-4" />
+        Cancelar pedido
+      </Button>
+
+      <AlertDialog open={open} onOpenChange={setOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Cancelar esta solicitud?</AlertDialogTitle>
+            <AlertDialogDescription>
+              {isStockAffected
+                ? "El stock reservado para esta solicitud será restaurado automáticamente."
+                : "La solicitud quedará cancelada. Esta acción no se puede deshacer."}{" "}
+              Ingresá el motivo de cancelación.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <Textarea
+            placeholder="Motivo de cancelación (obligatorio)"
+            maxLength={500}
+            rows={3}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            disabled={isPending}
+            className="resize-none"
+          />
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>
+              Volver
+            </AlertDialogCancel>
+            <Button
+              variant="destructive"
+              onClick={handleConfirm}
+              disabled={isPending || reason.trim().length === 0}
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="mr-1.5 size-4 animate-spin" />
+                  Cancelando...
+                </>
+              ) : (
+                "Confirmar cancelación"
+              )}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/comprobante-review-actions.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/comprobante-review-actions.tsx
@@ -1,0 +1,176 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { CheckCircle, XCircle, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogCancel,
+} from "@/components/ui/alert-dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { aprobarComprobante, rechazarComprobante } from "@/lib/api/materiales";
+import { ApiError } from "@/lib/api/client";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface ComprobanteReviewActionsProps {
+  folio: string;
+  comprobanteId: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ComprobanteReviewActions({
+  folio,
+  comprobanteId,
+}: ComprobanteReviewActionsProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  // Approve dialog state
+  const [approveOpen, setApproveOpen] = useState(false);
+
+  // Reject dialog state
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+
+  // ─── Approve ────────────────────────────────────────────────────────────────
+
+  async function handleApprove() {
+    try {
+      await aprobarComprobante(folio, comprobanteId);
+      toast.success("Comprobante aprobado. Solicitud marcada como pagada.");
+      setApproveOpen(false);
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      const message =
+        err instanceof ApiError ? err.message : "Error al aprobar el comprobante.";
+      toast.error(message);
+    }
+  }
+
+  // ─── Reject ─────────────────────────────────────────────────────────────────
+
+  async function handleReject() {
+    const trimmed = rejectReason.trim();
+    if (!trimmed) {
+      toast.error("El motivo de rechazo es obligatorio.");
+      return;
+    }
+    try {
+      await rechazarComprobante(folio, comprobanteId, trimmed);
+      toast.success("Comprobante rechazado.");
+      setRejectOpen(false);
+      setRejectReason("");
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      const message =
+        err instanceof ApiError ? err.message : "Error al rechazar el comprobante.";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <Button
+          variant="default"
+          size="xs"
+          disabled={isPending}
+          onClick={() => setApproveOpen(true)}
+        >
+          <CheckCircle className="mr-1 size-3.5" />
+          Aprobar
+        </Button>
+        <Button
+          variant="destructive"
+          size="xs"
+          disabled={isPending}
+          onClick={() => setRejectOpen(true)}
+        >
+          <XCircle className="mr-1 size-3.5" />
+          Rechazar
+        </Button>
+      </div>
+
+      {/* Approve confirmation */}
+      <AlertDialog open={approveOpen} onOpenChange={setApproveOpen}>
+        <AlertDialogContent size="sm">
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Aprobar comprobante?</AlertDialogTitle>
+            <AlertDialogDescription>
+              La solicitud pasará al estado <strong>Pagada</strong>. Esta
+              acción no se puede deshacer.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <Button variant="default" onClick={handleApprove} disabled={isPending}>
+              {isPending ? (
+                <>
+                  <Loader2 className="mr-1.5 size-4 animate-spin" />
+                  Aprobando...
+                </>
+              ) : (
+                "Confirmar"
+              )}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Reject dialog with reason */}
+      <AlertDialog open={rejectOpen} onOpenChange={setRejectOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Rechazar comprobante</AlertDialogTitle>
+            <AlertDialogDescription>
+              El director podrá subir un nuevo comprobante. Ingresá el motivo
+              de rechazo.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <Textarea
+            placeholder="Motivo de rechazo (obligatorio)"
+            rows={3}
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            disabled={isPending}
+            className="resize-none"
+          />
+
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isPending}>
+              Volver
+            </AlertDialogCancel>
+            <Button
+              variant="destructive"
+              onClick={handleReject}
+              disabled={isPending || rejectReason.trim().length === 0}
+            >
+              {isPending ? (
+                <>
+                  <Loader2 className="mr-1.5 size-4 animate-spin" />
+                  Rechazando...
+                </>
+              ) : (
+                "Confirmar rechazo"
+              )}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/comprobantes-section.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/comprobantes-section.tsx
@@ -1,0 +1,138 @@
+import { FileText, ExternalLink } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { MoneyFormat } from "@/components/materiales/money-format";
+import { ComprobanteReviewActions } from "./comprobante-review-actions";
+import type { Comprobante } from "@/lib/types/materiales";
+
+// ─── Status config ────────────────────────────────────────────────────────────
+
+const STATUS_CONFIG: Record<
+  string,
+  { label: string; variant: "secondary" | "success" | "destructive" | "warning" | "outline" }
+> = {
+  pendiente: { label: "Pendiente", variant: "warning" },
+  aprobado: { label: "Aprobado", variant: "success" },
+  rechazado: { label: "Rechazado", variant: "destructive" },
+};
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Intl.DateTimeFormat("es-MX", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface ComprobantesSectionProps {
+  folio: string;
+  comprobantes: Comprobante[];
+  /** When true, review actions (approve/reject) are rendered for pendiente items */
+  canReview: boolean;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ComprobantesSection({
+  folio,
+  comprobantes,
+  canReview,
+}: ComprobantesSectionProps) {
+  if (comprobantes.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground">
+        No se han subido comprobantes aún.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {comprobantes.map((c) => {
+        const statusCfg = STATUS_CONFIG[c.status] ?? {
+          label: c.status,
+          variant: "outline" as const,
+        };
+
+        return (
+          <div
+            key={c.id}
+            className="rounded-lg border border-border/60 bg-card px-4 py-3 space-y-2"
+          >
+            {/* Header row */}
+            <div className="flex flex-wrap items-center gap-2">
+              <FileText className="size-4 shrink-0 text-muted-foreground" />
+              <span className="text-sm font-medium truncate flex-1 min-w-0">
+                {c.file_name}
+              </span>
+              <Badge variant={statusCfg.variant}>{statusCfg.label}</Badge>
+              {c.signed_url && (
+                <a
+                  href={c.signed_url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                >
+                  Ver archivo
+                  <ExternalLink className="size-3" />
+                </a>
+              )}
+            </div>
+
+            {/* Meta row */}
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              <span>
+                Monto:{" "}
+                <span className="font-medium text-foreground tabular-nums">
+                  <MoneyFormat centavos={c.monto_centavos} />
+                </span>
+              </span>
+              {c.fecha_pago && (
+                <span>
+                  Fecha pago:{" "}
+                  <span className="text-foreground">{formatDate(c.fecha_pago)}</span>
+                </span>
+              )}
+              {c.ref_bancaria_declarada && (
+                <span>
+                  Ref:{" "}
+                  <span className="font-mono text-foreground">
+                    {c.ref_bancaria_declarada}
+                  </span>
+                </span>
+              )}
+              <span>
+                Subido: <span className="text-foreground">{formatDate(c.created_at)}</span>
+              </span>
+              <span>{formatBytes(c.size_bytes)}</span>
+            </div>
+
+            {/* Reject reason */}
+            {c.status === "rechazado" && c.reject_reason && (
+              <p className="text-xs text-destructive">
+                Motivo de rechazo: {c.reject_reason}
+              </p>
+            )}
+
+            {/* Review actions — only for pendiente comprobantes when reviewer role present */}
+            {c.status === "pendiente" && canReview && (
+              <ComprobanteReviewActions folio={folio} comprobanteId={c.id} />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/deliver-button.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/deliver-button.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Truck, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { entregarOrden } from "@/lib/api/materiales";
+import { ApiError } from "@/lib/api/client";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface DeliverButtonProps {
+  folio: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function DeliverButton({ folio }: DeliverButtonProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+
+  async function handleDeliver() {
+    try {
+      await entregarOrden(folio);
+      toast.success("Solicitud marcada como entregada.");
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : "Error al registrar entrega.";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <Button variant="outline" size="sm" disabled={isPending} onClick={handleDeliver}>
+      {isPending ? (
+        <>
+          <Loader2 className="mr-1.5 size-4 animate-spin" />
+          Registrando...
+        </>
+      ) : (
+        <>
+          <Truck className="mr-1.5 size-4" />
+          Marcar como entregada
+        </>
+      )}
+    </Button>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/line-availability-form.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/line-availability-form.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { patchOrdenLinea } from "@/lib/api/materiales";
+import type { MaterialDisponibilidad } from "@/lib/types/materiales";
+import type { PatchOrdenLineaPayload } from "@/lib/api/materiales";
+import { ApiError } from "@/lib/api/client";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface LineAvailabilityFormProps {
+  folio: string;
+  lineId: string;
+  currentDisponibilidad: MaterialDisponibilidad;
+  currentQtyDisponible: number | null;
+  qty: number;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function LineAvailabilityForm({
+  folio,
+  lineId,
+  currentDisponibilidad,
+  currentQtyDisponible,
+  qty,
+}: LineAvailabilityFormProps) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [disponibilidad, setDisponibilidad] =
+    useState<MaterialDisponibilidad>(currentDisponibilidad);
+  const [qtyDisponible, setQtyDisponible] = useState<string>(
+    currentQtyDisponible != null ? String(currentQtyDisponible) : "",
+  );
+
+  async function submitPatch(
+    newDisponibilidad: PatchOrdenLineaPayload["disponibilidad"],
+    newQtyDisponible?: number,
+  ) {
+    try {
+      await patchOrdenLinea(folio, lineId, {
+        disponibilidad: newDisponibilidad,
+        qty_disponible: newQtyDisponible,
+      });
+      startTransition(() => {
+        router.refresh();
+      });
+    } catch (err) {
+      const message =
+        err instanceof ApiError
+          ? err.message
+          : "Error al actualizar disponibilidad.";
+      toast.error(message);
+    }
+  }
+
+  function handleDisponibilidadChange(value: string) {
+    const disp = value as MaterialDisponibilidad;
+    setDisponibilidad(disp);
+
+    if (disp === "disponible") {
+      submitPatch("disponible", qty);
+    } else if (disp === "agotado") {
+      submitPatch("agotado", 0);
+    }
+    // "pendiente" or "parcial" — "parcial" waits for qty input blur
+  }
+
+  function handleQtyBlur() {
+    if (disponibilidad !== "parcial") return;
+    const parsed = parseInt(qtyDisponible, 10);
+    if (!Number.isFinite(parsed) || parsed < 1 || parsed > qty) {
+      toast.error(
+        `Cantidad disponible debe ser entre 1 y ${qty}.`,
+      );
+      return;
+    }
+    submitPatch("parcial", parsed);
+  }
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Select
+        value={disponibilidad}
+        onValueChange={handleDisponibilidadChange}
+        disabled={isPending}
+      >
+        <SelectTrigger className="h-8 w-[140px] text-xs">
+          <SelectValue placeholder="Disponibilidad" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="pendiente">Pendiente</SelectItem>
+          <SelectItem value="disponible">Disponible</SelectItem>
+          <SelectItem value="parcial">Parcial</SelectItem>
+          <SelectItem value="agotado">Agotado</SelectItem>
+        </SelectContent>
+      </Select>
+
+      {disponibilidad === "parcial" && (
+        <Input
+          type="number"
+          min={1}
+          max={qty}
+          className="h-8 w-[80px] text-xs"
+          placeholder={`1–${qty}`}
+          value={qtyDisponible}
+          onChange={(e) => setQtyDisponible(e.target.value)}
+          onBlur={handleQtyBlur}
+          disabled={isPending}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/lines-table.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/_components/lines-table.tsx
@@ -1,0 +1,109 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { MoneyFormat } from "@/components/materiales/money-format";
+import { LineAvailabilityForm } from "./line-availability-form";
+import type { OrdenLine, MaterialEstado } from "@/lib/types/materiales";
+
+// ─── Disponibilidad label ─────────────────────────────────────────────────────
+
+const DISP_LABELS: Record<string, string> = {
+  pendiente: "Pendiente",
+  disponible: "Disponible",
+  parcial: "Parcial",
+  agotado: "Agotado",
+};
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface LinesTableProps {
+  folio: string;
+  lines: OrdenLine[];
+  estado: MaterialEstado;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function LinesTable({ folio, lines, estado }: LinesTableProps) {
+  const isEditable = estado === "en_revision";
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Producto
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              SKU
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+              Cant.
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              Disponibilidad
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+              Qty disp.
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+              Precio u.
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+              Total línea
+            </TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {lines.map((line) => (
+            <TableRow key={line.id} className="hover:bg-muted/30">
+              <TableCell className="px-3 py-2.5 align-middle">
+                <span className="text-sm font-medium">
+                  {line.product.title}
+                </span>
+              </TableCell>
+              <TableCell className="px-3 py-2.5 align-middle">
+                <span className="font-mono text-xs text-muted-foreground">
+                  {line.product.sku}
+                </span>
+              </TableCell>
+              <TableCell className="px-3 py-2.5 align-middle text-right tabular-nums">
+                {line.qty}
+              </TableCell>
+              <TableCell className="px-3 py-2.5 align-middle">
+                {isEditable ? (
+                  <LineAvailabilityForm
+                    folio={folio}
+                    lineId={line.id}
+                    currentDisponibilidad={line.disponibilidad}
+                    currentQtyDisponible={line.qty_disponible}
+                    qty={line.qty}
+                  />
+                ) : (
+                  <span className="text-sm">
+                    {DISP_LABELS[line.disponibilidad] ?? line.disponibilidad}
+                  </span>
+                )}
+              </TableCell>
+              <TableCell className="px-3 py-2.5 align-middle text-right tabular-nums">
+                {line.qty_disponible != null ? line.qty_disponible : "—"}
+              </TableCell>
+              <TableCell className="px-3 py-2.5 align-middle text-right">
+                <MoneyFormat centavos={line.price_centavos} />
+              </TableCell>
+              <TableCell className="px-3 py-2.5 align-middle text-right">
+                <MoneyFormat centavos={line.line_total_centavos} />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/solicitud/[folio]/page.tsx
@@ -1,0 +1,333 @@
+import { notFound } from "next/navigation";
+import {
+  Package,
+  Building2,
+  MapPin,
+  Calendar,
+  Banknote,
+  ShoppingBag,
+} from "lucide-react";
+import { PageHeader } from "@/components/shared/page-header";
+import { EstadoBadge } from "@/components/materiales/estado-badge";
+import { MoneyFormat } from "@/components/materiales/money-format";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { getOrden } from "@/lib/api/materiales";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasPermission } from "@/lib/auth/permission-utils";
+import { ApiError } from "@/lib/api/client";
+import { LinesTable } from "./_components/lines-table";
+import { ComprobantesSection } from "./_components/comprobantes-section";
+import { ApproveButton } from "./_components/approve-button";
+import { CancelDialog } from "./_components/cancel-dialog";
+import { DeliverButton } from "./_components/deliver-button";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type Params = Promise<{ folio: string }>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    return new Intl.DateTimeFormat("es-MX", {
+      day: "2-digit",
+      month: "long",
+      year: "numeric",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}
+
+// ─── Page ─────────────────────────────────────────────────────────────────────
+
+export default async function SolicitudDetailPage({ params }: { params: Params }) {
+  const { folio } = await params;
+  const user = await requireAdminUser();
+
+  // Permission flags (passed down to client components as props)
+  const canApprove = hasPermission(user, "materiales:approve");
+  const canDeliver = hasPermission(user, "materiales:deliver");
+  const canValidateReceipt = hasPermission(user, "materiales:validate-receipt");
+
+  // Fetch order
+  let orden;
+  try {
+    orden = await getOrden(folio);
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      notFound();
+    }
+    throw err;
+  }
+
+  const allLinesResolved =
+    orden.lines.length > 0 &&
+    orden.lines.every((l) => l.disponibilidad !== "pendiente");
+
+  const isTerminal =
+    orden.estado === "entregada" || orden.estado === "cancelada";
+
+  const showComprobantes =
+    orden.estado === "aprobada" ||
+    orden.estado === "pagada" ||
+    orden.estado === "entregada";
+
+  const entregaLabel =
+    orden.entrega === "envio" ? "Envío a domicilio" : "Recoger en sede";
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <PageHeader
+        title={orden.folio_referencia ?? `Solicitud ${folio.slice(0, 8)}…`}
+        description={`Pedido creado el ${formatDate(orden.created_at)}`}
+        breadcrumbs={[
+          { label: "Bandeja", href: "/dashboard/materiales/bandeja" },
+          {
+            label: orden.folio_referencia ?? "Solicitud",
+          },
+        ]}
+        actions={<EstadoBadge estado={orden.estado} />}
+      />
+
+      {/* ── Summary card ──────────────────────────────────────────────────── */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Card className="gap-3 py-4">
+          <CardContent className="flex items-start gap-3">
+            <Building2 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div>
+              <p className="text-xs text-muted-foreground">Director / Club</p>
+              <p className="text-sm font-medium">
+                {orden.director?.nombre ?? orden.created_by}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {orden.director?.club}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="gap-3 py-4">
+          <CardContent className="flex items-start gap-3">
+            <MapPin className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div>
+              <p className="text-xs text-muted-foreground">Entrega</p>
+              <p className="text-sm font-medium">{entregaLabel}</p>
+              {orden.pickup_address && (
+                <p className="text-xs text-muted-foreground">
+                  {orden.pickup_address}
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="gap-3 py-4">
+          <CardContent className="flex items-start gap-3">
+            <Calendar className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div>
+              <p className="text-xs text-muted-foreground">Fechas</p>
+              <p className="text-xs">
+                Creada: <span className="text-foreground">{formatDate(orden.created_at)}</span>
+              </p>
+              {orden.approved_at && (
+                <p className="text-xs">
+                  Aprobada: <span className="text-foreground">{formatDate(orden.approved_at)}</span>
+                </p>
+              )}
+              {orden.paid_at && (
+                <p className="text-xs">
+                  Pagada: <span className="text-foreground">{formatDate(orden.paid_at)}</span>
+                </p>
+              )}
+              {orden.delivered_at && (
+                <p className="text-xs">
+                  Entregada: <span className="text-foreground">{formatDate(orden.delivered_at)}</span>
+                </p>
+              )}
+              {orden.cancelled_at && (
+                <p className="text-xs">
+                  Cancelada: <span className="text-foreground">{formatDate(orden.cancelled_at)}</span>
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="gap-3 py-4">
+          <CardContent className="flex items-start gap-3">
+            <ShoppingBag className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+            <div>
+              <p className="text-xs text-muted-foreground">Totales</p>
+              <p className="text-xs">
+                Subtotal:{" "}
+                <span className="tabular-nums text-foreground">
+                  <MoneyFormat centavos={orden.subtotal_centavos} />
+                </span>
+              </p>
+              <p className="text-xs">
+                Envío:{" "}
+                <span className="tabular-nums text-foreground">
+                  <MoneyFormat centavos={orden.envio_centavos} />
+                </span>
+              </p>
+              <p className="text-sm font-semibold">
+                Total:{" "}
+                <span className="tabular-nums">
+                  <MoneyFormat centavos={orden.total_centavos} />
+                </span>
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ── Notes ─────────────────────────────────────────────────────────── */}
+      {orden.notas && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Notas del director</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">{orden.notas}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Lines table ───────────────────────────────────────────────────── */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <Package className="size-4" />
+            Líneas del pedido ({orden.lines.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="p-0 pb-2">
+          <LinesTable
+            folio={folio}
+            lines={orden.lines}
+            estado={orden.estado}
+          />
+        </CardContent>
+      </Card>
+
+      {/* ── Bank snapshot (approved+) ─────────────────────────────────────── */}
+      {orden.bank_account_clabe && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <Banknote className="size-4" />
+              Datos bancarios (snapshot al aprobar)
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-2 gap-x-6 gap-y-1 text-sm sm:grid-cols-3">
+              {orden.bank_name && (
+                <>
+                  <dt className="text-muted-foreground">Banco</dt>
+                  <dd className="col-span-2">{orden.bank_name}</dd>
+                </>
+              )}
+              <dt className="text-muted-foreground">CLABE</dt>
+              <dd className="col-span-2 font-mono">{orden.bank_account_clabe}</dd>
+              {orden.account_holder && (
+                <>
+                  <dt className="text-muted-foreground">Titular</dt>
+                  <dd className="col-span-2">{orden.account_holder}</dd>
+                </>
+              )}
+            </dl>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Comprobantes section ──────────────────────────────────────────── */}
+      {showComprobantes && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Comprobantes de pago</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ComprobantesSection
+              folio={folio}
+              comprobantes={orden.comprobantes}
+              canReview={canValidateReceipt}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Cancel reason (cancelled) ─────────────────────────────────────── */}
+      {orden.estado === "cancelada" && orden.cancel_reason && (
+        <Card className="border-destructive/30">
+          <CardHeader>
+            <CardTitle className="text-sm text-destructive">
+              Motivo de cancelación
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">{orden.cancel_reason}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Actions card ──────────────────────────────────────────────────── */}
+      {!isTerminal && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm">Acciones</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap items-center gap-3">
+              {/* en_revision: approve + cancel */}
+              {orden.estado === "en_revision" && canApprove && (
+                <ApproveButton
+                  folio={folio}
+                  allLinesResolved={allLinesResolved}
+                  canApprove={canApprove}
+                />
+              )}
+
+              {/* aprobada: cancel */}
+              {/* pagada: deliver + cancel */}
+              {orden.estado === "pagada" && canDeliver && (
+                <DeliverButton folio={folio} />
+              )}
+
+              {/* Cancel available from en_revision and aprobada and pagada (campo only) */}
+              {(orden.estado === "en_revision" ||
+                orden.estado === "aprobada" ||
+                orden.estado === "pagada") &&
+                canApprove && (
+                  <CancelDialog folio={folio} estado={orden.estado} />
+                )}
+            </div>
+
+            {/* Hint when lines not all resolved yet */}
+            {orden.estado === "en_revision" && !allLinesResolved && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                Resolvé todas las líneas antes de aprobar la solicitud.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Terminal state banner ─────────────────────────────────────────── */}
+      {isTerminal && (
+        <div className="rounded-lg border border-border/60 bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+          {orden.estado === "entregada"
+            ? "Esta solicitud fue entregada. No se pueden realizar más acciones."
+            : "Esta solicitud fue cancelada. No se pueden realizar más acciones."}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -29,6 +29,7 @@ import {
   Users2,
   Layers,
   SlidersHorizontal,
+  ShoppingBag,
   type LucideIcon,
 } from "lucide-react";
 import {
@@ -215,6 +216,37 @@ export const navConfig: NavGroup[] = [
           { title: "items.insurance_by_section", url: "/dashboard/insurance", permission: "insurance:read" },
           { title: "items.insurance_expiring", url: "/dashboard/insurance/expiring", permission: "insurance:read" },
         ],
+      },
+    ],
+  },
+
+  // ─── Materiales (pedidos, comprobantes, inventario, config) ─────────────────
+  {
+    label: "sections.materiales",
+    items: [
+      {
+        title: "items.materiales_bandeja",
+        url: "/dashboard/materiales/bandeja",
+        icon: ShoppingBag,
+        permission: "materiales:read",
+      },
+      {
+        title: "items.materiales_comprobantes",
+        url: "/dashboard/materiales/comprobantes",
+        icon: FileText,
+        permission: "materiales:validate-receipt",
+      },
+      {
+        title: "items.materiales_inventario",
+        url: "/dashboard/materiales/inventario",
+        icon: Package,
+        permission: "materiales:manage-inventory",
+      },
+      {
+        title: "items.materiales_configuracion",
+        url: "/dashboard/materiales/configuracion",
+        icon: Settings2,
+        permission: "materiales:configure",
       },
     ],
   },

--- a/src/components/materiales/estado-badge.tsx
+++ b/src/components/materiales/estado-badge.tsx
@@ -1,0 +1,34 @@
+import { Badge } from "@/components/ui/badge";
+import type { MaterialEstado } from "@/lib/types/materiales";
+
+const ESTADO_CONFIG: Record<
+  MaterialEstado,
+  {
+    label: string;
+    variant: "secondary" | "warning" | "success" | "destructive" | "outline";
+  }
+> = {
+  en_revision: { label: "En revisión", variant: "secondary" },
+  aprobada: { label: "Aprobada", variant: "warning" },
+  pagada: { label: "Pagada", variant: "success" },
+  entregada: { label: "Entregada", variant: "success" },
+  cancelada: { label: "Cancelada", variant: "destructive" },
+};
+
+interface EstadoBadgeProps {
+  estado: MaterialEstado;
+  className?: string;
+}
+
+export function EstadoBadge({ estado, className }: EstadoBadgeProps) {
+  const config = ESTADO_CONFIG[estado] ?? {
+    label: estado,
+    variant: "outline" as const,
+  };
+
+  return (
+    <Badge variant={config.variant} className={className}>
+      {config.label}
+    </Badge>
+  );
+}

--- a/src/components/materiales/folio-pill.tsx
+++ b/src/components/materiales/folio-pill.tsx
@@ -1,0 +1,29 @@
+import { cn } from "@/lib/utils";
+
+interface FolioPillProps {
+  folio: string | null;
+  className?: string;
+}
+
+/**
+ * Renders a folio_referencia string in a monospace pill.
+ * Shows "—" when folio is null (order still in en_revision).
+ */
+export function FolioPill({ folio, className }: FolioPillProps) {
+  if (!folio) {
+    return (
+      <span className={cn("text-sm text-muted-foreground", className)}>—</span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(
+        "font-mono text-sm font-medium tracking-wider",
+        className,
+      )}
+    >
+      {folio}
+    </span>
+  );
+}

--- a/src/components/materiales/money-format.tsx
+++ b/src/components/materiales/money-format.tsx
@@ -1,0 +1,20 @@
+interface MoneyFormatProps {
+  /** Amount in centavos (integer). E.g. 123456 → $1,234.56 */
+  centavos: number;
+  className?: string;
+}
+
+/**
+ * Formats an integer centavos value to a MXN currency string.
+ * Example: 123456 → "$1,234.56"
+ */
+export function MoneyFormat({ centavos, className }: MoneyFormatProps) {
+  const formatted = new Intl.NumberFormat("es-MX", {
+    style: "currency",
+    currency: "MXN",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(centavos / 100);
+
+  return <span className={className}>{formatted}</span>;
+}

--- a/src/lib/api/materiales.ts
+++ b/src/lib/api/materiales.ts
@@ -1,0 +1,234 @@
+import { apiRequest, apiRequestFromClient } from "@/lib/api/client";
+import type {
+  Paginated,
+  OrdenSummary,
+  Orden,
+  Comprobante,
+  MaterialProduct,
+  MaterialConfig,
+} from "@/lib/types/materiales";
+import type { MaterialEstado } from "@/lib/types/materiales";
+
+// ─── Query shapes ─────────────────────────────────────────────────────────────
+
+export type ListOrdenesQuery = {
+  estado?: MaterialEstado | "all";
+  club_section_id?: number;
+  q?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+export type ListInventarioQuery = {
+  cat?: string;
+  q?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+export type ListCatalogoQuery = {
+  cat?: string;
+  programa?: number;
+  q?: string;
+  page?: number;
+  pageSize?: number;
+};
+
+// ─── DTO shapes for mutations ─────────────────────────────────────────────────
+
+export type CreateProductDto = {
+  sku: string;
+  title: string;
+  material_category_id: string;
+  club_type_id: number;
+  price_centavos: number;
+  description?: string;
+  stock?: number;
+  active?: boolean;
+};
+
+export type UpdateProductDto = Partial<{
+  title: string;
+  description: string;
+  price_centavos: number;
+  stock: number;
+  active: boolean;
+}>;
+
+export type PatchOrdenLineaPayload = {
+  disponibilidad: "disponible" | "parcial" | "agotado";
+  qty_disponible?: number;
+};
+
+export type UpdateConfiguracionDto = Partial<{
+  bank_name: string;
+  bank_account_clabe: string;
+  account_holder: string;
+  envio_centavos_default: number;
+  pickup_address: string;
+  delivery_options: unknown[];
+}>;
+
+// ─── Ordenes — server-side reads ──────────────────────────────────────────────
+
+export async function listOrdenes(
+  query: ListOrdenesQuery = {},
+): Promise<Paginated<OrdenSummary>> {
+  const params: Record<string, string | number | boolean | undefined> = {};
+  if (query.estado && query.estado !== "all") params.estado = query.estado;
+  if (query.club_section_id != null) params.club_section_id = query.club_section_id;
+  if (query.q) params.q = query.q;
+  if (query.page) params.page = query.page;
+  if (query.pageSize) params.pageSize = query.pageSize;
+
+  return apiRequest<Paginated<OrdenSummary>>("/materiales/ordenes", { params });
+}
+
+export async function getOrden(folioOrId: string): Promise<Orden> {
+  return apiRequest<Orden>(`/materiales/ordenes/${folioOrId}`);
+}
+
+// ─── Ordenes — client-side mutations ─────────────────────────────────────────
+
+export async function patchOrdenLinea(
+  folioOrId: string,
+  lineId: string,
+  payload: PatchOrdenLineaPayload,
+): Promise<Orden> {
+  return apiRequestFromClient<Orden>(
+    `/materiales/ordenes/${folioOrId}/lineas/${lineId}`,
+    { method: "PATCH", body: payload },
+  );
+}
+
+export async function aprobarOrden(folioOrId: string): Promise<Orden> {
+  return apiRequestFromClient<Orden>(
+    `/materiales/ordenes/${folioOrId}/aprobar`,
+    { method: "POST", body: {} },
+  );
+}
+
+export async function cancelarOrden(
+  folioOrId: string,
+  cancel_reason: string,
+): Promise<Orden> {
+  return apiRequestFromClient<Orden>(
+    `/materiales/ordenes/${folioOrId}/cancelar`,
+    { method: "POST", body: { cancel_reason } },
+  );
+}
+
+export async function entregarOrden(folioOrId: string): Promise<Orden> {
+  return apiRequestFromClient<Orden>(
+    `/materiales/ordenes/${folioOrId}/entregar`,
+    { method: "POST", body: {} },
+  );
+}
+
+// ─── Comprobantes ─────────────────────────────────────────────────────────────
+
+export async function listComprobantes(folioOrId: string): Promise<Comprobante[]> {
+  return apiRequest<Comprobante[]>(`/materiales/comprobantes/${folioOrId}`);
+}
+
+export async function aprobarComprobante(
+  folioOrId: string,
+  comprobante_id: string,
+): Promise<{ comprobante: Comprobante; order: Orden }> {
+  return apiRequestFromClient<{ comprobante: Comprobante; order: Orden }>(
+    `/materiales/comprobantes/${folioOrId}/aprobar`,
+    { method: "POST", body: { comprobante_id } },
+  );
+}
+
+export async function rechazarComprobante(
+  folioOrId: string,
+  comprobante_id: string,
+  reject_reason: string,
+): Promise<Comprobante> {
+  return apiRequestFromClient<Comprobante>(
+    `/materiales/comprobantes/${folioOrId}/rechazar`,
+    { method: "POST", body: { comprobante_id, reject_reason } },
+  );
+}
+
+// ─── Inventario — server-side reads ──────────────────────────────────────────
+
+export async function listInventario(
+  query: ListInventarioQuery = {},
+): Promise<Paginated<MaterialProduct>> {
+  const params: Record<string, string | number | boolean | undefined> = {};
+  if (query.cat) params.cat = query.cat;
+  if (query.q) params.q = query.q;
+  if (query.page) params.page = query.page;
+  if (query.pageSize) params.pageSize = query.pageSize;
+
+  return apiRequest<Paginated<MaterialProduct>>("/materiales/inventario", { params });
+}
+
+// ─── Inventario — client-side mutations ──────────────────────────────────────
+
+export async function createProduct(dto: CreateProductDto): Promise<MaterialProduct> {
+  return apiRequestFromClient<MaterialProduct>("/materiales/inventario", {
+    method: "POST",
+    body: dto,
+  });
+}
+
+export async function updateProduct(
+  id: string,
+  dto: UpdateProductDto,
+): Promise<MaterialProduct> {
+  return apiRequestFromClient<MaterialProduct>(`/materiales/inventario/${id}`, {
+    method: "PATCH",
+    body: dto,
+  });
+}
+
+export async function deleteProduct(id: string): Promise<{ id: string; active: false }> {
+  return apiRequestFromClient<{ id: string; active: false }>(
+    `/materiales/inventario/${id}`,
+    { method: "DELETE" },
+  );
+}
+
+export async function updateVariantStock(
+  productId: string,
+  variantId: string,
+  stock: number,
+): Promise<{ option: unknown; product: MaterialProduct }> {
+  return apiRequestFromClient<{ option: unknown; product: MaterialProduct }>(
+    `/materiales/inventario/${productId}/variantes/${variantId}`,
+    { method: "PATCH", body: { stock } },
+  );
+}
+
+// ─── Catálogo (public-ish, directors) ────────────────────────────────────────
+
+export async function listCatalogo(
+  query: ListCatalogoQuery = {},
+): Promise<Paginated<MaterialProduct>> {
+  const params: Record<string, string | number | boolean | undefined> = {};
+  if (query.cat) params.cat = query.cat;
+  if (query.programa != null) params.programa = query.programa;
+  if (query.q) params.q = query.q;
+  if (query.page) params.page = query.page;
+  if (query.pageSize) params.pageSize = query.pageSize;
+
+  return apiRequest<Paginated<MaterialProduct>>("/materiales/catalogo", { params });
+}
+
+// ─── Configuración ────────────────────────────────────────────────────────────
+
+export async function getConfiguracion(): Promise<MaterialConfig> {
+  return apiRequest<MaterialConfig>("/materiales/configuracion");
+}
+
+export async function updateConfiguracion(
+  dto: UpdateConfiguracionDto,
+): Promise<MaterialConfig> {
+  return apiRequestFromClient<MaterialConfig>("/materiales/configuracion", {
+    method: "PATCH",
+    body: dto,
+  });
+}

--- a/src/lib/types/materiales.ts
+++ b/src/lib/types/materiales.ts
@@ -1,0 +1,162 @@
+// ─── Enums ────────────────────────────────────────────────────────────────────
+
+export type MaterialEstado =
+  | "en_revision"
+  | "aprobada"
+  | "pagada"
+  | "entregada"
+  | "cancelada";
+
+export type MaterialDisponibilidad =
+  | "pendiente"
+  | "disponible"
+  | "parcial"
+  | "agotado";
+
+export type MaterialComprobanteStatus = "pendiente" | "aprobado" | "rechazado";
+
+export type MaterialEntrega = "recoger" | "envio";
+
+// ─── Catalog ──────────────────────────────────────────────────────────────────
+
+export type MaterialCategory = {
+  id: string;
+  slug: string;
+  label: string;
+  icon: string | null;
+  sort_order: number;
+  /** Count of active products in this category */
+  count?: number;
+};
+
+export type MaterialPrograma = {
+  id: number;
+  label: string;
+};
+
+// ─── Products & Variants ──────────────────────────────────────────────────────
+
+export type MaterialVariantOption = {
+  id: string;
+  label: string;
+  stock: number;
+};
+
+export type MaterialVariant = {
+  type: string;
+  options: MaterialVariantOption[];
+};
+
+export type MaterialProduct = {
+  id: string;
+  sku: string;
+  title: string;
+  description: string | null;
+  price_centavos: number;
+  stock: number;
+  active: boolean;
+  cat: MaterialCategory;
+  programa: MaterialPrograma;
+  variants: MaterialVariant | null;
+  /** Variant count — present in inventario list responses */
+  _count?: { variants: number };
+};
+
+// ─── Orders ───────────────────────────────────────────────────────────────────
+
+export type OrdenSummary = {
+  id: string;
+  folio_referencia: string | null;
+  estado: MaterialEstado;
+  created_at: string;
+  director: {
+    nombre: string;
+    club: string;
+  };
+  subtotal_centavos: number;
+  total_centavos: number;
+};
+
+export type OrdenLine = {
+  id: string;
+  product_id: string;
+  variant_option_id: string | null;
+  qty: number;
+  price_centavos: number;
+  disponibilidad: MaterialDisponibilidad;
+  qty_disponible: number | null;
+  line_total_centavos: number;
+  product: Pick<MaterialProduct, "id" | "sku" | "title">;
+};
+
+export type Orden = {
+  id: string;
+  folio_referencia: string | null;
+  estado: MaterialEstado;
+  club_section_id: number;
+  created_by: string;
+  approved_by: string | null;
+  validated_by: string | null;
+  delivered_by: string | null;
+  cancelled_by: string | null;
+  subtotal_centavos: number;
+  envio_centavos: number;
+  total_centavos: number;
+  entrega: MaterialEntrega;
+  notas: string | null;
+  cancel_reason: string | null;
+  refund_pending: boolean;
+  // Snapshotted bank fields (set at approval)
+  bank_name: string | null;
+  bank_account_clabe: string | null;
+  account_holder: string | null;
+  pickup_address: string | null;
+  created_at: string;
+  approved_at: string | null;
+  paid_at: string | null;
+  delivered_at: string | null;
+  cancelled_at: string | null;
+  lines: OrdenLine[];
+  comprobantes: Comprobante[];
+};
+
+// ─── Comprobantes ─────────────────────────────────────────────────────────────
+
+export type Comprobante = {
+  id: string;
+  status: MaterialComprobanteStatus;
+  file_name: string;
+  mime_type: string;
+  size_bytes: number;
+  monto_centavos: number;
+  ref_bancaria_declarada: string | null;
+  fecha_pago: string | null;
+  /** R2 signed URL (TTL 15 min). May be null on URL-generation failure. */
+  signed_url: string | null;
+  uploaded_by: string;
+  validated_by: string | null;
+  reject_reason: string | null;
+  created_at: string;
+  validated_at: string | null;
+};
+
+// ─── Config ───────────────────────────────────────────────────────────────────
+
+export type MaterialConfig = {
+  bank_name: string;
+  bank_account_clabe: string;
+  account_holder: string;
+  envio_centavos_default: number;
+  pickup_address: string | null;
+  delivery_options: unknown[];
+  updated_at: string;
+};
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+export type Paginated<T> = {
+  data: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};

--- a/src/lib/types/materiales.ts
+++ b/src/lib/types/materiales.ts
@@ -116,6 +116,10 @@ export type Orden = {
   paid_at: string | null;
   delivered_at: string | null;
   cancelled_at: string | null;
+  director?: {
+    nombre: string;
+    club: string;
+  };
   lines: OrdenLine[];
   comprobantes: Comprobante[];
 };


### PR DESCRIPTION
## Summary
- New nav group "Materiales" with 4 entries (Bandeja, Comprobantes, Inventario, Configuración) gated by `materiales:*` permissions
- 6 routes under `/dashboard/materiales/*`:
  - `bandeja` — order list with filters + pagination
  - `solicitud/[folio]` — order detail with per-line availability form + approve/cancel/deliver actions + comprobantes section
  - `comprobantes` + `comprobantes/[folio]` — receipt validation list + per-folio review
  - `inventario` — product CRUD with Sheet form + AlertDialog delete
  - `configuracion` — bank account + envío form with CLABE validation
- Typed API client (`src/lib/api/materiales.ts`) and types mirror the backend DTOs
- Shared widgets: EstadoBadge, MoneyFormat, FolioPill
- i18n keys for es / en / fr / pt-BR

Companion PRs:
- sacdia-backend#131
- sacdia-app#TBD

## Verification
- SDD verify: 0 CRITICAL findings
- TypeScript clean on new code
- Follows DS rules: shadcn/ui only, AlertDialog for destructive, Geist titles, semantic tokens (no hardcoded Tailwind colors)

## Test plan
- [ ] /dashboard/materiales redirects to /bandeja
- [ ] Bandeja filters by estado update searchParams and refetch
- [ ] Solicitud detail: PATCH linea recalculates totals after refresh
- [ ] Approve button is disabled until all lines resolved; 409 insufficient_stock surfaces affected products
- [ ] Cancel dialog requires reason; aprobada cancellation triggers stock restore on backend
- [ ] Comprobantes review: aprobar transitions order to pagada; rechazar keeps it in aprobada with reject_reason
- [ ] Inventario: SKU duplicate shows form-level error; soft-delete blocked when product has open orders
- [ ] Configuración: CLABE rejects non-18-digit input client-side
- [ ] Sidebar entry hidden for roles without materiales:* permissions