### PR TITLE
feat(materials): UI for per-local-field scoping

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
+    "@types/google.maps": "^3.64.1",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
+      '@types/google.maps':
+        specifier: ^3.64.1
+        version: 3.64.1
       '@types/node':
         specifier: ^20
         version: 20.19.30
@@ -2419,8 +2422,8 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
-  '@types/google.maps@3.64.0':
-    resolution: {integrity: sha512-dN0H6tB4lgLQLovcbPXFYYOEV41TpyyJghzb5jrzjB96FZmjeOghevVdC+BMGd6YqyCqXaggyEtqRXLRjzCBZA==}
+  '@types/google.maps@3.64.1':
+    resolution: {integrity: sha512-nEBoa6iDNipICtxJ5VlrOgPNZQ6ixIg5nuv8iryFj0Z/1NLgxyg3pQCVegPuCzGCyTQwQI/N3uZvLUysqAzaaw==}
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
@@ -5400,7 +5403,7 @@ snapshots:
 
   '@googlemaps/js-api-loader@2.0.2':
     dependencies:
-      '@types/google.maps': 3.64.0
+      '@types/google.maps': 3.64.1
 
   '@hookform/resolvers@5.2.2(react-hook-form@7.71.1(react@19.2.3))':
     dependencies:
@@ -7262,7 +7265,7 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
-  '@types/google.maps@3.64.0': {}
+  '@types/google.maps@3.64.1': {}
 
   '@types/json-schema@7.0.15': {}
 
@@ -7459,7 +7462,7 @@ snapshots:
   '@vis.gl/react-google-maps@1.8.3(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@googlemaps/js-api-loader': 2.0.2
-      '@types/google.maps': 3.64.0
+      '@types/google.maps': 3.64.1
       fast-deep-equal: 3.1.3
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)

--- a/src/app/(dashboard)/dashboard/materials/categories/_components/categories-table.tsx
+++ b/src/app/(dashboard)/dashboard/materials/categories/_components/categories-table.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useState } from "react";
+import { Pencil, Trash2 } from "lucide-react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CategoryFormSheet } from "./category-form-sheet";
+import { DeleteCategoryDialog } from "./delete-category-dialog";
+import type { MaterialCategoryAdmin } from "@/lib/types/materials";
+
+interface CategoriesTableProps {
+  categorias: MaterialCategoryAdmin[];
+}
+
+export function CategoriesTable({ categorias }: CategoriesTableProps) {
+  const [editTarget, setEditTarget] = useState<MaterialCategoryAdmin | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<MaterialCategoryAdmin | null>(null);
+
+  return (
+    <>
+      <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-xs">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Slug
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Nombre
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Ícono
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+                Orden
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground text-right">
+                Productos
+              </TableHead>
+              <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+                Estado
+              </TableHead>
+              <TableHead className="h-9 w-24 px-3" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {categorias.map((cat) => (
+              <TableRow key={cat.id} className="hover:bg-muted/30">
+                <TableCell className="px-3 py-2.5 align-middle">
+                  <span className="font-mono text-xs text-muted-foreground">
+                    {cat.slug}
+                  </span>
+                </TableCell>
+                <TableCell className="px-3 py-2.5 align-middle text-sm font-medium">
+                  {cat.label}
+                </TableCell>
+                <TableCell className="px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                  {cat.icon ?? "—"}
+                </TableCell>
+                <TableCell className="px-3 py-2.5 align-middle text-right tabular-nums text-sm">
+                  {cat.sort_order}
+                </TableCell>
+                <TableCell className="px-3 py-2.5 align-middle text-right tabular-nums text-sm">
+                  {cat.product_count}
+                </TableCell>
+                <TableCell className="px-3 py-2.5 align-middle">
+                  <Badge variant={cat.active ? "success" : "secondary"}>
+                    {cat.active ? "Activa" : "Inactiva"}
+                  </Badge>
+                </TableCell>
+                <TableCell className="px-3 py-2.5 align-middle">
+                  <div className="flex items-center justify-end gap-1">
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="Editar"
+                      onClick={() => setEditTarget(cat)}
+                    >
+                      <Pencil className="size-4" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      aria-label="Eliminar"
+                      onClick={() => setDeleteTarget(cat)}
+                    >
+                      <Trash2 className="size-4 text-destructive" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <CategoryFormSheet
+        open={editTarget !== null}
+        onOpenChange={(open) => !open && setEditTarget(null)}
+        mode="edit"
+        categoria={editTarget}
+      />
+
+      <DeleteCategoryDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+        categoria={deleteTarget}
+      />
+    </>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/categories/_components/category-form-sheet.tsx
+++ b/src/app/(dashboard)/dashboard/materials/categories/_components/category-form-sheet.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useEffect, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useForm } from "react-hook-form";
+import type { Resolver } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Button } from "@/components/ui/button";
+import {
+  createCategory,
+  updateCategory,
+} from "@/lib/api/materials";
+import { ApiError } from "@/lib/api/client";
+import type { MaterialCategoryAdmin } from "@/lib/types/materials";
+
+const createSchema = z.object({
+  slug: z
+    .string()
+    .min(1, "El slug es requerido")
+    .max(100)
+    .regex(/^[a-z0-9-]+$/, "Sólo minúsculas, dígitos y guiones"),
+  label: z.string().min(1, "El nombre es requerido").max(200),
+  icon: z.string().max(100).optional(),
+  sort_order: z.coerce.number().int().min(0).optional(),
+  active: z.boolean().optional(),
+});
+
+const editSchema = z.object({
+  label: z.string().min(1, "El nombre es requerido").max(200),
+  icon: z.string().max(100).optional(),
+  sort_order: z.coerce.number().int().min(0),
+  active: z.boolean(),
+});
+
+type CreateFormValues = z.infer<typeof createSchema>;
+type EditFormValues = z.infer<typeof editSchema>;
+
+interface CategoryFormSheetProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  categoria?: MaterialCategoryAdmin | null;
+}
+
+function CreateForm({ onSuccess }: { onSuccess: () => void }) {
+  const [isPending, startTransition] = useTransition();
+  const form = useForm<CreateFormValues>({
+    resolver: zodResolver(createSchema) as unknown as Resolver<CreateFormValues>,
+    defaultValues: {
+      slug: "",
+      label: "",
+      icon: "",
+      sort_order: 0,
+      active: true,
+    },
+  });
+
+  async function onSubmit(values: CreateFormValues) {
+    try {
+      await createCategory({
+        slug: values.slug,
+        label: values.label,
+        icon: values.icon || null,
+        sort_order: values.sort_order ?? 0,
+        active: values.active ?? true,
+      });
+      toast.success("Categoría creada.");
+      form.reset();
+      startTransition(() => onSuccess());
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        form.setError("slug", { message: "Este slug ya existe." });
+      } else {
+        toast.error(
+          err instanceof ApiError ? err.message : "Error al crear la categoría.",
+        );
+      }
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <FormField
+          control={form.control}
+          name="slug"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Slug</FormLabel>
+              <FormControl>
+                <Input placeholder="ej. uniforme, insumos, libros" {...field} />
+              </FormControl>
+              <FormDescription>
+                Identificador URL-safe. Usá minúsculas y guiones.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="label"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nombre</FormLabel>
+              <FormControl>
+                <Input placeholder="ej. Uniformes" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="icon"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Ícono{" "}
+                <span className="text-xs text-muted-foreground">(opcional)</span>
+              </FormLabel>
+              <FormControl>
+                <Input placeholder="ej. shirt, book, pin" {...field} />
+              </FormControl>
+              <FormDescription>
+                Nombre del ícono lucide-react (en kebab-case).
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="sort_order"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Orden</FormLabel>
+              <FormControl>
+                <Input
+                  type="number"
+                  min={0}
+                  {...field}
+                  value={field.value ?? 0}
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <SheetFooter className="pt-2">
+          <Button type="submit" disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+            Crear categoría
+          </Button>
+        </SheetFooter>
+      </form>
+    </Form>
+  );
+}
+
+function EditForm({
+  categoria,
+  onSuccess,
+}: {
+  categoria: MaterialCategoryAdmin;
+  onSuccess: () => void;
+}) {
+  const [isPending, startTransition] = useTransition();
+  const form = useForm<EditFormValues>({
+    resolver: zodResolver(editSchema) as unknown as Resolver<EditFormValues>,
+    defaultValues: {
+      label: categoria.label,
+      icon: categoria.icon ?? "",
+      sort_order: categoria.sort_order,
+      active: categoria.active,
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      label: categoria.label,
+      icon: categoria.icon ?? "",
+      sort_order: categoria.sort_order,
+      active: categoria.active,
+    });
+  }, [categoria.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function onSubmit(values: EditFormValues) {
+    try {
+      await updateCategory(categoria.id, {
+        label: values.label,
+        icon: values.icon || null,
+        sort_order: values.sort_order,
+        active: values.active,
+      });
+      toast.success("Categoría actualizada.");
+      startTransition(() => onSuccess());
+    } catch (err) {
+      const message =
+        err instanceof ApiError ? err.message : "Error al actualizar la categoría.";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        <div className="space-y-1.5">
+          <FormLabel>Slug</FormLabel>
+          <p className="rounded-md border bg-muted/40 px-3 py-2 font-mono text-sm text-muted-foreground">
+            {categoria.slug}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            El slug no se puede modificar una vez creada la categoría.
+          </p>
+        </div>
+
+        <FormField
+          control={form.control}
+          name="label"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nombre</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="icon"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>
+                Ícono{" "}
+                <span className="text-xs text-muted-foreground">(opcional)</span>
+              </FormLabel>
+              <FormControl>
+                <Input placeholder="ej. shirt, book, pin" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="sort_order"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Orden</FormLabel>
+              <FormControl>
+                <Input type="number" min={0} {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="active"
+          render={({ field }) => (
+            <FormItem className="flex items-center justify-between rounded-lg border p-3">
+              <div className="space-y-0.5">
+                <FormLabel className="text-base">Activa</FormLabel>
+                <p className="text-sm text-muted-foreground">
+                  Las categorías inactivas no aparecen para los directores.
+                </p>
+              </div>
+              <FormControl>
+                <Switch checked={field.value} onCheckedChange={field.onChange} />
+              </FormControl>
+            </FormItem>
+          )}
+        />
+
+        <SheetFooter className="pt-2">
+          <Button type="submit" disabled={isPending}>
+            {isPending && <Loader2 className="mr-2 size-4 animate-spin" />}
+            Guardar cambios
+          </Button>
+        </SheetFooter>
+      </form>
+    </Form>
+  );
+}
+
+export function CategoryFormSheet({
+  open,
+  onOpenChange,
+  mode,
+  categoria,
+}: CategoryFormSheetProps) {
+  const router = useRouter();
+
+  function handleSuccess() {
+    onOpenChange(false);
+    router.refresh();
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="overflow-y-auto sm:max-w-lg">
+        <SheetHeader className="px-6 pt-6">
+          <SheetTitle>
+            {mode === "create" ? "Nueva categoría" : "Editar categoría"}
+          </SheetTitle>
+          <SheetDescription>
+            {mode === "create"
+              ? "Definí una categoría de materiales reutilizable por todos los campos."
+              : "Modificá el nombre, ícono, orden y estado de la categoría."}
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-2 px-6 pb-6">
+          {mode === "create" ? (
+            <CreateForm onSuccess={handleSuccess} />
+          ) : categoria ? (
+            <EditForm categoria={categoria} onSuccess={handleSuccess} />
+          ) : null}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/categories/_components/delete-category-dialog.tsx
+++ b/src/app/(dashboard)/dashboard/materials/categories/_components/delete-category-dialog.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { deleteCategory } from "@/lib/api/materials";
+import { ApiError } from "@/lib/api/client";
+import type { MaterialCategoryAdmin } from "@/lib/types/materials";
+
+interface DeleteCategoryDialogProps {
+  categoria: MaterialCategoryAdmin | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeleteCategoryDialog({
+  categoria,
+  open,
+  onOpenChange,
+}: DeleteCategoryDialogProps) {
+  const router = useRouter();
+  const [busy, setBusy] = useState(false);
+  const [, startTransition] = useTransition();
+
+  async function confirm() {
+    if (!categoria) return;
+    setBusy(true);
+    try {
+      await deleteCategory(categoria.id);
+      toast.success("Categoría desactivada.");
+      onOpenChange(false);
+      startTransition(() => router.refresh());
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 409) {
+        toast.error(
+          "No se puede eliminar: la categoría tiene productos asociados.",
+        );
+      } else {
+        toast.error(
+          err instanceof ApiError ? err.message : "Error al eliminar.",
+        );
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Eliminar categoría</AlertDialogTitle>
+          <AlertDialogDescription>
+            Vas a desactivar &quot;{categoria?.label}&quot;. Si la categoría
+            tiene productos asociados la operación fallará — debés reasignar o
+            eliminar esos productos primero.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Cancelar</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              confirm();
+            }}
+            disabled={busy}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {busy && <Loader2 className="mr-2 size-4 animate-spin" />}
+            Eliminar
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/categories/_components/new-category-button.tsx
+++ b/src/app/(dashboard)/dashboard/materials/categories/_components/new-category-button.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { CategoryFormSheet } from "./category-form-sheet";
+
+export function NewCategoryButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button size="sm" onClick={() => setOpen(true)}>
+        <Plus className="mr-1.5 size-4" />
+        Nueva categoría
+      </Button>
+      <CategoryFormSheet open={open} onOpenChange={setOpen} mode="create" />
+    </>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/categories/page.tsx
+++ b/src/app/(dashboard)/dashboard/materials/categories/page.tsx
@@ -1,0 +1,66 @@
+import { redirect } from "next/navigation";
+import { Tag } from "lucide-react";
+import { PageHeader } from "@/components/shared/page-header";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { EmptyState } from "@/components/shared/empty-state";
+import { CategoriesTable } from "./_components/categories-table";
+import { NewCategoryButton } from "./_components/new-category-button";
+import { listCategoriesAdmin } from "@/lib/api/materials";
+import { ApiError } from "@/lib/api/client";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasPermission } from "@/lib/auth/permission-utils";
+import type { MaterialCategoryAdmin } from "@/lib/types/materials";
+
+export default async function CategoriesPage() {
+  const user = await requireAdminUser();
+
+  if (!hasPermission(user, "materiales:manage-inventory")) {
+    redirect("/dashboard");
+  }
+
+  let categorias: MaterialCategoryAdmin[] = [];
+  let loadError: string | null = null;
+  let loadErrorStatus: number | null = null;
+
+  try {
+    categorias = await listCategoriesAdmin();
+  } catch (error) {
+    if (error instanceof ApiError) {
+      loadError = error.message;
+      loadErrorStatus = error.status;
+    } else {
+      loadError = "Error al cargar las categorías.";
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <PageHeader
+          title="Categorías de materiales"
+          description="Taxonomía compartida entre todos los campos locales."
+        />
+        <NewCategoryButton />
+      </div>
+
+      {loadError && (
+        <EndpointErrorBanner
+          state={loadErrorStatus === 403 ? "forbidden" : "missing"}
+          detail={loadError}
+        />
+      )}
+
+      {!loadError && categorias.length === 0 && (
+        <EmptyState
+          icon={<Tag className="size-6 text-muted-foreground" aria-hidden="true" />}
+          title="Sin categorías"
+          description="Aún no se ha creado ninguna categoría. Creá la primera."
+        />
+      )}
+
+      {!loadError && categorias.length > 0 && (
+        <CategoriesTable categorias={categorias} />
+      )}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/config/_components/local-field-picker.tsx
+++ b/src/app/(dashboard)/dashboard/materials/config/_components/local-field-picker.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useCallback, useTransition } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Label } from "@/components/ui/label";
+import type { LocalFieldOption } from "@/lib/types/materials";
+
+interface LocalFieldPickerProps {
+  currentLocalFieldId: number | null;
+  localFields: LocalFieldOption[];
+}
+
+export function LocalFieldPicker({
+  currentLocalFieldId,
+  localFields,
+}: LocalFieldPickerProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [, startTransition] = useTransition();
+
+  const onChange = useCallback(
+    (value: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (value) {
+        params.set("local_field_id", value);
+      } else {
+        params.delete("local_field_id");
+      }
+      startTransition(() => {
+        router.push(`${pathname}?${params.toString()}`);
+      });
+    },
+    [router, pathname, searchParams],
+  );
+
+  return (
+    <div className="flex flex-wrap items-end gap-3 rounded-lg border bg-card p-4">
+      <div className="space-y-1.5">
+        <Label className="text-xs uppercase tracking-wider text-muted-foreground">
+          Campo local
+        </Label>
+        <Select
+          value={currentLocalFieldId != null ? String(currentLocalFieldId) : ""}
+          onValueChange={onChange}
+        >
+          <SelectTrigger className="h-9 w-[240px]">
+            <SelectValue placeholder="Seleccioná un campo local" />
+          </SelectTrigger>
+          <SelectContent>
+            {localFields.map((lf) => (
+              <SelectItem
+                key={lf.local_field_id}
+                value={String(lf.local_field_id)}
+              >
+                {lf.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/bank-snapshot-card.tsx
+++ b/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/bank-snapshot-card.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { AlertTriangle, Landmark } from "lucide-react";
+import { CopyButton } from "@/components/ui/copy-button";
+import { FolioPill } from "@/components/materials/folio-pill";
+import { MoneyFormat } from "@/components/materials/money-format";
+import { Button } from "@/components/ui/button";
+import type { Orden } from "@/lib/types/materials";
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatClabe(clabe: string): string {
+  return clabe.replace(/(\d{4})/g, "$1 ").trim();
+}
+
+function formatCentavosPlain(centavos: number): string {
+  return new Intl.NumberFormat("es-MX", {
+    style: "currency",
+    currency: "MXN",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(centavos / 100);
+}
+
+// ─── Field row ────────────────────────────────────────────────────────────────
+
+interface FieldRowProps {
+  label: string;
+  copyAriaLabel: string;
+  copyText: string;
+  children: React.ReactNode;
+  fullWidth?: boolean;
+}
+
+function FieldRow({
+  label,
+  copyAriaLabel,
+  copyText,
+  children,
+  fullWidth,
+}: FieldRowProps) {
+  return (
+    <div
+      className={fullWidth ? "sm:col-span-2 group flex items-start gap-3" : "group flex items-start gap-3"}
+    >
+      <div className="flex flex-1 flex-col">
+        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+          {label}
+        </span>
+        <div className="text-sm text-foreground">{children}</div>
+      </div>
+      <CopyButton text={copyText} ariaLabel={copyAriaLabel} />
+    </div>
+  );
+}
+
+// ─── Copy-all button ──────────────────────────────────────────────────────────
+
+interface CopyAllButtonProps {
+  text: string;
+}
+
+function CopyAllButton({ text }: CopyAllButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // no-op
+    }
+  }
+
+  return (
+    <Button type="button" variant="ghost" size="sm" onClick={copy}>
+      {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+      {copied ? "Copiado" : "Copiar todo"}
+    </Button>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface BankSnapshotCardProps {
+  orden: Orden;
+}
+
+export function BankSnapshotCard({ orden }: BankSnapshotCardProps) {
+  const clabe = orden.bank_account_clabe;
+  const hasBank = Boolean(orden.bank_name) && Boolean(clabe);
+
+  if (!hasBank || !clabe) {
+    return (
+      <section
+        aria-labelledby="bank-snapshot-heading"
+        className="mt-6 rounded-lg border border-warning/30 bg-warning/10 p-5"
+      >
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="mt-0.5 size-5 shrink-0 text-warning-foreground" />
+          <div className="space-y-1">
+            <h2
+              id="bank-snapshot-heading"
+              className="text-sm font-semibold text-warning-foreground"
+            >
+              Datos bancarios no configurados
+            </h2>
+            <p className="text-sm text-warning-foreground/80">
+              Configurá la cuenta bancaria en Materiales → Configuración antes
+              de compartir esta solicitud con el director.
+            </p>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  const formattedClabe = formatClabe(clabe);
+  const totalString = formatCentavosPlain(orden.total_centavos);
+
+  const copyAllLines: string[] = [];
+  if (orden.folio_referencia) copyAllLines.push(`Folio: ${orden.folio_referencia}`);
+  copyAllLines.push(`Total: ${totalString}`);
+  if (orden.bank_name) copyAllLines.push(`Banco: ${orden.bank_name}`);
+  copyAllLines.push(`CLABE: ${clabe}`);
+  if (orden.account_holder) copyAllLines.push(`Titular: ${orden.account_holder}`);
+  if (orden.entrega === "recoger" && orden.pickup_address) {
+    copyAllLines.push(`Recoger en: ${orden.pickup_address}`);
+  }
+
+  return (
+    <section
+      aria-labelledby="bank-snapshot-heading"
+      className="mt-6 rounded-lg border border-border/60 bg-card p-5"
+    >
+      <div className="mb-5 flex items-center gap-2">
+        <Landmark className="size-5 text-muted-foreground" />
+        <h2
+          id="bank-snapshot-heading"
+          className="text-sm font-semibold uppercase tracking-wide"
+        >
+          Datos de pago
+        </h2>
+        <div className="ml-auto">
+          <CopyAllButton text={copyAllLines.join("\n")} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 gap-x-8 gap-y-3 sm:grid-cols-2">
+        {orden.folio_referencia && (
+          <FieldRow
+            label="Folio"
+            copyAriaLabel="Copiar folio"
+            copyText={orden.folio_referencia}
+          >
+            <FolioPill folio={orden.folio_referencia} />
+          </FieldRow>
+        )}
+
+        <FieldRow
+          label="Total"
+          copyAriaLabel="Copiar total"
+          copyText={totalString}
+        >
+          <span className="text-base font-semibold tabular-nums">
+            <MoneyFormat centavos={orden.total_centavos} />
+          </span>
+        </FieldRow>
+
+        {orden.bank_name && (
+          <FieldRow
+            label="Banco"
+            copyAriaLabel="Copiar banco"
+            copyText={orden.bank_name}
+          >
+            {orden.bank_name}
+          </FieldRow>
+        )}
+
+        <FieldRow
+          label="CLABE"
+          copyAriaLabel="Copiar CLABE"
+          copyText={clabe}
+        >
+          <span className="font-mono tracking-tight">{formattedClabe}</span>
+        </FieldRow>
+
+        {orden.account_holder && (
+          <FieldRow
+            label="Titular"
+            copyAriaLabel="Copiar titular"
+            copyText={orden.account_holder}
+          >
+            {orden.account_holder}
+          </FieldRow>
+        )}
+
+        {orden.entrega === "recoger" && orden.pickup_address && (
+          <FieldRow
+            label="Dirección de recogida"
+            copyAriaLabel="Copiar dirección"
+            copyText={orden.pickup_address}
+            fullWidth
+          >
+            {orden.pickup_address}
+          </FieldRow>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/director-cell.tsx
+++ b/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/director-cell.tsx
@@ -1,0 +1,59 @@
+import { CopyButton } from "@/components/ui/copy-button";
+
+interface DirectorCellProps {
+  director?: {
+    nombre: string | null;
+    club: string | null;
+    user_id: string;
+  } | null;
+  /** Fallback UUID when no director relation is available. */
+  fallbackId: string;
+}
+
+/**
+ * Renders the director identity for an order:
+ *  - Full name + club when both are present.
+ *  - Just the name (plus em-dash) when club is missing.
+ *  - "Director (id: xxxxxxxx…)" with a copy-to-clipboard control when no
+ *    director relation exists (only the created_by UUID is known).
+ */
+export function DirectorCell({ director, fallbackId }: DirectorCellProps) {
+  const userId = director?.user_id ?? fallbackId;
+  const nombre = director?.nombre?.trim() || null;
+  const club = director?.club?.trim() || null;
+
+  if (nombre && club) {
+    return (
+      <div className="flex flex-col">
+        <span className="text-sm font-medium text-foreground">{nombre}</span>
+        <span className="text-sm text-muted-foreground">{club}</span>
+      </div>
+    );
+  }
+
+  if (nombre) {
+    return (
+      <div className="flex flex-col">
+        <span className="text-sm font-medium text-foreground">{nombre}</span>
+        <span className="text-sm text-muted-foreground">—</span>
+      </div>
+    );
+  }
+
+  const trimmedId = userId.slice(0, 8);
+
+  return (
+    <div className="flex flex-col">
+      <span className="text-sm font-medium text-foreground">
+        Director (id: {trimmedId}…)
+      </span>
+      <div className="flex items-center gap-1 text-sm text-muted-foreground">
+        <span className="font-mono text-xs">{userId}</span>
+        <CopyButton
+          text={userId}
+          ariaLabel="Copiar ID del director"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/order-actions.tsx
+++ b/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/order-actions.tsx
@@ -1,0 +1,182 @@
+import { CheckCircle2, Clock, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { Orden } from "@/lib/types/materials";
+import { ApproveButton } from "./approve-button";
+import { CancelDialog } from "./cancel-dialog";
+import { DeliverButton } from "./deliver-button";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    const date = new Date(iso);
+    const day = new Intl.DateTimeFormat("es-MX", {
+      day: "2-digit",
+      month: "long",
+      year: "numeric",
+    }).format(date);
+    const time = new Intl.DateTimeFormat("es-MX", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).format(date);
+    return `${day} · ${time}`;
+  } catch {
+    return iso;
+  }
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface OrderActionsProps {
+  orden: Orden;
+  canApprove: boolean;
+  canValidateReceipt: boolean;
+  canDeliver: boolean;
+  linesResolved: number;
+  linesTotal: number;
+  /** Use full-width buttons (right rail). */
+  fullWidth?: boolean;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function OrderActions({
+  orden,
+  canApprove,
+  canDeliver,
+  linesResolved,
+  linesTotal,
+  fullWidth = true,
+}: OrderActionsProps) {
+  const { estado } = orden;
+  const allResolved = linesTotal > 0 && linesResolved === linesTotal;
+  const pending = Math.max(0, linesTotal - linesResolved);
+
+  // ─── en_revision ───────────────────────────────────────────────────────────
+  if (estado === "en_revision") {
+    if (!canApprove) {
+      return (
+        <p className="text-sm text-muted-foreground">
+          No tenés permisos para aprobar esta solicitud.
+        </p>
+      );
+    }
+
+    return (
+      <div className="flex flex-col gap-2">
+        <ApproveButton
+          folio={orden.id}
+          disabled={!allResolved}
+          disabledReason={
+            !allResolved
+              ? `Resolvé ${pending} ${pending === 1 ? "partida" : "partidas"} antes de aprobar.`
+              : undefined
+          }
+          fullWidth={fullWidth}
+        />
+        <CancelDialog folio={orden.id}>
+          <Button variant="outline" size="sm" className={fullWidth ? "w-full" : undefined}>
+            <XCircle className="size-4" />
+            Cancelar solicitud
+          </Button>
+        </CancelDialog>
+        {!allResolved && (
+          <p className="mt-1 text-xs text-muted-foreground">
+            Resolvé {pending} {pending === 1 ? "partida" : "partidas"} antes de aprobar.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // ─── aprobada ──────────────────────────────────────────────────────────────
+  if (estado === "aprobada") {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="flex items-start gap-2 rounded-md border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground">
+          <Clock className="mt-0.5 size-4 shrink-0" />
+          <span>Esperando comprobante de pago</span>
+        </div>
+        {canApprove && (
+          <CancelDialog
+            folio={orden.id}
+            extraWarning="Cancelar después de aprobar restaurará el stock reservado y notificará al director."
+          >
+            <Button variant="outline" size="sm" className={fullWidth ? "w-full" : undefined}>
+              <XCircle className="size-4" />
+              Cancelar solicitud
+            </Button>
+          </CancelDialog>
+        )}
+      </div>
+    );
+  }
+
+  // ─── pagada ────────────────────────────────────────────────────────────────
+  if (estado === "pagada") {
+    return (
+      <div className="flex flex-col gap-2">
+        {canDeliver && <DeliverButton folio={orden.id} fullWidth={fullWidth} />}
+        {canApprove && (
+          <CancelDialog
+            folio={orden.id}
+            extraWarning="Cancelar después del pago generará una devolución pendiente que deberá procesarse manualmente."
+          >
+            <Button variant="outline" size="sm" className={fullWidth ? "w-full" : undefined}>
+              <XCircle className="size-4" />
+              Cancelar solicitud
+            </Button>
+          </CancelDialog>
+        )}
+      </div>
+    );
+  }
+
+  // ─── entregada ─────────────────────────────────────────────────────────────
+  if (estado === "entregada") {
+    return (
+      <div className="flex items-start gap-3 rounded-md border border-success/30 bg-success/10 p-4">
+        <CheckCircle2 className="size-5 shrink-0 text-success-foreground" />
+        <div>
+          <div className="text-sm font-medium text-success-foreground">
+            Entregada
+          </div>
+          <div className="text-sm text-success-foreground/80">
+            {formatDateTime(orden.delivered_at)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // ─── cancelada ─────────────────────────────────────────────────────────────
+  if (estado === "cancelada") {
+    return (
+      <div className="flex items-start gap-3 rounded-md border border-destructive/30 bg-destructive/10 p-4">
+        <XCircle className="size-5 shrink-0 text-destructive" />
+        <div className="space-y-1">
+          <div className="text-sm font-medium text-destructive">
+            Cancelada
+          </div>
+          <div className="text-xs text-muted-foreground">
+            {formatDateTime(orden.cancelled_at)}
+          </div>
+          {orden.cancel_reason && (
+            <p className="text-sm italic text-muted-foreground">
+              “{orden.cancel_reason}”
+            </p>
+          )}
+          {orden.refund_pending && (
+            <p className="text-xs font-medium text-warning-foreground">
+              Devolución pendiente
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/order-metadata-strip.tsx
+++ b/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/order-metadata-strip.tsx
@@ -1,0 +1,179 @@
+import { MoneyFormat } from "@/components/materials/money-format";
+import type { Orden } from "@/lib/types/materials";
+import { DirectorCell } from "./director-cell";
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return "—";
+  try {
+    const date = new Date(iso);
+    const day = new Intl.DateTimeFormat("es-MX", {
+      day: "2-digit",
+      month: "short",
+      year: "numeric",
+    }).format(date);
+    const time = new Intl.DateTimeFormat("es-MX", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    }).format(date);
+    return `${day} · ${time}`;
+  } catch {
+    return iso;
+  }
+}
+
+// ─── Cells ────────────────────────────────────────────────────────────────────
+
+interface CellProps {
+  label: string;
+  children: React.ReactNode;
+}
+
+function Cell({ label, children }: CellProps) {
+  return (
+    <div className="flex flex-col">
+      <span className="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+interface ChronologyRowProps {
+  label: string;
+  value: string;
+  muted?: boolean;
+  destructive?: boolean;
+}
+
+function ChronologyRow({ label, value, muted, destructive }: ChronologyRowProps) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <span className="text-sm text-muted-foreground">{label}</span>
+      <span
+        className={
+          destructive
+            ? "text-sm font-medium text-destructive"
+            : muted
+              ? "text-sm text-muted-foreground"
+              : "text-sm font-medium text-foreground"
+        }
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+interface OrderMetadataStripProps {
+  orden: Orden;
+}
+
+export function OrderMetadataStrip({ orden }: OrderMetadataStripProps) {
+  const isEnvio = orden.entrega === "envio";
+
+  return (
+    <div className="rounded-lg border border-border/60 bg-card p-5">
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+        {/* Director */}
+        <Cell label="Director">
+          <DirectorCell
+            director={orden.director}
+            fallbackId={orden.created_by}
+          />
+        </Cell>
+
+        {/* Entrega */}
+        <Cell label="Entrega">
+          {isEnvio ? (
+            <div className="flex flex-col">
+              <span className="text-sm font-medium text-foreground">
+                Envío a domicilio
+              </span>
+              <span className="text-sm text-muted-foreground tabular-nums">
+                <MoneyFormat centavos={orden.envio_centavos} />
+              </span>
+            </div>
+          ) : (
+            <div className="flex flex-col">
+              <span className="text-sm font-medium text-foreground">
+                Recoger en sucursal
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {orden.pickup_address ?? "Sin dirección configurada"}
+              </span>
+            </div>
+          )}
+        </Cell>
+
+        {/* Cronología */}
+        <Cell label="Cronología">
+          <div className="flex flex-col gap-1.5">
+            <ChronologyRow
+              label="Creada"
+              value={formatDateTime(orden.created_at)}
+            />
+
+            {orden.estado === "en_revision" && (
+              <ChronologyRow label="Aprobada" value="—" muted />
+            )}
+
+            {orden.estado === "aprobada" && (
+              <>
+                <ChronologyRow
+                  label="Aprobada"
+                  value={formatDateTime(orden.approved_at)}
+                />
+                <ChronologyRow label="Pagada" value="—" muted />
+              </>
+            )}
+
+            {orden.estado === "pagada" && (
+              <>
+                <ChronologyRow
+                  label="Aprobada"
+                  value={formatDateTime(orden.approved_at)}
+                />
+                <ChronologyRow
+                  label="Pagada"
+                  value={formatDateTime(orden.paid_at)}
+                />
+                <ChronologyRow label="Entregada" value="—" muted />
+              </>
+            )}
+
+            {orden.estado === "entregada" && (
+              <>
+                <ChronologyRow
+                  label="Aprobada"
+                  value={formatDateTime(orden.approved_at)}
+                />
+                <ChronologyRow
+                  label="Pagada"
+                  value={formatDateTime(orden.paid_at)}
+                />
+                <ChronologyRow
+                  label="Entregada"
+                  value={formatDateTime(orden.delivered_at)}
+                />
+              </>
+            )}
+
+            {orden.estado === "cancelada" && (
+              <ChronologyRow
+                label="Cancelada"
+                value={formatDateTime(orden.cancelled_at)}
+                destructive
+              />
+            )}
+          </div>
+        </Cell>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/order-sticky-bar.tsx
+++ b/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/order-sticky-bar.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { MoreVertical, XCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { MoneyFormat } from "@/components/materials/money-format";
+import type { Orden } from "@/lib/types/materials";
+import { ApproveButton } from "./approve-button";
+import { CancelDialog } from "./cancel-dialog";
+import { DeliverButton } from "./deliver-button";
+import { useState } from "react";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface OrderStickyBarProps {
+  orden: Orden;
+  canApprove: boolean;
+  canDeliver: boolean;
+  linesResolved: number;
+  linesTotal: number;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function OrderStickyBar({
+  orden,
+  canApprove,
+  canDeliver,
+  linesResolved,
+  linesTotal,
+}: OrderStickyBarProps) {
+  const { estado } = orden;
+  const allResolved = linesTotal > 0 && linesResolved === linesTotal;
+  const pending = Math.max(0, linesTotal - linesResolved);
+
+  // External cancel dialog open state controlled by the dropdown menu item.
+  const [cancelOpenKey, setCancelOpenKey] = useState(0);
+
+  const showCancel =
+    (estado === "en_revision" ||
+      estado === "aprobada" ||
+      estado === "pagada") &&
+    canApprove;
+
+  const cancelExtraWarning =
+    estado === "pagada"
+      ? "Cancelar después del pago generará una devolución pendiente."
+      : estado === "aprobada"
+        ? "Cancelar después de aprobar restaurará el stock reservado."
+        : undefined;
+
+  // For terminal states, hide the bar (no primary action, footer not useful).
+  if (estado === "entregada" || estado === "cancelada") {
+    return null;
+  }
+
+  // Primary CTA per estado
+  let primary: React.ReactNode = null;
+  if (estado === "en_revision" && canApprove) {
+    primary = (
+      <ApproveButton
+        folio={orden.id}
+        disabled={!allResolved}
+        disabledReason={
+          !allResolved
+            ? `Resolvé ${pending} ${pending === 1 ? "partida" : "partidas"} antes de aprobar.`
+            : undefined
+        }
+      />
+    );
+  } else if (estado === "pagada" && canDeliver) {
+    primary = <DeliverButton folio={orden.id} />;
+  } else if (estado === "aprobada") {
+    primary = (
+      <span className="text-sm text-muted-foreground">
+        Esperando comprobante
+      </span>
+    );
+  }
+
+  return (
+    <div className="sticky bottom-0 z-30 -mx-6 mt-6 flex h-16 items-center justify-between border-t border-border/60 bg-background/95 px-6 backdrop-blur xl:hidden lg:-mx-8 lg:px-8">
+      <div className="flex flex-col">
+        <span className="text-xs text-muted-foreground">Total</span>
+        <span className="font-mono font-semibold tabular-nums">
+          <MoneyFormat centavos={orden.total_centavos} />
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {primary}
+        {showCancel && (
+          <>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon-sm"
+                  aria-label="Más acciones"
+                >
+                  <MoreVertical className="size-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem
+                  variant="destructive"
+                  onSelect={(e) => {
+                    e.preventDefault();
+                    setCancelOpenKey((k) => k + 1);
+                  }}
+                >
+                  <XCircle className="size-4" />
+                  Cancelar solicitud
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+
+            {/* Headless: dropdown item triggers the dialog by bumping the
+                key so the CancelDialog mounts fresh and opens via the trigger. */}
+            <CancelDialogHidden
+              key={cancelOpenKey}
+              triggerOnMount={cancelOpenKey > 0}
+              folio={orden.id}
+              extraWarning={cancelExtraWarning}
+            />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Headless cancel dialog wrapper ───────────────────────────────────────────
+
+/**
+ * Wraps CancelDialog so it can be opened imperatively from a DropdownMenuItem
+ * (which closes its own portal on select). We mount a button-trigger off-screen
+ * and click it via ref when `triggerOnMount` is true.
+ */
+function CancelDialogHidden({
+  folio,
+  extraWarning,
+  triggerOnMount,
+}: {
+  folio: string;
+  extraWarning?: string;
+  triggerOnMount: boolean;
+}) {
+  return (
+    <CancelDialog folio={folio} extraWarning={extraWarning}>
+      <HiddenTrigger triggerOnMount={triggerOnMount} />
+    </CancelDialog>
+  );
+}
+
+function HiddenTrigger({ triggerOnMount }: { triggerOnMount: boolean }) {
+  // Using a button with sr-only to fire the click programmatically on mount.
+  return (
+    <button
+      type="button"
+      ref={(el) => {
+        if (el && triggerOnMount) {
+          // Defer click so Radix portal mounts cleanly
+          window.setTimeout(() => el.click(), 0);
+        }
+      }}
+      className="sr-only"
+      aria-hidden
+      tabIndex={-1}
+    >
+      Cancelar
+    </button>
+  );
+}

--- a/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/order-summary-rail.tsx
+++ b/src/app/(dashboard)/dashboard/materials/request/[folio]/_components/order-summary-rail.tsx
@@ -1,0 +1,96 @@
+import { MoneyFormat } from "@/components/materials/money-format";
+import type { Orden } from "@/lib/types/materials";
+import { OrderActions } from "./order-actions";
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface OrderSummaryRailProps {
+  orden: Orden;
+  canApprove: boolean;
+  canValidateReceipt: boolean;
+  canDeliver: boolean;
+  linesResolved: number;
+  linesTotal: number;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function OrderSummaryRail({
+  orden,
+  canApprove,
+  canValidateReceipt,
+  canDeliver,
+  linesResolved,
+  linesTotal,
+}: OrderSummaryRailProps) {
+  const totalPieces = orden.lines.reduce((acc, l) => acc + l.qty, 0);
+  const nLines = orden.lines.length;
+
+  return (
+    <aside className="hidden w-[340px] shrink-0 xl:flex xl:flex-col xl:gap-4">
+      <div className="sticky top-6 flex flex-col gap-4">
+        {/* Resumen */}
+        <section
+          aria-labelledby="resumen-heading"
+          className="rounded-lg border border-border/60 bg-card p-5"
+        >
+          <h3
+            id="resumen-heading"
+            className="mb-3 text-xs uppercase tracking-wide text-muted-foreground"
+          >
+            Resumen
+          </h3>
+
+          <dl className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Subtotal</dt>
+              <dd className="font-mono tabular-nums">
+                <MoneyFormat centavos={orden.subtotal_centavos} />
+              </dd>
+            </div>
+            <div className="flex justify-between">
+              <dt className="text-muted-foreground">Envío</dt>
+              <dd className="font-mono tabular-nums">
+                <MoneyFormat centavos={orden.envio_centavos} />
+              </dd>
+            </div>
+            <div className="my-2 border-t border-border/40" />
+            <div className="flex items-baseline justify-between">
+              <dt className="text-sm font-medium">Total</dt>
+              <dd className="font-mono text-lg font-semibold tabular-nums">
+                <MoneyFormat centavos={orden.total_centavos} />
+              </dd>
+            </div>
+          </dl>
+
+          <p className="mt-3 text-xs text-muted-foreground">
+            {nLines} {nLines === 1 ? "partida" : "partidas"} · {totalPieces}{" "}
+            {totalPieces === 1 ? "pieza" : "piezas"}
+          </p>
+        </section>
+
+        {/* Acciones */}
+        <section
+          aria-labelledby="acciones-heading"
+          className="rounded-lg border border-border/60 bg-card p-5"
+        >
+          <h3
+            id="acciones-heading"
+            className="mb-3 text-xs uppercase tracking-wide text-muted-foreground"
+          >
+            Acciones
+          </h3>
+          <OrderActions
+            orden={orden}
+            canApprove={canApprove}
+            canValidateReceipt={canValidateReceipt}
+            canDeliver={canDeliver}
+            linesResolved={linesResolved}
+            linesTotal={linesTotal}
+            fullWidth
+          />
+        </section>
+      </div>
+    </aside>
+  );
+}

--- a/src/components/shared/location-picker.tsx
+++ b/src/components/shared/location-picker.tsx
@@ -7,6 +7,7 @@ import {
   AdvancedMarker,
   useMap,
   useMapsLibrary,
+  type MapMouseEvent,
 } from "@vis.gl/react-google-maps";
 import { MapPin, Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -144,7 +145,7 @@ export function LocationPicker({
     [],
   );
 
-  const handleMapClick = useCallback((event: google.maps.MapMouseEvent) => {
+  const handleMapClick = useCallback((event: MapMouseEvent) => {
     if (!event.detail.latLng) return;
     setPosition({
       lat: event.detail.latLng.lat,

--- a/src/components/ui/copy-button.tsx
+++ b/src/components/ui/copy-button.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface CopyButtonProps {
+  text: string;
+  ariaLabel: string;
+  size?: "icon-xs" | "icon-sm";
+  className?: string;
+}
+
+/**
+ * Copy-to-clipboard ghost button. Shows a transient check icon on success.
+ * Falls back silently if the clipboard API is unavailable.
+ */
+export function CopyButton({
+  text,
+  ariaLabel,
+  size = "icon-xs",
+  className,
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // no-op — environment without clipboard access
+    }
+  }
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size={size}
+      onClick={copy}
+      aria-label={ariaLabel}
+      className={cn(
+        "text-muted-foreground hover:text-foreground",
+        className,
+      )}
+    >
+      {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+    </Button>
+  );
+}

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -40,6 +40,7 @@ export interface IntlMessages {
       members: string;
       operations: string;
       rankings_analytics: string;
+      materials: string;
     };
     items: {
       dashboard: string;
@@ -132,6 +133,11 @@ export interface IntlMessages {
       subgroup_business: string;
       subgroup_honors_cat: string;
       ranking_weights_root: string;
+      materials_inbox: string;
+      materials_receipts: string;
+      materials_inventory: string;
+      materials_categories: string;
+      materials_config: string;
     };
     breadcrumbs: {
       dashboard: string;
@@ -783,6 +789,7 @@ export interface IntlMessages {
       member_not_identified: string;
       assignment_not_identified: string;
       assignment_remove_not_identified: string;
+      bulk_row_invalid: string;
     };
     success: {
       section_created: string;
@@ -798,6 +805,14 @@ export interface IntlMessages {
       district: string;
       church: string;
       ecclesiastical_year: string;
+    };
+    locationPicker: {
+      searchLabel: string;
+      searchPlaceholder: string;
+      hint: string;
+      noPin: string;
+      clear: string;
+      missingApiKey: string;
     };
     form: {
       labelName: string;
@@ -860,10 +875,56 @@ export interface IntlMessages {
         emptyTitle: string;
         emptyDescription: string;
         emptyCreateButton: string;
+        createMenuManual: string;
+        createMenuBulk: string;
       };
       new: {
         title: string;
         back: string;
+      };
+      import: {
+        title: string;
+        description: string;
+        back: string;
+        uploadCardTitle: string;
+        uploadCardDescription: string;
+        downloadTemplate: string;
+        chooseFile: string;
+        reset: string;
+        expectedHeadersTitle: string;
+        matchHint: string;
+        previewTitle: string;
+        previewSummary: string;
+        colName: string;
+        colLocalField: string;
+        colDistrict: string;
+        colChurch: string;
+        colStatus: string;
+        colMessage: string;
+        rowValid: string;
+        rowInvalid: string;
+        rowCreated: string;
+        rowFailed: string;
+        submitButton: string;
+        resultTitle: string;
+        resultSummary: string;
+        resultForbidden: string;
+        validation: {
+          missingName: string;
+          missingLocalField: string;
+          missingDistrict: string;
+          missingChurch: string;
+          unknownLocalField: string;
+          unknownDistrict: string;
+          unknownChurch: string;
+          coordinatesInvalid: string;
+        };
+        errors: {
+          emptyWorkbook: string;
+          noRows: string;
+          missingHeaders: string;
+          parseFailed: string;
+        };
       };
       detail: {
         back: string;

--- a/src/lib/auth/user-local-field.ts
+++ b/src/lib/auth/user-local-field.ts
@@ -1,0 +1,59 @@
+import type { AuthUser } from "@/lib/auth/types";
+
+/**
+ * Describes whether a session is bound to a single local_field (directors,
+ * director-lf, assistant-lf) or is unscoped (admin / super-admin) and can
+ * therefore address any local_field with an explicit override.
+ */
+export type UserLocalFieldScope =
+  | { scope: "single"; localFieldId: number }
+  | { scope: "all" };
+
+type ScopeNode = { id?: number | string | null } | null | undefined;
+
+/**
+ * Reads the AuthorizationSnapshot attached to the session user and returns
+ * the local_field constraint that should drive UI filters and form payloads:
+ *
+ *   1. effective.scope.global.local_field.id   → director-lf / assistant-lf
+ *   2. effective.scope.club.local_field_id      → director (CLUB role); we
+ *      fall back to legacy.club.local_field_id which the backend includes
+ *      when the user has an active club assignment
+ *   3. otherwise                                 → 'all'
+ *
+ * The backend enforces the same scope server-side via PermissionsGuard +
+ * resolveActorLocalField. This helper exists so the UI can hide the LF
+ * selector and pre-fill values for LF-scoped users.
+ */
+export function resolveUserLocalField(
+  user: AuthUser | null | undefined,
+): UserLocalFieldScope {
+  if (!user?.authorization) return { scope: "all" };
+
+  const effective = (user.authorization as Record<string, unknown>).effective as
+    | { scope?: { global?: { local_field?: ScopeNode }; club?: unknown } }
+    | undefined;
+
+  const lfNode = effective?.scope?.global?.local_field;
+  const lfNodeId = lfNode?.id;
+  const lfFromTerritory =
+    typeof lfNodeId === "string"
+      ? parseInt(lfNodeId, 10)
+      : typeof lfNodeId === "number"
+        ? lfNodeId
+        : null;
+  if (lfFromTerritory != null && Number.isFinite(lfFromTerritory)) {
+    return { scope: "single", localFieldId: lfFromTerritory };
+  }
+
+  // Fallback: legacy club hierarchy carries local_field_id for directors
+  const legacy = (user.authorization as Record<string, unknown>).legacy as
+    | { club?: { local_field_id?: number | null } | null }
+    | undefined;
+  const clubLf = legacy?.club?.local_field_id;
+  if (typeof clubLf === "number" && Number.isFinite(clubLf)) {
+    return { scope: "single", localFieldId: clubLf };
+  }
+
+  return { scope: "all" };
+}


### PR DESCRIPTION
## Summary
Admin panel components that consume the per-local-field schema introduced in the backend migration. Each local_field has its own products, bank account, folio sequence, and order namespace; the admin UI lets local field administrators manage their own scope and lets super-admins switch context.

## New screens / components
- `materials/categories/` — full CRUD page for material categories (`categories-table`, `category-form-sheet`, `delete-category-dialog`, `new-category-button`)
- `materials/config/_components/local-field-picker.tsx` — selector that drives which local_field's bank/delivery config is being edited
- `materials/request/[folio]/_components/` — `bank-snapshot-card`, `director-cell`, `order-actions`, `order-metadata-strip`, `order-sticky-bar`, `order-summary-rail`. Render the request review page with local-field-aware metadata
- `components/ui/copy-button.tsx` — reusable copy-to-clipboard button used by bank snapshot for CLABE / reference values
- `lib/auth/user-local-field.ts` — helper resolving active local_field for current user

## Depends on
sacdia-backend `feat/materials-per-local-field` — introduces `local_field_id` columns and per-local-field unique constraints. Admin must merge AFTER backend deploy.

## Test plan
- [ ] `pnpm build` passes
- [ ] Categories CRUD: create, edit, delete scoped to local_field
- [ ] Config picker: super-admin can switch between local_fields; local admin sees only their own
- [ ] Request review page renders bank snapshot, director cell, order metadata correctly
- [ ] Copy button works for CLABE / folio