### PR TITLE
feat(admin): replace raw ids with shared selectors

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1208,13 +1208,13 @@
       "club_send_failed": "The club notification could not be sent"
     },
     "validation": {
-      "user_id_required": "Enter the user ID",
+      "user_id_required": "Select a member",
       "title_required": "Enter the title",
       "body_required": "Enter the message",
       "instance_type_required": "Select the club type",
       "instance_type_invalid": "The club type is invalid",
-      "instance_id_required": "Enter the instance ID",
-      "instance_id_invalid": "The instance ID is invalid"
+      "instance_id_required": "Select a section",
+      "instance_id_invalid": "The selected section is invalid"
     },
     "success": {
       "sent": "Notification sent successfully",
@@ -1229,8 +1229,8 @@
       "broadcast_warning": "This action will send the notification to all users with a registered FCM token.",
       "club_title": "By club",
       "club_description": "Send a notification to all members of a club.",
-      "label_user_id": "User ID",
-      "placeholder_user_id": "User UUID",
+      "label_user_id": "Member",
+      "placeholder_user_id": "Search member...",
       "label_title": "Title",
       "placeholder_title_notification": "Notification title",
       "placeholder_title_broadcast": "Broadcast title",
@@ -1241,8 +1241,8 @@
       "option_adventurers": "Adventurers",
       "option_pathfinders": "Pathfinders",
       "option_master_guilds": "Master Guides",
-      "label_instance_id": "Instance ID",
-      "placeholder_instance_id": "Numeric club ID",
+      "label_instance_id": "Section",
+      "placeholder_instance_id": "Select a section",
       "submit_send": "Send notification",
       "submit_broadcast": "Send broadcast",
       "submit_club": "Send to club"
@@ -2446,7 +2446,17 @@
       "helpInsurance": "Registration will fail if the insurance is not validated.",
       "cancel": "Cancel",
       "registering": "Registering...",
-      "register": "Register member"
+      "register": "Register member",
+      "description": "Select the club and member to register them for the camporee.",
+      "labelClub": "Club",
+      "labelMember": "Member",
+      "placeholderMember": "Search member...",
+      "placeholderSelectClubFirst": "Select a club first",
+      "insuranceLoading": "Looking for active insurance...",
+      "insuranceActive": "Active insurance",
+      "insuranceExpires": "Expires",
+      "noInsuranceTitle": "No active insurance",
+      "noInsuranceDescription": "This member has no active insurance and cannot be registered."
     },
     "pages": {
       "list": {
@@ -5531,6 +5541,34 @@
       "statusInactive": "Inactive",
       "reorderUp": "Move up",
       "reorderDown": "Move down"
+    }
+  },
+  "selectors": {
+    "ecclesiasticalYear": {
+      "placeholder": "Select an ecclesiastical year",
+      "searchPlaceholder": "Search year...",
+      "loading": "Loading years...",
+      "empty": "No results",
+      "loadError": "Failed to load years",
+      "clearSelection": "Clear selection",
+      "activeBadge": "Active"
+    },
+    "club": {
+      "placeholder": "Select a club",
+      "searchPlaceholder": "Search club...",
+      "loading": "Loading clubs...",
+      "empty": "No results",
+      "loadError": "Failed to load clubs",
+      "clearSelection": "Clear selection"
+    },
+    "clubSection": {
+      "placeholder": "Select a section",
+      "placeholderNoClub": "Select a club first",
+      "searchPlaceholder": "Search section...",
+      "loading": "Loading sections...",
+      "empty": "No results",
+      "loadError": "Failed to load sections",
+      "clearSelection": "Clear selection"
     }
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1208,13 +1208,13 @@
       "club_send_failed": "No se pudo enviar la notificación al club"
     },
     "validation": {
-      "user_id_required": "Ingrese el ID de usuario",
+      "user_id_required": "Seleccioná un miembro",
       "title_required": "Ingrese el título",
       "body_required": "Ingrese el mensaje",
       "instance_type_required": "Seleccione el tipo de club",
       "instance_type_invalid": "El tipo de club no es válido",
-      "instance_id_required": "Ingrese el ID de instancia",
-      "instance_id_invalid": "El ID de instancia no es válido"
+      "instance_id_required": "Seleccioná una sección",
+      "instance_id_invalid": "La sección seleccionada no es válida"
     },
     "success": {
       "sent": "Notificación enviada correctamente",
@@ -1229,8 +1229,8 @@
       "broadcast_warning": "Esta acción enviará la notificación a todos los usuarios con token FCM registrado.",
       "club_title": "Por club",
       "club_description": "Enviar notificación a todos los miembros de un club.",
-      "label_user_id": "ID de usuario",
-      "placeholder_user_id": "UUID del usuario",
+      "label_user_id": "Miembro",
+      "placeholder_user_id": "Buscar miembro...",
       "label_title": "Título",
       "placeholder_title_notification": "Título de la notificación",
       "placeholder_title_broadcast": "Título del broadcast",
@@ -1241,8 +1241,8 @@
       "option_adventurers": "Aventureros",
       "option_pathfinders": "Conquistadores",
       "option_master_guilds": "Guías Mayores",
-      "label_instance_id": "ID de instancia",
-      "placeholder_instance_id": "ID numérico del club",
+      "label_instance_id": "Sección",
+      "placeholder_instance_id": "Seleccioná una sección",
       "submit_send": "Enviar notificación",
       "submit_broadcast": "Enviar broadcast",
       "submit_club": "Enviar a club"
@@ -2450,7 +2450,17 @@
       "helpInsurance": "El registro fallará si el seguro no está validado.",
       "cancel": "Cancelar",
       "registering": "Registrando...",
-      "register": "Registrar miembro"
+      "register": "Registrar miembro",
+      "description": "Seleccioná el club y el miembro para inscribirlo en el camporee.",
+      "labelClub": "Club",
+      "labelMember": "Miembro",
+      "placeholderMember": "Buscar miembro...",
+      "placeholderSelectClubFirst": "Seleccioná un club primero",
+      "insuranceLoading": "Buscando seguro activo...",
+      "insuranceActive": "Seguro activo",
+      "insuranceExpires": "Vence",
+      "noInsuranceTitle": "Sin seguro activo",
+      "noInsuranceDescription": "Este miembro no tiene seguro activo. No se puede inscribir."
     },
     "pages": {
       "list": {
@@ -5550,6 +5560,34 @@
       "statusInactive": "Inactivo",
       "reorderUp": "Subir",
       "reorderDown": "Bajar"
+    }
+  },
+  "selectors": {
+    "ecclesiasticalYear": {
+      "placeholder": "Seleccioná un año eclesiástico",
+      "searchPlaceholder": "Buscar año...",
+      "loading": "Cargando años...",
+      "empty": "Sin resultados",
+      "loadError": "Error al cargar años",
+      "clearSelection": "Limpiar selección",
+      "activeBadge": "Activo"
+    },
+    "club": {
+      "placeholder": "Seleccioná un club",
+      "searchPlaceholder": "Buscar club...",
+      "loading": "Cargando clubes...",
+      "empty": "Sin resultados",
+      "loadError": "Error al cargar clubes",
+      "clearSelection": "Limpiar selección"
+    },
+    "clubSection": {
+      "placeholder": "Seleccioná una sección",
+      "placeholderNoClub": "Seleccioná un club primero",
+      "searchPlaceholder": "Buscar sección...",
+      "loading": "Cargando secciones...",
+      "empty": "Sin resultados",
+      "loadError": "Error al cargar secciones",
+      "clearSelection": "Limpiar selección"
     }
   }
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1207,13 +1207,13 @@
       "club_send_failed": "Impossible d'envoyer la notification au club"
     },
     "validation": {
-      "user_id_required": "Saisissez l'identifiant de l'utilisateur",
+      "user_id_required": "Sélectionner un membre",
       "title_required": "Saisissez le titre",
       "body_required": "Saisissez le message",
       "instance_type_required": "Sélectionnez le type de club",
       "instance_type_invalid": "Le type de club n'est pas valide",
-      "instance_id_required": "Saisissez l'identifiant de l'instance",
-      "instance_id_invalid": "L'identifiant de l'instance n'est pas valide"
+      "instance_id_required": "Sélectionner une section",
+      "instance_id_invalid": "La section sélectionnée est invalide"
     },
     "success": {
       "sent": "Notification envoyée avec succès",
@@ -1228,8 +1228,8 @@
       "broadcast_warning": "Cette action enverra la notification à tous les utilisateurs avec un token FCM enregistré.",
       "club_title": "Par club",
       "club_description": "Envoyer une notification à tous les membres d'un club.",
-      "label_user_id": "ID utilisateur",
-      "placeholder_user_id": "UUID de l'utilisateur",
+      "label_user_id": "Membre",
+      "placeholder_user_id": "Rechercher un membre...",
       "label_title": "Titre",
       "placeholder_title_notification": "Titre de la notification",
       "placeholder_title_broadcast": "Titre de la diffusion",
@@ -1240,8 +1240,8 @@
       "option_adventurers": "Aventuriers",
       "option_pathfinders": "Éclaireurs",
       "option_master_guilds": "Guides principaux",
-      "label_instance_id": "ID instance",
-      "placeholder_instance_id": "ID numérique du club",
+      "label_instance_id": "Section",
+      "placeholder_instance_id": "Sélectionner une section",
       "submit_send": "Envoyer la notification",
       "submit_broadcast": "Envoyer la diffusion",
       "submit_club": "Envoyer au club"
@@ -2433,7 +2433,17 @@
       "helpInsurance": "L'enregistrement échouera si l'assurance n'est pas validée.",
       "cancel": "Annuler",
       "registering": "Enregistrement...",
-      "register": "Enregistrer le membre"
+      "register": "Enregistrer le membre",
+      "description": "Sélectionnez le club et le membre à inscrire au camporee.",
+      "labelClub": "Club",
+      "labelMember": "Membre",
+      "placeholderMember": "Rechercher un membre...",
+      "placeholderSelectClubFirst": "Sélectionnez d’abord un club",
+      "insuranceLoading": "Recherche d’une assurance active...",
+      "insuranceActive": "Assurance active",
+      "insuranceExpires": "Expire le",
+      "noInsuranceTitle": "Aucune assurance active",
+      "noInsuranceDescription": "Ce membre n’a pas d’assurance active et ne peut pas être inscrit."
     },
     "pages": {
       "list": {
@@ -5397,6 +5407,34 @@
       "statusInactive": "Inactif",
       "reorderUp": "Monter",
       "reorderDown": "Descendre"
+    }
+  },
+  "selectors": {
+    "ecclesiasticalYear": {
+      "placeholder": "Sélectionner une année ecclésiastique",
+      "searchPlaceholder": "Rechercher une année...",
+      "loading": "Chargement des années...",
+      "empty": "Aucun résultat",
+      "loadError": "Erreur lors du chargement",
+      "clearSelection": "Effacer la sélection",
+      "activeBadge": "Actif"
+    },
+    "club": {
+      "placeholder": "Sélectionner un club",
+      "searchPlaceholder": "Rechercher un club...",
+      "loading": "Chargement des clubs...",
+      "empty": "Aucun résultat",
+      "loadError": "Erreur lors du chargement",
+      "clearSelection": "Effacer la sélection"
+    },
+    "clubSection": {
+      "placeholder": "Sélectionner une section",
+      "placeholderNoClub": "Sélectionnez d'abord un club",
+      "searchPlaceholder": "Rechercher une section...",
+      "loading": "Chargement des sections...",
+      "empty": "Aucun résultat",
+      "loadError": "Erreur lors du chargement",
+      "clearSelection": "Effacer la sélection"
     }
   }
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1207,13 +1207,13 @@
       "club_send_failed": "Não foi possível enviar a notificação ao clube"
     },
     "validation": {
-      "user_id_required": "Informe o ID do usuário",
+      "user_id_required": "Selecione um membro",
       "title_required": "Informe o título",
       "body_required": "Informe a mensagem",
       "instance_type_required": "Selecione o tipo de clube",
       "instance_type_invalid": "O tipo de clube não é válido",
-      "instance_id_required": "Informe o ID da instância",
-      "instance_id_invalid": "O ID da instância não é válido"
+      "instance_id_required": "Selecione uma seção",
+      "instance_id_invalid": "A seção selecionada é inválida"
     },
     "success": {
       "sent": "Notificação enviada com sucesso",
@@ -1228,8 +1228,8 @@
       "broadcast_warning": "Esta ação enviará a notificação para todos os usuários com token FCM registrado.",
       "club_title": "Por clube",
       "club_description": "Enviar notificação para todos os membros de um clube.",
-      "label_user_id": "ID do usuário",
-      "placeholder_user_id": "UUID do usuário",
+      "label_user_id": "Membro",
+      "placeholder_user_id": "Buscar membro...",
       "label_title": "Título",
       "placeholder_title_notification": "Título da notificação",
       "placeholder_title_broadcast": "Título do broadcast",
@@ -1240,8 +1240,8 @@
       "option_adventurers": "Aventureiros",
       "option_pathfinders": "Desbravadores",
       "option_master_guilds": "Guias Máster",
-      "label_instance_id": "ID da instância",
-      "placeholder_instance_id": "ID numérico do clube",
+      "label_instance_id": "Seção",
+      "placeholder_instance_id": "Selecione uma seção",
       "submit_send": "Enviar notificação",
       "submit_broadcast": "Enviar broadcast",
       "submit_club": "Enviar ao clube"
@@ -2433,7 +2433,17 @@
       "helpInsurance": "O registro falhará se o seguro não estiver validado.",
       "cancel": "Cancelar",
       "registering": "Registrando...",
-      "register": "Registrar membro"
+      "register": "Registrar membro",
+      "description": "Selecione o clube e o membro para registrá-lo no camporee.",
+      "labelClub": "Clube",
+      "labelMember": "Membro",
+      "placeholderMember": "Buscar membro...",
+      "placeholderSelectClubFirst": "Selecione um clube primeiro",
+      "insuranceLoading": "Buscando seguro ativo...",
+      "insuranceActive": "Seguro ativo",
+      "insuranceExpires": "Vence",
+      "noInsuranceTitle": "Sem seguro ativo",
+      "noInsuranceDescription": "Este membro não tem seguro ativo e não pode ser inscrito."
     },
     "pages": {
       "list": {
@@ -5397,6 +5407,34 @@
       "statusInactive": "Inativo",
       "reorderUp": "Mover para cima",
       "reorderDown": "Mover para baixo"
+    }
+  },
+  "selectors": {
+    "ecclesiasticalYear": {
+      "placeholder": "Selecione um ano eclesiástico",
+      "searchPlaceholder": "Buscar ano...",
+      "loading": "Carregando anos...",
+      "empty": "Sem resultados",
+      "loadError": "Falha ao carregar anos",
+      "clearSelection": "Limpar seleção",
+      "activeBadge": "Ativo"
+    },
+    "club": {
+      "placeholder": "Selecione um clube",
+      "searchPlaceholder": "Buscar clube...",
+      "loading": "Carregando clubes...",
+      "empty": "Sem resultados",
+      "loadError": "Falha ao carregar clubes",
+      "clearSelection": "Limpar seleção"
+    },
+    "clubSection": {
+      "placeholder": "Selecione uma seção",
+      "placeholderNoClub": "Selecione um clube primeiro",
+      "searchPlaceholder": "Buscar seção...",
+      "loading": "Carregando seções...",
+      "empty": "Sem resultados",
+      "loadError": "Falha ao carregar seções",
+      "clearSelection": "Limpar seleção"
     }
   }
 }

--- a/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-filters.tsx
+++ b/src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-filters.tsx
@@ -1,10 +1,13 @@
 "use client";
 
+import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { EcclesiasticalYearSelect } from "@/components/shared/selectors/ecclesiastical-year-select";
+import { ClubSelect } from "@/components/shared/selectors/club-select";
+import { ClubSectionSelect } from "@/components/shared/selectors/club-section-select";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -19,12 +22,12 @@ interface MemberRankingsFiltersProps {
 /**
  * GET-form filter bar for the member-rankings list page.
  *
- * Uses plain number inputs for year, club, and section.
- * TODO: Replace with catalog-backed <Select> components once
- *       catalog hooks / fetch helpers are available for each entity.
+ * Uses catalog-backed selectors for year, club, and section.
+ * Controlled state drives hidden inputs so the plain GET form
+ * submission still encodes values as bookmarkable URL params.
  *
- * Submitting the form encodes values as query params (bookmarkable URLs).
- * The reset link navigates to the bare route, clearing all params.
+ * When club_id changes, section_id resets to null — both internally
+ * in ClubSectionSelect and in the parent state via its onChange callback.
  */
 export function MemberRankingsFilters({
   defaultYear,
@@ -33,61 +36,75 @@ export function MemberRankingsFilters({
 }: MemberRankingsFiltersProps) {
   const t = useTranslations("rankings.filters");
 
+  const [yearId, setYearId] = useState<number | null>(defaultYear ?? null);
+  const [clubId, setClubId] = useState<number | null>(defaultClubId ?? null);
+  const [sectionId, setSectionId] = useState<number | null>(
+    defaultSectionId ?? null,
+  );
+
+  function handleClubChange(id: number | null) {
+    setClubId(id);
+    // Reset section whenever the club changes.
+    // ClubSectionSelect also fires its own onChange(null) via its internal
+    // useEffect — that call is idempotent here.
+    setSectionId(null);
+  }
+
   return (
     <form className="flex flex-wrap items-end gap-3" method="GET">
+      {/* Hidden inputs carry selected values as GET params on submit */}
+      {yearId != null && (
+        <input type="hidden" name="year_id" value={yearId} />
+      )}
+      {clubId != null && (
+        <input type="hidden" name="club_id" value={clubId} />
+      )}
+      {sectionId != null && (
+        <input type="hidden" name="section_id" value={sectionId} />
+      )}
+
       {/* Year filter */}
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="filter-year" className="text-xs text-muted-foreground">
+        <Label className="text-xs text-muted-foreground">
           {t("labelYear")}
         </Label>
-        <Input
-          id="filter-year"
-          name="year_id"
-          type="number"
-          min={2000}
-          max={2100}
-          placeholder={t("placeholderYear")}
-          defaultValue={defaultYear}
-          className="h-9 w-32"
-        />
+        <div className="w-52">
+          <EcclesiasticalYearSelect
+            value={yearId}
+            onChange={setYearId}
+            placeholder={t("placeholderYear")}
+            activeOnly={false}
+          />
+        </div>
       </div>
 
       {/* Club filter */}
       <div className="flex flex-col gap-1.5">
-        <Label
-          htmlFor="filter-club"
-          className="text-xs text-muted-foreground"
-        >
+        <Label className="text-xs text-muted-foreground">
           {t("labelClub")}
         </Label>
-        <Input
-          id="filter-club"
-          name="club_id"
-          type="number"
-          min={1}
-          placeholder={t("placeholderClub")}
-          defaultValue={defaultClubId}
-          className="h-9 w-32"
-        />
+        <div className="w-56">
+          <ClubSelect
+            value={clubId}
+            onChange={handleClubChange}
+            placeholder={t("placeholderClub")}
+          />
+        </div>
       </div>
 
       {/* Section filter */}
       <div className="flex flex-col gap-1.5">
-        <Label
-          htmlFor="filter-section"
-          className="text-xs text-muted-foreground"
-        >
+        <Label className="text-xs text-muted-foreground">
           {t("labelSection")}
         </Label>
-        <Input
-          id="filter-section"
-          name="section_id"
-          type="number"
-          min={1}
-          placeholder={t("placeholderSection")}
-          defaultValue={defaultSectionId}
-          className="h-9 w-32"
-        />
+        <div className="w-56">
+          <ClubSectionSelect
+            clubId={clubId}
+            value={sectionId}
+            onChange={setSectionId}
+            placeholder={t("placeholderSection")}
+          />
+        </div>
       </div>
 
       {/* Actions */}

--- a/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-filters.tsx
+++ b/src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-filters.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { EcclesiasticalYearSelect } from "@/components/shared/selectors/ecclesiastical-year-select";
+import { ClubSelect } from "@/components/shared/selectors/club-select";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -21,11 +23,9 @@ interface SectionRankingsFiltersProps {
  * Filters: year_id + club_id only.
  * section_id is intentionally omitted — sections ARE the rows, not a filter.
  *
- * TODO: Replace number inputs with catalog-backed <Select> components once
- *       fetch helpers for ecclesiastical years and clubs are available.
- *
- * Submitting the form encodes values as query params (bookmarkable URLs).
- * The reset link navigates to the bare route, clearing all params.
+ * Uses catalog-backed selectors for year and club.
+ * Controlled state drives hidden inputs so the plain GET form
+ * submission still encodes values as bookmarkable URL params.
  */
 export function SectionRankingsFilters({
   defaultYear,
@@ -33,39 +33,46 @@ export function SectionRankingsFilters({
 }: SectionRankingsFiltersProps) {
   const t = useTranslations("rankings.sectionFilters");
 
+  const [yearId, setYearId] = useState<number | null>(defaultYear ?? null);
+  const [clubId, setClubId] = useState<number | null>(defaultClubId ?? null);
+
   return (
     <form className="flex flex-wrap items-end gap-3" method="GET">
+      {/* Hidden inputs carry selected values as GET params on submit */}
+      {yearId != null && (
+        <input type="hidden" name="year_id" value={yearId} />
+      )}
+      {clubId != null && (
+        <input type="hidden" name="club_id" value={clubId} />
+      )}
+
       {/* Year filter */}
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="filter-year" className="text-xs text-muted-foreground">
+        <Label className="text-xs text-muted-foreground">
           {t("labelYear")}
         </Label>
-        <Input
-          id="filter-year"
-          name="year_id"
-          type="number"
-          min={2000}
-          max={2100}
-          placeholder={t("placeholderYear")}
-          defaultValue={defaultYear}
-          className="h-9 w-32"
-        />
+        <div className="w-52">
+          <EcclesiasticalYearSelect
+            value={yearId}
+            onChange={setYearId}
+            placeholder={t("placeholderYear")}
+            activeOnly={false}
+          />
+        </div>
       </div>
 
       {/* Club filter */}
       <div className="flex flex-col gap-1.5">
-        <Label htmlFor="filter-club" className="text-xs text-muted-foreground">
+        <Label className="text-xs text-muted-foreground">
           {t("labelClub")}
         </Label>
-        <Input
-          id="filter-club"
-          name="club_id"
-          type="number"
-          min={1}
-          placeholder={t("placeholderClub")}
-          defaultValue={defaultClubId}
-          className="h-9 w-32"
-        />
+        <div className="w-56">
+          <ClubSelect
+            value={clubId}
+            onChange={setClubId}
+            placeholder={t("placeholderClub")}
+          />
+        </div>
       </div>
 
       {/* Actions */}

--- a/src/components/camporees/register-member-dialog.test.tsx
+++ b/src/components/camporees/register-member-dialog.test.tsx
@@ -1,22 +1,9 @@
 /**
  * Integration tests for RegisterMemberDialog.
  *
- * Architecture notes:
- * ------------------------------------------------------------------
- * The dialog uses React Hook Form + Zod (static schema, no useMemo).
- * It calls `registerCamporeeMember` from `@/lib/api/camporees` (HTTP).
- * We mock the module entirely — no MSW needed.
- *
- * Special behavior:
- *   - Insurance-related errors (containing "seguro"/"insurance"/"póliza")
- *     render a dedicated alert callout (role="alert") instead of toast.
- *   - Generic errors go to toast.error.
- *   - `camporee_type` defaults to "local"; the "union" type shows a hint
- *     on the club_name label.
- *
- * Renders are wrapped in `NextIntlClientProvider` with real `messages/es.json`.
- *
- * Vitest uses `globals: false` — explicit `cleanup()` per `afterEach`.
+ * The dialog now uses Club → Member selectors and auto-fills insurance from the
+ * backend. Selectors are mocked here because this suite verifies dialog submit
+ * behavior, not selector internals.
  */
 
 import React from "react";
@@ -48,11 +35,30 @@ if (!Element.prototype.scrollIntoView) {
 }
 
 // ---------------------------------------------------------------------------
-// Module-level mocks
+// Test constants + mocks
 // ---------------------------------------------------------------------------
+
+const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
+const ACTIVE_INSURANCE = {
+  insurance_id: 42,
+  insurance_type: "CAMPOREE",
+  policy_number: "POL-42",
+  provider: "Seguro Test",
+  start_date: "2026-01-01",
+  end_date: "2026-12-31",
+  coverage_amount: 1000,
+  active: true,
+  evidence_file_url: null,
+  evidence_file_name: null,
+  created_at: null,
+  modified_at: null,
+  created_by_name: null,
+  modified_by_name: null,
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const mockRegister = vi.fn<(...args: any[]) => Promise<unknown>>();
+const mockGetMemberInsurance = vi.fn();
 
 vi.mock("@/lib/api/camporees", async (importOriginal) => {
   const original = await importOriginal<typeof import("@/lib/api/camporees")>();
@@ -61,6 +67,41 @@ vi.mock("@/lib/api/camporees", async (importOriginal) => {
     registerCamporeeMember: (...args: unknown[]) => mockRegister(...args),
   };
 });
+
+vi.mock("@/lib/api/insurance", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api/insurance")>();
+  return {
+    ...original,
+    getMemberInsuranceFromClient: (...args: unknown[]) =>
+      mockGetMemberInsurance(...args),
+  };
+});
+
+vi.mock("@/components/shared/selectors/club-select", () => ({
+  ClubSelect: ({ onChange }: { onChange: (clubId: number | null) => void }) => (
+    <button type="button" onClick={() => onChange(1)}>
+      Seleccionar club
+    </button>
+  ),
+}));
+
+vi.mock("@/components/units/member-combobox", () => ({
+  MemberCombobox: ({
+    onChange,
+    disabled,
+  }: {
+    onChange: (userId: string) => void;
+    disabled?: boolean;
+  }) => (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={() => onChange(VALID_UUID)}
+    >
+      Seleccionar miembro
+    </button>
+  ),
+}));
 
 const mockToastError = vi.fn();
 const mockToastSuccess = vi.fn();
@@ -74,15 +115,10 @@ vi.mock("sonner", () => ({
 import { RegisterMemberDialog } from "@/components/camporees/register-member-dialog";
 
 // ---------------------------------------------------------------------------
-// Constants
+// Render helpers
 // ---------------------------------------------------------------------------
 
 const t = messages.camporees;
-const VALID_UUID = "550e8400-e29b-41d4-a716-446655440000";
-
-// ---------------------------------------------------------------------------
-// Render helper
-// ---------------------------------------------------------------------------
 
 interface RenderOpts {
   open?: boolean;
@@ -115,6 +151,15 @@ async function submitForm() {
   });
 }
 
+async function selectClubAndMember() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: "Seleccionar club" }));
+  await user.click(screen.getByRole("button", { name: "Seleccionar miembro" }));
+  await waitFor(() => {
+    expect(mockGetMemberInsurance).toHaveBeenCalledWith(VALID_UUID);
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -123,75 +168,54 @@ describe("RegisterMemberDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRegister.mockResolvedValue({ ok: true });
+    mockGetMemberInsurance.mockResolvedValue(ACTIVE_INSURANCE);
   });
 
   afterEach(() => {
     cleanup();
   });
 
-  // ── 1. Rendering ──────────────────────────────────────────────────────────
-
-  it("renders title, user-id input, camporee-type select, club-name and insurance inputs", () => {
+  it("renders selector-based fields and no raw ID inputs", () => {
     renderDialog();
 
     expect(
       screen.getByRole("heading", { name: t.registerMemberDialog.title }),
     ).toBeInTheDocument();
 
-    // Use placeholder text to find inputs — avoids issues with label + <span> children
     expect(
-      screen.getByPlaceholderText("xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByPlaceholderText(t.registerMemberDialog.placeholderClubName),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByPlaceholderText(t.registerMemberDialog.placeholderInsuranceId),
-    ).toBeInTheDocument();
-
-    expect(
-      screen.getByRole("button", { name: t.registerMemberDialog.register }),
+      screen.getByRole("button", { name: "Seleccionar club" }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: t.registerMemberDialog.cancel }),
-    ).toBeInTheDocument();
+      screen.getByText(t.registerMemberDialog.placeholderSelectClubFirst),
+    ).toBeVisible();
+    expect(
+      screen
+        .getByText(t.registerMemberDialog.placeholderSelectClubFirst)
+        .closest("button"),
+    ).toBeDisabled();
+    expect(
+      document.querySelector('input[name="insurance_id"]'),
+    ).not.toBeInTheDocument();
   });
 
-  // ── 2. Validation — invalid UUID ─────────────────────────────────────────
-
-  it("shows UUID validation error when user_id is not a valid UUID", async () => {
+  it("requires selecting a member before submit", async () => {
     renderDialog();
-
-    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
-    await act(async () => {
-      if (userIdInput) fireEvent.change(userIdInput, { target: { value: "not-a-uuid" } });
-    });
 
     await submitForm();
 
     await waitFor(() => {
-      // The Zod uuid error is "El ID de usuario debe ser un UUID válido"
       expect(
         screen.getByText(/El ID de usuario debe ser un UUID válido/i),
       ).toBeInTheDocument();
     });
-
     expect(mockRegister).not.toHaveBeenCalled();
   });
 
-  // ── 3. Happy path — local camporee ───────────────────────────────────────
-
-  it("calls registerCamporeeMember with correct args for local type", async () => {
+  it("auto-fills insurance and calls registerCamporeeMember with correct args", async () => {
     const { onOpenChange, onSuccess } = renderDialog();
 
-    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
-    await act(async () => {
-      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
-    });
-
-    // camporee_type defaults to "local" — no change needed
+    await selectClubAndMember();
+    expect(screen.getByText(/Seguro activo/i)).toBeInTheDocument();
 
     await submitForm();
 
@@ -201,11 +225,20 @@ describe("RegisterMemberDialog", () => {
 
     const [camporeeId, payload] = mockRegister.mock.calls[0] as [
       number,
-      { user_id: string; camporee_type: string; club_name?: string; insurance_id?: number },
+      {
+        user_id: string;
+        camporee_type: string;
+        club_name?: string;
+        insurance_id?: number;
+      },
     ];
+
     expect(camporeeId).toBe(10);
-    expect(payload.user_id).toBe(VALID_UUID);
-    expect(payload.camporee_type).toBe("local");
+    expect(payload).toMatchObject({
+      user_id: VALID_UUID,
+      camporee_type: "local",
+      insurance_id: 42,
+    });
     expect(payload.club_name).toBeUndefined();
 
     expect(mockToastSuccess).toHaveBeenCalledWith(t.toasts.member_registered);
@@ -213,63 +246,34 @@ describe("RegisterMemberDialog", () => {
     expect(onSuccess).toHaveBeenCalledOnce();
   });
 
-  // ── 4. Happy path — union camporee with club name ─────────────────────────
-
-  it("forwards club_name and insurance_id when provided for union type", async () => {
+  it("disables submit and shows warning when selected member has no active insurance", async () => {
+    mockGetMemberInsurance.mockResolvedValue(null);
     renderDialog();
 
-    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
-    await act(async () => {
-      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
-    });
-
-    // Switch camporee_type to "union" via the hidden Radix native <select>
-    // (only one select in this form — for camporee_type)
-    const typeNative = document.querySelector("select") as HTMLSelectElement | null;
-    if (typeNative) {
-      await act(async () => {
-        fireEvent.change(typeNative, { target: { value: "union" } });
-      });
-    }
-
-    const clubNameInput = document.querySelector('input[name="club_name"]') as HTMLInputElement | null;
-    await act(async () => {
-      if (clubNameInput) fireEvent.change(clubNameInput, { target: { value: "Club Central" } });
-    });
-
-    const insuranceInput = document.querySelector('input[name="insurance_id"]') as HTMLInputElement | null;
-    await act(async () => {
-      if (insuranceInput) fireEvent.change(insuranceInput, { target: { value: "42" } });
-    });
-
-    await submitForm();
+    await selectClubAndMember();
 
     await waitFor(() => {
-      expect(mockRegister).toHaveBeenCalledOnce();
+      expect(
+        screen.getByText(t.registerMemberDialog.noInsuranceTitle),
+      ).toBeInTheDocument();
     });
 
-    const [, payload] = mockRegister.mock.calls[0] as [
-      number,
-      { camporee_type: string; club_name?: string; insurance_id?: number },
-    ];
-    expect(payload.camporee_type).toBe("union");
-    expect(payload.club_name).toBe("Club Central");
-    expect(payload.insurance_id).toBe(42);
+    expect(
+      screen.getByRole("button", { name: t.registerMemberDialog.register }),
+    ).toBeDisabled();
   });
-
-  // ── 5. Cancel closes dialog ───────────────────────────────────────────────
 
   it("calls onOpenChange(false) and does NOT call API when cancel clicked", async () => {
     const user = userEvent.setup();
     const { onOpenChange } = renderDialog();
 
-    await user.click(screen.getByRole("button", { name: t.registerMemberDialog.cancel }));
+    await user.click(
+      screen.getByRole("button", { name: t.registerMemberDialog.cancel }),
+    );
 
     expect(onOpenChange).toHaveBeenCalledWith(false);
     expect(mockRegister).not.toHaveBeenCalled();
   });
-
-  // ── 6. Submit button disabled while in flight ─────────────────────────────
 
   it("disables submit button while submission is in flight", async () => {
     let resolveRegister!: () => void;
@@ -280,12 +284,7 @@ describe("RegisterMemberDialog", () => {
     );
 
     renderDialog();
-
-    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
-    await act(async () => {
-      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
-    });
-
+    await selectClubAndMember();
     await submitForm();
 
     await waitFor(() => {
@@ -301,20 +300,13 @@ describe("RegisterMemberDialog", () => {
     });
   });
 
-  // ── 7. Insurance error — renders dedicated alert callout ─────────────────
-
-  it("shows insurance error callout (not toast) when error message contains 'seguro'", async () => {
+  it("shows insurance error callout (not toast) when register API rejects with insurance error", async () => {
     mockRegister.mockRejectedValue(
       new Error("El seguro no está validado para este usuario"),
     );
 
     renderDialog();
-
-    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
-    await act(async () => {
-      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
-    });
-
+    await selectClubAndMember();
     await submitForm();
 
     await waitFor(() => {
@@ -324,44 +316,26 @@ describe("RegisterMemberDialog", () => {
     expect(
       screen.getByText(t.registerMemberDialog.insuranceErrorTitle),
     ).toBeInTheDocument();
-
-    // Toast must NOT be called for insurance errors
     expect(mockToastError).not.toHaveBeenCalled();
   });
-
-  // ── 8. Generic API error — routes to toast ────────────────────────────────
 
   it("shows toast.error for generic non-insurance errors", async () => {
     mockRegister.mockRejectedValue(new Error("Duplicate member"));
 
     renderDialog();
-
-    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
-    await act(async () => {
-      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
-    });
-
+    await selectClubAndMember();
     await submitForm();
 
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith("Duplicate member");
     });
-
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
-
-  // ── 9. Fallback translated error ──────────────────────────────────────────
 
   it("shows fallback translated error when non-Error is thrown", async () => {
     mockRegister.mockRejectedValue("string error");
 
     renderDialog();
-
-    const userIdInput = document.querySelector('input[name="user_id"]') as HTMLInputElement | null;
-    await act(async () => {
-      if (userIdInput) fireEvent.change(userIdInput, { target: { value: VALID_UUID } });
-    });
-
+    await selectClubAndMember();
     await submitForm();
 
     await waitFor(() => {

--- a/src/components/camporees/register-member-dialog.tsx
+++ b/src/components/camporees/register-member-dialog.tsx
@@ -15,7 +15,6 @@ import {
   DialogFooter,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import {
   Select,
   SelectContent,
@@ -26,14 +25,21 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { registerCamporeeMember } from "@/lib/api/camporees";
+import {
+  getMemberInsuranceFromClient,
+  type InsuranceRecord,
+} from "@/lib/api/insurance";
+import { ClubSelect } from "@/components/shared/selectors/club-select";
+import { MemberCombobox } from "@/components/units/member-combobox";
 
 // ─── Schema ────────────────────────────────────────────────────────────────────
 
@@ -45,6 +51,17 @@ const formSchema = z.object({
 });
 
 type FormValues = z.infer<typeof formSchema>;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDate(dateStr: string | null): string {
+  if (!dateStr) return "—";
+  return new Date(dateStr).toLocaleDateString("es-AR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
 
 // ─── Props ─────────────────────────────────────────────────────────────────────
 
@@ -67,6 +84,15 @@ export function RegisterMemberDialog({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [insuranceError, setInsuranceError] = useState<string | null>(null);
 
+  // Club → Member cascade state (not a form field — only used to scope the member list)
+  const [selectedClubId, setSelectedClubId] = useState<number | null>(null);
+
+  // Insurance auto-fill state
+  const [selectedInsurance, setSelectedInsurance] =
+    useState<InsuranceRecord | null>(null);
+  const [insuranceFetching, setInsuranceFetching] = useState(false);
+  const [noInsuranceWarning, setNoInsuranceWarning] = useState(false);
+
   const form = useForm<FormValues>({
     resolver: zodResolver(formSchema as z.ZodType<FormValues, FormValues>),
     defaultValues: {
@@ -83,8 +109,42 @@ export function RegisterMemberDialog({
     if (!nextOpen) {
       form.reset();
       setInsuranceError(null);
+      setSelectedClubId(null);
+      setSelectedInsurance(null);
+      setInsuranceFetching(false);
+      setNoInsuranceWarning(false);
     }
     onOpenChange(nextOpen);
+  }
+
+  async function handleMemberChange(userId: string) {
+    form.setValue("user_id", userId, { shouldValidate: true });
+    // Clear previous insurance state
+    setSelectedInsurance(null);
+    setNoInsuranceWarning(false);
+    form.setValue("insurance_id", "");
+
+    if (!userId) return;
+
+    // Auto-fetch insurance for the selected member
+    setInsuranceFetching(true);
+    try {
+      const insurance = await getMemberInsuranceFromClient(userId);
+      if (insurance && insurance.active) {
+        setSelectedInsurance(insurance);
+        form.setValue("insurance_id", insurance.insurance_id);
+        setNoInsuranceWarning(false);
+      } else {
+        setSelectedInsurance(null);
+        setNoInsuranceWarning(true);
+      }
+    } catch {
+      // Non-fatal: show no-insurance warning rather than crashing the form
+      setSelectedInsurance(null);
+      setNoInsuranceWarning(true);
+    } finally {
+      setInsuranceFetching(false);
+    }
   }
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
@@ -107,7 +167,6 @@ export function RegisterMemberDialog({
       const message =
         err instanceof Error ? err.message : t("errors.register_member");
 
-      // Insurance-related errors get a dedicated callout
       if (
         message.toLowerCase().includes("seguro") ||
         message.toLowerCase().includes("insurance") ||
@@ -122,51 +181,128 @@ export function RegisterMemberDialog({
     }
   };
 
+  const submitDisabled = isSubmitting || noInsuranceWarning;
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>{t("registerMemberDialog.title")}</DialogTitle>
           <DialogDescription>
-            Ingresá el UUID del usuario y los datos necesarios para inscribirlo en el camporee.
+            {t("registerMemberDialog.description")}
           </DialogDescription>
         </DialogHeader>
 
         <Form {...form}>
-          <form onSubmit={form.handleSubmit(onSubmit)} noValidate className="space-y-4">
-            {/* Insurance error callout */}
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            noValidate
+            className="space-y-4"
+          >
+            {/* Insurance error callout (submit-time) */}
             {insuranceError && (
               <div
                 role="alert"
                 aria-live="polite"
                 className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
               >
-                <p className="font-medium">{t("registerMemberDialog.insuranceErrorTitle")}</p>
+                <p className="font-medium">
+                  {t("registerMemberDialog.insuranceErrorTitle")}
+                </p>
                 <p className="mt-0.5">{insuranceError}</p>
               </div>
             )}
 
-            {/* User ID */}
+            {/* Club selector (cascade filter — not a form field) */}
+            <div className="space-y-2">
+              <p className="text-sm font-medium leading-none">
+                {t("registerMemberDialog.labelClub")}{" "}
+                <span aria-hidden="true" className="text-destructive">*</span>
+              </p>
+              <ClubSelect
+                value={selectedClubId}
+                onChange={(clubId) => {
+                  setSelectedClubId(clubId);
+                  // Reset member when club changes
+                  form.setValue("user_id", "");
+                  setSelectedInsurance(null);
+                  setNoInsuranceWarning(false);
+                  form.setValue("insurance_id", "");
+                }}
+              />
+            </div>
+
+            {/* Member selector (scoped to club) */}
             <FormField
               control={form.control}
               name="user_id"
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>
-                    {t("registerMemberDialog.labelUserId")} <span aria-hidden="true" className="text-destructive">*</span>
+                    {t("registerMemberDialog.labelMember")}{" "}
+                    <span aria-hidden="true" className="text-destructive">
+                      *
+                    </span>
                   </FormLabel>
                   <FormControl>
-                    <Input
-                      aria-required="true"
-                      placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                      className="font-mono text-sm"
-                      {...field}
-                    />
+                    {selectedClubId ? (
+                      <MemberCombobox
+                        clubId={selectedClubId}
+                        value={field.value}
+                        onChange={handleMemberChange}
+                        placeholder={t("registerMemberDialog.placeholderMember")}
+                      />
+                    ) : (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        disabled
+                        className="h-9 w-full justify-start px-3 font-normal text-muted-foreground"
+                      >
+                        {t("registerMemberDialog.placeholderSelectClubFirst")}
+                      </Button>
+                    )}
                   </FormControl>
                   <FormMessage />
                 </FormItem>
               )}
             />
+
+            {/* Insurance auto-fill status */}
+            {insuranceFetching && (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="size-3.5 animate-spin" />
+                {t("registerMemberDialog.insuranceLoading")}
+              </div>
+            )}
+
+            {!insuranceFetching && selectedInsurance && (
+              <div className="rounded-md bg-muted/40 p-3 text-xs">
+                <p className="font-medium">
+                  {t("registerMemberDialog.insuranceActive")}:{" "}
+                  {selectedInsurance.policy_number ?? String(selectedInsurance.insurance_id)}
+                </p>
+                <p className="text-muted-foreground">
+                  {t("registerMemberDialog.insuranceExpires")}:{" "}
+                  {formatDate(selectedInsurance.end_date)}
+                </p>
+              </div>
+            )}
+
+            {!insuranceFetching && noInsuranceWarning && (
+              <div
+                role="alert"
+                aria-live="polite"
+                className="rounded-lg border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+              >
+                <p className="font-medium">
+                  {t("registerMemberDialog.noInsuranceTitle")}
+                </p>
+                <p className="mt-0.5">
+                  {t("registerMemberDialog.noInsuranceDescription")}
+                </p>
+              </div>
+            )}
 
             {/* Tipo de camporee */}
             <FormField
@@ -175,19 +311,32 @@ export function RegisterMemberDialog({
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>
-                    {t("registerMemberDialog.labelCamporeeType")} <span aria-hidden="true" className="text-destructive">*</span>
+                    {t("registerMemberDialog.labelCamporeeType")}{" "}
+                    <span aria-hidden="true" className="text-destructive">
+                      *
+                    </span>
                   </FormLabel>
                   <FormControl>
                     <Select
                       value={field.value}
-                      onValueChange={(val) => field.onChange(val as "local" | "union")}
+                      onValueChange={(val) =>
+                        field.onChange(val as "local" | "union")
+                      }
                     >
                       <SelectTrigger aria-required="true">
-                        <SelectValue placeholder={t("registerMemberDialog.placeholderCamporeeType")} />
+                        <SelectValue
+                          placeholder={t(
+                            "registerMemberDialog.placeholderCamporeeType",
+                          )}
+                        />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="local">{t("registerMemberDialog.typeLocal")}</SelectItem>
-                        <SelectItem value="union">{t("registerMemberDialog.typeUnion")}</SelectItem>
+                        <SelectItem value="local">
+                          {t("registerMemberDialog.typeLocal")}
+                        </SelectItem>
+                        <SelectItem value="union">
+                          {t("registerMemberDialog.typeUnion")}
+                        </SelectItem>
                       </SelectContent>
                     </Select>
                   </FormControl>
@@ -205,38 +354,22 @@ export function RegisterMemberDialog({
                   <FormLabel>
                     {t("registerMemberDialog.labelClubName")}
                     {camporeeType === "union" && (
-                      <span className="text-muted-foreground"> {t("registerMemberDialog.clubNameRequiredForUnion")}</span>
+                      <span className="text-muted-foreground">
+                        {" "}
+                        {t(
+                          "registerMemberDialog.clubNameRequiredForUnion",
+                        )}
+                      </span>
                     )}
                   </FormLabel>
                   <FormControl>
                     <Input
-                      placeholder={t("registerMemberDialog.placeholderClubName")}
+                      placeholder={t(
+                        "registerMemberDialog.placeholderClubName",
+                      )}
                       {...field}
                     />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            {/* Insurance ID */}
-            <FormField
-              control={form.control}
-              name="insurance_id"
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>{t("registerMemberDialog.labelInsuranceId")}</FormLabel>
-                  <FormControl>
-                    <Input
-                      type="number"
-                      min={1}
-                      placeholder={t("registerMemberDialog.placeholderInsuranceId")}
-                      {...field}
-                    />
-                  </FormControl>
-                  <FormDescription>
-                    {t("registerMemberDialog.helpInsurance")}
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -251,8 +384,10 @@ export function RegisterMemberDialog({
               >
                 {t("registerMemberDialog.cancel")}
               </Button>
-              <Button type="submit" disabled={isSubmitting}>
-                {isSubmitting ? t("registerMemberDialog.registering") : t("registerMemberDialog.register")}
+              <Button type="submit" disabled={submitDisabled}>
+                {isSubmitting
+                  ? t("registerMemberDialog.registering")
+                  : t("registerMemberDialog.register")}
               </Button>
             </DialogFooter>
           </form>

--- a/src/components/notifications/notification-forms.tsx
+++ b/src/components/notifications/notification-forms.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useActionState } from "react";
+import { useState, useActionState } from "react";
 import { useFormStatus } from "react-dom";
 import { Loader2, Send, Radio, Users } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -22,6 +22,9 @@ import {
   clubNotificationAction,
   type NotificationActionState,
 } from "@/lib/notifications/actions";
+import { ClubSelect } from "@/components/shared/selectors/club-select";
+import { ClubSectionSelect } from "@/components/shared/selectors/club-section-select";
+import { MemberCombobox } from "@/components/units/member-combobox";
 
 function SubmitButton({ label }: { label: string }) {
   const { pending } = useFormStatus();
@@ -87,6 +90,14 @@ export function DirectNotificationForm() {
     "notif-direct",
   );
 
+  const [selectedClubId, setSelectedClubId] = useState<number | null>(null);
+  const [selectedUserId, setSelectedUserId] = useState<string>("");
+
+  function handleClubChange(id: number | null) {
+    setSelectedClubId(id);
+    setSelectedUserId("");
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -99,18 +110,25 @@ export function DirectNotificationForm() {
       <CardContent>
         <form action={action} className="space-y-4" noValidate>
           <StatusBanner state={state} />
-          <div className="space-y-2">
-            <Label htmlFor="direct_user_id">
+          {/* Hidden input carrying user_id for the server action */}
+          <input type="hidden" name="user_id" value={selectedUserId} />
+          <div
+            className="space-y-2"
+            aria-invalid={ariaInvalid("user_id")}
+            aria-describedby={describedBy("user_id")}
+          >
+            <Label>
               {t("label_user_id")} <span className="text-destructive">*</span>
             </Label>
-            <Input
-              id="direct_user_id"
-              name="user_id"
-              placeholder={t("placeholder_user_id")}
-              required
-              aria-required="true"
-              aria-invalid={ariaInvalid("user_id")}
-              aria-describedby={describedBy("user_id")}
+            <ClubSelect
+              value={selectedClubId}
+              onChange={handleClubChange}
+            />
+            <MemberCombobox
+              clubId={selectedClubId ?? 0}
+              value={selectedUserId}
+              onChange={setSelectedUserId}
+              disabled={!selectedClubId}
             />
             {renderError("user_id")}
           </div>
@@ -221,6 +239,20 @@ export function ClubNotificationForm() {
     "notif-club",
   );
 
+  const [instanceType, setInstanceType] = useState<string>("");
+  const [selectedClubIdForNotif, setSelectedClubIdForNotif] = useState<number | null>(null);
+  const [selectedSectionId, setSelectedSectionId] = useState<number | null>(null);
+
+  function handleInstanceTypeChange(value: string) {
+    setInstanceType(value);
+    setSelectedSectionId(null);
+  }
+
+  function handleClubForNotifChange(id: number | null) {
+    setSelectedClubIdForNotif(id);
+    setSelectedSectionId(null);
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -233,11 +265,22 @@ export function ClubNotificationForm() {
       <CardContent>
         <form action={action} className="space-y-4" noValidate>
           <StatusBanner state={state} />
+          {/* Hidden input carrying instance_id for the server action */}
+          <input
+            type="hidden"
+            name="instance_id"
+            value={selectedSectionId ?? ""}
+          />
           <div className="space-y-2">
             <Label htmlFor="club_instance_type">
               {t("label_instance_type")} <span className="text-destructive">*</span>
             </Label>
-            <Select name="instance_type" required>
+            <Select
+              name="instance_type"
+              required
+              value={instanceType}
+              onValueChange={handleInstanceTypeChange}
+            >
               <SelectTrigger
                 id="club_instance_type"
                 aria-invalid={ariaInvalid("instance_type")}
@@ -253,19 +296,24 @@ export function ClubNotificationForm() {
             </Select>
             {renderError("instance_type")}
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="club_instance_id">
+          <div
+            className="space-y-2"
+            aria-invalid={ariaInvalid("instance_id")}
+            aria-describedby={describedBy("instance_id")}
+          >
+            <Label>
               {t("label_instance_id")} <span className="text-destructive">*</span>
             </Label>
-            <Input
-              id="club_instance_id"
-              name="instance_id"
-              type="number"
-              placeholder={t("placeholder_instance_id")}
-              required
-              aria-required="true"
-              aria-invalid={ariaInvalid("instance_id")}
-              aria-describedby={describedBy("instance_id")}
+            <ClubSelect
+              value={selectedClubIdForNotif}
+              onChange={handleClubForNotifChange}
+            />
+            <ClubSectionSelect
+              clubId={selectedClubIdForNotif}
+              sectionTypeKey={instanceType || undefined}
+              value={selectedSectionId}
+              onChange={setSelectedSectionId}
+              disabled={!selectedClubIdForNotif || !instanceType}
             />
             {renderError("instance_id")}
           </div>

--- a/src/components/resources/resources-crud-page.tsx
+++ b/src/components/resources/resources-crud-page.tsx
@@ -638,15 +638,9 @@ function ResourceFormFields({
                 </SelectContent>
               </Select>
             ) : (
-              <Input
-                id="res-scope-id"
-                name="scope_id"
-                type="number"
-                min={1}
-                defaultValue={currentScopeIdValue}
-                required
-                placeholder={t("placeholders.unionId")}
-              />
+              <div className="rounded-md border border-dashed border-muted-foreground/30 bg-muted/30 p-3 text-sm text-muted-foreground">
+                No hay uniones disponibles. Contactá al administrador.
+              </div>
             )
           ) : localFields.length > 0 ? (
             <Select
@@ -666,15 +660,9 @@ function ResourceFormFields({
               </SelectContent>
             </Select>
           ) : (
-            <Input
-              id="res-scope-id"
-              name="scope_id"
-              type="number"
-              min={1}
-              defaultValue={currentScopeIdValue}
-              required
-              placeholder={t("placeholders.localFieldId")}
-            />
+            <div className="rounded-md border border-dashed border-muted-foreground/30 bg-muted/30 p-3 text-sm text-muted-foreground">
+              No hay campos locales disponibles. Contactá al administrador.
+            </div>
           )}
         </div>
       )}

--- a/src/components/shared/selectors/club-section-select.tsx
+++ b/src/components/shared/selectors/club-section-select.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Check, ChevronsUpDown, X, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useQuery } from "@tanstack/react-query";
+import { listClubSections, type ClubSection } from "@/lib/api/clubs";
+
+// ─── Re-export for consumers ───────────────────────────────────────────────────
+
+/** Alias kept in sync with the backend ClubSection type. */
+export type ClubSectionListItem = ClubSection;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * `listClubSections` returns either a bare array or a paginated envelope
+ * `{ data: ClubSection[], ... }`. Normalize both shapes.
+ */
+function parseSectionList(payload: unknown): ClubSectionListItem[] {
+  if (Array.isArray(payload)) return payload as ClubSectionListItem[];
+  if (payload && typeof payload === "object") {
+    const envelope = payload as { data?: unknown };
+    if (Array.isArray(envelope.data)) return envelope.data as ClubSectionListItem[];
+  }
+  return [];
+}
+
+/**
+ * Maps a sectionTypeKey string to the corresponding `club_type_id` integer.
+ *
+ * Convention confirmed in enroll-club-dialog.tsx:
+ *   1 = Aventureros (adventurers)
+ *   2 = Conquistadores (pathfinders)
+ *   3 = Guías Mayores (master_guilds)
+ */
+const SECTION_TYPE_KEY_TO_ID: Record<string, number> = {
+  adventurers: 1,
+  pathfinders: 2,
+  master_guilds: 3,
+};
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface ClubSectionSelectProps {
+  /** When null/undefined, the selector is disabled with a "select a club first" placeholder */
+  clubId: number | null;
+  value: number | null;
+  onChange: (sectionId: number | null, section?: ClubSectionListItem) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  /**
+   * Filter by section type key: 'adventurers' | 'pathfinders' | 'master_guilds'.
+   * Applied client-side by mapping to club_type_id (1, 2, 3).
+   */
+  sectionTypeKey?: string;
+  /** Filter by club_type_id directly (alternative to sectionTypeKey) */
+  clubTypeId?: number;
+  activeOnly?: boolean;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ClubSectionSelect({
+  clubId,
+  value,
+  onChange,
+  placeholder,
+  disabled = false,
+  className,
+  sectionTypeKey,
+  clubTypeId,
+  activeOnly,
+}: ClubSectionSelectProps) {
+  const t = useTranslations("selectors.clubSection");
+  const [open, setOpen] = useState(false);
+  // Lazy load: only enable the query once the popover has been opened at least once.
+  const [hasOpened, setHasOpened] = useState(false);
+  const previousClubId = useRef<number | null>(clubId ?? null);
+
+  // Reset value when clubId changes after the initial mount.
+  // This preserves URL-hydrated default section values in GET filter forms.
+  useEffect(() => {
+    const nextClubId = clubId ?? null;
+    if (previousClubId.current === nextClubId) return;
+
+    previousClubId.current = nextClubId;
+    onChange(null);
+  }, [clubId, onChange]);
+
+  const isDisabled = disabled || clubId == null;
+
+  const {
+    data: fetchedSections = [],
+    isFetching: loading,
+    error: fetchError,
+  } = useQuery({
+    queryKey: ["club-sections-selector", clubId],
+    queryFn: async () => {
+      // clubId is guaranteed non-null here because enabled guards it.
+      const payload = await listClubSections(clubId!);
+      return parseSectionList(payload);
+    },
+    enabled: (hasOpened || value != null) && clubId != null,
+    staleTime: 60_000,
+  });
+
+  // Resolve the effective club_type_id filter (sectionTypeKey takes precedence).
+  const effectiveClubTypeId: number | undefined =
+    sectionTypeKey !== undefined
+      ? SECTION_TYPE_KEY_TO_ID[sectionTypeKey]
+      : clubTypeId;
+
+  // Apply optional filters.
+  const sections: ClubSectionListItem[] = fetchedSections.filter((s) => {
+    if (activeOnly && s.active === false) return false;
+    if (effectiveClubTypeId !== undefined && s.club_type_id !== effectiveClubTypeId) return false;
+    return true;
+  });
+
+  const error = fetchError
+    ? fetchError instanceof Error
+      ? fetchError.message
+      : t("loadError")
+    : null;
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (isDisabled) return;
+    setOpen(nextOpen);
+    if (nextOpen && !hasOpened) setHasOpened(true);
+  }
+
+  const selected = sections.find((s) => s.club_section_id === value) ?? null;
+
+  function handleSelect(sectionId: number) {
+    const section = fetchedSections.find((s) => s.club_section_id === sectionId);
+    if (sectionId === value) {
+      onChange(null);
+    } else {
+      onChange(sectionId, section);
+    }
+    setOpen(false);
+  }
+
+  function handleClear(e: React.MouseEvent) {
+    e.stopPropagation();
+    onChange(null);
+  }
+
+  const triggerPlaceholder =
+    clubId == null
+      ? t("placeholderNoClub")
+      : placeholder ?? t("placeholder");
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={triggerPlaceholder}
+          disabled={isDisabled}
+          className={cn(
+            "h-9 w-full justify-between px-3 font-normal",
+            !selected && "text-muted-foreground",
+            className,
+          )}
+        >
+          {selected ? (
+            <span className="truncate text-sm">
+              {selected.club_type?.name
+                ? `${selected.club_type.name}${selected.name ? ` · ${selected.name}` : ""}`
+                : selected.name}
+            </span>
+          ) : (
+            <span className="truncate text-sm">{triggerPlaceholder}</span>
+          )}
+
+          <span className="ml-2 flex shrink-0 items-center gap-0.5">
+            {selected && !isDisabled && (
+              <span
+                role="button"
+                aria-label={t("clearSelection")}
+                onClick={handleClear}
+                className="rounded p-0.5 hover:bg-muted"
+              >
+                <X className="size-3.5 text-muted-foreground" />
+              </span>
+            )}
+            <ChevronsUpDown className="size-3.5 text-muted-foreground opacity-50" />
+          </span>
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder={t("searchPlaceholder")} />
+          <CommandList>
+            {loading && (
+              <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+                <Loader2 className="size-4 animate-spin" />
+                {t("loading")}
+              </div>
+            )}
+
+            {!loading && error && (
+              <div className="py-6 text-center text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            {!loading && !error && sections.length === 0 && (
+              <CommandEmpty>{t("empty")}</CommandEmpty>
+            )}
+
+            {!loading && !error && sections.length > 0 && (
+              <CommandGroup>
+                {sections.map((section) => {
+                  const label = section.club_type?.name
+                    ? `${section.club_type.name}${section.name ? ` · ${section.name}` : ""}`
+                    : section.name;
+                  return (
+                    <CommandItem
+                      key={section.club_section_id}
+                      value={`${label} ${section.club_section_id}`}
+                      onSelect={() => handleSelect(section.club_section_id)}
+                    >
+                      <span className="truncate">{label}</span>
+
+                      <Check
+                        className={cn(
+                          "ml-auto size-3.5 shrink-0",
+                          value === section.club_section_id
+                            ? "opacity-100"
+                            : "opacity-0",
+                        )}
+                      />
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/shared/selectors/club-select.tsx
+++ b/src/components/shared/selectors/club-select.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronsUpDown, X, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useQuery } from "@tanstack/react-query";
+import { listClubs, type Club } from "@/lib/api/clubs";
+
+// ─── Re-export for consumers ───────────────────────────────────────────────────
+
+/** Alias kept in sync with the backend Club type. */
+export type ClubListItem = Club;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * `listClubs` returns either a bare array or a paginated envelope
+ * `{ data: Club[], metadata: { ... } }`. Normalize both shapes.
+ */
+function parseClubList(payload: unknown): ClubListItem[] {
+  if (Array.isArray(payload)) return payload as ClubListItem[];
+  if (payload && typeof payload === "object") {
+    const envelope = payload as { data?: unknown };
+    if (Array.isArray(envelope.data)) return envelope.data as ClubListItem[];
+  }
+  return [];
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface ClubSelectProps {
+  value: number | null;
+  onChange: (clubId: number | null, club?: ClubListItem) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  /** Optional filters forwarded to the endpoint */
+  localFieldId?: number;
+  districtId?: number;
+  churchId?: number;
+  activeOnly?: boolean;
+  /** Pass a pre-loaded list to skip the fetch */
+  clubs?: ClubListItem[];
+  /** Called once when the list finishes loading so the parent can share it */
+  onClubsLoaded?: (clubs: ClubListItem[]) => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ClubSelect({
+  value,
+  onChange,
+  placeholder,
+  disabled = false,
+  className,
+  localFieldId,
+  districtId,
+  churchId,
+  activeOnly,
+  clubs: externalClubs,
+  onClubsLoaded,
+}: ClubSelectProps) {
+  const t = useTranslations("selectors.club");
+  const [open, setOpen] = useState(false);
+  // Lazy load: only enable the query once the popover has been opened at least once.
+  const [hasOpened, setHasOpened] = useState(false);
+
+  const {
+    data: fetchedClubs = [],
+    isFetching: loading,
+    error: fetchError,
+  } = useQuery({
+    queryKey: [
+      "clubs-selector",
+      { localFieldId, districtId, churchId, activeOnly },
+    ],
+    queryFn: async () => {
+      const payload = await listClubs({
+        localFieldId,
+        districtId,
+        churchId,
+        active: activeOnly,
+        limit: 1000,
+        page: 1,
+      });
+      const clubs = parseClubList(payload);
+      onClubsLoaded?.(clubs);
+      return clubs;
+    },
+    enabled: (hasOpened || value != null) && externalClubs === undefined,
+    staleTime: 60_000,
+  });
+
+  const clubs: ClubListItem[] = externalClubs ?? fetchedClubs;
+
+  const error = fetchError
+    ? fetchError instanceof Error
+      ? fetchError.message
+      : t("loadError")
+    : null;
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (nextOpen && !hasOpened) setHasOpened(true);
+  }
+
+  const selected = clubs.find((c) => c.club_id === value) ?? null;
+
+  function handleSelect(clubId: number) {
+    const club = clubs.find((c) => c.club_id === clubId);
+    if (clubId === value) {
+      onChange(null);
+    } else {
+      onChange(clubId, club);
+    }
+    setOpen(false);
+  }
+
+  function handleClear(e: React.MouseEvent) {
+    e.stopPropagation();
+    onChange(null);
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={placeholder ?? t("placeholder")}
+          disabled={disabled}
+          className={cn(
+            "h-9 w-full justify-between px-3 font-normal",
+            !selected && "text-muted-foreground",
+            className,
+          )}
+        >
+          {selected ? (
+            <span className="truncate text-sm">{selected.name}</span>
+          ) : (
+            <span className="truncate text-sm">{placeholder ?? t("placeholder")}</span>
+          )}
+
+          <span className="ml-2 flex shrink-0 items-center gap-0.5">
+            {selected && !disabled && (
+              <span
+                role="button"
+                aria-label={t("clearSelection")}
+                onClick={handleClear}
+                className="rounded p-0.5 hover:bg-muted"
+              >
+                <X className="size-3.5 text-muted-foreground" />
+              </span>
+            )}
+            <ChevronsUpDown className="size-3.5 text-muted-foreground opacity-50" />
+          </span>
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder={t("searchPlaceholder")} />
+          <CommandList>
+            {loading && (
+              <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+                <Loader2 className="size-4 animate-spin" />
+                {t("loading")}
+              </div>
+            )}
+
+            {!loading && error && (
+              <div className="py-6 text-center text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            {!loading && !error && clubs.length === 0 && (
+              <CommandEmpty>{t("empty")}</CommandEmpty>
+            )}
+
+            {!loading && !error && clubs.length > 0 && (
+              <CommandGroup>
+                {clubs.map((club) => (
+                  <CommandItem
+                    key={club.club_id}
+                    value={`${club.name} ${club.club_id}`}
+                    onSelect={() => handleSelect(club.club_id)}
+                  >
+                    <span className="truncate">{club.name}</span>
+
+                    <Check
+                      className={cn(
+                        "ml-auto size-3.5 shrink-0",
+                        value === club.club_id ? "opacity-100" : "opacity-0",
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/components/shared/selectors/ecclesiastical-year-select.tsx
+++ b/src/components/shared/selectors/ecclesiastical-year-select.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useState } from "react";
+import { Check, ChevronsUpDown, X, Loader2 } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { useQuery } from "@tanstack/react-query";
+import {
+  listEcclesiasticalYears,
+  type EcclesiasticalYear,
+} from "@/lib/api/catalogs";
+
+// ─── Re-export type for consumers ─────────────────────────────────────────────
+
+export type { EcclesiasticalYear };
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function formatDateRange(start: string, end: string): string {
+  const fmt = (iso: string) => {
+    const [year, month, day] = iso.split("T")[0].split("-");
+    return `${day}/${month}/${year}`;
+  };
+  return `${fmt(start)} – ${fmt(end)}`;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface EcclesiasticalYearSelectProps {
+  value: number | null;
+  onChange: (yearId: number | null) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  /** Pass a pre-loaded list to avoid redundant fetches across multiple instances */
+  years?: EcclesiasticalYear[];
+  /** Called when the list finishes loading so the parent can share it */
+  onYearsLoaded?: (years: EcclesiasticalYear[]) => void;
+  /** Show only active years. Default: true */
+  activeOnly?: boolean;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function EcclesiasticalYearSelect({
+  value,
+  onChange,
+  placeholder,
+  disabled = false,
+  className,
+  years: externalYears,
+  onYearsLoaded,
+  activeOnly = true,
+}: EcclesiasticalYearSelectProps) {
+  const t = useTranslations("selectors.ecclesiasticalYear");
+  const [open, setOpen] = useState(false);
+  // Lazy load: only enable the query once the popover has been opened at least once.
+  const [hasOpened, setHasOpened] = useState(false);
+
+  const {
+    data: fetchedYears = [],
+    isFetching: loading,
+    error: fetchError,
+  } = useQuery({
+    queryKey: ["ecclesiastical-years"],
+    queryFn: async () => {
+      const data = await listEcclesiasticalYears();
+      onYearsLoaded?.(data);
+      return data;
+    },
+    enabled: (hasOpened || value != null) && externalYears === undefined,
+    staleTime: 60_000,
+  });
+
+  const allYears: EcclesiasticalYear[] = externalYears ?? fetchedYears;
+
+  const years: EcclesiasticalYear[] = activeOnly
+    ? allYears.filter((y) => y.active)
+    : allYears;
+
+  const error = fetchError
+    ? fetchError instanceof Error
+      ? fetchError.message
+      : t("loadError")
+    : null;
+
+  function handleOpenChange(nextOpen: boolean) {
+    setOpen(nextOpen);
+    if (nextOpen && !hasOpened) setHasOpened(true);
+  }
+
+  const selected = allYears.find((y) => y.ecclesiastical_year_id === value) ?? null;
+
+  function handleSelect(yearId: number) {
+    onChange(yearId === value ? null : yearId);
+    setOpen(false);
+  }
+
+  function handleClear(e: React.MouseEvent) {
+    e.stopPropagation();
+    onChange(null);
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-label={placeholder ?? t("placeholder")}
+          aria-controls="ecclesiastical-year-listbox"
+          disabled={disabled}
+          className={cn(
+            "h-9 w-full justify-between px-3 font-normal",
+            !selected && "text-muted-foreground",
+            className,
+          )}
+        >
+          {selected ? (
+            <span className="flex min-w-0 items-center gap-2">
+              <span className="truncate text-sm">{selected.name}</span>
+              {selected.active && (
+                <Badge variant="soft-success" className="shrink-0">
+                  {t("activeBadge")}
+                </Badge>
+              )}
+            </span>
+          ) : (
+            <span className="truncate text-sm">{placeholder ?? t("placeholder")}</span>
+          )}
+
+          <span className="ml-2 flex shrink-0 items-center gap-0.5">
+            {selected && !disabled && (
+              <span
+                role="button"
+                aria-label={t("clearSelection")}
+                onClick={handleClear}
+                className="rounded p-0.5 hover:bg-muted"
+              >
+                <X className="size-3.5 text-muted-foreground" />
+              </span>
+            )}
+            <ChevronsUpDown className="size-3.5 text-muted-foreground opacity-50" />
+          </span>
+        </Button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        id="ecclesiastical-year-listbox"
+        className="w-[var(--radix-popover-trigger-width)] p-0"
+        align="start"
+      >
+        <Command>
+          <CommandInput placeholder={t("searchPlaceholder")} />
+          <CommandList>
+            {loading && (
+              <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+                <Loader2 className="size-4 animate-spin" />
+                {t("loading")}
+              </div>
+            )}
+
+            {!loading && error && (
+              <div className="py-6 text-center text-sm text-destructive">
+                {error}
+              </div>
+            )}
+
+            {!loading && !error && years.length === 0 && (
+              <CommandEmpty>{t("empty")}</CommandEmpty>
+            )}
+
+            {!loading && !error && years.length > 0 && (
+              <CommandGroup>
+                {years.map((year) => (
+                  <CommandItem
+                    key={year.ecclesiastical_year_id}
+                    value={`${year.name} ${year.ecclesiastical_year_id}`}
+                    onSelect={() => handleSelect(year.ecclesiastical_year_id)}
+                  >
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                      <div className="flex items-center gap-2">
+                        <span className="truncate text-sm">{year.name}</span>
+                        {year.active && (
+                          <Badge variant="soft-success" className="shrink-0">
+                            {t("activeBadge")}
+                          </Badge>
+                        )}
+                      </div>
+                      {year.start_date && year.end_date && (
+                        <span className="text-xs text-muted-foreground">
+                          {formatDateRange(year.start_date, year.end_date)}
+                        </span>
+                      )}
+                    </div>
+
+                    <Check
+                      className={cn(
+                        "ml-auto size-3.5 shrink-0",
+                        value === year.ecclesiastical_year_id
+                          ? "opacity-100"
+                          : "opacity-0",
+                      )}
+                    />
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -2480,6 +2480,16 @@ export interface IntlMessages {
       cancel: string;
       registering: string;
       register: string;
+      description: string;
+      labelClub: string;
+      labelMember: string;
+      placeholderMember: string;
+      placeholderSelectClubFirst: string;
+      insuranceLoading: string;
+      insuranceActive: string;
+      insuranceExpires: string;
+      noInsuranceTitle: string;
+      noInsuranceDescription: string;
     };
     pages: {
       list: {
@@ -4929,15 +4939,6 @@ export interface IntlMessages {
         statDuration: string;
       };
     };
-    display: {
-      yearSingular: string;
-      yearPlural: string;
-      yearFallback: string;
-      availableFromAnyYear: string;
-      noProgrammedExpiration: string;
-      availableFromYear: string;
-      availableUntilYear: string;
-    };
     expiration: {
       title: string;
       description: string;
@@ -4949,6 +4950,15 @@ export interface IntlMessages {
       modeApply: string;
       result: string;
       confirmApply: string;
+    };
+    display: {
+      yearSingular: string;
+      yearPlural: string;
+      yearFallback: string;
+      availableFromAnyYear: string;
+      noProgrammedExpiration: string;
+      availableFromYear: string;
+      availableUntilYear: string;
     };
   };
   membership: {
@@ -5579,6 +5589,34 @@ export interface IntlMessages {
       statusInactive: string;
       reorderUp: string;
       reorderDown: string;
+    };
+  };
+  selectors: {
+    ecclesiasticalYear: {
+      placeholder: string;
+      searchPlaceholder: string;
+      loading: string;
+      empty: string;
+      loadError: string;
+      clearSelection: string;
+      activeBadge: string;
+    };
+    club: {
+      placeholder: string;
+      searchPlaceholder: string;
+      loading: string;
+      empty: string;
+      loadError: string;
+      clearSelection: string;
+    };
+    clubSection: {
+      placeholder: string;
+      placeholderNoClub: string;
+      searchPlaceholder: string;
+      loading: string;
+      empty: string;
+      loadError: string;
+      clearSelection: string;
     };
   };
 }

--- a/src/lib/api/insurance.ts
+++ b/src/lib/api/insurance.ts
@@ -1,4 +1,4 @@
-import { apiRequest, apiRequestFromClient, API_BASE_URL } from "@/lib/api/client";
+import { apiRequest, apiRequestFromClient } from "@/lib/api/client";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -118,6 +118,16 @@ export async function listMembersInsurance(
 
 export async function getMemberInsurance(memberId: string): Promise<unknown> {
   return apiRequest(`/users/${memberId}/insurance`);
+}
+
+export async function getMemberInsuranceFromClient(
+  memberId: string,
+): Promise<InsuranceRecord | null> {
+  const payload = await apiRequestFromClient<{
+    status: string;
+    data: InsuranceRecord | null;
+  }>(`/users/${memberId}/insurance`);
+  return payload?.data ?? null;
 }
 
 // ─── Client-side API functions ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Add reusable admin selectors for ecclesiastical years, clubs, and club sections.
- Replace raw ID entry flows in rankings filters, camporee member registration, notifications, and related resource UI touchpoints.
- Update camporee registration insurance auto-fill tests and regenerate next-intl message types.

## Verification
- `pnpm exec eslint 'src/components/shared/selectors/ecclesiastical-year-select.tsx' 'src/components/shared/selectors/club-select.tsx' 'src/components/shared/selectors/club-section-select.tsx' 'src/app/(dashboard)/dashboard/member-rankings/_components/member-rankings-filters.tsx' 'src/app/(dashboard)/dashboard/section-rankings/_components/section-rankings-filters.tsx' 'src/components/camporees/register-member-dialog.tsx' 'src/components/camporees/register-member-dialog.test.tsx' 'src/components/notifications/notification-forms.tsx' 'src/components/resources/resources-crud-page.tsx' 'src/lib/api/insurance.ts'`
- `pnpm exec vitest run ./src/components/camporees/register-member-dialog.test.tsx --exclude '.worktrees/**'`
- `pnpm exec tsc --noEmit --pretty false`

## Notes
- No build run, per project rule.
- Branch was isolated from `origin/development` to avoid mixed WIP from the main local working tree.
