### PR TITLE
fix(evidence-review): align honor review states

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -74,7 +74,7 @@
       "notifications": "Notifications",
       "notifications_send": "Send",
       "notifications_history": "History",
-      "evidence_review": "Evidence Review",
+      "evidence_review": "User Evidence Review",
       "evidence_folders": "Annual Evidence Folders",
       "annual_folders": "Annual Evidence Folder",
       "annual_folders_templates": "Templates",
@@ -1437,8 +1437,8 @@
         "invalidIdError": "Invalid honor ID."
       },
       "requirementsReview": {
-        "title": "Requirements Review",
-        "description": "Review and approve imported requirements that need validation.",
+        "title": "Catalog Requirements Review",
+        "description": "Review and approve imported catalog requirements. This is not institutional review of user evidence.",
         "backToList": "Back to list",
         "reviewItemTitle": "Requirement review",
         "pendingBadge": "{count} pending",

--- a/messages/es.json
+++ b/messages/es.json
@@ -74,7 +74,7 @@
       "notifications": "Notificaciones",
       "notifications_send": "Enviar",
       "notifications_history": "Historial",
-      "evidence_review": "Revisión de evidencias",
+      "evidence_review": "Revisión de evidencias de usuarios",
       "evidence_folders": "Carpetas Anuales de Evidencias",
       "annual_folders": "Carpeta Anual de Evidencias",
       "annual_folders_templates": "Plantillas",
@@ -1437,8 +1437,8 @@
         "invalidIdError": "ID de especialidad inválido."
       },
       "requirementsReview": {
-        "title": "Revisión de Requisitos",
-        "description": "Revisa y aprueba los requisitos importados que necesitan validación.",
+        "title": "Revisión de requisitos de catálogo",
+        "description": "Revisá y aprobá requisitos importados del catálogo. No corresponde a revisión institucional de evidencias de usuarios.",
         "backToList": "Volver a la lista",
         "reviewItemTitle": "Revisión de requisito",
         "pendingBadge": "{count} pendientes",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -74,7 +74,7 @@
       "notifications": "Notifications",
       "notifications_send": "Envoyer",
       "notifications_history": "Historique",
-      "evidence_review": "Révision des preuves",
+      "evidence_review": "Révision des preuves des utilisateurs",
       "evidence_folders": "Dossiers annuels de preuves",
       "annual_folders": "Dossier annuel de preuves",
       "annual_folders_templates": "Modèles",
@@ -1436,8 +1436,8 @@
         "invalidIdError": "ID de spécialité invalide."
       },
       "requirementsReview": {
-        "title": "Révision des exigences",
-        "description": "Révisez et approuvez les exigences importées qui nécessitent une validation.",
+        "title": "Révision des exigences du catalogue",
+        "description": "Révisez et approuvez les exigences importées du catalogue. Ce n'est pas une révision institutionnelle des preuves des utilisateurs.",
         "backToList": "Retour à la liste",
         "reviewItemTitle": "Révision d'exigence",
         "pendingBadge": "{count} en attente",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -74,7 +74,7 @@
       "notifications": "Notificações",
       "notifications_send": "Enviar",
       "notifications_history": "Histórico",
-      "evidence_review": "Revisão de evidências",
+      "evidence_review": "Revisão de evidências de usuários",
       "evidence_folders": "Pastas de evidências",
       "annual_folders": "Pasta Anual de Evidências",
       "annual_folders_templates": "Modelos",
@@ -1436,8 +1436,8 @@
         "invalidIdError": "ID de especialidade inválido."
       },
       "requirementsReview": {
-        "title": "Revisão de Requisitos",
-        "description": "Revise e aprove os requisitos importados que precisam de validação.",
+        "title": "Revisão de requisitos de catálogo",
+        "description": "Revise e aprove requisitos importados do catálogo. Isso não é revisão institucional de evidências de usuários.",
         "backToList": "Voltar à lista",
         "reviewItemTitle": "Revisão de requisito",
         "pendingBadge": "{count} pendentes",

--- a/src/components/evidence-review/evidence-status-badge.tsx
+++ b/src/components/evidence-review/evidence-status-badge.tsx
@@ -21,7 +21,9 @@ const classIntentMap: Record<string, IntentConfig> = {
 const honorIntentMap: Record<string, IntentConfig> = {
   PENDING:     { labelKey: "no_submit",  intent: "neutral" },
   SUBMITTED:   { labelKey: "submitted",  intent: "info" },
+  IN_PROGRESS: { labelKey: "submitted",  intent: "info" },
   VALIDATED:   { labelKey: "validated",  intent: "success" },
+  APPROVED:    { labelKey: "validated",  intent: "success" },
   REJECTED:    { labelKey: "rejected",   intent: "destructive" },
   PENDING_REVIEW: { labelKey: "submitted",  intent: "info" },
 

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -32,6 +32,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 import {
+  USER_HONORS_VALIDATE,
   RANKINGS_READ,
   RANKING_WEIGHTS_READ,
 } from "@/lib/auth/permissions";
@@ -267,7 +268,7 @@ export const navConfig: NavGroup[] = [
         title: "items.evidence_review",
         url: "/dashboard/evidence-review",
         icon: FileSearch,
-        permission: "investiture:read",
+        permission: USER_HONORS_VALIDATE,
       },
       {
         title: "items.certificate_bulk_imports",

--- a/src/lib/api/evidence-review.ts
+++ b/src/lib/api/evidence-review.ts
@@ -4,16 +4,39 @@ import { apiRequest, apiRequestFromClient } from "@/lib/api/client";
 
 export type EvidenceType = "class" | "honor";
 
-export type EvidenceStatus =
+export type ClassEvidenceStatus =
   | "PENDING"
   | "SUBMITTED"
   | "VALIDATED"
   | "REJECTED";
 
+export type LegacyEvidenceStatus =
+  | "pending"
+  | "pendiente"
+  | "validado"
+  | "rechazado"
+  | "rejected";
+
+export type HonorValidationStatus =
+  | "PENDING"
+  | "PENDING_REVIEW"
+  | "IN_PROGRESS"
+  | "APPROVED"
+  | "REJECTED";
+
+export type EvidenceStatus =
+  | ClassEvidenceStatus
+  | HonorValidationStatus
+  | LegacyEvidenceStatus;
+
+export type EvidenceMutationStatus =
+  | ClassEvidenceStatus
+  | "APPROVED";
+
 export type EvidenceItem = {
   id: number;
   type: EvidenceType;
-  status: string;
+  status: EvidenceStatus;
   member_name: string;
   member_id: string;
   section_name: string;
@@ -47,7 +70,7 @@ export type HonorReviewPacket = {
   user_honor_id: number;
   honor_id: number;
   honor_name: string;
-  validation_status: string;
+  validation_status: HonorValidationStatus;
   progress: {
     total_requirements: number;
     completed_count: number;
@@ -133,15 +156,15 @@ export async function approveEvidence(
   type: EvidenceType,
   id: number,
   comments?: string,
-): Promise<{ id: number; type: EvidenceType; status: string }> {
+): Promise<{ id: number; type: EvidenceType; status: EvidenceMutationStatus }> {
   const res = await apiRequestFromClient<{
     status: string;
-    data: { id: number; type: EvidenceType; status: string };
+    data: { id: number; type: EvidenceType; status: EvidenceMutationStatus };
   }>(`/evidence-review/${type}/${id}/approve`, {
     method: "POST",
     body: { comments },
   });
-  return (res as { data: { id: number; type: EvidenceType; status: string } }).data;
+  return (res as { data: { id: number; type: EvidenceType; status: EvidenceMutationStatus } }).data;
 }
 
 /**
@@ -152,15 +175,15 @@ export async function rejectEvidence(
   type: EvidenceType,
   id: number,
   reason: string,
-): Promise<{ id: number; type: EvidenceType; status: string }> {
+): Promise<{ id: number; type: EvidenceType; status: EvidenceMutationStatus }> {
   const res = await apiRequestFromClient<{
     status: string;
-    data: { id: number; type: EvidenceType; status: string };
+    data: { id: number; type: EvidenceType; status: EvidenceMutationStatus };
   }>(`/evidence-review/${type}/${id}/reject`, {
     method: "POST",
     body: { reason },
   });
-  return (res as { data: { id: number; type: EvidenceType; status: string } }).data;
+  return (res as { data: { id: number; type: EvidenceType; status: EvidenceMutationStatus } }).data;
 }
 
 // ─── Bulk operations ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Align evidence-review TypeScript statuses with honor validation states and legacy statuses already supported by UI.
- Gate the Evidence Review nav entry with `user_honors:validate`.
- Clarify catalog requirements review copy so it is not confused with institutional user evidence review.

## Test Plan
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm exec eslint src/lib/api/evidence-review.ts src/components/evidence-review/evidence-status-badge.tsx src/components/layout/nav-config.ts`

## Notes
Post-QA follow-up for the honors/especialidades workflow merged to development.
