### PR TITLE
fix(ui): render empty state icons safely

### DIFF
--- a/src/components/shared/empty-state.test.tsx
+++ b/src/components/shared/empty-state.test.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { FileText } from "lucide-react";
+import { EmptyState } from "@/components/shared/empty-state";
+
+describe("EmptyState", () => {
+  afterEach(() => cleanup());
+
+  it("renders lucide forwardRef icons passed as component references", () => {
+    const { container } = render(
+      <EmptyState
+        icon={FileText}
+        title="Sin cargas pendientes"
+        description="No hay cargas por certificado esperando revisión."
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: "Sin cargas pendientes" })).toBeInTheDocument();
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+});

--- a/src/components/shared/empty-state.tsx
+++ b/src/components/shared/empty-state.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import { createElement, isValidElement, type ElementType, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { type LucideIcon } from "lucide-react";
 
@@ -17,10 +17,17 @@ interface EmptyStateProps {
 }
 
 function renderIcon(icon: LucideIcon | ReactNode): ReactNode {
-  if (typeof icon === "function") {
-    const Icon = icon as LucideIcon;
-    return <Icon className="size-6 text-muted-foreground" aria-hidden="true" />;
+  if (isValidElement(icon)) {
+    return icon;
   }
+
+  if (typeof icon === "function" || (typeof icon === "object" && icon !== null && "$$typeof" in icon)) {
+    return createElement(icon as ElementType, {
+      className: "size-6 text-muted-foreground",
+      "aria-hidden": true,
+    });
+  }
+
   return icon;
 }
 


### PR DESCRIPTION
## Summary
- Fix shared EmptyState to render Lucide forwardRef icon references instead of returning the icon object as a child.
- Add a regression test covering lucide icon references.

## Verification
- pnpm test src/components/shared/empty-state.test.tsx src/components/certificate-bulk-imports/certificate-bulk-import-action-dialog.test.tsx src/lib/api/certificate-bulk-imports.test.ts
- pnpm run typecheck
- Browser verified /dashboard/certificate-bulk-imports renders the empty pending state