### PR TITLE
feat: expose scoring category cap in admin

### DIFF
--- a/src/app/(dashboard)/dashboard/catalogs/geography/local-fields/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/local-fields/page.tsx
@@ -137,6 +137,7 @@ export default async function LocalFieldsPage({
         canEdit={canEdit}
         canDelete={canDelete}
         deleteAction={deleteLocalFieldAction}
+        enableScoringConfiguration
       />
     </div>
   );

--- a/src/app/(dashboard)/dashboard/catalogs/geography/unions/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/geography/unions/page.tsx
@@ -133,6 +133,7 @@ export default async function UnionsPage({
         canEdit={canEdit}
         canDelete={canDelete}
         deleteAction={deleteUnionAction}
+        enableScoringConfiguration
       />
     </div>
   );

--- a/src/components/catalogs/geography-list-client.test.tsx
+++ b/src/components/catalogs/geography-list-client.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "next-intl";
+import messages from "../../../messages/es.json";
+import { GeographyListClient } from "@/components/catalogs/geography-list-client";
+import type { GenericCatalogActionState } from "@/lib/generic-catalogs-i18n/actions";
+
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+if (!Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+const mockPush = vi.fn();
+const mockReplace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: mockPush,
+    replace: mockReplace,
+  }),
+  usePathname: () => "/dashboard/catalogs/geography/unions",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const noopDeleteAction = async (
+  _prev: GenericCatalogActionState,
+  _data: FormData,
+): Promise<GenericCatalogActionState> => ({});
+
+function renderClient(enableScoringConfiguration: boolean) {
+  return render(
+    <NextIntlClientProvider locale="es" messages={messages}>
+      <GeographyListClient
+        i18nNamespace="unions"
+        basePath="/dashboard/catalogs/geography/unions"
+        pkField="union_id"
+        includeAbbreviation
+        parentLabel="País"
+        parentField="_parent_name"
+        fallbackName="esta unión"
+        items={[
+          {
+            union_id: 12,
+            name: "Unión Norte",
+            abbreviation: "UN",
+            _parent_name: "Argentina",
+            active: true,
+          },
+        ]}
+        meta={{ page: 1, limit: 20, total: 1, totalPages: 1 }}
+        canCreate={false}
+        canEdit
+        canDelete={false}
+        deleteAction={noopDeleteAction}
+        enableScoringConfiguration={enableScoringConfiguration}
+      />
+    </NextIntlClientProvider>,
+  );
+}
+
+describe("GeographyListClient scoring navigation", () => {
+  beforeEach(() => {
+    mockPush.mockReset();
+    mockReplace.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("shows 'Configurar puntuación' action linking to scoring-categories tab when enabled", () => {
+    renderClient(true);
+
+    const scoringLink = screen.getByRole("link", {
+      name: /configurar puntuación/i,
+    });
+    expect(scoringLink).toBeInTheDocument();
+    expect(scoringLink).toHaveAttribute(
+      "href",
+      "/dashboard/catalogs/geography/unions/12?tab=scoring-categories",
+    );
+  });
+
+  it("hides scoring navigation action when disabled", () => {
+    renderClient(false);
+
+    expect(
+      screen.queryByRole("link", { name: /configurar puntuación/i }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/catalogs/geography-list-client.tsx
+++ b/src/components/catalogs/geography-list-client.tsx
@@ -20,6 +20,7 @@ import {
   Pencil,
   Plus,
   Search,
+  Settings2,
   Trash2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -104,6 +105,7 @@ export interface GeographyListClientProps {
   canEdit: boolean;
   canDelete: boolean;
   deleteAction: FormAction;
+  enableScoringConfiguration?: boolean;
 }
 
 function toText(value: unknown): string | null {
@@ -147,6 +149,7 @@ export function GeographyListClient({
   canEdit,
   canDelete,
   deleteAction,
+  enableScoringConfiguration = false,
 }: GeographyListClientProps) {
   const t = useTranslations(`catalogs.pages.${i18nNamespace}`);
   const router = useRouter();
@@ -365,6 +368,22 @@ export function GeographyListClient({
                         {(canEdit || canDelete) && (
                           <TableCell className="sticky right-0 z-10 border-l bg-background">
                             <div className="hidden gap-1 md:flex">
+                              {enableScoringConfiguration && itemId && (
+                                <Button
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-8 px-2.5 text-xs"
+                                  asChild
+                                  title="Configurar puntuación"
+                                >
+                                  <Link
+                                    href={`${basePath}/${itemId}?tab=scoring-categories`}
+                                  >
+                                    <Settings2 className="size-3.5" />
+                                    Configurar puntuación
+                                  </Link>
+                                </Button>
+                              )}
                               {canEdit && itemId && (
                                 <Button
                                   variant="ghost"
@@ -408,6 +427,16 @@ export function GeographyListClient({
                                       <Link href={`${basePath}/${itemId}/edit`}>
                                         <Pencil className="size-4" />
                                         Editar
+                                      </Link>
+                                    </DropdownMenuItem>
+                                  )}
+                                  {enableScoringConfiguration && itemId && (
+                                    <DropdownMenuItem asChild>
+                                      <Link
+                                        href={`${basePath}/${itemId}?tab=scoring-categories`}
+                                      >
+                                        <Settings2 className="size-4" />
+                                        Configurar puntuación
                                       </Link>
                                     </DropdownMenuItem>
                                   )}

--- a/src/components/scoring-categories/scoring-categories-table.tsx
+++ b/src/components/scoring-categories/scoring-categories-table.tsx
@@ -23,6 +23,10 @@ import {
   SortableHeader,
   type SortDirection,
 } from "@/components/shared/sortable-header";
+import {
+  DEFAULT_SCORING_CATEGORY_MAX_POINTS_CAP,
+  getScoringCategoryMaxPointsCap,
+} from "@/lib/api/system-config";
 import type { ScoringCategoryDialogProps } from "@/components/scoring-categories/scoring-category-dialog";
 import type { ScoringCategoryDeleteDialogProps } from "@/components/scoring-categories/scoring-category-delete-dialog";
 import type {
@@ -169,6 +173,9 @@ export function ScoringCategoriesTable({
     useState<ScoringCategory | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [togglingIds, setTogglingIds] = useState<Set<number>>(new Set());
+  const [maxPointsCap, setMaxPointsCap] = useState(
+    DEFAULT_SCORING_CATEGORY_MAX_POINTS_CAP,
+  );
 
   const loadCategories = useCallback(async () => {
     setLoading(true);
@@ -191,6 +198,22 @@ export function ScoringCategoriesTable({
   useEffect(() => {
     loadCategories();
   }, [loadCategories]);
+
+  useEffect(() => {
+    let mounted = true;
+
+    async function loadMaxPointsCap() {
+      const resolved = await getScoringCategoryMaxPointsCap();
+      if (!mounted) return;
+      setMaxPointsCap(resolved);
+    }
+
+    void loadMaxPointsCap();
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   // ─── Save handler (create or update) ───────────────────────────────────────
 
@@ -322,6 +345,10 @@ export function ScoringCategoriesTable({
           {tTable("newCategory")}
         </Button>
       </div>
+      <p className="text-sm text-muted-foreground">
+        Puntaje máximo permitido por el sistema: {maxPointsCap} puntos por
+        aspecto.
+      </p>
 
       {/* Table or empty */}
       {sortedCategories.length === 0 ? (
@@ -478,6 +505,7 @@ export function ScoringCategoriesTable({
           }
         }}
         category={editCategory}
+        maxPointsCap={maxPointsCap}
         onSave={handleSave}
         onSuccess={() => {
           setEditCategory(null);

--- a/src/components/scoring-categories/scoring-category-dialog.test.tsx
+++ b/src/components/scoring-categories/scoring-category-dialog.test.tsx
@@ -110,6 +110,7 @@ interface RenderOpts {
   category?: ScoringCategory | null;
   onSave?: ReturnType<typeof vi.fn>;
   onSuccess?: ReturnType<typeof vi.fn>;
+  maxPointsCap?: number;
 }
 
 function renderDialog(opts: RenderOpts = {}) {
@@ -118,6 +119,7 @@ function renderDialog(opts: RenderOpts = {}) {
     category,
     onSave,
     onSuccess,
+    maxPointsCap,
   } = opts;
   const onOpenChange = vi.fn();
   const saveCb = onSave ?? vi.fn<(payload: unknown, id?: number) => Promise<ScoringCategory>>().mockResolvedValue(SAVED_CATEGORY);
@@ -131,6 +133,7 @@ function renderDialog(opts: RenderOpts = {}) {
         category={category}
         onSuccess={successCb}
         onSave={saveCb}
+        maxPointsCap={maxPointsCap}
       />
     </NextIntlClientProvider>,
   );
@@ -246,7 +249,50 @@ describe("ScoringCategoryDialog", () => {
     expect(mockToastError).toHaveBeenCalledWith(t.validation.points_invalid);
   });
 
-  // ── 8. Happy path create — calls onSave without id ───────────────────────
+  // ── 8. Cap legend + max attribute ────────────────────────────────────────
+
+  it("shows system cap legend and applies max attribute to points input", () => {
+    renderDialog({ maxPointsCap: 17 });
+
+    expect(
+      screen.getByText(
+        "Puntaje máximo permitido por el sistema: 17 puntos por aspecto.",
+      ),
+    ).toBeInTheDocument();
+
+    const pointsInput = document.querySelector(
+      'input[id="sc_max_points"]',
+    ) as HTMLInputElement;
+    expect(pointsInput).toHaveAttribute("max", "17");
+  });
+
+  // ── 9. Validation — maxPoints > cap ──────────────────────────────────────
+
+  it("shows cap validation error when max_points exceeds the configured cap", async () => {
+    const { onSave } = renderDialog({ maxPointsCap: 20 });
+
+    const pointsInput = document.querySelector(
+      'input[id="sc_max_points"]',
+    ) as HTMLInputElement;
+    fireEvent.change(pointsInput, { target: { value: "21" } });
+
+    const nameInput = document.querySelector(
+      'input[id="sc_name"]',
+    ) as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: "Nombre válido" } });
+
+    const form = document.querySelector("form") as HTMLFormElement;
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith(
+      "Los puntos máximos no pueden superar 20",
+    );
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  // ── 10. Happy path create — calls onSave without id ──────────────────────
 
   it("calls onSave with name, max_points but no id in create mode", async () => {
     const { onOpenChange, onSave, onSuccess } = renderDialog();
@@ -271,7 +317,7 @@ describe("ScoringCategoryDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  // ── 9. Happy path edit — calls onSave with existing id ───────────────────
+  // ── 11. Happy path edit — calls onSave with existing id ──────────────────
 
   it("calls onSave with category id in edit mode", async () => {
     const { onSave } = renderDialog({ category: STUB_CATEGORY });
@@ -289,7 +335,7 @@ describe("ScoringCategoryDialog", () => {
     });
   });
 
-  // ── 10. Error path — shows Error.message in toast ────────────────────────
+  // ── 12. Error path — shows Error.message in toast ────────────────────────
 
   it("shows Error.message in toast when onSave throws", async () => {
     const failingSave = vi.fn<(payload: unknown, id?: number) => Promise<ScoringCategory>>().mockRejectedValue(
@@ -310,7 +356,7 @@ describe("ScoringCategoryDialog", () => {
     });
   });
 
-  // ── 11. Cancel closes dialog without API call ─────────────────────────────
+  // ── 13. Cancel closes dialog without API call ─────────────────────────────
 
   it("calls onOpenChange(false) and does NOT call onSave on cancel", async () => {
     const user = userEvent.setup();
@@ -322,7 +368,7 @@ describe("ScoringCategoryDialog", () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 
-  // ── 12. In-flight state — buttons disabled while saving ───────────────────
+  // ── 14. In-flight state — buttons disabled while saving ───────────────────
 
   it("disables buttons while save is in flight", async () => {
     let resolve!: (v: ScoringCategory) => void;

--- a/src/components/scoring-categories/scoring-category-dialog.tsx
+++ b/src/components/scoring-categories/scoring-category-dialog.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/ui/dialog";
 import { TranslationsTabsField } from "@/components/forms/translations-tabs-field";
 import type { CatalogTranslation } from "@/lib/types/catalog-translation";
+import { DEFAULT_SCORING_CATEGORY_MAX_POINTS_CAP } from "@/lib/api/system-config";
 import type {
   ScoringCategory,
   CreateScoringCategoryPayload,
@@ -37,6 +38,8 @@ export interface ScoringCategoryDialogProps {
     payload: CreateScoringCategoryPayload | UpdateScoringCategoryPayload,
     id?: number,
   ) => Promise<ScoringCategory>;
+  /** Global max points cap enforced by system config. */
+  maxPointsCap?: number;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -47,9 +50,13 @@ export function ScoringCategoryDialog({
   category,
   onSuccess,
   onSave,
+  maxPointsCap = DEFAULT_SCORING_CATEGORY_MAX_POINTS_CAP,
 }: ScoringCategoryDialogProps) {
   const t = useTranslations("scoring_categories");
   const isEdit = Boolean(category);
+  const resolvedMaxPointsCap = Number.isInteger(maxPointsCap) && maxPointsCap > 0
+    ? maxPointsCap
+    : DEFAULT_SCORING_CATEGORY_MAX_POINTS_CAP;
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [name, setName] = useState("");
   const [maxPoints, setMaxPoints] = useState(1);
@@ -86,6 +93,12 @@ export function ScoringCategoryDialog({
     }
     if (!Number.isInteger(maxPoints) || maxPoints < 1) {
       toast.error(t("validation.points_invalid"));
+      return;
+    }
+    if (maxPoints > resolvedMaxPointsCap) {
+      toast.error(
+        `Los puntos máximos no pueden superar ${resolvedMaxPointsCap}`,
+      );
       return;
     }
 
@@ -151,13 +164,15 @@ export function ScoringCategoryDialog({
               id="sc_max_points"
               type="number"
               min={1}
+              max={resolvedMaxPointsCap}
               value={maxPoints}
               onChange={(e) => setMaxPoints(Number(e.target.value))}
               required
               disabled={isSubmitting}
             />
             <p className="text-[11px] text-muted-foreground">
-              Techo de puntos por sesión para esta categoría.
+              Puntaje máximo permitido por el sistema: {resolvedMaxPointsCap}{" "}
+              puntos por aspecto.
             </p>
           </div>
 

--- a/src/lib/api/system-config.ts
+++ b/src/lib/api/system-config.ts
@@ -18,6 +18,10 @@ export type UpdateSystemConfigPayload = {
   config_value: string;
 };
 
+export const SCORING_CATEGORY_MAX_POINTS_CAP_KEY =
+  "scoring.category_max_points_cap";
+export const DEFAULT_SCORING_CATEGORY_MAX_POINTS_CAP = 20;
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 function extractList(payload: unknown): SystemConfig[] {
@@ -29,6 +33,14 @@ function extractList(payload: unknown): SystemConfig[] {
   return [];
 }
 
+function parsePositiveInteger(value: string | null | undefined): number | null {
+  if (value == null) return null;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return null;
+  if (!Number.isInteger(parsed) || parsed < 1) return null;
+  return parsed;
+}
+
 // ─── API functions ────────────────────────────────────────────────────────────
 
 /**
@@ -38,6 +50,24 @@ function extractList(payload: unknown): SystemConfig[] {
 export async function getSystemConfigs(): Promise<SystemConfig[]> {
   const res = await apiRequest<unknown>("/system-config");
   return extractList(res);
+}
+
+/**
+ * Resolve current scoring max points cap from system config.
+ * Falls back to DEFAULT_SCORING_CATEGORY_MAX_POINTS_CAP when config
+ * is missing, invalid or the request fails.
+ */
+export async function getScoringCategoryMaxPointsCap(): Promise<number> {
+  try {
+    const configs = await getSystemConfigs();
+    const capRaw = configs.find(
+      (item) => item.config_key === SCORING_CATEGORY_MAX_POINTS_CAP_KEY,
+    )?.config_value;
+    const parsed = parsePositiveInteger(capRaw);
+    return parsed ?? DEFAULT_SCORING_CATEGORY_MAX_POINTS_CAP;
+  } catch {
+    return DEFAULT_SCORING_CATEGORY_MAX_POINTS_CAP;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- Expone navegación/configuración de puntuación en admin.
- Muestra leyenda del límite configurable de scoring.

## Verification
- Branch pushed to origin.
- Working tree clean before PR creation.
- No build executed.
