### PR TITLE
feat(admin): configure legacy class duration

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -430,7 +430,17 @@
       "delete": "Delete",
       "cancel": "Cancel",
       "saveChanges": "Save changes",
-      "noPermissions": "You do not have permission to modify this catalog."
+      "noPermissions": "You do not have permission to modify this catalog.",
+      "colDuration": "Duration",
+      "colAvailability": "Availability",
+      "classConfigTitle": "Availability and duration",
+      "classConfigDescription": "Configure when the class can be started and how many ecclesiastical years it may last.",
+      "fieldAvailableFromYear": "Available from",
+      "fieldAvailableFromAny": "No start restriction",
+      "fieldAvailableUntilYear": "Available until",
+      "fieldAvailableUntilNone": "No programmed expiration",
+      "fieldMinDurationYears": "Minimum duration (years)",
+      "fieldMaxDurationYears": "Maximum duration (years)"
     },
     "pages": {
       "countries": {
@@ -4821,7 +4831,9 @@
       "col_club_type": "Club type",
       "col_modules": "Modules",
       "col_status": "Status",
-      "view_detail": "View detail for {name}"
+      "view_detail": "View detail for {name}",
+      "col_duration": "Duration",
+      "col_availability": "Availability"
     },
     "tree": {
       "no_modules": "This class has no registered modules.",
@@ -4862,8 +4874,23 @@
         "statPoints": "Required points",
         "tabStructure": "Program structure",
         "structureCardTitle": "Modules & sections",
-        "modulesEndpointMissing": "The classes endpoint did not return modules in the detail response. Modules load from GET /classes/:id — verify the backend includes them."
+        "modulesEndpointMissing": "The classes endpoint did not return modules in the detail response. Modules load from GET /classes/:id — verify the backend includes them.",
+        "labelDuration": "Configured duration",
+        "labelAvailableFrom": "Availability start",
+        "labelAvailableUntil": "Availability end",
+        "statDuration": "Duration"
       }
+    },
+    "expiration": {
+      "title": "Manual class expiration",
+      "description": "Run a simulation or apply expiration for enrollments that exceeded the maximum duration.",
+      "yearLabel": "Cutoff ecclesiastical year",
+      "currentYearOption": "Use backend active year",
+      "dryRun": "Dry run",
+      "apply": "Apply expiration",
+      "modeDryRun": "dry run",
+      "modeApply": "apply",
+      "result": "{mode}: {scanned} enrollments scanned, {expired} expired."
     }
   },
   "membership": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -4890,7 +4890,17 @@
       "apply": "Apply expiration",
       "modeDryRun": "dry run",
       "modeApply": "apply",
-      "result": "{mode}: {scanned} enrollments scanned, {expired} expired."
+      "result": "{mode}: {scanned} enrollments scanned, {expired} expired.",
+      "confirmApply": "You are about to expire {expired} enrollments. This changes real data. Continue?"
+    },
+    "display": {
+      "yearSingular": "year",
+      "yearPlural": "years",
+      "yearFallback": "Year #{id}",
+      "availableFromAnyYear": "Available from any year",
+      "noProgrammedExpiration": "No programmed expiration",
+      "availableFromYear": "Available from ecclesiastical year {label}",
+      "availableUntilYear": "Available until ecclesiastical year {label}"
     }
   },
   "membership": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -4909,7 +4909,17 @@
       "apply": "Aplicar vencimiento",
       "modeDryRun": "simulación",
       "modeApply": "aplicación",
-      "result": "{mode}: {scanned} inscripciones revisadas, {expired} vencidas."
+      "result": "{mode}: {scanned} inscripciones revisadas, {expired} vencidas.",
+      "confirmApply": "Vas a vencer {expired} inscripciones. Esta acción modifica datos reales. ¿Querés continuar?"
+    },
+    "display": {
+      "yearSingular": "año",
+      "yearPlural": "años",
+      "yearFallback": "Año #{id}",
+      "availableFromAnyYear": "Disponible desde cualquier año",
+      "noProgrammedExpiration": "Sin expiración programada",
+      "availableFromYear": "Disponible desde año eclesiástico {label}",
+      "availableUntilYear": "Disponible hasta año eclesiástico {label}"
     }
   },
   "membership": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -430,7 +430,17 @@
       "delete": "Eliminar",
       "cancel": "Cancelar",
       "saveChanges": "Guardar cambios",
-      "noPermissions": "No cuentas con permisos para modificar este catálogo."
+      "noPermissions": "No cuentas con permisos para modificar este catálogo.",
+      "colDuration": "Duración",
+      "colAvailability": "Disponibilidad",
+      "classConfigTitle": "Disponibilidad y duración",
+      "classConfigDescription": "Configura desde cuándo se puede iniciar la clase y cuántos años eclesiásticos puede durar.",
+      "fieldAvailableFromYear": "Disponible desde",
+      "fieldAvailableFromAny": "Sin restricción de inicio",
+      "fieldAvailableUntilYear": "Disponible hasta",
+      "fieldAvailableUntilNone": "Sin expiración programada",
+      "fieldMinDurationYears": "Duración mínima (años)",
+      "fieldMaxDurationYears": "Duración máxima (años)"
     },
     "pages": {
       "countries": {
@@ -4840,7 +4850,9 @@
       "col_club_type": "Tipo de club",
       "col_modules": "Módulos",
       "col_status": "Estado",
-      "view_detail": "Ver detalle de {name}"
+      "view_detail": "Ver detalle de {name}",
+      "col_duration": "Duración",
+      "col_availability": "Disponibilidad"
     },
     "tree": {
       "no_modules": "Esta clase no tiene módulos registrados.",
@@ -4881,8 +4893,23 @@
         "statPoints": "Puntos requeridos",
         "tabStructure": "Estructura del programa",
         "structureCardTitle": "Módulos y secciones",
-        "modulesEndpointMissing": "El endpoint de clases no retornó módulos en la respuesta de detalle. Los módulos se cargan desde GET /classes/:id — verifica que el backend los incluya."
+        "modulesEndpointMissing": "El endpoint de clases no retornó módulos en la respuesta de detalle. Los módulos se cargan desde GET /classes/:id — verifica que el backend los incluya.",
+        "labelDuration": "Duración configurable",
+        "labelAvailableFrom": "Inicio de disponibilidad",
+        "labelAvailableUntil": "Fin de disponibilidad",
+        "statDuration": "Duración"
       }
+    },
+    "expiration": {
+      "title": "Vencimiento manual de clases",
+      "description": "Ejecuta una simulación o aplica el vencimiento de inscripciones que superaron la duración máxima.",
+      "yearLabel": "Año eclesiástico de corte",
+      "currentYearOption": "Usar año activo del backend",
+      "dryRun": "Simular",
+      "apply": "Aplicar vencimiento",
+      "modeDryRun": "simulación",
+      "modeApply": "aplicación",
+      "result": "{mode}: {scanned} inscripciones revisadas, {expired} vencidas."
     }
   },
   "membership": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -430,7 +430,17 @@
       "delete": "Supprimer",
       "cancel": "Annuler",
       "saveChanges": "Enregistrer les modifications",
-      "noPermissions": "Vous n'avez pas la permission de modifier ce catalogue."
+      "noPermissions": "Vous n'avez pas la permission de modifier ce catalogue.",
+      "colDuration": "Durée",
+      "colAvailability": "Disponibilité",
+      "classConfigTitle": "Disponibilité et durée",
+      "classConfigDescription": "Configure quand la classe peut commencer et combien d’années ecclésiastiques elle peut durer.",
+      "fieldAvailableFromYear": "Disponible depuis",
+      "fieldAvailableFromAny": "Aucune restriction de début",
+      "fieldAvailableUntilYear": "Disponible jusqu’à",
+      "fieldAvailableUntilNone": "Aucune expiration programmée",
+      "fieldMinDurationYears": "Durée minimale (années)",
+      "fieldMaxDurationYears": "Durée maximale (années)"
     },
     "pages": {
       "countries": {
@@ -4687,7 +4697,9 @@
       "col_club_type": "Type de club",
       "col_modules": "Modules",
       "col_status": "Statut",
-      "view_detail": "Voir le détail de {name}"
+      "view_detail": "Voir le détail de {name}",
+      "col_duration": "Durée",
+      "col_availability": "Disponibilité"
     },
     "tree": {
       "no_modules": "Cette classe n'a aucun module enregistré.",
@@ -4728,8 +4740,23 @@
         "statPoints": "Points requis",
         "tabStructure": "Structure du programme",
         "structureCardTitle": "Modules et sections",
-        "modulesEndpointMissing": "Le point de terminaison des classes n’a pas retourné de modules dans la réponse de détail. Les modules se chargent depuis GET /classes/:id — vérifiez que le backend les inclut."
+        "modulesEndpointMissing": "Le point de terminaison des classes n’a pas retourné de modules dans la réponse de détail. Les modules se chargent depuis GET /classes/:id — vérifiez que le backend les inclut.",
+        "labelDuration": "Durée configurée",
+        "labelAvailableFrom": "Début de disponibilité",
+        "labelAvailableUntil": "Fin de disponibilité",
+        "statDuration": "Durée"
       }
+    },
+    "expiration": {
+      "title": "Expiration manuelle des classes",
+      "description": "Exécute une simulation ou applique l’expiration des inscriptions qui ont dépassé la durée maximale.",
+      "yearLabel": "Année ecclésiastique de référence",
+      "currentYearOption": "Utiliser l’année active du backend",
+      "dryRun": "Simuler",
+      "apply": "Appliquer l’expiration",
+      "modeDryRun": "simulation",
+      "modeApply": "application",
+      "result": "{mode}: {scanned} inscriptions vérifiées, {expired} expirées."
     }
   },
   "membership": {

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -4756,7 +4756,17 @@
       "apply": "Appliquer l’expiration",
       "modeDryRun": "simulation",
       "modeApply": "application",
-      "result": "{mode}: {scanned} inscriptions vérifiées, {expired} expirées."
+      "result": "{mode}: {scanned} inscriptions vérifiées, {expired} expirées.",
+      "confirmApply": "Vous allez expirer {expired} inscriptions. Cette action modifie des données réelles. Continuer ?"
+    },
+    "display": {
+      "yearSingular": "an",
+      "yearPlural": "ans",
+      "yearFallback": "Année #{id}",
+      "availableFromAnyYear": "Disponible depuis n’importe quelle année",
+      "noProgrammedExpiration": "Aucune expiration programmée",
+      "availableFromYear": "Disponible depuis l’année ecclésiastique {label}",
+      "availableUntilYear": "Disponible jusqu’à l’année ecclésiastique {label}"
     }
   },
   "membership": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -4756,7 +4756,17 @@
       "apply": "Aplicar expiração",
       "modeDryRun": "simulação",
       "modeApply": "aplicação",
-      "result": "{mode}: {scanned} inscrições revisadas, {expired} expiradas."
+      "result": "{mode}: {scanned} inscrições revisadas, {expired} expiradas.",
+      "confirmApply": "Você vai expirar {expired} inscrições. Esta ação altera dados reais. Continuar?"
+    },
+    "display": {
+      "yearSingular": "ano",
+      "yearPlural": "anos",
+      "yearFallback": "Ano #{id}",
+      "availableFromAnyYear": "Disponível a partir de qualquer ano",
+      "noProgrammedExpiration": "Sem expiração programada",
+      "availableFromYear": "Disponível a partir do ano eclesiástico {label}",
+      "availableUntilYear": "Disponível até o ano eclesiástico {label}"
     }
   },
   "membership": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -430,7 +430,17 @@
       "delete": "Excluir",
       "cancel": "Cancelar",
       "saveChanges": "Salvar alterações",
-      "noPermissions": "Você não tem permissão para modificar este catálogo."
+      "noPermissions": "Você não tem permissão para modificar este catálogo.",
+      "colDuration": "Duração",
+      "colAvailability": "Disponibilidade",
+      "classConfigTitle": "Disponibilidade e duração",
+      "classConfigDescription": "Configure quando a classe pode ser iniciada e quantos anos eclesiásticos pode durar.",
+      "fieldAvailableFromYear": "Disponível desde",
+      "fieldAvailableFromAny": "Sem restrição de início",
+      "fieldAvailableUntilYear": "Disponível até",
+      "fieldAvailableUntilNone": "Sem expiração programada",
+      "fieldMinDurationYears": "Duração mínima (anos)",
+      "fieldMaxDurationYears": "Duração máxima (anos)"
     },
     "pages": {
       "countries": {
@@ -4687,7 +4697,9 @@
       "col_club_type": "Tipo de clube",
       "col_modules": "Módulos",
       "col_status": "Status",
-      "view_detail": "Ver detalhe de {name}"
+      "view_detail": "Ver detalhe de {name}",
+      "col_duration": "Duração",
+      "col_availability": "Disponibilidade"
     },
     "tree": {
       "no_modules": "Esta classe não possui módulos registrados.",
@@ -4728,8 +4740,23 @@
         "statPoints": "Pontos necessários",
         "tabStructure": "Estrutura do programa",
         "structureCardTitle": "Módulos e seções",
-        "modulesEndpointMissing": "O endpoint de classes não retornou módulos na resposta de detalhes. Os módulos são carregados de GET /classes/:id — verifique se o backend os inclui."
+        "modulesEndpointMissing": "O endpoint de classes não retornou módulos na resposta de detalhes. Os módulos são carregados de GET /classes/:id — verifique se o backend os inclui.",
+        "labelDuration": "Duração configurada",
+        "labelAvailableFrom": "Início da disponibilidade",
+        "labelAvailableUntil": "Fim da disponibilidade",
+        "statDuration": "Duração"
       }
+    },
+    "expiration": {
+      "title": "Expiração manual de classes",
+      "description": "Execute uma simulação ou aplique a expiração das inscrições que excederam a duração máxima.",
+      "yearLabel": "Ano eclesiástico de corte",
+      "currentYearOption": "Usar ano ativo do backend",
+      "dryRun": "Simular",
+      "apply": "Aplicar expiração",
+      "modeDryRun": "simulação",
+      "modeApply": "aplicação",
+      "result": "{mode}: {scanned} inscrições revisadas, {expired} expiradas."
     }
   },
   "membership": {

--- a/src/app/(dashboard)/dashboard/catalogs/classes/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/classes/page.tsx
@@ -27,6 +27,7 @@ const PhaseECatalogCrudPage = dynamic(
 );
 import { ApiError } from "@/lib/api/client";
 import { listAdminClasses } from "@/lib/api/phase-e-catalogs";
+import { listEcclesiasticalYears } from "@/lib/api/catalogs";
 import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
 import { requireAdminUser } from "@/lib/auth/session";
 import { hasAnyPermission } from "@/lib/auth/permission-utils";
@@ -52,6 +53,7 @@ export default async function AdminClassesPage({ searchParams }: { searchParams:
   let items: Record<string, unknown>[] = [];
   let meta = { page, limit, total: 0, totalPages: 1 };
   let loadError: string | null = null;
+  let ecclesiasticalYears: Array<{ ecclesiastical_year_id: number; name: string }> = [];
 
   try {
     const params: Record<string, string | number | boolean> = { page, limit };
@@ -59,9 +61,16 @@ export default async function AdminClassesPage({ searchParams }: { searchParams:
     if (activeRaw === "true") params.active = true;
     if (activeRaw === "false") params.active = false;
 
-    const payload = await listAdminClasses(params);
+    const [payload, years] = await Promise.all([
+      listAdminClasses(params),
+      listEcclesiasticalYears().catch(() => []),
+    ]);
     items = extractItems(payload);
     meta = extractMeta(payload, page, limit, items.length);
+    ecclesiasticalYears = years.map((year) => ({
+      ecclesiastical_year_id: year.ecclesiastical_year_id,
+      name: year.name,
+    }));
   } catch (error) {
     if (!(error instanceof ApiError && error.status === 429)) {
       loadError = error instanceof ApiError ? error.message : t("loadError");
@@ -91,6 +100,7 @@ export default async function AdminClassesPage({ searchParams }: { searchParams:
         createAction={createClassAction}
         updateAction={updateClassAction}
         deleteAction={deleteClassAction}
+        classConfigYearOptions={ecclesiasticalYears}
       />
     </div>
   );

--- a/src/app/(dashboard)/dashboard/classes/[classId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/classes/[classId]/page.tsx
@@ -15,6 +15,11 @@ import { getClassById, listClasses } from "@/lib/api/classes";
 import type { ClassModule, ClassSection } from "@/lib/api/classes";
 import { listClubTypes } from "@/lib/api/catalogs";
 import { requireAdminUser } from "@/lib/auth/session";
+import {
+  formatClassAvailabilityFrom,
+  formatClassAvailabilityUntil,
+  formatClassDurationRange,
+} from "@/lib/classes/display";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -198,6 +203,10 @@ export default async function ClassDetailPage({ params }: { params: Params }) {
   const isActive = classData.active !== false;
   const maxPoints = toPositiveNumber(classData.max_points ?? classData.maxPoints);
   const minPoints = toPositiveNumber(classData.minimum_points ?? classData.minimumPoints);
+  const availableFromYearId = toPositiveNumber(classData.available_from_year_id);
+  const availableUntilYearId = toPositiveNumber(classData.available_until_year_id);
+  const minDurationYears = toPositiveNumber(classData.min_duration_years) ?? 1;
+  const maxDurationYears = toPositiveNumber(classData.max_duration_years) ?? 1;
   const modulesCount = modules.length;
   const totalSections = modules.reduce((acc, m) => acc + m.sections.length, 0);
 
@@ -240,11 +249,15 @@ export default async function ClassDetailPage({ params }: { params: Params }) {
       </Card>
 
       {/* Stats strip */}
-      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-5">
         {[
           { label: t("statOrder"), value: displayOrder ?? "—" },
           { label: t("statModules"), value: modulesCount > 0 ? modulesCount : "—" },
           { label: t("statSections"), value: totalSections > 0 ? totalSections : "—" },
+          {
+            label: t("statDuration"),
+            value: formatClassDurationRange(minDurationYears, maxDurationYears),
+          },
           {
             label: t("statPoints"),
             value: minPoints != null ? `${minPoints} / ${maxPoints ?? "—"}` : "—",
@@ -269,6 +282,18 @@ export default async function ClassDetailPage({ params }: { params: Params }) {
           <InfoRow label={t("labelClubType")} value={clubTypeName} />
           <InfoRow label={t("labelOrder")} value={displayOrder ?? "—"} />
           <InfoRow label={t("labelStatus")} value={<ClassStatusBadge active={isActive} />} />
+          <InfoRow
+            label={t("labelDuration")}
+            value={formatClassDurationRange(minDurationYears, maxDurationYears)}
+          />
+          <InfoRow
+            label={t("labelAvailableFrom")}
+            value={formatClassAvailabilityFrom(availableFromYearId)}
+          />
+          <InfoRow
+            label={t("labelAvailableUntil")}
+            value={formatClassAvailabilityUntil(availableUntilYearId)}
+          />
           {maxPoints != null && (
             <InfoRow label={t("labelMaxPoints")} value={maxPoints} />
           )}

--- a/src/app/(dashboard)/dashboard/classes/[classId]/page.tsx
+++ b/src/app/(dashboard)/dashboard/classes/[classId]/page.tsx
@@ -19,6 +19,7 @@ import {
   formatClassAvailabilityFrom,
   formatClassAvailabilityUntil,
   formatClassDurationRange,
+  type ClassDisplayLabels,
 } from "@/lib/classes/display";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -134,6 +135,16 @@ function InfoRow({ label, value }: { label: string; value: React.ReactNode }) {
 export default async function ClassDetailPage({ params }: { params: Params }) {
   await requireAdminUser();
   const t = await getTranslations("classes.pages.detail");
+  const displayT = await getTranslations("classes.display");
+  const displayLabels: ClassDisplayLabels = {
+    yearSingular: displayT("yearSingular"),
+    yearPlural: displayT("yearPlural"),
+    yearFallback: (id) => displayT("yearFallback", { id }),
+    availableFromAnyYear: displayT("availableFromAnyYear"),
+    noProgrammedExpiration: displayT("noProgrammedExpiration"),
+    availableFromYear: (label) => displayT("availableFromYear", { label }),
+    availableUntilYear: (label) => displayT("availableUntilYear", { label }),
+  };
 
   const { classId: classIdParam } = await params;
   const classId = toPositiveNumber(classIdParam);
@@ -256,7 +267,7 @@ export default async function ClassDetailPage({ params }: { params: Params }) {
           { label: t("statSections"), value: totalSections > 0 ? totalSections : "—" },
           {
             label: t("statDuration"),
-            value: formatClassDurationRange(minDurationYears, maxDurationYears),
+            value: formatClassDurationRange(minDurationYears, maxDurationYears, displayLabels),
           },
           {
             label: t("statPoints"),
@@ -284,15 +295,15 @@ export default async function ClassDetailPage({ params }: { params: Params }) {
           <InfoRow label={t("labelStatus")} value={<ClassStatusBadge active={isActive} />} />
           <InfoRow
             label={t("labelDuration")}
-            value={formatClassDurationRange(minDurationYears, maxDurationYears)}
+            value={formatClassDurationRange(minDurationYears, maxDurationYears, displayLabels)}
           />
           <InfoRow
             label={t("labelAvailableFrom")}
-            value={formatClassAvailabilityFrom(availableFromYearId)}
+            value={formatClassAvailabilityFrom(availableFromYearId, displayLabels)}
           />
           <InfoRow
             label={t("labelAvailableUntil")}
-            value={formatClassAvailabilityUntil(availableUntilYearId)}
+            value={formatClassAvailabilityUntil(availableUntilYearId, displayLabels)}
           />
           {maxPoints != null && (
             <InfoRow label={t("labelMaxPoints")} value={maxPoints} />

--- a/src/app/(dashboard)/dashboard/classes/page.tsx
+++ b/src/app/(dashboard)/dashboard/classes/page.tsx
@@ -5,10 +5,13 @@ import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 import { EmptyState } from "@/components/shared/empty-state";
 import { ClassesList } from "@/components/classes/classes-list";
 import type { ClassRow } from "@/components/classes/classes-list";
+import { ClassExpirationCard } from "@/components/classes/class-expiration-card";
 import { ApiError } from "@/lib/api/client";
 import { listClasses } from "@/lib/api/classes";
-import { listClubTypes } from "@/lib/api/catalogs";
+import { listClubTypes, listEcclesiasticalYears } from "@/lib/api/catalogs";
 import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import { CLASSES_MANAGE } from "@/lib/auth/permissions";
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -32,14 +35,20 @@ function toPositiveNumber(value: unknown): number | null {
 // ─── Page ─────────────────────────────────────────────────────────────────────
 
 export default async function ClassesPage() {
-  await requireAdminUser();
+  const user = await requireAdminUser();
   const t = await getTranslations("classes.pages.list");
   const tList = await getTranslations("classes.list");
+  const canManageClasses = hasAnyPermission(user, [CLASSES_MANAGE]);
 
   // Build club type lookup map
   const clubTypeNameById = new Map<number, string>();
+  let ecclesiasticalYears: Awaited<ReturnType<typeof listEcclesiasticalYears>> = [];
   try {
-    const clubTypes = await listClubTypes();
+    const [clubTypes, years] = await Promise.all([
+      listClubTypes(),
+      listEcclesiasticalYears().catch(() => []),
+    ]);
+    ecclesiasticalYears = years;
     for (const ct of clubTypes) {
       if (typeof ct.club_type_id === "number" && typeof ct.name === "string" && ct.name.trim()) {
         clubTypeNameById.set(ct.club_type_id, ct.name.trim());
@@ -84,6 +93,10 @@ export default async function ClassesPage() {
           club_type_id: clubTypeId ?? 0,
           club_type_name: clubTypeName,
           display_order: toPositiveNumber(item.display_order) ?? 0,
+          available_from_year_id: toPositiveNumber(item.available_from_year_id),
+          available_until_year_id: toPositiveNumber(item.available_until_year_id),
+          min_duration_years: toPositiveNumber(item.min_duration_years) ?? 1,
+          max_duration_years: toPositiveNumber(item.max_duration_years) ?? 1,
           modules_count: modulesCount,
           active: item.active !== false,
         };
@@ -106,6 +119,10 @@ export default async function ClassesPage() {
 
       {loadError && (
         <EndpointErrorBanner state="missing" detail={loadError} />
+      )}
+
+      {canManageClasses && (
+        <ClassExpirationCard ecclesiasticalYears={ecclesiasticalYears} />
       )}
 
       {!loadError && rows.length === 0 && (

--- a/src/components/camporee-events/timeline/event-day-card.tsx
+++ b/src/components/camporee-events/timeline/event-day-card.tsx
@@ -7,7 +7,7 @@ import { Separator } from "@/components/ui/separator";
 import { SECTION_COLOR } from "@/lib/camporee-timeline/event-categories";
 import { cn } from "@/lib/utils";
 
-import type { CamporeeDay, CamporeeEvent, Venue } from "@/lib/camporee-timeline/types";
+import type { CamporeeDay, CamporeeEvent, Section, Venue } from "@/lib/camporee-timeline/types";
 import { EventRow } from "./event-row";
 import { durMin, sortByStart, toMin, formatHours } from "@/lib/camporee-timeline/helpers";
 
@@ -59,6 +59,12 @@ function HeatBar({ events }: { events: CamporeeEvent[] }) {
   );
 }
 
+const SECTION_NAMES: Section[] = [
+  "Aventureros",
+  "Conquistadores",
+  "Guías Mayores",
+];
+
 function DayBadge({ day }: { day: CamporeeDay }) {
   return (
     <div className="size-[52px] rounded-xl bg-primary text-primary-foreground grid place-items-center">
@@ -77,7 +83,7 @@ export function EventDayCard({ day, events, venues, onAdd, onEdit, readonly = fa
   const totalMin = sorted.reduce((s, e) => s + durMin(e.startsAt, e.endsAt), 0);
   const venuesUsed = new Set(sorted.map((e) => e.venueId)).size;
 
-  const secCount: Record<string, number> = {
+  const secCount: Record<Section, number> = {
     Aventureros: 0,
     Conquistadores: 0,
     "Guías Mayores": 0,
@@ -130,12 +136,12 @@ export function EventDayCard({ day, events, venues, onAdd, onEdit, readonly = fa
             <span className="inline-flex items-center gap-1">
               Secciones
               <span className="inline-flex gap-0.5">
-                {Object.entries(secCount).map(([s, n]) =>
-                  n > 0 ? (
+                {SECTION_NAMES.map((s) =>
+                  secCount[s] > 0 ? (
                     <span
                       key={s}
-                      className={cn("size-1.5 rounded-full", SECTION_COLOR[s]?.dot)}
-                      title={`${s}: ${n}`}
+                      className={cn("size-1.5 rounded-full", SECTION_COLOR[s].dot)}
+                      title={`${s}: ${secCount[s]}`}
                     />
                   ) : null,
                 )}

--- a/src/components/catalogs/phase-e-catalog-crud-page.tsx
+++ b/src/components/catalogs/phase-e-catalog-crud-page.tsx
@@ -75,6 +75,10 @@ import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
 import { DataTablePagination } from "@/components/shared/data-table-pagination";
 import type { PhaseEActionState } from "@/lib/phase-e-catalogs/actions";
+import {
+  formatClassAvailabilityUntil,
+  formatClassDurationRange,
+} from "@/lib/classes/display";
 import { useFormStatus } from "react-dom";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import type { ReactNode } from "react";
@@ -84,6 +88,11 @@ import { useTranslations } from "next-intl";
 
 type AnyRecord = Record<string, unknown>;
 type FormAction = (prev: PhaseEActionState, data: FormData) => Promise<PhaseEActionState>;
+
+export type ClassConfigYearOption = {
+  ecclesiastical_year_id: number;
+  name: string;
+};
 
 export interface PhaseECatalogCrudPageProps {
   /** Page title shown in PageHeader */
@@ -112,6 +121,8 @@ export interface PhaseECatalogCrudPageProps {
   createAction: FormAction;
   updateAction: FormAction;
   deleteAction: FormAction;
+  /** Enables class-specific availability/duration fields and columns. */
+  classConfigYearOptions?: ClassConfigYearOption[];
 }
 
 // ─── SubmitButton ─────────────────────────────────────────────────────────────
@@ -152,6 +163,7 @@ interface FormFieldsProps {
   translations: CatalogTranslation[];
   onTranslationsChange: (t: CatalogTranslation[]) => void;
   entityLabel: string;
+  classConfigYearOptions?: ClassConfigYearOption[];
 }
 
 function CatalogFormFields({
@@ -163,10 +175,22 @@ function CatalogFormFields({
   translations,
   onTranslationsChange,
   entityLabel,
+  classConfigYearOptions,
 }: FormFieldsProps) {
   const t = useTranslations("catalogs.phaseE");
   const nameVal = typeof item?.name === "string" ? item.name : "";
   const descVal = typeof item?.description === "string" ? item.description : "";
+  const showClassConfig = Array.isArray(classConfigYearOptions);
+  const availableFromVal = toPositiveInt(item?.available_from_year_id);
+  const availableUntilVal = toPositiveInt(item?.available_until_year_id);
+  const minDurationVal = toPositiveInt(item?.min_duration_years) ?? 1;
+  const maxDurationVal = toPositiveInt(item?.max_duration_years) ?? 1;
+  const yearOptions = [...(classConfigYearOptions ?? [])];
+  for (const yearId of [availableFromVal, availableUntilVal]) {
+    if (yearId && !yearOptions.some((year) => year.ecclesiastical_year_id === yearId)) {
+      yearOptions.push({ ecclesiastical_year_id: yearId, name: `Año #${yearId}` });
+    }
+  }
 
   const esContent = (
     <div className="space-y-4">
@@ -193,6 +217,90 @@ function CatalogFormFields({
             defaultValue={descVal}
             placeholder={t("fieldDescriptionPlaceholder")}
           />
+        </div>
+      )}
+
+      {showClassConfig && (
+        <div className="rounded-lg border bg-muted/20 p-4">
+          <div className="mb-4">
+            <h4 className="text-sm font-semibold">{t("classConfigTitle")}</h4>
+            <p className="text-xs text-muted-foreground">{t("classConfigDescription")}</p>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor={`${idPrefix}-available-from`}>
+                {t("fieldAvailableFromYear")}
+              </Label>
+              <select
+                id={`${idPrefix}-available-from`}
+                name="available_from_year_id"
+                defaultValue={availableFromVal ? String(availableFromVal) : ""}
+                className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="">{t("fieldAvailableFromAny")}</option>
+                {yearOptions.map((year) => (
+                  <option
+                    key={year.ecclesiastical_year_id}
+                    value={String(year.ecclesiastical_year_id)}
+                  >
+                    {year.name || `Año #${year.ecclesiastical_year_id}`}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={`${idPrefix}-available-until`}>
+                {t("fieldAvailableUntilYear")}
+              </Label>
+              <select
+                id={`${idPrefix}-available-until`}
+                name="available_until_year_id"
+                defaultValue={availableUntilVal ? String(availableUntilVal) : ""}
+                className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="">{t("fieldAvailableUntilNone")}</option>
+                {yearOptions.map((year) => (
+                  <option
+                    key={year.ecclesiastical_year_id}
+                    value={String(year.ecclesiastical_year_id)}
+                  >
+                    {year.name || `Año #${year.ecclesiastical_year_id}`}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={`${idPrefix}-min-duration`}>
+                {t("fieldMinDurationYears")}
+              </Label>
+              <Input
+                id={`${idPrefix}-min-duration`}
+                name="min_duration_years"
+                type="number"
+                min={1}
+                step={1}
+                defaultValue={minDurationVal}
+                required
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor={`${idPrefix}-max-duration`}>
+                {t("fieldMaxDurationYears")}
+              </Label>
+              <Input
+                id={`${idPrefix}-max-duration`}
+                name="max_duration_years"
+                type="number"
+                min={1}
+                step={1}
+                defaultValue={maxDurationVal}
+                required
+              />
+            </div>
+          </div>
         </div>
       )}
 
@@ -251,6 +359,7 @@ export function PhaseECatalogCrudPage({
   createAction,
   updateAction,
   deleteAction,
+  classConfigYearOptions,
 }: PhaseECatalogCrudPageProps) {
   const router = useRouter();
   const pathname = usePathname();
@@ -342,6 +451,13 @@ export function PhaseECatalogCrudPage({
   const t = useTranslations("catalogs.phaseE");
   const hasActiveFilters = Boolean(currentSearch || currentStatusFilter !== "all");
   const canMutate = canCreate || canEdit || canDelete;
+  const showClassConfig = Array.isArray(classConfigYearOptions);
+  const yearNameById = new Map(
+    (classConfigYearOptions ?? []).map((year) => [
+      year.ecclesiastical_year_id,
+      year.name || `Año #${year.ecclesiastical_year_id}`,
+    ]),
+  );
   const safePage = Math.max(1, meta.page || 1);
   const safeLimit = Math.max(1, meta.limit || 20);
   const safeTotalPages = Math.max(1, meta.totalPages || 1);
@@ -434,6 +550,8 @@ export function PhaseECatalogCrudPage({
                   <TableRow>
                     <TableHead>{t("colName")}</TableHead>
                     {includeDescription && <TableHead>{t("colDescription")}</TableHead>}
+                    {showClassConfig && <TableHead>{t("colDuration")}</TableHead>}
+                    {showClassConfig && <TableHead>{t("colAvailability")}</TableHead>}
                     <TableHead>{t("colStatus")}</TableHead>
                     {(canEdit || canDelete) && (
                       <TableHead className="sticky right-0 z-20 w-[100px] border-l bg-background">
@@ -454,6 +572,22 @@ export function PhaseECatalogCrudPage({
                         {includeDescription && (
                           <TableCell className="max-w-[380px] text-sm text-muted-foreground">
                             {toText(item.description) ?? "—"}
+                          </TableCell>
+                        )}
+                        {showClassConfig && (
+                          <TableCell className="text-sm text-muted-foreground">
+                            {formatClassDurationRange(
+                              toPositiveInt(item.min_duration_years) ?? 1,
+                              toPositiveInt(item.max_duration_years) ?? 1,
+                            )}
+                          </TableCell>
+                        )}
+                        {showClassConfig && (
+                          <TableCell className="max-w-[260px] text-sm text-muted-foreground">
+                            {formatClassAvailabilityUntil(
+                              toPositiveInt(item.available_until_year_id),
+                              yearNameById.get(toPositiveInt(item.available_until_year_id) ?? 0),
+                            )}
                           </TableCell>
                         )}
                         <TableCell>
@@ -582,6 +716,7 @@ export function PhaseECatalogCrudPage({
                 translations={createTranslations}
                 onTranslationsChange={setCreateTranslations}
                 entityLabel={entityLabel}
+                classConfigYearOptions={classConfigYearOptions}
               />
               <DialogFooter>
                 <Button type="button" variant="outline" onClick={() => setCreateOpen(false)}>
@@ -617,6 +752,7 @@ export function PhaseECatalogCrudPage({
                 translations={editTranslations}
                 onTranslationsChange={setEditTranslations}
                 entityLabel={entityLabel}
+                classConfigYearOptions={classConfigYearOptions}
               />
               <DialogFooter>
                 <Button type="button" variant="outline" onClick={() => setEditItem(null)}>

--- a/src/components/catalogs/phase-e-catalog-crud-page.tsx
+++ b/src/components/catalogs/phase-e-catalog-crud-page.tsx
@@ -78,6 +78,7 @@ import type { PhaseEActionState } from "@/lib/phase-e-catalogs/actions";
 import {
   formatClassAvailabilityUntil,
   formatClassDurationRange,
+  type ClassDisplayLabels,
 } from "@/lib/classes/display";
 import { useFormStatus } from "react-dom";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -449,13 +450,23 @@ export function PhaseECatalogCrudPage({
   );
 
   const t = useTranslations("catalogs.phaseE");
+  const displayT = useTranslations("classes.display");
+  const displayLabels: ClassDisplayLabels = {
+    yearSingular: displayT("yearSingular"),
+    yearPlural: displayT("yearPlural"),
+    yearFallback: (id) => displayT("yearFallback", { id }),
+    availableFromAnyYear: displayT("availableFromAnyYear"),
+    noProgrammedExpiration: displayT("noProgrammedExpiration"),
+    availableFromYear: (label) => displayT("availableFromYear", { label }),
+    availableUntilYear: (label) => displayT("availableUntilYear", { label }),
+  };
   const hasActiveFilters = Boolean(currentSearch || currentStatusFilter !== "all");
   const canMutate = canCreate || canEdit || canDelete;
   const showClassConfig = Array.isArray(classConfigYearOptions);
   const yearNameById = new Map(
     (classConfigYearOptions ?? []).map((year) => [
       year.ecclesiastical_year_id,
-      year.name || `Año #${year.ecclesiastical_year_id}`,
+      year.name || displayLabels.yearFallback(year.ecclesiastical_year_id),
     ]),
   );
   const safePage = Math.max(1, meta.page || 1);
@@ -579,6 +590,7 @@ export function PhaseECatalogCrudPage({
                             {formatClassDurationRange(
                               toPositiveInt(item.min_duration_years) ?? 1,
                               toPositiveInt(item.max_duration_years) ?? 1,
+                              displayLabels,
                             )}
                           </TableCell>
                         )}
@@ -586,6 +598,7 @@ export function PhaseECatalogCrudPage({
                           <TableCell className="max-w-[260px] text-sm text-muted-foreground">
                             {formatClassAvailabilityUntil(
                               toPositiveInt(item.available_until_year_id),
+                              displayLabels,
                               yearNameById.get(toPositiveInt(item.available_until_year_id) ?? 0),
                             )}
                           </TableCell>

--- a/src/components/classes/class-expiration-card.test.tsx
+++ b/src/components/classes/class-expiration-card.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+
+let actionState: {
+  error?: string;
+  result?: {
+    ecclesiastical_year_id: number;
+    dry_run: boolean;
+    scanned_count: number;
+    expired_count: number;
+    enrollment_ids: number[];
+  };
+} = {};
+
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useActionState: () => [actionState, vi.fn(), false],
+  };
+});
+
+vi.mock("@/lib/classes/actions", () => ({
+  expireOverdueClassEnrollmentsAction: vi.fn(),
+}));
+
+import { ClassExpirationCard } from "@/components/classes/class-expiration-card";
+
+function renderCard() {
+  render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <ClassExpirationCard
+        ecclesiasticalYears={[
+          { ecclesiastical_year_id: 10, name: "Año 2026", active: true },
+        ]}
+      />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("ClassExpirationCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    actionState = {};
+  });
+
+  afterEach(() => cleanup());
+
+  it("disables destructive apply until a dry-run result exists", () => {
+    renderCard();
+
+    expect(screen.getByRole("button", { name: /aplicar vencimiento/i })).toBeDisabled();
+  });
+
+  it("requires confirmation with the dry-run expiration count before applying", async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    actionState = {
+      result: {
+        ecclesiastical_year_id: 10,
+        dry_run: true,
+        scanned_count: 4,
+        expired_count: 2,
+        enrollment_ids: [1, 2],
+      },
+    };
+
+    renderCard();
+    await user.click(screen.getByRole("button", { name: /aplicar vencimiento/i }));
+
+    expect(confirmSpy).toHaveBeenCalledWith(expect.stringContaining("2"));
+    confirmSpy.mockRestore();
+  });
+});

--- a/src/components/classes/class-expiration-card.tsx
+++ b/src/components/classes/class-expiration-card.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useActionState } from "react";
+import { useFormStatus } from "react-dom";
+import { Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import {
+  expireOverdueClassEnrollmentsAction,
+  type ClassExpirationActionState,
+} from "@/lib/classes/actions";
+
+type YearOption = {
+  ecclesiastical_year_id: number;
+  name: string;
+  active?: boolean;
+};
+
+interface ClassExpirationCardProps {
+  ecclesiasticalYears: YearOption[];
+}
+
+function SubmitButton({
+  dryRun,
+  label,
+}: {
+  dryRun: boolean;
+  label: string;
+}) {
+  const { pending } = useFormStatus();
+  return (
+    <Button
+      type="submit"
+      name="dry_run"
+      value={dryRun ? "true" : "false"}
+      variant={dryRun ? "outline" : "default"}
+      disabled={pending}
+    >
+      {pending && <Loader2 className="size-4 animate-spin" />}
+      {label}
+    </Button>
+  );
+}
+
+export function ClassExpirationCard({ ecclesiasticalYears }: ClassExpirationCardProps) {
+  const t = useTranslations("classes.expiration");
+  const [state, action, pending] = useActionState<ClassExpirationActionState, FormData>(
+    expireOverdueClassEnrollmentsAction,
+    {},
+  );
+  const defaultYearId =
+    ecclesiasticalYears.find((year) => year.active)?.ecclesiastical_year_id ??
+    ecclesiasticalYears[0]?.ecclesiastical_year_id;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{t("title")}</CardTitle>
+        <CardDescription>{t("description")}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <form action={action} aria-busy={pending} className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-[minmax(220px,1fr)_auto] sm:items-end">
+            <div className="space-y-2">
+              <Label htmlFor="class-expiration-year">{t("yearLabel")}</Label>
+              <select
+                id="class-expiration-year"
+                name="ecclesiastical_year_id"
+                defaultValue={defaultYearId ? String(defaultYearId) : ""}
+                className="border-input bg-background ring-offset-background placeholder:text-muted-foreground focus-visible:ring-ring flex h-9 w-full rounded-md border px-3 py-1 text-sm shadow-xs transition-colors focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <option value="">{t("currentYearOption")}</option>
+                {ecclesiasticalYears.map((year) => (
+                  <option
+                    key={year.ecclesiastical_year_id}
+                    value={String(year.ecclesiastical_year_id)}
+                  >
+                    {year.name || `Año #${year.ecclesiastical_year_id}`}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <SubmitButton dryRun={true} label={t("dryRun")} />
+              <SubmitButton dryRun={false} label={t("apply")} />
+            </div>
+          </div>
+
+          {state.error && (
+            <p className="rounded-md bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {state.error}
+            </p>
+          )}
+          {state.result && (
+            <p className="rounded-md bg-muted px-3 py-2 text-sm text-muted-foreground">
+              {t("result", {
+                scanned: state.result.scanned_count,
+                expired: state.result.expired_count,
+                mode: state.result.dry_run ? t("modeDryRun") : t("modeApply"),
+              })}
+            </p>
+          )}
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/classes/class-expiration-card.tsx
+++ b/src/components/classes/class-expiration-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState } from "react";
+import type { MouseEventHandler } from "react";
 import { useFormStatus } from "react-dom";
 import { Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -25,9 +26,13 @@ interface ClassExpirationCardProps {
 function SubmitButton({
   dryRun,
   label,
+  disabled = false,
+  onClick,
 }: {
   dryRun: boolean;
   label: string;
+  disabled?: boolean;
+  onClick?: MouseEventHandler<HTMLButtonElement>;
 }) {
   const { pending } = useFormStatus();
   return (
@@ -36,7 +41,8 @@ function SubmitButton({
       name="dry_run"
       value={dryRun ? "true" : "false"}
       variant={dryRun ? "outline" : "default"}
-      disabled={pending}
+      disabled={pending || disabled}
+      onClick={onClick}
     >
       {pending && <Loader2 className="size-4 animate-spin" />}
       {label}
@@ -53,6 +59,10 @@ export function ClassExpirationCard({ ecclesiasticalYears }: ClassExpirationCard
   const defaultYearId =
     ecclesiasticalYears.find((year) => year.active)?.ecclesiastical_year_id ??
     ecclesiasticalYears[0]?.ecclesiastical_year_id;
+  const canApply = state.result?.dry_run === true;
+  const confirmApplyMessage = t("confirmApply", {
+    expired: state.result?.expired_count ?? 0,
+  });
 
   return (
     <Card>
@@ -85,7 +95,16 @@ export function ClassExpirationCard({ ecclesiasticalYears }: ClassExpirationCard
 
             <div className="flex flex-wrap gap-2">
               <SubmitButton dryRun={true} label={t("dryRun")} />
-              <SubmitButton dryRun={false} label={t("apply")} />
+              <SubmitButton
+                dryRun={false}
+                label={t("apply")}
+                disabled={!canApply}
+                onClick={(event) => {
+                  if (!window.confirm(confirmApplyMessage)) {
+                    event.preventDefault();
+                  }
+                }}
+              />
             </div>
           </div>
 

--- a/src/components/classes/classes-list.tsx
+++ b/src/components/classes/classes-list.tsx
@@ -18,6 +18,7 @@ import { ClassStatusBadge } from "@/components/classes/class-status-badge";
 import {
   formatClassAvailabilityUntil,
   formatClassDurationRange,
+  type ClassDisplayLabels,
 } from "@/lib/classes/display";
 
 export type ClassRow = {
@@ -41,6 +42,16 @@ interface ClassesListProps {
 
 export function ClassesList({ items }: ClassesListProps) {
   const t = useTranslations("classes.list");
+  const displayT = useTranslations("classes.display");
+  const displayLabels: ClassDisplayLabels = {
+    yearSingular: displayT("yearSingular"),
+    yearPlural: displayT("yearPlural"),
+    yearFallback: (id) => displayT("yearFallback", { id }),
+    availableFromAnyYear: displayT("availableFromAnyYear"),
+    noProgrammedExpiration: displayT("noProgrammedExpiration"),
+    availableFromYear: (label) => displayT("availableFromYear", { label }),
+    availableUntilYear: (label) => displayT("availableUntilYear", { label }),
+  };
 
   if (items.length === 0) {
     return (
@@ -104,10 +115,14 @@ export function ClassesList({ items }: ClassesListProps) {
                 {cls.modules_count > 0 ? cls.modules_count : "—"}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle text-sm">
-                {formatClassDurationRange(cls.min_duration_years, cls.max_duration_years)}
+                {formatClassDurationRange(
+                  cls.min_duration_years,
+                  cls.max_duration_years,
+                  displayLabels,
+                )}
               </TableCell>
               <TableCell className="max-w-[260px] px-3 py-2.5 align-middle text-sm text-muted-foreground">
-                {formatClassAvailabilityUntil(cls.available_until_year_id)}
+                {formatClassAvailabilityUntil(cls.available_until_year_id, displayLabels)}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle">
                 <ClassStatusBadge active={cls.active} />

--- a/src/components/classes/classes-list.tsx
+++ b/src/components/classes/classes-list.tsx
@@ -15,6 +15,10 @@ import {
 } from "@/components/ui/table";
 import { EmptyState } from "@/components/shared/empty-state";
 import { ClassStatusBadge } from "@/components/classes/class-status-badge";
+import {
+  formatClassAvailabilityUntil,
+  formatClassDurationRange,
+} from "@/lib/classes/display";
 
 export type ClassRow = {
   class_id: number;
@@ -23,6 +27,10 @@ export type ClassRow = {
   club_type_id: number;
   club_type_name: string;
   display_order: number;
+  available_from_year_id?: number | null;
+  available_until_year_id?: number | null;
+  min_duration_years: number;
+  max_duration_years: number;
   modules_count: number;
   active: boolean;
 };
@@ -62,6 +70,12 @@ export function ClassesList({ items }: ClassesListProps) {
               {t("col_modules")}
             </TableHead>
             <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              {t("col_duration")}
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
+              {t("col_availability")}
+            </TableHead>
+            <TableHead className="h-9 px-3 text-xs font-medium uppercase tracking-wider text-muted-foreground">
               {t("col_status")}
             </TableHead>
             <TableHead className="h-9 w-12 px-3" />
@@ -88,6 +102,12 @@ export function ClassesList({ items }: ClassesListProps) {
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle text-sm tabular-nums">
                 {cls.modules_count > 0 ? cls.modules_count : "—"}
+              </TableCell>
+              <TableCell className="px-3 py-2.5 align-middle text-sm">
+                {formatClassDurationRange(cls.min_duration_years, cls.max_duration_years)}
+              </TableCell>
+              <TableCell className="max-w-[260px] px-3 py-2.5 align-middle text-sm text-muted-foreground">
+                {formatClassAvailabilityUntil(cls.available_until_year_id)}
               </TableCell>
               <TableCell className="px-3 py-2.5 align-middle">
                 <ClassStatusBadge active={cls.active} />

--- a/src/components/rbac/permissions-matrix.test.tsx
+++ b/src/components/rbac/permissions-matrix.test.tsx
@@ -184,7 +184,7 @@ describe("PermissionsMatrix", () => {
   });
 
   it("save dispatches syncAction with the role id and selected ids", async () => {
-    const action = vi.fn(async () => ({}));
+    const action = vi.fn<SyncAction>(async () => ({}));
     renderMatrix(action as unknown as SyncAction);
 
     await userEvent.click(getCellCheckbox("r1", "p2"));
@@ -194,7 +194,7 @@ describe("PermissionsMatrix", () => {
       expect(action).toHaveBeenCalledTimes(1);
     });
 
-    const [roleId, , formData] = action.mock.calls[0];
+    const [roleId, , formData] = action.mock.calls[0]!;
     expect(roleId).toBe("r1");
     expect(formData).toBeInstanceOf(FormData);
     const ids = (formData as FormData).get("permission_ids") as string;
@@ -205,7 +205,7 @@ describe("PermissionsMatrix", () => {
   });
 
   it("surfaces toast.error when syncAction returns an error", async () => {
-    const action = vi.fn(async () => ({ error: "boom" }));
+    const action = vi.fn<SyncAction>(async () => ({ error: "boom" }));
     renderMatrix(action as unknown as SyncAction);
 
     await userEvent.click(getCellCheckbox("r2", "p3"));

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -460,6 +460,16 @@ export interface IntlMessages {
       cancel: string;
       saveChanges: string;
       noPermissions: string;
+      colDuration: string;
+      colAvailability: string;
+      classConfigTitle: string;
+      classConfigDescription: string;
+      fieldAvailableFromYear: string;
+      fieldAvailableFromAny: string;
+      fieldAvailableUntilYear: string;
+      fieldAvailableUntilNone: string;
+      fieldMinDurationYears: string;
+      fieldMaxDurationYears: string;
     };
     pages: {
       countries: {
@@ -4870,6 +4880,8 @@ export interface IntlMessages {
       col_modules: string;
       col_status: string;
       view_detail: string;
+      col_duration: string;
+      col_availability: string;
     };
     tree: {
       no_modules: string;
@@ -4911,7 +4923,22 @@ export interface IntlMessages {
         tabStructure: string;
         structureCardTitle: string;
         modulesEndpointMissing: string;
+        labelDuration: string;
+        labelAvailableFrom: string;
+        labelAvailableUntil: string;
+        statDuration: string;
       };
+    };
+    expiration: {
+      title: string;
+      description: string;
+      yearLabel: string;
+      currentYearOption: string;
+      dryRun: string;
+      apply: string;
+      modeDryRun: string;
+      modeApply: string;
+      result: string;
     };
   };
   membership: {

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -4929,6 +4929,15 @@ export interface IntlMessages {
         statDuration: string;
       };
     };
+    display: {
+      yearSingular: string;
+      yearPlural: string;
+      yearFallback: string;
+      availableFromAnyYear: string;
+      noProgrammedExpiration: string;
+      availableFromYear: string;
+      availableUntilYear: string;
+    };
     expiration: {
       title: string;
       description: string;
@@ -4939,6 +4948,7 @@ export interface IntlMessages {
       modeDryRun: string;
       modeApply: string;
       result: string;
+      confirmApply: string;
     };
   };
   membership: {

--- a/src/lib/api/classes.test.ts
+++ b/src/lib/api/classes.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockApiRequest = vi.fn();
+
+vi.mock("@/lib/api/client", () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}));
+
+import { expireOverdueClassEnrollments } from "@/lib/api/classes";
+import { createAdminClass } from "@/lib/api/phase-e-catalogs";
+
+describe("classes admin API", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sends duration and availability fields when creating an admin class", async () => {
+    mockApiRequest.mockResolvedValue({ status: "success", data: { class_id: 1 } });
+
+    await createAdminClass({
+      name: "Guía Mayor",
+      description: "Clase legacy",
+      active: true,
+      available_from_year_id: 10,
+      available_until_year_id: null,
+      min_duration_years: 2,
+      max_duration_years: 3,
+    });
+
+    expect(mockApiRequest).toHaveBeenCalledWith("/admin/classes", {
+      method: "POST",
+      body: {
+        name: "Guía Mayor",
+        description: "Clase legacy",
+        active: true,
+        available_from_year_id: 10,
+        available_until_year_id: null,
+        min_duration_years: 2,
+        max_duration_years: 3,
+      },
+    });
+  });
+
+  it("posts manual expiration requests to the admin endpoint", async () => {
+    mockApiRequest.mockResolvedValue({
+      status: "success",
+      data: {
+        ecclesiastical_year_id: 10,
+        dry_run: true,
+        scanned_count: 4,
+        expired_count: 2,
+        enrollment_ids: [1, 2],
+      },
+    });
+
+    await expireOverdueClassEnrollments({ ecclesiastical_year_id: 10, dry_run: true });
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      "/admin/classes/enrollments/expire-overdue",
+      {
+        method: "POST",
+        body: { ecclesiastical_year_id: 10, dry_run: true },
+      },
+    );
+  });
+});

--- a/src/lib/api/classes.ts
+++ b/src/lib/api/classes.ts
@@ -8,6 +8,10 @@ export type ProgressiveClass = {
   description?: string | null;
   club_type_id: number;
   display_order: number;
+  available_from_year_id?: number | null;
+  available_until_year_id?: number | null;
+  min_duration_years?: number;
+  max_duration_years?: number;
   max_points?: number | null;
   minimum_points?: number | null;
   active: boolean;
@@ -58,6 +62,19 @@ export type ClassListQuery = {
   limit?: number;
 };
 
+export type ExpireOverdueClassEnrollmentsPayload = {
+  ecclesiastical_year_id?: number;
+  dry_run?: boolean;
+};
+
+export type ExpireOverdueClassEnrollmentsResult = {
+  ecclesiastical_year_id: number;
+  dry_run: boolean;
+  scanned_count: number;
+  expired_count: number;
+  enrollment_ids: number[];
+};
+
 // ─── API Functions ────────────────────────────────────────────────────────────
 
 /**
@@ -83,4 +100,16 @@ export async function getClassById(classId: number) {
  */
 export async function listClassModules(classId: number) {
   return apiRequest<ClassModule[]>(`/classes/${classId}/modules`);
+}
+
+export async function expireOverdueClassEnrollments(
+  payload: ExpireOverdueClassEnrollmentsPayload = {},
+) {
+  return apiRequest<{
+    status: "success";
+    data: ExpireOverdueClassEnrollmentsResult;
+  }>("/admin/classes/enrollments/expire-overdue", {
+    method: "POST",
+    body: payload,
+  });
 }

--- a/src/lib/api/phase-e-catalogs.ts
+++ b/src/lib/api/phase-e-catalogs.ts
@@ -29,6 +29,13 @@ export type TranslatablePayload = {
   translations?: CatalogTranslation[];
 };
 
+export type ClassAvailabilityDurationPayload = {
+  available_from_year_id?: number | null;
+  available_until_year_id?: number | null;
+  min_duration_years?: number;
+  max_duration_years?: number;
+};
+
 export type NameOnlyPayload = {
   name: string;
   active?: boolean;
@@ -43,6 +50,10 @@ export type AdminClass = {
   description?: string | null;
   club_type_id?: number | null;
   display_order?: number | null;
+  available_from_year_id?: number | null;
+  available_until_year_id?: number | null;
+  min_duration_years?: number;
+  max_duration_years?: number;
   active?: boolean;
   translations?: CatalogTranslation[];
 };
@@ -51,11 +62,11 @@ export async function listAdminClasses(params?: Record<string, string | number |
   return apiRequest<unknown>("/admin/classes", { params });
 }
 
-export async function createAdminClass(payload: TranslatablePayload) {
+export async function createAdminClass(payload: TranslatablePayload & ClassAvailabilityDurationPayload) {
   return apiRequest("/admin/classes", { method: "POST", body: payload });
 }
 
-export async function updateAdminClass(id: number, payload: Partial<TranslatablePayload>) {
+export async function updateAdminClass(id: number, payload: Partial<TranslatablePayload & ClassAvailabilityDurationPayload>) {
   return apiRequest(`/admin/classes/${id}`, { method: "PATCH", body: payload });
 }
 

--- a/src/lib/classes/actions.test.ts
+++ b/src/lib/classes/actions.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockExpireOverdueClassEnrollments = vi.fn();
+const mockRequireAdminUser = vi.fn();
+const mockHasAnyPermission = vi.fn();
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("@/lib/api/classes", () => ({
+  expireOverdueClassEnrollments: (...args: unknown[]) =>
+    mockExpireOverdueClassEnrollments(...args),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  requireAdminUser: () => mockRequireAdminUser(),
+}));
+
+vi.mock("@/lib/auth/permission-utils", () => ({
+  hasAnyPermission: (...args: unknown[]) => mockHasAnyPermission(...args),
+}));
+
+import { expireOverdueClassEnrollmentsAction } from "@/lib/classes/actions";
+
+function makeFormData(entries: Record<string, string>) {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    formData.set(key, value);
+  }
+  return formData;
+}
+
+describe("expireOverdueClassEnrollmentsAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdminUser.mockResolvedValue({ user_id: "admin-1" });
+    mockHasAnyPermission.mockReturnValue(true);
+    mockExpireOverdueClassEnrollments.mockResolvedValue({
+      status: "success",
+      data: {
+        ecclesiastical_year_id: 10,
+        dry_run: true,
+        scanned_count: 0,
+        expired_count: 0,
+        enrollment_ids: [],
+      },
+    });
+  });
+
+  it("fails fast when ecclesiastical_year_id is malformed", async () => {
+    const result = await expireOverdueClassEnrollmentsAction(
+      {},
+      makeFormData({ ecclesiastical_year_id: "not-a-year", dry_run: "true" }),
+    );
+
+    expect(result.error).toMatch(/año eclesiástico/i);
+    expect(mockExpireOverdueClassEnrollments).not.toHaveBeenCalled();
+  });
+
+  it("fails fast when ecclesiastical_year_id is nonpositive", async () => {
+    const result = await expireOverdueClassEnrollmentsAction(
+      {},
+      makeFormData({ ecclesiastical_year_id: "0", dry_run: "false" }),
+    );
+
+    expect(result.error).toMatch(/año eclesiástico/i);
+    expect(mockExpireOverdueClassEnrollments).not.toHaveBeenCalled();
+  });
+
+  it("allows empty ecclesiastical_year_id so the backend can use its default year", async () => {
+    await expireOverdueClassEnrollmentsAction(
+      {},
+      makeFormData({ ecclesiastical_year_id: "", dry_run: "true" }),
+    );
+
+    expect(mockExpireOverdueClassEnrollments).toHaveBeenCalledWith({ dry_run: true });
+  });
+});

--- a/src/lib/classes/actions.ts
+++ b/src/lib/classes/actions.ts
@@ -1,0 +1,54 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getActionErrorMessage } from "@/lib/api/action-error";
+import {
+  expireOverdueClassEnrollments,
+  type ExpireOverdueClassEnrollmentsResult,
+} from "@/lib/api/classes";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import { CLASSES_MANAGE } from "@/lib/auth/permissions";
+
+export type ClassExpirationActionState = {
+  error?: string;
+  result?: ExpireOverdueClassEnrollmentsResult;
+};
+
+function readOptionalPositiveInt(formData: FormData, field: string): number | undefined {
+  const raw = String(formData.get(field) ?? "").trim();
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+}
+
+export async function expireOverdueClassEnrollmentsAction(
+  _: ClassExpirationActionState,
+  formData: FormData,
+): Promise<ClassExpirationActionState> {
+  const user = await requireAdminUser();
+  if (!hasAnyPermission(user, [CLASSES_MANAGE])) {
+    return { error: "Sin permisos para vencer inscripciones." };
+  }
+
+  try {
+    const ecclesiasticalYearId = readOptionalPositiveInt(formData, "ecclesiastical_year_id");
+    const response = await expireOverdueClassEnrollments({
+      ...(ecclesiasticalYearId ? { ecclesiastical_year_id: ecclesiasticalYearId } : {}),
+      dry_run: formData.get("dry_run") !== "false",
+    });
+
+    if (!response.data.dry_run) {
+      revalidatePath("/dashboard/classes");
+    }
+
+    return { result: response.data };
+  } catch (error) {
+    return {
+      error: getActionErrorMessage(error, "No se pudo ejecutar el vencimiento manual.", {
+        endpointLabel: "/admin/classes/enrollments/expire-overdue",
+      }),
+    };
+  }
+}

--- a/src/lib/classes/actions.ts
+++ b/src/lib/classes/actions.ts
@@ -15,12 +15,21 @@ export type ClassExpirationActionState = {
   result?: ExpireOverdueClassEnrollmentsResult;
 };
 
-function readOptionalPositiveInt(formData: FormData, field: string): number | undefined {
+type OptionalPositiveIntResult =
+  | { ok: true; value?: number }
+  | { ok: false; error: string };
+
+function readOptionalPositiveInt(formData: FormData, field: string): OptionalPositiveIntResult {
   const raw = String(formData.get(field) ?? "").trim();
-  if (!raw) return undefined;
+  if (!raw) return { ok: true };
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
-  return Math.floor(parsed);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    return {
+      ok: false,
+      error: "El año eclesiástico debe ser un ID entero positivo o quedar vacío para usar el año activo del backend.",
+    };
+  }
+  return { ok: true, value: parsed };
 }
 
 export async function expireOverdueClassEnrollmentsAction(
@@ -32,10 +41,16 @@ export async function expireOverdueClassEnrollmentsAction(
     return { error: "Sin permisos para vencer inscripciones." };
   }
 
+  const ecclesiasticalYear = readOptionalPositiveInt(formData, "ecclesiastical_year_id");
+  if (!ecclesiasticalYear.ok) {
+    return { error: ecclesiasticalYear.error };
+  }
+
   try {
-    const ecclesiasticalYearId = readOptionalPositiveInt(formData, "ecclesiastical_year_id");
     const response = await expireOverdueClassEnrollments({
-      ...(ecclesiasticalYearId ? { ecclesiastical_year_id: ecclesiasticalYearId } : {}),
+      ...(ecclesiasticalYear.value
+        ? { ecclesiastical_year_id: ecclesiasticalYear.value }
+        : {}),
       dry_run: formData.get("dry_run") !== "false",
     });
 

--- a/src/lib/classes/class-config.test.ts
+++ b/src/lib/classes/class-config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { parseClassConfigFormData } from "@/lib/classes/class-config";
+
+function makeFormData(entries: Record<string, string>): FormData {
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(entries)) {
+    formData.set(key, value);
+  }
+  return formData;
+}
+
+describe("parseClassConfigFormData", () => {
+  it("rejects max duration lower than min duration", () => {
+    const result = parseClassConfigFormData(
+      makeFormData({
+        min_duration_years: "3",
+        max_duration_years: "2",
+        available_from_year_id: "",
+        available_until_year_id: "",
+      }),
+    );
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error).toContain("mayor o igual");
+    }
+  });
+
+  it("accepts null availability and sends default one-year duration", () => {
+    const result = parseClassConfigFormData(
+      makeFormData({
+        min_duration_years: "",
+        max_duration_years: "",
+        available_from_year_id: "",
+        available_until_year_id: "",
+      }),
+    );
+
+    expect(result).toEqual({
+      success: true,
+      data: {
+        available_from_year_id: null,
+        available_until_year_id: null,
+        min_duration_years: 1,
+        max_duration_years: 1,
+      },
+    });
+  });
+});

--- a/src/lib/classes/class-config.ts
+++ b/src/lib/classes/class-config.ts
@@ -1,0 +1,61 @@
+import { z } from "zod";
+
+export type ClassConfigPayload = {
+  available_from_year_id: number | null;
+  available_until_year_id: number | null;
+  min_duration_years: number;
+  max_duration_years: number;
+};
+
+export type ClassConfigParseResult =
+  | { success: true; data: ClassConfigPayload }
+  | { success: false; error: string };
+
+function optionalYearId(value: FormDataEntryValue | null): number | null {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+function durationYears(value: FormDataEntryValue | null): number {
+  const raw = String(value ?? "").trim();
+  if (!raw) return 1;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : Number.NaN;
+}
+
+const classConfigSchema = z
+  .object({
+    available_from_year_id: z.number().int().positive().nullable(),
+    available_until_year_id: z.number().int().positive().nullable(),
+    min_duration_years: z.number().int().min(1, "La duración mínima debe ser al menos 1 año."),
+    max_duration_years: z.number().int().min(1, "La duración máxima debe ser al menos 1 año."),
+  })
+  .superRefine((value, ctx) => {
+    if (value.max_duration_years < value.min_duration_years) {
+      ctx.addIssue({
+        code: "custom",
+        path: ["max_duration_years"],
+        message: "La duración máxima debe ser mayor o igual a la mínima.",
+      });
+    }
+  });
+
+export function parseClassConfigFormData(formData: FormData): ClassConfigParseResult {
+  const result = classConfigSchema.safeParse({
+    available_from_year_id: optionalYearId(formData.get("available_from_year_id")),
+    available_until_year_id: optionalYearId(formData.get("available_until_year_id")),
+    min_duration_years: durationYears(formData.get("min_duration_years")),
+    max_duration_years: durationYears(formData.get("max_duration_years")),
+  });
+
+  if (!result.success) {
+    return {
+      success: false,
+      error: result.error.issues[0]?.message ?? "La configuración de la clase no es válida.",
+    };
+  }
+
+  return { success: true, data: result.data };
+}

--- a/src/lib/classes/display.test.ts
+++ b/src/lib/classes/display.test.ts
@@ -1,22 +1,41 @@
 import { describe, expect, it } from "vitest";
 import {
   formatClassAvailabilityUntil,
+  formatClassAvailabilityFrom,
   formatClassDurationRange,
+  type ClassDisplayLabels,
 } from "@/lib/classes/display";
+
+const labels: ClassDisplayLabels = {
+  yearSingular: "year",
+  yearPlural: "years",
+  yearFallback: (id) => `Year #${id}`,
+  availableFromAnyYear: "Available from any year",
+  noProgrammedExpiration: "No programmed expiration",
+  availableFromYear: (label) => `Available from ecclesiastical year ${label}`,
+  availableUntilYear: (label) => `Available until ecclesiastical year ${label}`,
+};
 
 describe("class display helpers", () => {
   it("shows null available_until_year_id as no programmed expiration", () => {
-    expect(formatClassAvailabilityUntil(null)).toBe("Sin expiración programada");
+    expect(formatClassAvailabilityUntil(null, labels)).toBe("No programmed expiration");
   });
 
   it("shows cutoff year id with fallback label", () => {
-    expect(formatClassAvailabilityUntil(2026)).toBe(
-      "Disponible hasta año eclesiástico Año #2026",
+    expect(formatClassAvailabilityUntil(2026, labels)).toBe(
+      "Available until ecclesiastical year Year #2026",
+    );
+  });
+
+  it("shows available from using translated labels", () => {
+    expect(formatClassAvailabilityFrom(null, labels)).toBe("Available from any year");
+    expect(formatClassAvailabilityFrom(2025, labels, "Operational 2025")).toBe(
+      "Available from ecclesiastical year Operational 2025",
     );
   });
 
   it("formats single and ranged duration", () => {
-    expect(formatClassDurationRange(1, 1)).toBe("1 año");
-    expect(formatClassDurationRange(2, 3)).toBe("2–3 años");
+    expect(formatClassDurationRange(1, 1, labels)).toBe("1 year");
+    expect(formatClassDurationRange(2, 3, labels)).toBe("2–3 years");
   });
 });

--- a/src/lib/classes/display.test.ts
+++ b/src/lib/classes/display.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatClassAvailabilityUntil,
+  formatClassDurationRange,
+} from "@/lib/classes/display";
+
+describe("class display helpers", () => {
+  it("shows null available_until_year_id as no programmed expiration", () => {
+    expect(formatClassAvailabilityUntil(null)).toBe("Sin expiración programada");
+  });
+
+  it("shows cutoff year id with fallback label", () => {
+    expect(formatClassAvailabilityUntil(2026)).toBe(
+      "Disponible hasta año eclesiástico Año #2026",
+    );
+  });
+
+  it("formats single and ranged duration", () => {
+    expect(formatClassDurationRange(1, 1)).toBe("1 año");
+    expect(formatClassDurationRange(2, 3)).toBe("2–3 años");
+  });
+});

--- a/src/lib/classes/display.ts
+++ b/src/lib/classes/display.ts
@@ -1,4 +1,18 @@
-export function formatClassDurationRange(minDurationYears: number, maxDurationYears: number): string {
+export type ClassDisplayLabels = {
+  yearSingular: string;
+  yearPlural: string;
+  yearFallback: (yearId: number) => string;
+  availableFromAnyYear: string;
+  noProgrammedExpiration: string;
+  availableFromYear: (yearLabel: string) => string;
+  availableUntilYear: (yearLabel: string) => string;
+};
+
+export function formatClassDurationRange(
+  minDurationYears: number,
+  maxDurationYears: number,
+  labels: Pick<ClassDisplayLabels, "yearSingular" | "yearPlural">,
+): string {
   const min = Number.isFinite(minDurationYears) && minDurationYears >= 1
     ? Math.floor(minDurationYears)
     : 1;
@@ -7,32 +21,34 @@ export function formatClassDurationRange(minDurationYears: number, maxDurationYe
     : min;
 
   if (min === max) {
-    return `${min} ${min === 1 ? "año" : "años"}`;
+    return `${min} ${min === 1 ? labels.yearSingular : labels.yearPlural}`;
   }
 
-  return `${min}–${max} años`;
+  return `${min}–${max} ${labels.yearPlural}`;
 }
 
 export function formatClassAvailabilityUntil(
   availableUntilYearId: number | null | undefined,
+  labels: Pick<ClassDisplayLabels, "yearFallback" | "noProgrammedExpiration" | "availableUntilYear">,
   yearLabel?: string | null,
 ): string {
   if (availableUntilYearId == null) {
-    return "Sin expiración programada";
+    return labels.noProgrammedExpiration;
   }
 
-  const label = yearLabel?.trim() || `Año #${availableUntilYearId}`;
-  return `Disponible hasta año eclesiástico ${label}`;
+  const label = yearLabel?.trim() || labels.yearFallback(availableUntilYearId);
+  return labels.availableUntilYear(label);
 }
 
 export function formatClassAvailabilityFrom(
   availableFromYearId: number | null | undefined,
+  labels: Pick<ClassDisplayLabels, "yearFallback" | "availableFromAnyYear" | "availableFromYear">,
   yearLabel?: string | null,
 ): string {
   if (availableFromYearId == null) {
-    return "Disponible desde cualquier año";
+    return labels.availableFromAnyYear;
   }
 
-  const label = yearLabel?.trim() || `Año #${availableFromYearId}`;
-  return `Disponible desde año eclesiástico ${label}`;
+  const label = yearLabel?.trim() || labels.yearFallback(availableFromYearId);
+  return labels.availableFromYear(label);
 }

--- a/src/lib/classes/display.ts
+++ b/src/lib/classes/display.ts
@@ -1,0 +1,38 @@
+export function formatClassDurationRange(minDurationYears: number, maxDurationYears: number): string {
+  const min = Number.isFinite(minDurationYears) && minDurationYears >= 1
+    ? Math.floor(minDurationYears)
+    : 1;
+  const max = Number.isFinite(maxDurationYears) && maxDurationYears >= min
+    ? Math.floor(maxDurationYears)
+    : min;
+
+  if (min === max) {
+    return `${min} ${min === 1 ? "año" : "años"}`;
+  }
+
+  return `${min}–${max} años`;
+}
+
+export function formatClassAvailabilityUntil(
+  availableUntilYearId: number | null | undefined,
+  yearLabel?: string | null,
+): string {
+  if (availableUntilYearId == null) {
+    return "Sin expiración programada";
+  }
+
+  const label = yearLabel?.trim() || `Año #${availableUntilYearId}`;
+  return `Disponible hasta año eclesiástico ${label}`;
+}
+
+export function formatClassAvailabilityFrom(
+  availableFromYearId: number | null | undefined,
+  yearLabel?: string | null,
+): string {
+  if (availableFromYearId == null) {
+    return "Disponible desde cualquier año";
+  }
+
+  const label = yearLabel?.trim() || `Año #${availableFromYearId}`;
+  return `Disponible desde año eclesiástico ${label}`;
+}

--- a/src/lib/phase-e-catalogs/actions.ts
+++ b/src/lib/phase-e-catalogs/actions.ts
@@ -66,6 +66,7 @@ import {
   updateAdminMasterHonor,
   deleteAdminMasterHonor,
 } from "@/lib/api/phase-e-catalogs";
+import { parseClassConfigFormData } from "@/lib/classes/class-config";
 
 // ─── Shared types ──────────────────────────────────────────────────────────────
 
@@ -234,7 +235,47 @@ function makeActions(
 
 // ─── Classes ──────────────────────────────────────────────────────────────────
 
-const classesActions = makeActions(
+export async function createClassAction(_: PhaseEActionState, formData: FormData): Promise<PhaseEActionState> {
+  const user = await requireAdminUser();
+  if (!hasAnyPermission(user, [CLASSES_MANAGE, CATALOGS_CREATE])) {
+    return { error: "Sin permisos para crear." };
+  }
+  const config = parseClassConfigFormData(formData);
+  if (!config.success) return { error: config.error };
+  try {
+    await createAdminClass({
+      ...buildTranslatableCreate(formData),
+      ...config.data,
+    });
+  } catch (error) {
+    return { error: getActionErrorMessage(error, "No se pudo crear el registro.", { endpointLabel: "/dashboard/catalogs/classes" }) };
+  }
+  revalidatePath("/dashboard/catalogs/classes");
+  redirect("/dashboard/catalogs/classes");
+}
+
+export async function updateClassAction(_: PhaseEActionState, formData: FormData): Promise<PhaseEActionState> {
+  const user = await requireAdminUser();
+  if (!hasAnyPermission(user, [CLASSES_MANAGE, CATALOGS_UPDATE])) {
+    return { error: "Sin permisos para editar." };
+  }
+  const id = parsePositiveInt(formData, "id");
+  if (!id) return { error: "No se pudo identificar el registro a editar." };
+  const config = parseClassConfigFormData(formData);
+  if (!config.success) return { error: config.error };
+  try {
+    await updateAdminClass(id, {
+      ...buildTranslatableUpdate(formData),
+      ...config.data,
+    });
+  } catch (error) {
+    return { error: getActionErrorMessage(error, "No se pudo actualizar el registro.", { endpointLabel: `/dashboard/catalogs/classes/${id}` }) };
+  }
+  revalidatePath("/dashboard/catalogs/classes");
+  redirect("/dashboard/catalogs/classes");
+}
+
+const classDeleteActions = makeActions(
   "/dashboard/catalogs/classes",
   { create: [CLASSES_MANAGE, CATALOGS_CREATE], update: [CLASSES_MANAGE, CATALOGS_UPDATE], delete: [CLASSES_MANAGE, CATALOGS_DELETE] },
   {
@@ -245,9 +286,7 @@ const classesActions = makeActions(
   true,
 );
 
-export const createClassAction = classesActions.createAction;
-export const updateClassAction = classesActions.updateAction;
-export const deleteClassAction = classesActions.deleteAction;
+export const deleteClassAction = classDeleteActions.deleteAction;
 
 // ─── Class Modules ────────────────────────────────────────────────────────────
 

--- a/src/lib/phase-e-catalogs/actions.ts
+++ b/src/lib/phase-e-catalogs/actions.ts
@@ -248,7 +248,7 @@ export async function createClassAction(_: PhaseEActionState, formData: FormData
       ...config.data,
     });
   } catch (error) {
-    return { error: getActionErrorMessage(error, "No se pudo crear el registro.", { endpointLabel: "/dashboard/catalogs/classes" }) };
+    return { error: getActionErrorMessage(error, "No se pudo crear el registro.", { endpointLabel: "/admin/classes" }) };
   }
   revalidatePath("/dashboard/catalogs/classes");
   redirect("/dashboard/catalogs/classes");
@@ -269,7 +269,7 @@ export async function updateClassAction(_: PhaseEActionState, formData: FormData
       ...config.data,
     });
   } catch (error) {
-    return { error: getActionErrorMessage(error, "No se pudo actualizar el registro.", { endpointLabel: `/dashboard/catalogs/classes/${id}` }) };
+    return { error: getActionErrorMessage(error, "No se pudo actualizar el registro.", { endpointLabel: `/admin/classes/${id}` }) };
   }
   revalidatePath("/dashboard/catalogs/classes");
   redirect("/dashboard/catalogs/classes");


### PR DESCRIPTION
## Summary
- Adds admin class configuration for availability window and min/max duration.
- Adds manual overdue enrollment expiration UI with dry-run, explicit confirmation, and fail-fast year parsing.
- Aligns class display/i18n helpers and API wrappers with backend contract.

## Verification
- [x] `pnpm test` — 66 files / 731 tests passed
- [x] `pnpm exec tsc --noEmit` was run; it fails only on pre-existing unrelated issues in `camporee-events/timeline/event-day-card.tsx` and `rbac/permissions-matrix.test.tsx`.

## Notes
- No builds run per workspace instruction.
- Depends on backend PR for the new `/admin/classes` fields and expiration endpoint.

## Companion PRs
- Backend: https://github.com/abn-r/sacdia-backend/pull/143
- Admin: https://github.com/abn-r/sacdia-admin/pull/181
- App: https://github.com/abn-r/sacdia-app/pull/100
- Docs: https://github.com/abn-r/sacdia/pull/22
