### PR TITLE
feat(evidence-review): render honor review packet

### DIFF
--- a/src/components/evidence-review/evidence-detail-dialog.test.tsx
+++ b/src/components/evidence-review/evidence-detail-dialog.test.tsx
@@ -20,13 +20,7 @@
 
 import React from "react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import {
-  render,
-  screen,
-  waitFor,
-  act,
-  cleanup,
-} from "@testing-library/react";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
 import { NextIntlClientProvider } from "next-intl";
 import messages from "../../../messages/es.json";
 import type { EvidenceDetail, EvidenceType } from "@/lib/api/evidence-review";
@@ -66,11 +60,15 @@ vi.mock("@/lib/format-locale", () => ({
 
 // EvidenceStatusBadge and EvidenceTypeBadge — render as simple text nodes
 vi.mock("@/components/evidence-review/evidence-status-badge", () => ({
-  EvidenceStatusBadge: ({ status }: { status: string }) => <span data-testid="status-badge">{status}</span>,
+  EvidenceStatusBadge: ({ status }: { status: string }) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
 }));
 
 vi.mock("@/components/evidence-review/evidence-type-badge", () => ({
-  EvidenceTypeBadge: ({ type }: { type: string }) => <span data-testid="type-badge">{type}</span>,
+  EvidenceTypeBadge: ({ type }: { type: string }) => (
+    <span data-testid="type-badge">{type}</span>
+  ),
 }));
 
 import { EvidenceDetailDialog } from "@/components/evidence-review/evidence-detail-dialog";
@@ -120,6 +118,93 @@ const STUB_DETAIL_REJECTED: EvidenceDetail = {
   validated_at: "2026-04-01T12:00:00.000Z",
   validated_by_name: "Admin Pérez",
 };
+
+const STUB_HONOR_DETAIL_WITH_PACKET = {
+  ...STUB_DETAIL,
+  id: 77,
+  type: "honor",
+  status: "PENDING_REVIEW",
+  section_name: "Arte cristiano",
+  file_count: 4,
+  files: [
+    ...STUB_DETAIL.files,
+    {
+      evidence_file_id: -100100,
+      file_url: "https://example.com/requisito.jpg",
+      file_name: "requisito.jpg",
+      file_type: "image/jpeg",
+      uploaded_at: "2026-03-15T10:10:00.000Z",
+    },
+    {
+      evidence_file_id: -1,
+      file_url: "https://example.com/certificado.pdf",
+      file_name: "certificado.pdf",
+      file_type: "application/pdf",
+      uploaded_at: "2026-03-15T10:15:00.000Z",
+    },
+  ],
+  honor_review_packet: {
+    user_honor_id: 77,
+    honor_id: 20,
+    honor_name: "Arte cristiano",
+    validation_status: "PENDING_REVIEW",
+    progress: {
+      total_requirements: 2,
+      completed_count: 1,
+      progress_percentage: 50,
+    },
+    general_files: [
+      {
+        evidence_file_id: -1,
+        file_url: "https://example.com/certificado.pdf",
+        file_name: "certificado.pdf",
+        file_type: "application/pdf",
+        uploaded_at: "2026-03-15T10:15:00.000Z",
+      },
+    ],
+    requirement_files: [
+    {
+      evidence_file_id: -100100,
+        file_url: "https://example.com/requisito.jpg",
+        file_name: "requisito.jpg",
+        file_type: "image/jpeg",
+        uploaded_at: "2026-03-15T10:10:00.000Z",
+      },
+    ],
+    requirements: [
+      {
+        requirement_id: 1,
+        requirement_number: "1",
+        display_label: "1",
+        requirement_text: "Explicar el objetivo del honor",
+        requires_evidence: true,
+        completed: true,
+        completed_at: "2026-03-15T10:10:00.000Z",
+        evidence_count: 1,
+        evidences: [
+          {
+            evidence_file_id: -100100,
+            file_url: "https://example.com/requisito.jpg",
+            file_name: "requisito.jpg",
+            file_type: "image/jpeg",
+            uploaded_at: "2026-03-15T10:10:00.000Z",
+          },
+        ],
+      },
+      {
+        requirement_id: 2,
+        requirement_number: "2",
+        display_label: "2",
+        requirement_text: "Completar una actividad práctica",
+        requires_evidence: false,
+        completed: false,
+        completed_at: null,
+        evidence_count: 0,
+        evidences: [],
+      },
+    ],
+  },
+} as EvidenceDetail;
 
 // ---------------------------------------------------------------------------
 // Render helper
@@ -304,6 +389,24 @@ describe("EvidenceDetailDialog", () => {
     await waitFor(() => {
       expect(screen.getByTestId("type-badge")).toBeInTheDocument();
       expect(screen.getByTestId("status-badge")).toBeInTheDocument();
+    });
+  });
+
+  // ── 13. Honor review packet rendering ────────────────────────────────────
+
+  it("renders honor review packet progress and requirement evidence", async () => {
+    mockGetEvidenceDetail.mockResolvedValue(STUB_HONOR_DETAIL_WITH_PACKET);
+
+    renderDialog({ type: "honor", id: 77 });
+
+    await waitFor(() => {
+      expect(screen.getByText("Progreso del honor")).toBeInTheDocument();
+      expect(screen.getByText("1 de 2 requisitos")).toBeInTheDocument();
+      expect(screen.getByText("50% completado")).toBeInTheDocument();
+      expect(
+        screen.getByText("Explicar el objetivo del honor"),
+      ).toBeInTheDocument();
+      expect(screen.getByText("requisito.jpg")).toBeInTheDocument();
     });
   });
 });

--- a/src/components/evidence-review/evidence-detail-dialog.tsx
+++ b/src/components/evidence-review/evidence-detail-dialog.tsx
@@ -10,6 +10,9 @@ import {
   User,
   Calendar,
   AlertCircle,
+  CheckCircle2,
+  Circle,
+  ListChecks,
 } from "lucide-react";
 import {
   Dialog,
@@ -21,14 +24,26 @@ import {
 import { Separator } from "@/components/ui/separator";
 import { Badge } from "@/components/ui/badge";
 import { useTranslations } from "next-intl";
-import { getEvidenceDetail, type EvidenceDetail, type EvidenceType } from "@/lib/api/evidence-review";
+import {
+  getEvidenceDetail,
+  type EvidenceDetail,
+  type EvidenceType,
+} from "@/lib/api/evidence-review";
 import { EvidenceStatusBadge } from "@/components/evidence-review/evidence-status-badge";
 import { EvidenceTypeBadge } from "@/components/evidence-review/evidence-type-badge";
 import { ApiError } from "@/lib/api/client";
 import { useFormatDateTime } from "@/lib/format-locale";
 
+type HonorReviewPacket = NonNullable<EvidenceDetail["honor_review_packet"]>;
+
 function isImageFile(fileType: string, fileUrl: string): boolean {
-  const imageTypes = ["image", "image/jpeg", "image/png", "image/webp", "image/gif"];
+  const imageTypes = [
+    "image",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+    "image/gif",
+  ];
   if (imageTypes.some((t) => fileType.toLowerCase().startsWith(t))) return true;
   const urlLower = fileUrl.toLowerCase();
   return (
@@ -110,6 +125,108 @@ function FileCard({ file, index }: FileCardProps) {
   );
 }
 
+// ─── Honor review packet ─────────────────────────────────────────────────────
+
+interface HonorReviewPacketSectionProps {
+  packet: HonorReviewPacket;
+}
+
+function HonorReviewPacketSection({ packet }: HonorReviewPacketSectionProps) {
+  const requirements = packet.requirements ?? [];
+  const completedCount = packet.progress.completed_count;
+  const totalRequirements = packet.progress.total_requirements;
+  const progressPercentage = Math.round(packet.progress.progress_percentage);
+
+  return (
+    <section className="rounded-lg border border-border bg-muted/20 p-4">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <ListChecks className="size-4 text-muted-foreground" />
+          <h4 className="text-sm font-medium">Progreso del honor</h4>
+        </div>
+        <Badge variant="secondary" className="text-xs">
+          {completedCount} de {totalRequirements} requisitos
+        </Badge>
+      </div>
+
+      <div className="mb-4">
+        <div className="mb-1 flex items-center justify-between text-xs text-muted-foreground">
+          <span>{packet.honor_name}</span>
+          <span>{progressPercentage}% completado</span>
+        </div>
+        <div className="h-2 overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full bg-primary"
+            style={{
+              width: `${Math.min(Math.max(progressPercentage, 0), 100)}%`,
+            }}
+          />
+        </div>
+      </div>
+
+      {requirements.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Este honor no tiene requisitos registrados.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {requirements.map((requirement) => (
+            <div
+              key={requirement.requirement_id}
+              className="rounded-md border border-border bg-background p-3"
+            >
+              <div className="flex items-start gap-2">
+                {requirement.completed ? (
+                  <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-emerald-600" />
+                ) : (
+                  <Circle className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-medium">
+                      {requirement.display_label ?? requirement.requirement_number}
+                    </p>
+                    <Badge
+                      variant={requirement.completed ? "default" : "outline"}
+                      className="text-xs"
+                    >
+                      {requirement.completed ? "Completado" : "Pendiente"}
+                    </Badge>
+                    {requirement.requires_evidence && (
+                      <Badge variant="secondary" className="text-xs">
+                        Requiere evidencia
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="mt-1 text-sm text-muted-foreground">
+                    {requirement.requirement_text}
+                  </p>
+                  {requirement.evidences.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {requirement.evidences.map((file) => (
+                        <a
+                          key={file.evidence_file_id}
+                          href={file.file_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs text-muted-foreground hover:text-foreground"
+                        >
+                          <FileText className="size-3" />
+                          Evidencia: {file.file_name || "Archivo adjunto"}
+                        </a>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
 // ─── Main component ───────────────────────────────────────────────────────────
 
 interface EvidenceDetailDialogProps {
@@ -154,7 +271,7 @@ export function EvidenceDetailDialog({
     }
 
     void load();
-  }, [open, type, id]);
+  }, [open, type, id, t]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -244,6 +361,10 @@ export function EvidenceDetailDialog({
                   <p className="mt-0.5 text-destructive/80">{detail.rejection_reason}</p>
                 </div>
               </div>
+            )}
+
+            {detail.type === "honor" && detail.honor_review_packet && (
+              <HonorReviewPacketSection packet={detail.honor_review_packet} />
             )}
 
             <Separator />

--- a/src/lib/api/evidence-review.ts
+++ b/src/lib/api/evidence-review.ts
@@ -31,9 +31,37 @@ export type EvidenceFile = {
   uploaded_at: string;
 };
 
+export type HonorRequirementReviewItem = {
+  requirement_id: number;
+  requirement_number: string;
+  display_label: string | null;
+  requirement_text: string;
+  requires_evidence: boolean;
+  completed: boolean;
+  completed_at: string | null;
+  evidence_count: number;
+  evidences: EvidenceFile[];
+};
+
+export type HonorReviewPacket = {
+  user_honor_id: number;
+  honor_id: number;
+  honor_name: string;
+  validation_status: string;
+  progress: {
+    total_requirements: number;
+    completed_count: number;
+    progress_percentage: number;
+  };
+  general_files: EvidenceFile[];
+  requirement_files: EvidenceFile[];
+  requirements: HonorRequirementReviewItem[];
+};
+
 export type EvidenceDetail = EvidenceItem & {
   files: EvidenceFile[];
   validated_by_name: string | null;
+  honor_review_packet?: HonorReviewPacket;
 };
 
 export type EvidenceHistoryEntry = {
@@ -66,7 +94,10 @@ export async function getEvidencePending(
   page = 1,
   limit = 50,
 ): Promise<PaginatedEvidenceItems> {
-  const params: Record<string, string | number | boolean | undefined> = { page, limit };
+  const params: Record<string, string | number | boolean | undefined> = {
+    page,
+    limit,
+  };
   if (type) params.type = type;
 
   const res = await apiRequest<{ status: string; data: PaginatedEvidenceItems }>(

--- a/src/lib/api/monthly-reports.test.ts
+++ b/src/lib/api/monthly-reports.test.ts
@@ -37,7 +37,7 @@ describe("getReportPdfUrl", () => {
         }),
       )
       .mockResolvedValueOnce(
-        new Response(new Blob(["pdf"]), {
+        new Response("pdf", {
           status: 200,
           headers: { "content-type": "application/pdf" },
         }),
@@ -45,9 +45,12 @@ describe("getReportPdfUrl", () => {
 
     globalThis.fetch = fetchMock;
 
-    await expect(
-      downloadMonthlyReportPdf("46bebcb7-3f0a-49c7-930a-a25efc9bde89"),
-    ).resolves.toBeInstanceOf(Blob);
+    const blob = await downloadMonthlyReportPdf(
+      "46bebcb7-3f0a-49c7-930a-a25efc9bde89",
+    );
+
+    expect(blob.size).toBe(3);
+    expect(blob.type).toBe("application/pdf");
 
     expect(fetchMock).toHaveBeenNthCalledWith(1, "/api/auth/token");
     expect(fetchMock).toHaveBeenNthCalledWith(


### PR DESCRIPTION
## Summary
- Adds `HonorReviewPacket` API types for evidence-review honor details.
- Renders honor progress, requirement completion, and per-requirement evidence in the review dialog.
- Adds regression coverage for the honor packet rendering.

## Test Plan
- [x] `pnpm test src/components/evidence-review/evidence-detail-dialog.test.tsx`
- [x] `pnpm exec eslint src/lib/api/evidence-review.ts src/components/evidence-review/evidence-detail-dialog.tsx src/components/evidence-review/evidence-detail-dialog.test.tsx`
- [x] `git diff --check`

## Notes
- Base branch: `development`.
