### PR TITLE
fix(materiales): pre-invoke icon JSX for EmptyState across RSC boundary

### DIFF
--- a/src/app/(dashboard)/dashboard/materiales/bandeja/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/bandeja/page.tsx
@@ -133,7 +133,7 @@ export default async function BandejaPage({
       {/* Empty state */}
       {!loadError && ordenes.length === 0 && (
         <EmptyState
-          icon={Inbox}
+          icon={<Inbox className="size-6 text-muted-foreground" aria-hidden="true" />}
           title="Sin solicitudes"
           description={
             estado === "all" || estado === "en_revision"

--- a/src/app/(dashboard)/dashboard/materiales/comprobantes/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/comprobantes/page.tsx
@@ -129,7 +129,7 @@ export default async function ComprobantesPage({
       {/* Empty state */}
       {!loadError && ordenes.length === 0 && (
         <EmptyState
-          icon={Receipt}
+          icon={<Receipt className="size-6 text-muted-foreground" aria-hidden="true" />}
           title="Sin órdenes pendientes"
           description={
             q

--- a/src/app/(dashboard)/dashboard/materiales/inventario/page.tsx
+++ b/src/app/(dashboard)/dashboard/materiales/inventario/page.tsx
@@ -116,7 +116,7 @@ export default async function InventarioPage({
       {/* Empty state */}
       {!loadError && products.length === 0 && (
         <EmptyState
-          icon={Package}
+          icon={<Package className="size-6 text-muted-foreground" aria-hidden="true" />}
           title="Sin productos"
           description={
             q || cat


### PR DESCRIPTION
## Bug
Bandeja, comprobantes and inventario pages logged on every render:

```
⨯ Error: Functions are not valid as a child of Client Components.
  function Inbox / function Receipt / function Package
```

## Root cause
`icon={Inbox}` etc. passes the Lucide component **function reference** as a prop. The dashboard layout wraps the page tree in client components (SidebarProvider, QueryProvider, AuthProvider). Next.js serializes the RSC page through that boundary and rejects function refs in the children tree.

EmptyState's own `renderIcon(icon)` runs after the boundary, so it never gets the chance — the serializer rejects the prop first.

## Fix
Pre-invoke the icon as JSX before it leaves the page:

```diff
-  icon={Inbox}
+  icon={<Inbox className="size-6 text-muted-foreground" aria-hidden="true" />}
```

The resulting prop is a plain `ReactElement` (serializable). `EmptyState`'s union accepts `ReactNode` already, so no shared component changes.

## Test plan
- [ ] /dashboard/materiales/bandeja with no matching estado → empty state renders, no error in terminal
- [ ] /dashboard/materiales/comprobantes with no aprobada orders → idem
- [ ] /dashboard/materiales/inventario with no products → idem