### PR TITLE
fix(master-honors): surface admin rule configuration

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -858,6 +858,8 @@
       }
     },
     "masterHonors": {
+      "colRulesSummary": "Rules summary",
+      "rulesSummaryNoRules": "No rules configured",
       "rulesTitle": "Master honor rules",
       "fieldPhilosophy": "Philosophy",
       "fieldPhilosophyPlaceholder": "Describe the official philosophy for this master honor.",
@@ -901,7 +903,9 @@
       "fieldOptionHonorIds": "Equivalent honors",
       "noHonors": "No honors available.",
       "noGroups": "No groups configured.",
-      "recalculateNow": "Recalculate now"
+      "recalculateNow": "Recalculate now",
+      "summaryGroupCount": "{count} groups",
+      "summaryMinimumTotal": "Minimum total: {count}"
     }
   },
   "auth": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -104,7 +104,7 @@
       "catalog_finance_categories": "Categorías de finanzas",
       "catalog_inventory_categories": "Categorías de inventario",
       "catalog_honors": "Especialidades (catálogo)",
-      "catalog_master_honors": "Honores maestros",
+      "catalog_master_honors": "Maestrías",
       "subgroup_overview": "General",
       "subgroup_geography": "Geografía",
       "subgroup_health": "Salud",
@@ -710,10 +710,10 @@
         "loadError": "No se pudieron cargar las especialidades."
       },
       "masterHonors": {
-        "title": "Honores maestros",
-        "description": "Catálogo de honores maestros con soporte multilingüe.",
-        "entityLabel": "Honor maestro",
-        "loadError": "No se pudieron cargar los honores maestros."
+        "title": "Maestrías",
+        "description": "Catálogo de maestrías con soporte multilingüe.",
+        "entityLabel": "Maestría",
+        "loadError": "No se pudieron cargar las maestrías."
       },
       "honorCategoriesList": {
         "forbidden": "No cuentas con permisos para ver categorías de especialidades.",
@@ -858,6 +858,8 @@
       }
     },
     "masterHonors": {
+      "colRulesSummary": "Resumen de reglas",
+      "rulesSummaryNoRules": "Sin reglas",
       "rulesTitle": "Reglas de maestría",
       "fieldPhilosophy": "Filosofía",
       "fieldPhilosophyPlaceholder": "Describe la filosofía oficial de esta maestría.",
@@ -901,7 +903,9 @@
       "fieldOptionHonorIds": "Especialidades equivalentes",
       "noHonors": "No hay especialidades disponibles.",
       "noGroups": "No hay grupos configurados.",
-      "recalculateNow": "Recalcular ahora"
+      "recalculateNow": "Recalcular ahora",
+      "summaryGroupCount": "{count} grupos",
+      "summaryMinimumTotal": "Mínimo total: {count}"
     }
   },
   "auth": {
@@ -1841,7 +1845,7 @@
       "honors:create": "Crear especialidad",
       "honors:update": "Editar especialidad",
       "honors:delete": "Eliminar especialidad",
-      "master_honors:manage": "Gestionar especialidades maestras",
+      "master_honors:manage": "Gestionar maestrías",
       "user_honors:submit": "Enviar progreso de honor",
       "user_honors:validate": "Validar honores",
       "honor_categories:read": "Ver categorías",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -858,6 +858,8 @@
       }
     },
     "masterHonors": {
+      "colRulesSummary": "Résumé des règles",
+      "rulesSummaryNoRules": "Aucune règle configurée",
       "rulesTitle": "Règles de l’honneur maître",
       "fieldPhilosophy": "Philosophie",
       "fieldPhilosophyPlaceholder": "Décris la philosophie officielle de cet honneur maître.",
@@ -901,7 +903,9 @@
       "fieldOptionHonorIds": "Honneurs équivalents",
       "noHonors": "Aucun honneur disponible.",
       "noGroups": "Aucun groupe configuré.",
-      "recalculateNow": "Recalculer maintenant"
+      "recalculateNow": "Recalculer maintenant",
+      "summaryGroupCount": "{count} groupes",
+      "summaryMinimumTotal": "Minimum total: {count}"
     }
   },
   "auth": {

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -858,6 +858,8 @@
       }
     },
     "masterHonors": {
+      "colRulesSummary": "Resumo das regras",
+      "rulesSummaryNoRules": "Nenhuma regra configurada",
       "rulesTitle": "Regras da honra mestre",
       "fieldPhilosophy": "Filosofia",
       "fieldPhilosophyPlaceholder": "Descreva a filosofia oficial desta honra mestre.",
@@ -901,7 +903,9 @@
       "fieldOptionHonorIds": "Honras equivalentes",
       "noHonors": "Não há honras disponíveis.",
       "noGroups": "Não há grupos configurados.",
-      "recalculateNow": "Recalcular agora"
+      "recalculateNow": "Recalcular agora",
+      "summaryGroupCount": "{count} grupos",
+      "summaryMinimumTotal": "Total mínimo: {count}"
     }
   },
   "auth": {

--- a/src/components/catalogs/master-honor-rules-editor.test.tsx
+++ b/src/components/catalogs/master-honor-rules-editor.test.tsx
@@ -178,6 +178,36 @@ describe("MasterHonorRulesEditor", () => {
     expect(initial.requirement_groups[0].options[0].honor_ids).toEqual([101]);
   });
 
+  it("normaliza y une la forma plana y anidada del backend", () => {
+    const { payload } = renderEditor({
+      applicability_scope: "SELECTED_DIVISIONS",
+      division_ids: [1],
+      master_honor_divisions: [{ division_id: 1 }, { division_id: 2 }, { division_id: 2 }],
+      requirement_groups: [
+        {
+          group_type: "EXPLICIT_OPTIONS",
+          minimum_required: 1,
+          display_order: 1,
+          options: [
+            {
+              option_id: 10,
+              label: "Acuáticas",
+              display_order: 1,
+              honor_ids: [101],
+              honors: [{ honor_id: 102 }, { honor: { honor_id: 101 } }, { honor: { honor_id: 101 } }],
+              active: true,
+            },
+          ],
+          active: true,
+        },
+      ],
+    } as unknown as MasterHonorPayload);
+
+    expect(payload().division_ids).toEqual([1, 2]);
+    expect(payload().requirement_groups).toHaveLength(1);
+    expect(payload().requirement_groups[0]?.options[0]?.honor_ids).toEqual([101, 102]);
+  });
+
   it("warns when explicit minimum exceeds active option count", () => {
     renderEditor({
       applicability_scope: "ALL",

--- a/src/components/catalogs/master-honor-rules-editor.tsx
+++ b/src/components/catalogs/master-honor-rules-editor.tsx
@@ -9,7 +9,12 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { type MasterHonorPayload } from "@/lib/api/phase-e-catalogs";
+import {
+  type MasterHonorPayload,
+  type MasterHonorRuleGroupPayload,
+  type MasterHonorRuleGroupType,
+  type MasterHonorRuleOptionPayload,
+} from "@/lib/api/phase-e-catalogs";
 
 export type MasterHonorAuxHonor = {
   honor_id: number;
@@ -36,21 +41,153 @@ export interface MasterHonorRulesEditorProps {
 
 const DEFAULT_SCOPE = "ALL" as const;
 
+function toPositiveId(value: unknown): number | undefined {
+  const parsed = typeof value === "string" || typeof value === "number" ? Number(value) : NaN;
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+}
+
+function toNonNegativeInt(value: unknown): number | undefined {
+  const parsed = typeof value === "string" || typeof value === "number" ? Number(value) : NaN;
+  if (!Number.isFinite(parsed) || parsed < 0) return undefined;
+  return Math.floor(parsed);
+}
+
+function toText(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function toGroupType(value: unknown): MasterHonorRuleGroupType {
+  return value === "CATEGORY_COUNT" ? "CATEGORY_COUNT" : "EXPLICIT_OPTIONS";
+}
+
+function parseIdList(values: unknown): number[] {
+  if (!Array.isArray(values)) return [];
+  const ids = values
+    .map((value) => toPositiveId(value))
+    .filter((id): id is number => Number.isFinite(id));
+  return Array.from(new Set(ids));
+}
+
+function parseMasterHonorDivisionIds(raw: unknown): number[] {
+  if (!raw || typeof raw !== "object") return [];
+  const value = raw as Record<string, unknown>;
+  const explicit = parseIdList(value.division_ids);
+
+  const nested = Array.isArray(value.master_honor_divisions)
+    ? value.master_honor_divisions
+    : [];
+  const nestedIds = nested
+    .map((entry) => toPositiveId(
+      typeof entry === "object" && entry !== null && "division_id" in entry
+        ? (entry as Record<string, unknown>).division_id
+        : undefined,
+    ))
+    .filter((id): id is number => typeof id === "number");
+
+  return Array.from(new Set([...explicit, ...nestedIds]));
+}
+
+function parseHonorIdsFromOption(rawOption: unknown): number[] {
+  if (!rawOption || typeof rawOption !== "object") return [];
+  const option = rawOption as Record<string, unknown>;
+  const honorIds = parseIdList(option.honor_ids);
+
+  const nestedHonors = Array.isArray(option.honors) ? option.honors : [];
+  const derived = nestedHonors
+    .map((honor) => {
+      if (typeof honor === "number") return toPositiveId(honor);
+      if (!honor || typeof honor !== "object") return undefined;
+      const record = honor as Record<string, unknown>;
+      if ("honor_id" in record) {
+        return toPositiveId(record.honor_id);
+      }
+      if (
+        "honor" in record &&
+        record.honor !== null &&
+        typeof record.honor === "object"
+      ) {
+        return toPositiveId((record.honor as Record<string, unknown>).honor_id);
+      }
+      return undefined;
+    })
+    .filter((id): id is number => typeof id === "number");
+
+  return Array.from(new Set([...honorIds, ...derived]));
+}
+
+function normalizeRequirementGroups(
+  groups: unknown[] | undefined,
+): MasterHonorRuleGroupPayload[] {
+  if (!Array.isArray(groups)) return [];
+
+  return groups.map((group, groupIndex) => {
+    if (!group || typeof group !== "object") {
+      return {
+        group_type: "EXPLICIT_OPTIONS",
+        minimum_required: 1,
+        display_order: groupIndex + 1,
+        options: [],
+      };
+    }
+
+    const record = group as Record<string, unknown>;
+    const groupType = toGroupType(record.group_type);
+    const rawOptions = Array.isArray(record.options) ? record.options : [];
+    const normalizedOptions: MasterHonorRuleOptionPayload[] = rawOptions.map((option, optionIndex) => {
+      if (!option || typeof option !== "object") {
+        return {
+          label: "",
+          display_order: optionIndex + 1,
+          honor_ids: [],
+          active: true,
+        };
+      }
+
+      const optionRecord = option as Record<string, unknown>;
+      return {
+        ...(toPositiveId(optionRecord.option_id)
+          ? { option_id: toPositiveId(optionRecord.option_id) }
+          : {}),
+        label: toText(optionRecord.label) ?? "",
+        display_order: toNonNegativeInt(optionRecord.display_order) ?? optionIndex + 1,
+        honor_ids: parseHonorIdsFromOption(option),
+        ...(typeof optionRecord.active === "boolean"
+          ? { active: optionRecord.active }
+          : {}),
+      };
+    });
+
+    return {
+      ...(toPositiveId(record.group_id)
+        ? { group_id: toPositiveId(record.group_id) }
+        : {}),
+      group_type: groupType,
+      ...(toText(record.title) ? { title: toText(record.title) } : {}),
+      ...(toText(record.description) ? { description: toText(record.description) } : {}),
+      minimum_required: toPositiveId(record.minimum_required) ?? 1,
+      ...(groupType === "CATEGORY_COUNT" && toPositiveId(record.honors_category_id)
+        ? { honors_category_id: toPositiveId(record.honors_category_id) }
+        : {}),
+      display_order: toNonNegativeInt(record.display_order) ?? groupIndex + 1,
+      options: groupType === "EXPLICIT_OPTIONS" ? normalizedOptions : [],
+      ...(typeof record.active === "boolean" ? { active: record.active } : {}),
+    };
+  });
+}
+
 function normalizePayload(value: MasterHonorPayload): MasterHonorPayload {
   const scope = value.applicability_scope || DEFAULT_SCOPE;
   const division_ids = scope === "SELECTED_DIVISIONS"
-    ? Array.isArray(value.division_ids)
-      ? value.division_ids.filter((id) => Number.isFinite(id) && id > 0)
-      : []
+    ? parseMasterHonorDivisionIds(value)
     : [];
 
   return {
-    ...value,
+    philosophy: value.philosophy,
+    notes: value.notes,
     applicability_scope: scope,
     division_ids,
-    requirement_groups: Array.isArray(value.requirement_groups)
-      ? value.requirement_groups
-      : [],
+    requirement_groups: normalizeRequirementGroups(value.requirement_groups),
   };
 }
 

--- a/src/components/catalogs/phase-e-catalog-crud-page.tsx
+++ b/src/components/catalogs/phase-e-catalog-crud-page.tsx
@@ -114,6 +114,7 @@ type MasterHonorRawRecord = {
   notes?: unknown;
   applicability_scope?: unknown;
   division_ids?: unknown;
+  master_honor_divisions?: unknown;
   requirement_groups?: unknown;
 };
 
@@ -220,7 +221,6 @@ function CatalogFormFields({
   onMasterHonorsPayloadChange,
 }: FormFieldsProps) {
   const t = useTranslations("catalogs.phaseE");
-  const masterHonorsT = useTranslations("catalogs.masterHonors");
   const nameVal = typeof item?.name === "string" ? item.name : "";
   const descVal = typeof item?.description === "string" ? item.description : "";
   const showClassConfig = Array.isArray(classConfigYearOptions);
@@ -447,15 +447,45 @@ function normalizeMasterHonorsGroup(
         const optionRecord = option as Record<string, unknown>;
         const optionId = toPositiveInt(optionRecord.option_id);
         const label = normalizeText(optionRecord.label) ?? "";
-        const honorIds = Array.isArray(optionRecord.honor_ids)
+        const honorIdsFromFlat = Array.isArray(optionRecord.honor_ids)
           ? optionRecord.honor_ids.map((id) => toPositiveInt(id)).filter((value): value is number => value !== null)
           : [];
+
+        const honorIdsFromNested = Array.isArray(optionRecord.honors)
+          ? optionRecord.honors
+            .map((honorRecord) => {
+              if (typeof honorRecord === "number") {
+                return toPositiveInt(honorRecord);
+              }
+              if (!honorRecord || typeof honorRecord !== "object") {
+                return null;
+              }
+              const honorObject = honorRecord as Record<string, unknown>;
+              if ("honor_id" in honorObject) {
+                return toPositiveInt(honorObject.honor_id);
+              }
+              if (
+                "honor" in honorObject &&
+                honorObject.honor !== null &&
+                typeof honorObject.honor === "object"
+              ) {
+                return toPositiveInt((honorObject.honor as Record<string, unknown>).honor_id);
+              }
+              return null;
+            })
+            .filter((value): value is number => value !== null)
+          : [];
+
+        const honor_ids = Array.from(new Set([
+          ...honorIdsFromFlat,
+          ...honorIdsFromNested,
+        ]));
 
         return {
           ...(optionId ? { option_id: optionId } : {}),
           label,
           display_order: Math.max(0, toNonNegativeInt(optionRecord.display_order) ?? index + 1),
-          honor_ids: honorIds,
+          honor_ids,
           ...(typeof optionRecord.active === "boolean" ? { active: optionRecord.active } : {}),
         };
       })
@@ -479,6 +509,29 @@ function normalizeMasterHonorsGroup(
   return normalized;
 }
 
+function normalizeMasterHonorsDivisionIds(
+  rawScope: unknown,
+  rawDivisionIds: unknown,
+  rawDivisionRecords: unknown,
+): number[] {
+  if (rawScope !== "SELECTED_DIVISIONS") return [];
+  const flatIds = Array.isArray(rawDivisionIds)
+    ? rawDivisionIds.map((id) => toPositiveInt(id)).filter((value): value is number => value !== null)
+    : [];
+
+  const nestedDivisionIds = Array.isArray(rawDivisionRecords)
+    ? rawDivisionRecords
+      .map((entry) =>
+        entry && typeof entry === "object" && "division_id" in entry
+          ? toPositiveInt((entry as Record<string, unknown>).division_id)
+          : null,
+      )
+      .filter((value): value is number => value !== null)
+    : [];
+
+  return Array.from(new Set([...flatIds, ...nestedDivisionIds]));
+}
+
 function normalizeMasterHonorsPayload(item?: MasterHonorRawRecord | null): MasterHonorPayload {
   const requirementGroups = Array.isArray(item?.requirement_groups)
     ? item?.requirement_groups
@@ -491,13 +544,53 @@ function normalizeMasterHonorsPayload(item?: MasterHonorRawRecord | null): Maste
       item?.applicability_scope === "SELECTED_DIVISIONS"
         ? "SELECTED_DIVISIONS"
         : "ALL",
-    division_ids:
-      item?.applicability_scope === "SELECTED_DIVISIONS" && Array.isArray(item?.division_ids)
-        ? item.division_ids.map((id) => toPositiveInt(id)).filter((value): value is number => value !== null)
-        : [],
+    division_ids: normalizeMasterHonorsDivisionIds(
+      item?.applicability_scope,
+      item?.division_ids,
+      item?.master_honor_divisions,
+    ),
     requirement_groups: requirementGroups.map((group, index) =>
       normalizeMasterHonorsGroup(group, index + 1),
     ),
+  };
+}
+
+function getMasterHonorsSummary(item: AnyRecord):
+  | { kind: "empty" }
+  | {
+      kind: "configured";
+      scope: "ALL" | "SELECTED_DIVISIONS";
+      divisionCount: number;
+      groupCount: number;
+      minimumTotal: number;
+    } {
+  const scope = item.applicability_scope === "SELECTED_DIVISIONS"
+    ? "SELECTED_DIVISIONS"
+    : "ALL";
+  const divisionIds = normalizeMasterHonorsDivisionIds(
+    scope,
+    item.division_ids,
+    item.master_honor_divisions,
+  );
+  const groups = Array.isArray(item.requirement_groups) ? item.requirement_groups : [];
+  const groupCount = groups.length;
+  if (groupCount === 0) {
+    return { kind: "empty" };
+  }
+
+  const minTotal = groups.reduce((total, rawGroup) => {
+    if (!rawGroup || typeof rawGroup !== "object") return total;
+    const group = rawGroup as Record<string, unknown>;
+    const minimum = toNonNegativeInt(group.minimum_required);
+    return total + (minimum ?? 0);
+  }, 0);
+
+  return {
+    kind: "configured",
+    scope,
+    divisionCount: divisionIds.length,
+    groupCount,
+    minimumTotal: minTotal,
   };
 }
 
@@ -747,6 +840,9 @@ export function PhaseECatalogCrudPage({
                     {includeDescription && <TableHead>{t("colDescription")}</TableHead>}
                     {showClassConfig && <TableHead>{t("colDuration")}</TableHead>}
                     {showClassConfig && <TableHead>{t("colAvailability")}</TableHead>}
+                    {isMasterHonorsCrud && (
+                      <TableHead>{masterHonorsT("colRulesSummary")}</TableHead>
+                    )}
                     <TableHead>{t("colStatus")}</TableHead>
                     {(canEdit || canDelete) && (
                       <TableHead className="sticky right-0 z-20 w-[100px] border-l bg-background">
@@ -787,6 +883,20 @@ export function PhaseECatalogCrudPage({
                             )}
                           </TableCell>
                         )}
+                        {isMasterHonorsCrud ? (
+                          <TableCell className="max-w-[260px] whitespace-pre-line text-sm text-muted-foreground">
+                            {(() => {
+                              const summary = getMasterHonorsSummary(item);
+                              if (summary.kind === "empty") {
+                                return masterHonorsT("rulesSummaryNoRules");
+                              }
+                              const scopeText = summary.scope === "ALL"
+                                ? masterHonorsT("scopeAll")
+                                : `${masterHonorsT("scopeSelected")} (${summary.divisionCount})`;
+                              return `${scopeText} · ${masterHonorsT("summaryGroupCount", { count: summary.groupCount })} · ${masterHonorsT("summaryMinimumTotal", { count: summary.minimumTotal })}`;
+                            })()}
+                          </TableCell>
+                        ) : null}
                         <TableCell>
                           <Badge
                             variant={item.active !== false ? "soft-success" : "outline"}
@@ -817,18 +927,19 @@ export function PhaseECatalogCrudPage({
                                     name="id"
                                     value={String(itemId)}
                                   />
-                                  <Button
-                                    type="submit"
-                                    variant="ghost"
-                                    size="icon"
-                                    className="size-8"
-                                    aria-label={masterHonorsT("recalculateNow")}
-                                    title={masterHonorsT("recalculateNow")}
-                                  >
-                                    <RefreshCcw className="size-3.5" />
-                                  </Button>
-                                </form>
-                              ) : null}
+                                <Button
+                                  type="submit"
+                                  variant="ghost"
+                                  size="sm"
+                                  className="h-8 gap-1.5"
+                                  aria-label={masterHonorsT("recalculateNow")}
+                                  title={masterHonorsT("recalculateNow")}
+                                >
+                                  <RefreshCcw className="size-3.5" />
+                                  <span className="hidden md:inline">{masterHonorsT("recalculateNow")}</span>
+                                </Button>
+                              </form>
+                            ) : null}
                               {canDelete && (
                                 <Button
                                   variant="ghost"

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -887,6 +887,8 @@ export interface IntlMessages {
       };
     };
     masterHonors: {
+      colRulesSummary: string;
+      rulesSummaryNoRules: string;
       rulesTitle: string;
       fieldPhilosophy: string;
       fieldPhilosophyPlaceholder: string;
@@ -931,6 +933,8 @@ export interface IntlMessages {
       noHonors: string;
       noGroups: string;
       recalculateNow: string;
+      summaryGroupCount: string;
+      summaryMinimumTotal: string;
     };
   };
   auth: {

--- a/src/lib/phase-e-catalogs/actions.ts
+++ b/src/lib/phase-e-catalogs/actions.ts
@@ -752,7 +752,7 @@ export async function recalculateMasterHonorAction(
     await recalculateMasterHonor(id);
   } catch (error) {
     return {
-      error: getActionErrorMessage(error, "No se pudo recalcular el honor maestro.", {
+      error: getActionErrorMessage(error, "No se pudo recalcular la maestría.", {
         endpointLabel: `/admin/master-honors/${id}/recalculate`,
       }),
     };


### PR DESCRIPTION
## Summary
- Make master honor rule configuration visible from the admin catalog table with a rules summary column.
- Normalize backend nested rule payloads (`master_honor_divisions`, `option.honors`) together with flat payloads before editing/saving.
- Rename Spanish admin copy from "Honores maestros" to "Maestrías" and make recalculation easier to discover.

## Validation
- `git diff --check`
- `../../node_modules/.bin/vitest run src/components/catalogs/master-honor-rules-editor.test.tsx`
- `../../node_modules/.bin/eslint src/components/catalogs/master-honor-rules-editor.tsx src/components/catalogs/master-honor-rules-editor.test.tsx src/components/catalogs/phase-e-catalog-crud-page.tsx src/lib/phase-e-catalogs/actions.ts`
- `../../node_modules/.bin/tsc --noEmit`
- JSON parse check for `messages/es.json`, `messages/en.json`, `messages/fr.json`, `messages/pt-BR.json`

No build executed per project rule.
