### PR TITLE
ci: notify sacdia-docs on source-affecting changes

### DIFF
--- a/.github/workflows/notify-docs.yml
+++ b/.github/workflows/notify-docs.yml
@@ -1,0 +1,24 @@
+name: Notify sacdia-docs of source changes
+
+# Triggers sacdia-docs sync workflow when admin changes that affect
+# generated artifacts (package versions, design system) land on main.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'package.json'
+      - 'DESIGN-SYSTEM.md'
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger sacdia-docs repository_dispatch
+        run: |
+          curl --fail -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.SACDIA_REPO_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/abn-r/sacdia-docs/dispatches \
+            -d '{"event_type":"sacdia-source-changed","client_payload":{"source":"sacdia-admin","sha":"${{ github.sha }}"}}'


### PR DESCRIPTION
## Summary
- Add `.github/workflows/notify-docs.yml` that fires `repository_dispatch` (event_type: `sacdia-source-changed`) on push to `main` for `package.json` or `DESIGN-SYSTEM.md` changes.
- Drives `sacdia-docs` to regenerate `_generated-versions.mdx` and refresh design-system mirror.

## Prerequisite
Repo secret `SACDIA_REPO_TOKEN` (fine-grained PAT, `contents: read` here + `contents: read` + `pull-requests: write` on `sacdia-docs`) must be configured before merge.

## Test plan
- [ ] Confirm `SACDIA_REPO_TOKEN` secret is set in this repo before merge
- [ ] After merge, bump a dep in `package.json` and verify `sacdia-docs/sync-docs.yml` triggers