### PR TITLE
feat(certificate-imports): add admin review console

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -108,7 +108,8 @@
       "materials_receipts": "Receipts",
       "materials_inventory": "Inventory",
       "materials_categories": "Categories",
-      "materials_config": "Settings"
+      "materials_config": "Settings",
+      "certificate_bulk_imports": "Cargas por certificado"
     },
     "breadcrumbs": {
       "dashboard": "Dashboard",
@@ -5132,5 +5133,39 @@
     "secretary": "Secretary",
     "treasurer": "Treasurer",
     "counselor": "Counselor"
+  },
+  "certificate_bulk_imports": {
+    "page": {
+      "title": "Cargas por certificado",
+      "description": "Consola admin para revisar lotes OCR enviados por certificado.",
+      "loadError": "No se pudieron cargar las cargas por certificado.",
+      "emptyTitle": "Sin cargas pendientes",
+      "emptyDescription": "No hay cargas por certificado esperando revisión."
+    },
+    "detailPage": {
+      "title": "Revisión de carga por certificado",
+      "description": "Lote {batchId}: comprobantes, filas OCR y auditoría.",
+      "breadcrumbList": "Cargas por certificado",
+      "loadError": "No se pudo cargar el detalle de la carga.",
+      "emptyTitle": "Carga no disponible",
+      "emptyDescription": "No encontramos datos visibles para este lote."
+    },
+    "actionDialog": {
+      "reasonRequired": "El motivo de rechazo es obligatorio",
+      "reasonMax": "Máximo 1000 caracteres",
+      "commentMax": "Máximo 1000 caracteres",
+      "reasonLabel": "Motivo de rechazo *",
+      "reasonPlaceholder": "Explicá qué debe corregir el miembro...",
+      "commentLabel": "Comentario opcional",
+      "commentPlaceholder": "Agregá una nota interna o visible para auditoría...",
+      "cancel": "Cancelar",
+      "approve": "Aprobar",
+      "reject": "Rechazar",
+      "batchApproved": "Lote aprobado correctamente",
+      "batchRejected": "Lote rechazado para corrección",
+      "itemApproved": "Fila aprobada correctamente",
+      "itemRejected": "Fila rechazada para corrección",
+      "genericError": "No se pudo completar la acción"
+    }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -108,7 +108,8 @@
       "materials_receipts": "Comprobantes",
       "materials_inventory": "Inventario",
       "materials_categories": "Categorías",
-      "materials_config": "Configuración"
+      "materials_config": "Configuración",
+      "certificate_bulk_imports": "Cargas por certificado"
     },
     "breadcrumbs": {
       "dashboard": "Dashboard",
@@ -5151,5 +5152,39 @@
     "secretary": "Secretario",
     "treasurer": "Tesorero",
     "counselor": "Consejero"
+  },
+  "certificate_bulk_imports": {
+    "page": {
+      "title": "Cargas por certificado",
+      "description": "Consola admin para revisar lotes OCR enviados por certificado.",
+      "loadError": "No se pudieron cargar las cargas por certificado.",
+      "emptyTitle": "Sin cargas pendientes",
+      "emptyDescription": "No hay cargas por certificado esperando revisión."
+    },
+    "detailPage": {
+      "title": "Revisión de carga por certificado",
+      "description": "Lote {batchId}: comprobantes, filas OCR y auditoría.",
+      "breadcrumbList": "Cargas por certificado",
+      "loadError": "No se pudo cargar el detalle de la carga.",
+      "emptyTitle": "Carga no disponible",
+      "emptyDescription": "No encontramos datos visibles para este lote."
+    },
+    "actionDialog": {
+      "reasonRequired": "El motivo de rechazo es obligatorio",
+      "reasonMax": "Máximo 1000 caracteres",
+      "commentMax": "Máximo 1000 caracteres",
+      "reasonLabel": "Motivo de rechazo *",
+      "reasonPlaceholder": "Explicá qué debe corregir el miembro...",
+      "commentLabel": "Comentario opcional",
+      "commentPlaceholder": "Agregá una nota interna o visible para auditoría...",
+      "cancel": "Cancelar",
+      "approve": "Aprobar",
+      "reject": "Rechazar",
+      "batchApproved": "Lote aprobado correctamente",
+      "batchRejected": "Lote rechazado para corrección",
+      "itemApproved": "Fila aprobada correctamente",
+      "itemRejected": "Fila rechazada para corrección",
+      "genericError": "No se pudo completar la acción"
+    }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -108,7 +108,8 @@
       "materials_receipts": "Reçus",
       "materials_inventory": "Inventaire",
       "materials_categories": "Catégories",
-      "materials_config": "Paramètres"
+      "materials_config": "Paramètres",
+      "certificate_bulk_imports": "Cargas por certificado"
     },
     "breadcrumbs": {
       "dashboard": "Tableau de bord",
@@ -5010,5 +5011,39 @@
     "secretary": "Secrétaire",
     "treasurer": "Trésorier",
     "counselor": "Conseiller"
+  },
+  "certificate_bulk_imports": {
+    "page": {
+      "title": "Cargas por certificado",
+      "description": "Consola admin para revisar lotes OCR enviados por certificado.",
+      "loadError": "No se pudieron cargar las cargas por certificado.",
+      "emptyTitle": "Sin cargas pendientes",
+      "emptyDescription": "No hay cargas por certificado esperando revisión."
+    },
+    "detailPage": {
+      "title": "Revisión de carga por certificado",
+      "description": "Lote {batchId}: comprobantes, filas OCR y auditoría.",
+      "breadcrumbList": "Cargas por certificado",
+      "loadError": "No se pudo cargar el detalle de la carga.",
+      "emptyTitle": "Carga no disponible",
+      "emptyDescription": "No encontramos datos visibles para este lote."
+    },
+    "actionDialog": {
+      "reasonRequired": "El motivo de rechazo es obligatorio",
+      "reasonMax": "Máximo 1000 caracteres",
+      "commentMax": "Máximo 1000 caracteres",
+      "reasonLabel": "Motivo de rechazo *",
+      "reasonPlaceholder": "Explicá qué debe corregir el miembro...",
+      "commentLabel": "Comentario opcional",
+      "commentPlaceholder": "Agregá una nota interna o visible para auditoría...",
+      "cancel": "Cancelar",
+      "approve": "Aprobar",
+      "reject": "Rechazar",
+      "batchApproved": "Lote aprobado correctamente",
+      "batchRejected": "Lote rechazado para corrección",
+      "itemApproved": "Fila aprobada correctamente",
+      "itemRejected": "Fila rechazada para corrección",
+      "genericError": "No se pudo completar la acción"
+    }
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -108,7 +108,8 @@
       "materials_receipts": "Comprovantes",
       "materials_inventory": "Inventário",
       "materials_categories": "Categorias",
-      "materials_config": "Configurações"
+      "materials_config": "Configurações",
+      "certificate_bulk_imports": "Cargas por certificado"
     },
     "breadcrumbs": {
       "dashboard": "Painel",
@@ -5010,5 +5011,39 @@
     "secretary": "Secretário",
     "treasurer": "Tesoureiro",
     "counselor": "Conselheiro"
+  },
+  "certificate_bulk_imports": {
+    "page": {
+      "title": "Cargas por certificado",
+      "description": "Consola admin para revisar lotes OCR enviados por certificado.",
+      "loadError": "No se pudieron cargar las cargas por certificado.",
+      "emptyTitle": "Sin cargas pendientes",
+      "emptyDescription": "No hay cargas por certificado esperando revisión."
+    },
+    "detailPage": {
+      "title": "Revisión de carga por certificado",
+      "description": "Lote {batchId}: comprobantes, filas OCR y auditoría.",
+      "breadcrumbList": "Cargas por certificado",
+      "loadError": "No se pudo cargar el detalle de la carga.",
+      "emptyTitle": "Carga no disponible",
+      "emptyDescription": "No encontramos datos visibles para este lote."
+    },
+    "actionDialog": {
+      "reasonRequired": "El motivo de rechazo es obligatorio",
+      "reasonMax": "Máximo 1000 caracteres",
+      "commentMax": "Máximo 1000 caracteres",
+      "reasonLabel": "Motivo de rechazo *",
+      "reasonPlaceholder": "Explicá qué debe corregir el miembro...",
+      "commentLabel": "Comentario opcional",
+      "commentPlaceholder": "Agregá una nota interna o visible para auditoría...",
+      "cancel": "Cancelar",
+      "approve": "Aprobar",
+      "reject": "Rechazar",
+      "batchApproved": "Lote aprobado correctamente",
+      "batchRejected": "Lote rechazado para corrección",
+      "itemApproved": "Fila aprobada correctamente",
+      "itemRejected": "Fila rechazada para corrección",
+      "genericError": "No se pudo completar la acción"
+    }
   }
 }

--- a/src/app/(dashboard)/dashboard/certificate-bulk-imports/[batchId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/certificate-bulk-imports/[batchId]/page.tsx
@@ -1,0 +1,67 @@
+import { notFound } from "next/navigation";
+import { getTranslations } from "next-intl/server";
+import { PageHeader } from "@/components/shared/page-header";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { EmptyState } from "@/components/shared/empty-state";
+import { CertificateBulkImportDetailPage } from "@/components/certificate-bulk-imports/certificate-bulk-import-detail-page";
+import { getCertificateBulkImportDetail } from "@/lib/api/certificate-bulk-imports";
+import { ApiError } from "@/lib/api/client";
+import { requireAdminUser } from "@/lib/auth/session";
+import { FileText } from "lucide-react";
+
+interface CertificateBulkImportDetailRouteProps {
+  params: Promise<{ batchId: string }>;
+}
+
+export default async function CertificateBulkImportDetailRoute({
+  params,
+}: CertificateBulkImportDetailRouteProps) {
+  await requireAdminUser();
+  const t = await getTranslations("certificate_bulk_imports.detailPage");
+  const { batchId } = await params;
+
+  let batch = null;
+  let loadError: string | null = null;
+  let loadErrorStatus: number | null = null;
+
+  try {
+    batch = await getCertificateBulkImportDetail(batchId);
+  } catch (error) {
+    if (error instanceof ApiError && error.status === 404) {
+      notFound();
+    }
+    if (error instanceof ApiError) {
+      loadError = error.message;
+      loadErrorStatus = error.status;
+    } else {
+      loadError = t("loadError");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeader
+        title={t("title")}
+        description={t("description", { batchId: batchId.slice(0, 8).toUpperCase() })}
+        breadcrumbs={[
+          { label: "Dashboard", href: "/dashboard" },
+          { label: t("breadcrumbList"), href: "/dashboard/certificate-bulk-imports" },
+          { label: batchId.slice(0, 8).toUpperCase() },
+        ]}
+      />
+
+      {loadError && (
+        <EndpointErrorBanner
+          state={loadErrorStatus === 403 ? "forbidden" : "missing"}
+          detail={loadError}
+        />
+      )}
+
+      {!loadError && !batch && (
+        <EmptyState icon={FileText} title={t("emptyTitle")} description={t("emptyDescription")} />
+      )}
+
+      {!loadError && batch && <CertificateBulkImportDetailPage batch={batch} />}
+    </div>
+  );
+}

--- a/src/app/(dashboard)/dashboard/certificate-bulk-imports/page.tsx
+++ b/src/app/(dashboard)/dashboard/certificate-bulk-imports/page.tsx
@@ -1,0 +1,53 @@
+import { FileText } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { PageHeader } from "@/components/shared/page-header";
+import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { EmptyState } from "@/components/shared/empty-state";
+import { CertificateBulkImportListPage } from "@/components/certificate-bulk-imports/certificate-bulk-import-list-page";
+import {
+  getPendingCertificateBulkImports,
+  type PaginatedCertificateBulkImports,
+} from "@/lib/api/certificate-bulk-imports";
+import { ApiError } from "@/lib/api/client";
+import { requireAdminUser } from "@/lib/auth/session";
+
+export default async function CertificateBulkImportsPage() {
+  await requireAdminUser();
+  const t = await getTranslations("certificate_bulk_imports.page");
+
+  let data: PaginatedCertificateBulkImports = { items: [], total: 0, page: 1, limit: 20 };
+  let loadError: string | null = null;
+  let loadErrorStatus: number | null = null;
+
+  try {
+    data = await getPendingCertificateBulkImports({ page: 1, limit: 100 });
+  } catch (error) {
+    if (error instanceof ApiError) {
+      loadError = error.message;
+      loadErrorStatus = error.status;
+    } else {
+      loadError = t("loadError");
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <PageHeader title={t("title")} description={t("description")} />
+
+      {loadError && (
+        <EndpointErrorBanner
+          state={loadErrorStatus === 403 ? "forbidden" : "missing"}
+          detail={loadError}
+        />
+      )}
+
+      {!loadError && data.items.length === 0 && (
+        <EmptyState icon={FileText} title={t("emptyTitle")} description={t("emptyDescription")} />
+      )}
+
+      {!loadError && data.items.length > 0 && (
+        <CertificateBulkImportListPage batches={data.items} total={data.total} />
+      )}
+    </div>
+  );
+}

--- a/src/components/certificate-bulk-imports/certificate-bulk-import-action-dialog.test.tsx
+++ b/src/components/certificate-bulk-imports/certificate-bulk-import-action-dialog.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+const mockApproveBatch = vi.fn();
+const mockRejectBatch = vi.fn();
+const mockApproveItem = vi.fn();
+const mockRejectItem = vi.fn();
+
+vi.mock("@/lib/api/certificate-bulk-imports", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/certificate-bulk-imports")>();
+  return {
+    ...original,
+    approveCertificateBulkImportBatch: (...args: unknown[]) => mockApproveBatch(...args),
+    rejectCertificateBulkImportBatch: (...args: unknown[]) => mockRejectBatch(...args),
+    approveCertificateBulkImportItem: (...args: unknown[]) => mockApproveItem(...args),
+    rejectCertificateBulkImportItem: (...args: unknown[]) => mockRejectItem(...args),
+  };
+});
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock("sonner", () => ({
+  toast: {
+    success: (message: string) => mockToastSuccess(message),
+    error: (message: string) => mockToastError(message),
+  },
+}));
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+import { CertificateBulkImportActionDialog } from "@/components/certificate-bulk-imports/certificate-bulk-import-action-dialog";
+
+function renderDialog(props: Partial<React.ComponentProps<typeof CertificateBulkImportActionDialog>> = {}) {
+  const onOpenChange = vi.fn();
+  const onSuccess = vi.fn();
+
+  render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <CertificateBulkImportActionDialog
+        open
+        action="reject"
+        scope="batch"
+        batchId="batch-1"
+        title="Rechazar lote completo"
+        description="El miembro podrá corregir el lote."
+        onOpenChange={onOpenChange}
+        onSuccess={onSuccess}
+        {...props}
+      />
+    </NextIntlClientProvider>,
+  );
+
+  return { onOpenChange, onSuccess };
+}
+
+describe("CertificateBulkImportActionDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApproveBatch.mockResolvedValue({ status: "APPROVED" });
+    mockRejectBatch.mockResolvedValue({ status: "NEEDS_CORRECTION" });
+    mockApproveItem.mockResolvedValue({ status: "APPROVED" });
+    mockRejectItem.mockResolvedValue({ status: "REJECTED" });
+  });
+
+  afterEach(() => cleanup());
+
+  it("requires a rejection reason before calling the API", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole("button", { name: /rechazar/i }));
+
+    expect(await screen.findByText(/motivo de rechazo es obligatorio/i)).toBeInTheDocument();
+    expect(mockRejectBatch).not.toHaveBeenCalled();
+  });
+
+  it("calls batch reject with trimmed reason", async () => {
+    const user = userEvent.setup();
+    const { onSuccess } = renderDialog();
+
+    await user.type(screen.getByLabelText(/motivo de rechazo/i), "  Fecha ilegible  ");
+    await user.click(screen.getByRole("button", { name: /rechazar/i }));
+
+    await waitFor(() => {
+      expect(mockRejectBatch).toHaveBeenCalledWith("batch-1", { reason: "Fecha ilegible" });
+    });
+    expect(onSuccess).toHaveBeenCalledOnce();
+  });
+
+  it("calls item approve with optional trimmed comment", async () => {
+    const user = userEvent.setup();
+    renderDialog({
+      action: "approve",
+      scope: "item",
+      itemId: "item-1",
+      title: "Aprobar fila",
+      description: "La fila se aplicará al perfil del miembro.",
+    });
+
+    await user.type(screen.getByLabelText(/comentario/i), "  Validado contra comprobante  ");
+    await user.click(screen.getByRole("button", { name: /aprobar/i }));
+
+    await waitFor(() => {
+      expect(mockApproveItem).toHaveBeenCalledWith("batch-1", "item-1", {
+        comment: "Validado contra comprobante",
+      });
+    });
+  });
+});

--- a/src/components/certificate-bulk-imports/certificate-bulk-import-action-dialog.tsx
+++ b/src/components/certificate-bulk-imports/certificate-bulk-import-action-dialog.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useTranslations } from "next-intl";
+import { CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { ApiError } from "@/lib/api/client";
+import {
+  approveCertificateBulkImportBatch,
+  approveCertificateBulkImportItem,
+  rejectCertificateBulkImportBatch,
+  rejectCertificateBulkImportItem,
+} from "@/lib/api/certificate-bulk-imports";
+
+type Action = "approve" | "reject";
+type Scope = "batch" | "item";
+
+type FormValues = {
+  comment: string;
+  reason: string;
+};
+
+export interface CertificateBulkImportActionDialogProps {
+  open: boolean;
+  action: Action;
+  scope: Scope;
+  batchId: string;
+  itemId?: string;
+  title: string;
+  description: string;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+function trimOptional(value?: string) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function CertificateBulkImportActionDialog({
+  open,
+  action,
+  scope,
+  batchId,
+  itemId,
+  title,
+  description,
+  onOpenChange,
+  onSuccess,
+}: CertificateBulkImportActionDialogProps) {
+  const t = useTranslations("certificate_bulk_imports.actionDialog");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const isReject = action === "reject";
+
+  const schema = useMemo(
+    () =>
+      z.object({
+        comment: z.string().max(1000, t("commentMax")),
+        reason: isReject
+          ? z.string().trim().min(1, t("reasonRequired")).max(1000, t("reasonMax"))
+          : z.string(),
+      }),
+    [isReject, t],
+  );
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(schema),
+    defaultValues: { comment: "", reason: "" },
+  });
+
+  function handleClose(nextOpen: boolean) {
+    if (isSubmitting) return;
+    if (!nextOpen) form.reset();
+    onOpenChange(nextOpen);
+  }
+
+  const submit = form.handleSubmit(async (values) => {
+    setIsSubmitting(true);
+    try {
+      if (isReject) {
+        const reason = values.reason?.trim() ?? "";
+        if (scope === "item") {
+          if (!itemId) throw new Error("Missing item id");
+          await rejectCertificateBulkImportItem(batchId, itemId, { reason });
+        } else {
+          await rejectCertificateBulkImportBatch(batchId, { reason });
+        }
+        toast.success(t(scope === "item" ? "itemRejected" : "batchRejected"));
+      } else {
+        const payload = { comment: trimOptional(values.comment) };
+        if (scope === "item") {
+          if (!itemId) throw new Error("Missing item id");
+          await approveCertificateBulkImportItem(batchId, itemId, payload);
+        } else {
+          await approveCertificateBulkImportBatch(batchId, payload);
+        }
+        toast.success(t(scope === "item" ? "itemApproved" : "batchApproved"));
+      }
+      form.reset();
+      onSuccess();
+    } catch (error) {
+      const message = error instanceof ApiError ? error.message : t("genericError");
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {isReject ? (
+              <XCircle className="text-destructive" aria-hidden="true" />
+            ) : (
+              <CheckCircle2 className="text-success" aria-hidden="true" />
+            )}
+            {title}
+          </DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <Form {...form}>
+          <form onSubmit={submit} className="flex flex-col gap-4">
+            {isReject ? (
+              <FormField
+                control={form.control}
+                name="reason"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("reasonLabel")}</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        rows={4}
+                        placeholder={t("reasonPlaceholder")}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : (
+              <FormField
+                control={form.control}
+                name="comment"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>{t("commentLabel")}</FormLabel>
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        rows={3}
+                        placeholder={t("commentPlaceholder")}
+                        disabled={isSubmitting}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleClose(false)}
+                disabled={isSubmitting}
+              >
+                {t("cancel")}
+              </Button>
+              <Button
+                type="submit"
+                variant={isReject ? "destructive" : "default"}
+                disabled={isSubmitting}
+              >
+                {isSubmitting && <Loader2 className="animate-spin" aria-hidden="true" />}
+                {isReject ? t("reject") : t("approve")}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/certificate-bulk-imports/certificate-bulk-import-badges.tsx
+++ b/src/components/certificate-bulk-imports/certificate-bulk-import-badges.tsx
@@ -1,0 +1,44 @@
+import { Badge } from "@/components/ui/badge";
+import type {
+  CertificateBulkImportBatchStatus,
+  CertificateBulkImportItemStatus,
+  CertificateBulkImportItemType,
+} from "@/lib/api/certificate-bulk-imports";
+
+const batchLabels: Record<CertificateBulkImportBatchStatus, string> = {
+  DRAFT: "Borrador",
+  READY_TO_SUBMIT: "Listo",
+  SUBMITTED: "Pendiente",
+  PARTIALLY_APPROVED: "Parcial",
+  APPROVED: "Aprobado",
+  REJECTED: "Rechazado",
+  NEEDS_CORRECTION: "Corrección",
+};
+
+const itemLabels: Record<CertificateBulkImportItemStatus, string> = {
+  NEEDS_REVIEW: "Revisar",
+  READY: "Listo",
+  SUBMITTED: "Pendiente",
+  APPROVED: "Aprobada",
+  REJECTED: "Rechazada",
+  RESUBMITTED: "Reenviada",
+};
+
+function variantForStatus(status: string): React.ComponentProps<typeof Badge>["variant"] {
+  if (status === "APPROVED") return "soft-success";
+  if (status === "REJECTED") return "destructive";
+  if (status === "NEEDS_CORRECTION" || status === "PARTIALLY_APPROVED") return "soft-warning";
+  return "soft-info";
+}
+
+export function CertificateBatchStatusBadge({ status }: { status: CertificateBulkImportBatchStatus }) {
+  return <Badge variant={variantForStatus(status)}>{batchLabels[status] ?? status}</Badge>;
+}
+
+export function CertificateItemStatusBadge({ status }: { status: CertificateBulkImportItemStatus }) {
+  return <Badge variant={variantForStatus(status)}>{itemLabels[status] ?? status}</Badge>;
+}
+
+export function CertificateItemTypeBadge({ type }: { type: CertificateBulkImportItemType }) {
+  return <Badge variant="outline">{type === "HONOR" ? "Especialidad" : "Clase"}</Badge>;
+}

--- a/src/components/certificate-bulk-imports/certificate-bulk-import-detail-page.tsx
+++ b/src/components/certificate-bulk-imports/certificate-bulk-import-detail-page.tsx
@@ -1,0 +1,345 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import {
+  ArrowLeft,
+  CheckCircle2,
+  ExternalLink,
+  FileText,
+  ImageIcon,
+  XCircle,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Separator } from "@/components/ui/separator";
+import { EmptyState } from "@/components/shared/empty-state";
+import { CertificateBulkImportActionDialog } from "@/components/certificate-bulk-imports/certificate-bulk-import-action-dialog";
+import {
+  CertificateBatchStatusBadge,
+  CertificateItemStatusBadge,
+  CertificateItemTypeBadge,
+} from "@/components/certificate-bulk-imports/certificate-bulk-import-badges";
+import { CertificateBulkImportProgress } from "@/components/certificate-bulk-imports/certificate-bulk-import-progress";
+import {
+  confidenceLabel,
+  confidencePercent,
+  formatDateTime,
+  formatShortId,
+  formatUserName,
+  getBatchCounts,
+  isReviewableItem,
+  itemCatalogName,
+} from "@/components/certificate-bulk-imports/helpers";
+import type {
+  CertificateBulkImportBatch,
+  CertificateBulkImportFile,
+  CertificateBulkImportItem,
+} from "@/lib/api/certificate-bulk-imports";
+
+type DialogState =
+  | { action: "approve"; scope: "batch" }
+  | { action: "reject"; scope: "batch" }
+  | { action: "approve"; scope: "item"; item: CertificateBulkImportItem }
+  | { action: "reject"; scope: "item"; item: CertificateBulkImportItem }
+  | null;
+
+function isImage(file: CertificateBulkImportFile) {
+  return file.file_type.toLowerCase().startsWith("image/") || /\.(png|jpe?g|webp)$/i.test(file.file_name);
+}
+
+function isPdf(file: CertificateBulkImportFile) {
+  return file.file_type.toLowerCase().includes("pdf") || /\.pdf$/i.test(file.file_name);
+}
+
+function ProofViewer({ files }: { files: CertificateBulkImportFile[] }) {
+  const [activeFileId, setActiveFileId] = useState(files[0]?.file_id ?? "");
+  const activeFile = files.find((file) => file.file_id === activeFileId) ?? files[0];
+
+  if (!activeFile) {
+    return (
+      <Card className="min-h-[520px]">
+        <CardContent className="flex flex-1 items-center justify-center">
+          <EmptyState
+            icon={FileText}
+            title="Sin comprobantes"
+            description="El lote no incluye archivos visibles para revisión."
+          />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="overflow-hidden py-0">
+      <CardHeader className="border-b px-4 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0">
+            <CardTitle className="truncate text-base">{activeFile.file_name}</CardTitle>
+            <p className="text-xs text-muted-foreground">Subido {formatDateTime(activeFile.uploaded_at)}</p>
+          </div>
+          <Button variant="outline" size="sm" asChild>
+            <Link href={activeFile.file_url} target="_blank" rel="noreferrer">
+              Abrir
+              <ExternalLink aria-hidden="true" />
+            </Link>
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="flex min-h-[520px] items-center justify-center bg-muted/40 p-4">
+          {isImage(activeFile) ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={activeFile.file_url}
+              alt={activeFile.file_name}
+              className="max-h-[70vh] rounded-lg border bg-background object-contain shadow-xs"
+            />
+          ) : isPdf(activeFile) ? (
+            <iframe
+              title={activeFile.file_name}
+              src={activeFile.file_url}
+              className="h-[70vh] w-full rounded-lg border bg-background"
+            />
+          ) : (
+            <div className="flex flex-col items-center gap-3 text-center text-muted-foreground">
+              <ImageIcon aria-hidden="true" />
+              <p className="text-sm">Vista previa no disponible para este tipo de archivo.</p>
+            </div>
+          )}
+        </div>
+        {files.length > 1 && (
+          <div className="flex gap-2 overflow-x-auto border-t p-3">
+            {files.map((file) => (
+              <Button
+                key={file.file_id}
+                type="button"
+                variant={file.file_id === activeFile.file_id ? "default" : "outline"}
+                size="sm"
+                onClick={() => setActiveFileId(file.file_id)}
+              >
+                {file.file_name}
+              </Button>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ItemRow({
+  item,
+  onApprove,
+  onReject,
+}: {
+  item: CertificateBulkImportItem;
+  onApprove: () => void;
+  onReject: () => void;
+}) {
+  const reviewable = isReviewableItem(item);
+
+  return (
+    <div className="rounded-xl border bg-card p-3 shadow-xs">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <CertificateItemTypeBadge type={item.item_type} />
+            <CertificateItemStatusBadge status={item.status} />
+            <Badge variant="outline">OCR {confidencePercent(item.ocr_confidence)} · {confidenceLabel(item.ocr_confidence)}</Badge>
+          </div>
+          <div className="font-medium">{item.detected_name ?? "Sin nombre detectado"}</div>
+          <div className="text-sm text-muted-foreground">
+            Catálogo: {itemCatalogName(item)} · Fecha: {formatDateTime(item.detected_date ?? item.completed_at)}
+          </div>
+          {item.rejection_reason && (
+            <div className="rounded-lg bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              Motivo: {item.rejection_reason}
+            </div>
+          )}
+        </div>
+        {reviewable && (
+          <div className="flex gap-2 lg:justify-end">
+            <Button variant="outline" size="sm" onClick={onReject}>
+              <XCircle aria-hidden="true" />
+              Rechazar
+            </Button>
+            <Button size="sm" onClick={onApprove}>
+              <CheckCircle2 aria-hidden="true" />
+              Aprobar
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AuditTimeline({ batch }: { batch: CertificateBulkImportBatch }) {
+  const events = batch.events ?? [];
+  if (events.length === 0) {
+    return (
+      <EmptyState
+        icon={FileText}
+        title="Sin auditoría"
+        description="Todavía no hay eventos registrados para este lote."
+        variant="no-results"
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      {events.map((event) => (
+        <div key={event.event_id} className="rounded-xl border bg-card p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <Badge variant="outline">{event.action}</Badge>
+            <span className="text-xs text-muted-foreground">{formatDateTime(event.created_at)}</span>
+          </div>
+          {event.comment && <p className="mt-2 text-sm text-muted-foreground">{event.comment}</p>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function CertificateBulkImportDetailPage({ batch }: { batch: CertificateBulkImportBatch }) {
+  const router = useRouter();
+  const [dialog, setDialog] = useState<DialogState>(null);
+  const [, startTransition] = useTransition();
+  const counts = useMemo(() => getBatchCounts(batch), [batch]);
+  const files = batch.files ?? [];
+  const items = batch.items ?? [];
+  const hasReviewableItems = items.some(isReviewableItem);
+
+  function handleSuccess() {
+    setDialog(null);
+    startTransition(() => router.refresh());
+  }
+
+  const dialogTitle = dialog?.scope === "batch"
+    ? dialog.action === "approve" ? "Aprobar lote" : "Rechazar lote completo"
+    : dialog?.action === "approve" ? "Aprobar fila" : "Rechazar fila";
+
+  const dialogDescription = dialog?.scope === "batch"
+    ? dialog.action === "approve"
+      ? `Se aprobarán ${counts.pending} filas pendientes. Las rechazadas no se modifican.`
+      : "El miembro recibirá el motivo y podrá corregir el lote."
+    : dialog?.action === "approve"
+      ? "La fila se aplicará al perfil del miembro."
+      : "Solo esta fila será marcada para corrección.";
+
+  return (
+    <div className="flex flex-col gap-4">
+      <Button variant="ghost" size="sm" className="w-fit" asChild>
+        <Link href="/dashboard/certificate-bulk-imports">
+          <ArrowLeft aria-hidden="true" />
+          Volver a cargas
+        </Link>
+      </Button>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(420px,0.85fr)]">
+        <ProofViewer files={files} />
+
+        <div className="flex min-w-0 flex-col gap-4">
+          <Card>
+            <CardHeader>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                <div className="min-w-0">
+                  <CardTitle className="text-xl">{formatUserName(batch.user)}</CardTitle>
+                  <p className="text-sm text-muted-foreground">
+                    Lote {formatShortId(batch.batch_id)} · Enviado {formatDateTime(batch.submitted_at)}
+                  </p>
+                </div>
+                <CertificateBatchStatusBadge status={batch.status} />
+              </div>
+            </CardHeader>
+            <CardContent className="flex flex-col gap-4">
+              <CertificateBulkImportProgress
+                approved={counts.approved}
+                rejected={counts.rejected}
+                pending={counts.pending + counts.needsReview}
+                total={counts.total}
+                className="max-w-xs"
+              />
+              <div className="grid grid-cols-4 gap-2 text-center">
+                <Stat label="Total" value={counts.total} />
+                <Stat label="Aprobadas" value={counts.approved} />
+                <Stat label="Rechazadas" value={counts.rejected} />
+                <Stat label="Pendientes" value={counts.pending} />
+              </div>
+              <Separator />
+              <div className="flex flex-col gap-2 sm:flex-row sm:justify-end">
+                <Button
+                  variant="outline"
+                  disabled={!hasReviewableItems}
+                  onClick={() => setDialog({ action: "reject", scope: "batch" })}
+                >
+                  <XCircle aria-hidden="true" />
+                  Rechazar lote
+                </Button>
+                <Button
+                  disabled={!hasReviewableItems}
+                  onClick={() => setDialog({ action: "approve", scope: "batch" })}
+                >
+                  <CheckCircle2 aria-hidden="true" />
+                  Aprobar lote
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+
+          <Tabs defaultValue="items">
+            <TabsList variant="line">
+              <TabsTrigger value="items">Filas · {items.length}</TabsTrigger>
+              <TabsTrigger value="audit">Auditoría · {(batch.events ?? []).length}</TabsTrigger>
+            </TabsList>
+            <TabsContent value="items" className="flex flex-col gap-2">
+              {items.length === 0 ? (
+                <EmptyState icon={FileText} title="Sin filas" description="No hay resultados OCR para revisar." />
+              ) : (
+                items.map((item) => (
+                  <ItemRow
+                    key={item.item_id}
+                    item={item}
+                    onApprove={() => setDialog({ action: "approve", scope: "item", item })}
+                    onReject={() => setDialog({ action: "reject", scope: "item", item })}
+                  />
+                ))
+              )}
+            </TabsContent>
+            <TabsContent value="audit">
+              <AuditTimeline batch={batch} />
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+
+      {dialog && (
+        <CertificateBulkImportActionDialog
+          open={Boolean(dialog)}
+          action={dialog.action}
+          scope={dialog.scope}
+          batchId={batch.batch_id}
+          itemId={dialog.scope === "item" ? dialog.item.item_id : undefined}
+          title={dialogTitle}
+          description={dialogDescription}
+          onOpenChange={(open) => !open && setDialog(null)}
+          onSuccess={handleSuccess}
+        />
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg bg-muted/50 px-2 py-3">
+      <div className="text-xl font-bold tabular-nums">{value}</div>
+      <div className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">{label}</div>
+    </div>
+  );
+}

--- a/src/components/certificate-bulk-imports/certificate-bulk-import-list-page.tsx
+++ b/src/components/certificate-bulk-imports/certificate-bulk-import-list-page.tsx
@@ -1,0 +1,190 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { ArrowRight, FileText, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { EmptyState } from "@/components/shared/empty-state";
+import { CertificateBatchStatusBadge } from "@/components/certificate-bulk-imports/certificate-bulk-import-badges";
+import { CertificateBulkImportProgress } from "@/components/certificate-bulk-imports/certificate-bulk-import-progress";
+import {
+  formatDateTime,
+  formatShortId,
+  formatUserName,
+  getBatchCounts,
+} from "@/components/certificate-bulk-imports/helpers";
+import type { CertificateBulkImportBatch } from "@/lib/api/certificate-bulk-imports";
+
+interface CertificateBulkImportListPageProps {
+  batches: CertificateBulkImportBatch[];
+  total: number;
+}
+
+function KpiCard({ label, value, hint }: { label: string; value: number; hint: string }) {
+  return (
+    <Card className="py-4">
+      <CardHeader className="px-4 pb-0">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
+      </CardHeader>
+      <CardContent className="px-4 pt-2">
+        <div className="text-3xl font-bold tabular-nums">{value}</div>
+        <p className="text-xs text-muted-foreground">{hint}</p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function CertificateBulkImportListPage({ batches, total }: CertificateBulkImportListPageProps) {
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState<"all" | "SUBMITTED" | "PARTIALLY_APPROVED" | "NEEDS_CORRECTION">("all");
+
+  const filteredBatches = useMemo(() => {
+    const normalized = query.trim().toLowerCase();
+    return batches.filter((batch) => {
+      const matchesStatus = status === "all" || batch.status === status;
+      if (!matchesStatus) return false;
+      if (!normalized) return true;
+      return [formatUserName(batch.user), batch.batch_id, batch.user?.email]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(normalized));
+    });
+  }, [batches, query, status]);
+
+  const pendingRows = batches.reduce((sum, batch) => sum + getBatchCounts(batch).pending, 0);
+  const correctionBatches = batches.filter((batch) => batch.status === "NEEDS_CORRECTION").length;
+  const submittedBatches = batches.filter((batch) => batch.status === "SUBMITTED").length;
+
+  if (batches.length === 0) {
+    return (
+      <EmptyState
+        icon={FileText}
+        title="Sin cargas pendientes"
+        description="No hay cargas por certificado esperando revisión."
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="grid gap-3 md:grid-cols-4">
+        <KpiCard label="Lotes pendientes" value={submittedBatches} hint={`${total} en bandeja`} />
+        <KpiCard label="Filas por revisar" value={pendingRows} hint="Listas para decisión" />
+        <KpiCard label="Con correcciones" value={correctionBatches} hint="Devueltas al miembro" />
+        <KpiCard label="Total cargado" value={total} hint="Según API admin" />
+      </div>
+
+      <Card className="py-0">
+        <CardHeader className="border-b px-4 py-4">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div>
+              <CardTitle>Cargas por certificado</CardTitle>
+              <p className="text-sm text-muted-foreground">Revisá OCR, comprobantes y filas detectadas.</p>
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-2.5 top-2.5 text-muted-foreground" aria-hidden="true" />
+                <Input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Buscar miembro o lote"
+                  className="pl-8 sm:w-64"
+                />
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {[
+                  ["all", "Todos"],
+                  ["SUBMITTED", "Pendientes"],
+                  ["PARTIALLY_APPROVED", "Parciales"],
+                  ["NEEDS_CORRECTION", "Corrección"],
+                ].map(([value, label]) => (
+                  <Button
+                    key={value}
+                    type="button"
+                    variant={status === value ? "default" : "outline"}
+                    size="sm"
+                    onClick={() => setStatus(value as typeof status)}
+                  >
+                    {label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Lote</TableHead>
+                  <TableHead>Miembro</TableHead>
+                  <TableHead>Enviado</TableHead>
+                  <TableHead>Estado</TableHead>
+                  <TableHead>Progreso</TableHead>
+                  <TableHead className="text-right">Acción</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredBatches.map((batch) => {
+                  const counts = getBatchCounts(batch);
+                  return (
+                    <TableRow key={batch.batch_id}>
+                      <TableCell className="font-mono text-xs">
+                        <Badge variant="outline">{formatShortId(batch.batch_id)}</Badge>
+                      </TableCell>
+                      <TableCell>
+                        <div className="font-medium">{formatUserName(batch.user)}</div>
+                        <div className="text-xs text-muted-foreground">{batch.user?.email ?? "Sin email"}</div>
+                      </TableCell>
+                      <TableCell className="whitespace-nowrap text-sm text-muted-foreground">
+                        {formatDateTime(batch.submitted_at)}
+                      </TableCell>
+                      <TableCell><CertificateBatchStatusBadge status={batch.status} /></TableCell>
+                      <TableCell>
+                        <CertificateBulkImportProgress
+                          approved={counts.approved}
+                          rejected={counts.rejected}
+                          pending={counts.pending + counts.needsReview}
+                          total={counts.total}
+                        />
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button size="sm" asChild>
+                          <Link href={`/dashboard/certificate-bulk-imports/${batch.batch_id}`}>
+                            Revisar
+                            <ArrowRight aria-hidden="true" />
+                          </Link>
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </div>
+          {filteredBatches.length === 0 && (
+            <div className="p-6">
+              <EmptyState
+                icon={Search}
+                title="Sin resultados"
+                description="No hay lotes que coincidan con el filtro actual."
+                variant="no-results"
+              />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/certificate-bulk-imports/certificate-bulk-import-progress.tsx
+++ b/src/components/certificate-bulk-imports/certificate-bulk-import-progress.tsx
@@ -1,0 +1,41 @@
+import { cn } from "@/lib/utils";
+
+export function CertificateBulkImportProgress({
+  approved,
+  rejected,
+  pending,
+  total,
+  className,
+}: {
+  approved: number;
+  rejected: number;
+  pending: number;
+  total: number;
+  className?: string;
+}) {
+  const safeTotal = Math.max(total, 1);
+  const segments = [
+    { value: approved, className: "bg-success" },
+    { value: rejected, className: "bg-destructive" },
+    { value: pending, className: "bg-warning" },
+  ];
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <div className="flex h-2 w-24 overflow-hidden rounded-full bg-muted" aria-hidden="true">
+        {segments.map((segment, index) =>
+          segment.value > 0 ? (
+            <div
+              key={index}
+              className={segment.className}
+              style={{ width: `${(segment.value / safeTotal) * 100}%` }}
+            />
+          ) : null,
+        )}
+      </div>
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {approved}/{total}
+      </span>
+    </div>
+  );
+}

--- a/src/components/certificate-bulk-imports/helpers.ts
+++ b/src/components/certificate-bulk-imports/helpers.ts
@@ -1,0 +1,62 @@
+import type {
+  CertificateBulkImportBatch,
+  CertificateBulkImportItem,
+  CertificateBulkImportUser,
+} from "@/lib/api/certificate-bulk-imports";
+
+export function formatUserName(user?: CertificateBulkImportUser | null): string {
+  if (!user) return "Miembro sin nombre";
+  const parts = [user.name, user.paternal_last_name, user.maternal_last_name]
+    .map((part) => part?.trim())
+    .filter(Boolean);
+  return parts.length > 0 ? parts.join(" ") : user.email ?? "Miembro sin nombre";
+}
+
+export function formatShortId(id: string): string {
+  return id.length <= 8 ? id : id.slice(0, 8).toUpperCase();
+}
+
+export function formatDateTime(value?: string | null): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("es-MX", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).format(date);
+}
+
+export function itemCatalogName(item: CertificateBulkImportItem): string {
+  return item.honor?.name ?? item.class?.name ?? "Sin match";
+}
+
+export function getBatchCounts(batch: CertificateBulkImportBatch) {
+  const items = batch.items ?? [];
+  return {
+    total: items.length,
+    approved: items.filter((item) => item.status === "APPROVED").length,
+    rejected: items.filter((item) => item.status === "REJECTED").length,
+    pending: items.filter((item) => item.status === "SUBMITTED" || item.status === "RESUBMITTED").length,
+    needsReview: items.filter((item) => item.status === "NEEDS_REVIEW" || item.status === "READY").length,
+  };
+}
+
+export function isReviewableItem(item: CertificateBulkImportItem): boolean {
+  return item.status === "SUBMITTED" || item.status === "RESUBMITTED";
+}
+
+export function confidenceLabel(value?: number | null): string {
+  if (typeof value !== "number") return "—";
+  if (value >= 0.85) return "Alta";
+  if (value >= 0.65) return "Media";
+  return "Baja";
+}
+
+export function confidencePercent(value?: number | null): string {
+  if (typeof value !== "number") return "—";
+  return `${Math.round(value * 100)}%`;
+}

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -275,6 +275,12 @@ export const navConfig: NavGroup[] = [
         permission: "investiture:read",
       },
       {
+        title: "items.certificate_bulk_imports",
+        url: "/dashboard/certificate-bulk-imports",
+        icon: FileText,
+        permission: "investiture:read",
+      },
+      {
         title: "items.investiture",
         url: "/dashboard/investiture",
         icon: Star,

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -138,6 +138,7 @@ export interface IntlMessages {
       materials_inventory: string;
       materials_categories: string;
       materials_config: string;
+      certificate_bulk_imports: string;
     };
     breadcrumbs: {
       dashboard: string;
@@ -5180,5 +5181,39 @@ export interface IntlMessages {
     secretary: string;
     treasurer: string;
     counselor: string;
+  };
+  certificate_bulk_imports: {
+    page: {
+      title: string;
+      description: string;
+      loadError: string;
+      emptyTitle: string;
+      emptyDescription: string;
+    };
+    detailPage: {
+      title: string;
+      description: string;
+      breadcrumbList: string;
+      loadError: string;
+      emptyTitle: string;
+      emptyDescription: string;
+    };
+    actionDialog: {
+      reasonRequired: string;
+      reasonMax: string;
+      commentMax: string;
+      reasonLabel: string;
+      reasonPlaceholder: string;
+      commentLabel: string;
+      commentPlaceholder: string;
+      cancel: string;
+      approve: string;
+      reject: string;
+      batchApproved: string;
+      batchRejected: string;
+      itemApproved: string;
+      itemRejected: string;
+      genericError: string;
+    };
   };
 }

--- a/src/lib/api/certificate-bulk-imports.test.ts
+++ b/src/lib/api/certificate-bulk-imports.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockApiRequest = vi.fn();
+const mockApiRequestFromClient = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+  apiRequestFromClient: (...args: unknown[]) => mockApiRequestFromClient(...args),
+}));
+
+import {
+  approveCertificateBulkImportBatch,
+  approveCertificateBulkImportItem,
+  getCertificateBulkImportDetail,
+  getPendingCertificateBulkImports,
+  rejectCertificateBulkImportBatch,
+  rejectCertificateBulkImportItem,
+} from "@/lib/api/certificate-bulk-imports";
+
+describe("certificate bulk imports API client", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("unwraps pending batches from the standard { status, data } envelope", async () => {
+    const data = { items: [{ batch_id: "batch-1" }], total: 1, page: 2, limit: 10 };
+    mockApiRequest.mockResolvedValue({ status: "success", data });
+
+    await expect(getPendingCertificateBulkImports({ page: 2, limit: 10 })).resolves.toBe(data);
+
+    expect(mockApiRequest).toHaveBeenCalledWith("/admin/certificate-bulk-imports/pending", {
+      params: { page: 2, limit: 10 },
+    });
+  });
+
+  it("fetches a batch detail by id and unwraps the envelope", async () => {
+    const data = { batch_id: "batch-1", items: [] };
+    mockApiRequest.mockResolvedValue({ status: "success", data });
+
+    await expect(getCertificateBulkImportDetail("batch-1")).resolves.toBe(data);
+
+    expect(mockApiRequest).toHaveBeenCalledWith("/admin/certificate-bulk-imports/batch-1");
+  });
+
+  it("sends batch approve/reject mutations through the client request helper", async () => {
+    mockApiRequestFromClient.mockResolvedValueOnce({ status: "success", data: { status: "APPROVED" } });
+    mockApiRequestFromClient.mockResolvedValueOnce({ status: "success", data: { status: "NEEDS_CORRECTION" } });
+
+    await approveCertificateBulkImportBatch("batch-1", { comment: "OK" });
+    await rejectCertificateBulkImportBatch("batch-1", { reason: "Fecha ilegible" });
+
+    expect(mockApiRequestFromClient).toHaveBeenNthCalledWith(1, "/admin/certificate-bulk-imports/batch-1/approve", {
+      method: "POST",
+      body: { comment: "OK" },
+    });
+    expect(mockApiRequestFromClient).toHaveBeenNthCalledWith(2, "/admin/certificate-bulk-imports/batch-1/reject", {
+      method: "POST",
+      body: { reason: "Fecha ilegible" },
+    });
+  });
+
+  it("sends item approve/reject mutations with batch and item ids", async () => {
+    mockApiRequestFromClient.mockResolvedValue({ status: "success", data: { item_id: "item-1" } });
+
+    await approveCertificateBulkImportItem("batch-1", "item-1", { comment: "Validado" });
+    await rejectCertificateBulkImportItem("batch-1", "item-1", { reason: "Sin firma" });
+
+    expect(mockApiRequestFromClient).toHaveBeenNthCalledWith(1, "/admin/certificate-bulk-imports/batch-1/items/item-1/approve", {
+      method: "POST",
+      body: { comment: "Validado" },
+    });
+    expect(mockApiRequestFromClient).toHaveBeenNthCalledWith(2, "/admin/certificate-bulk-imports/batch-1/items/item-1/reject", {
+      method: "POST",
+      body: { reason: "Sin firma" },
+    });
+  });
+});

--- a/src/lib/api/certificate-bulk-imports.ts
+++ b/src/lib/api/certificate-bulk-imports.ts
@@ -1,0 +1,179 @@
+import { apiRequest, apiRequestFromClient } from "@/lib/api/client";
+
+export type CertificateBulkImportBatchStatus =
+  | "DRAFT"
+  | "READY_TO_SUBMIT"
+  | "SUBMITTED"
+  | "PARTIALLY_APPROVED"
+  | "APPROVED"
+  | "REJECTED"
+  | "NEEDS_CORRECTION";
+
+export type CertificateBulkImportItemStatus =
+  | "NEEDS_REVIEW"
+  | "READY"
+  | "SUBMITTED"
+  | "APPROVED"
+  | "REJECTED"
+  | "RESUBMITTED";
+
+export type CertificateBulkImportItemType = "HONOR" | "CLASS";
+
+export type CertificateBulkImportUser = {
+  user_id: string;
+  name?: string | null;
+  paternal_last_name?: string | null;
+  maternal_last_name?: string | null;
+  email?: string | null;
+};
+
+export type CertificateBulkImportFile = {
+  file_id: string;
+  batch_id: string;
+  file_url: string;
+  file_name: string;
+  file_type: string;
+  uploaded_at: string;
+  ocr_raw_text?: string | null;
+};
+
+export type CertificateBulkImportItem = {
+  item_id: string;
+  batch_id: string;
+  item_type: CertificateBulkImportItemType;
+  detected_name?: string | null;
+  detected_date?: string | null;
+  completed_at?: string | null;
+  ocr_confidence?: number | null;
+  field_confidence?: unknown;
+  status: CertificateBulkImportItemStatus;
+  rejection_reason?: string | null;
+  reviewed_at?: string | null;
+  applied_entity_type?: string | null;
+  applied_entity_id?: number | null;
+  honor?: { honor_id: number; name: string } | null;
+  class?: { class_id: number; name: string } | null;
+};
+
+export type CertificateBulkImportEvent = {
+  event_id: string;
+  batch_id: string;
+  item_id?: string | null;
+  action: string;
+  performed_by_id?: string | null;
+  comment?: string | null;
+  payload?: unknown;
+  created_at: string;
+};
+
+export type CertificateBulkImportBatch = {
+  batch_id: string;
+  user_id: string;
+  local_field_id?: number | null;
+  status: CertificateBulkImportBatchStatus;
+  raw_ocr_payload?: unknown;
+  submitted_at?: string | null;
+  reviewed_at?: string | null;
+  created_at?: string | null;
+  modified_at?: string | null;
+  user?: CertificateBulkImportUser | null;
+  files?: CertificateBulkImportFile[];
+  items?: CertificateBulkImportItem[];
+  events?: CertificateBulkImportEvent[];
+};
+
+export type PaginatedCertificateBulkImports = {
+  items: CertificateBulkImportBatch[];
+  total: number;
+  page: number;
+  limit: number;
+};
+
+export type CertificateBulkImportsQuery = {
+  page?: number;
+  limit?: number;
+};
+
+export type ApproveCertificateBulkImportPayload = {
+  comment?: string;
+};
+
+export type RejectCertificateBulkImportPayload = {
+  reason: string;
+};
+
+type ApiEnvelope<T> = { status: string; data: T };
+
+function unwrap<T>(payload: T | ApiEnvelope<T>): T {
+  if (payload && typeof payload === "object" && "data" in payload && "status" in payload) {
+    return (payload as ApiEnvelope<T>).data;
+  }
+  return payload as T;
+}
+
+export async function getPendingCertificateBulkImports(
+  query: CertificateBulkImportsQuery = {},
+): Promise<PaginatedCertificateBulkImports> {
+  const params: Record<string, number | undefined> = {
+    page: query.page ?? 1,
+    limit: query.limit ?? 20,
+  };
+  const res = await apiRequest<ApiEnvelope<PaginatedCertificateBulkImports>>(
+    "/admin/certificate-bulk-imports/pending",
+    { params },
+  );
+  return unwrap(res);
+}
+
+export async function getCertificateBulkImportDetail(batchId: string): Promise<CertificateBulkImportBatch> {
+  const res = await apiRequest<ApiEnvelope<CertificateBulkImportBatch>>(
+    `/admin/certificate-bulk-imports/${batchId}`,
+  );
+  return unwrap(res);
+}
+
+export async function approveCertificateBulkImportBatch(
+  batchId: string,
+  payload: ApproveCertificateBulkImportPayload = {},
+): Promise<CertificateBulkImportBatch> {
+  const res = await apiRequestFromClient<ApiEnvelope<CertificateBulkImportBatch>>(
+    `/admin/certificate-bulk-imports/${batchId}/approve`,
+    { method: "POST", body: payload },
+  );
+  return unwrap(res);
+}
+
+export async function rejectCertificateBulkImportBatch(
+  batchId: string,
+  payload: RejectCertificateBulkImportPayload,
+): Promise<CertificateBulkImportBatch> {
+  const res = await apiRequestFromClient<ApiEnvelope<CertificateBulkImportBatch>>(
+    `/admin/certificate-bulk-imports/${batchId}/reject`,
+    { method: "POST", body: payload },
+  );
+  return unwrap(res);
+}
+
+export async function approveCertificateBulkImportItem(
+  batchId: string,
+  itemId: string,
+  payload: ApproveCertificateBulkImportPayload = {},
+): Promise<CertificateBulkImportItem> {
+  const res = await apiRequestFromClient<ApiEnvelope<CertificateBulkImportItem>>(
+    `/admin/certificate-bulk-imports/${batchId}/items/${itemId}/approve`,
+    { method: "POST", body: payload },
+  );
+  return unwrap(res);
+}
+
+export async function rejectCertificateBulkImportItem(
+  batchId: string,
+  itemId: string,
+  payload: RejectCertificateBulkImportPayload,
+): Promise<CertificateBulkImportItem> {
+  const res = await apiRequestFromClient<ApiEnvelope<CertificateBulkImportItem>>(
+    `/admin/certificate-bulk-imports/${batchId}/items/${itemId}/reject`,
+    { method: "POST", body: payload },
+  );
+  return unwrap(res);
+}


### PR DESCRIPTION
## Summary
- Adds admin API client for certificate bulk imports.
- Adds dashboard review console with pending list, detail view, evidence viewer, approve/reject actions, navigation, and i18n keys.
- Supports Campo Local review workflow for member-submitted OCR certificate batches.

## Test Plan
- [x] `pnpm test src/lib/api/certificate-bulk-imports.test.ts src/components/certificate-bulk-imports/certificate-bulk-import-action-dialog.test.tsx`
- [x] `pnpm exec tsc --noEmit`
- [ ] Authenticated visual QA against a live backend

## Notes
- New `en/fr/pt-BR` i18n keys are Spanish placeholders to preserve typed i18n until translations are provided.
