### PR TITLE
fix(master-honors): use valid admin auxiliary queries

### DIFF
--- a/src/app/(dashboard)/dashboard/catalogs/master-honors/page.tsx
+++ b/src/app/(dashboard)/dashboard/catalogs/master-honors/page.tsx
@@ -26,10 +26,9 @@ const PhaseECatalogCrudPage = dynamic(
   }
 );
 import { ApiError } from "@/lib/api/client";
-import { listAdminMasterHonors } from "@/lib/api/phase-e-catalogs";
+import { listAdminHonorsCatalog, listAdminMasterHonors } from "@/lib/api/phase-e-catalogs";
 import { listDivisions } from "@/lib/api/geography";
 import { listHonorCategoriesAdmin } from "@/lib/api/honor-categories";
-import { listHonors } from "@/lib/api/honors";
 import { extractItems, extractMeta, readParam, readPositiveNumberParam } from "@/lib/phase-e-catalogs/fetch-helpers";
 import { requireAdminUser } from "@/lib/auth/session";
 import { hasAnyPermission } from "@/lib/auth/permission-utils";
@@ -76,10 +75,20 @@ export default async function AdminMasterHonorsPage({ searchParams }: { searchPa
     if (activeRaw === "true") params.active = true;
     if (activeRaw === "false") params.active = false;
 
-    const [payload, honorsPayload, honorCategoriesPayload, divisionsPayload] = await Promise.all([
-      listAdminMasterHonors(params),
-      listHonors({ active: true, limit: 500 }),
-      listHonorCategoriesAdmin({ limit: 500, active: true }),
+    const payload = await listAdminMasterHonors(params);
+
+    items = extractItems(payload);
+    meta = extractMeta(payload, page, limit, items.length);
+  } catch (error) {
+    if (!(error instanceof ApiError && error.status === 429)) {
+      loadError = error instanceof ApiError ? error.message : t("loadError");
+    }
+  }
+
+  try {
+    const [honorsPayload, honorCategoriesPayload, divisionsPayload] = await Promise.all([
+      listAdminHonorsCatalog(),
+      listHonorCategoriesAdmin({ page: 1, limit: 100 }),
       listDivisions(),
     ]);
 
@@ -110,11 +119,15 @@ export default async function AdminMasterHonorsPage({ searchParams }: { searchPa
         .filter((division) => Number.isFinite(division.division_id) && division.division_id > 0),
       recalculateAction: recalculateMasterHonorAction,
     };
-
-    items = extractItems(payload);
-    meta = extractMeta(payload, page, limit, items.length);
   } catch (error) {
-    if (!(error instanceof ApiError && error.status === 429)) {
+    masterHonorsConfig = {
+      honors: [],
+      honorCategories: [],
+      divisions: [],
+      recalculateAction: recalculateMasterHonorAction,
+    };
+
+    if (!loadError && !(error instanceof ApiError && error.status === 429)) {
       loadError = error instanceof ApiError ? error.message : t("loadError");
     }
   }

--- a/src/components/catalogs/master-honor-rules-editor.tsx
+++ b/src/components/catalogs/master-honor-rules-editor.tsx
@@ -733,7 +733,7 @@ export function MasterHonorRulesEditor({
 
                             <div className="mt-3 space-y-2">
                               <p className="text-sm">{t("fieldOptionHonorIds")}</p>
-                              <div className="grid max-h-44 gap-2 overflow-auto rounded border bg-background p-2 sm:grid-cols-2">
+                              <div className="grid max-h-44 gap-2 overflow-auto rounded border bg-background p-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                                 {honors.map((honor) => {
                                   const honorId = honor.honor_id;
                                   const checked = optionHonorIds.has(honorId);

--- a/src/components/catalogs/phase-e-catalog-crud-page.tsx
+++ b/src/components/catalogs/phase-e-catalog-crud-page.tsx
@@ -1029,7 +1029,13 @@ export function PhaseECatalogCrudPage({
       {/* Create dialog */}
       {canCreate && (
         <Dialog open={createOpen} onOpenChange={handleCreateOpen}>
-          <DialogContent className="max-w-2xl">
+          <DialogContent
+            className={
+              masterHonorsConfig
+                ? "max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] overflow-y-auto sm:max-w-5xl xl:max-w-6xl"
+                : "sm:max-w-2xl"
+            }
+          >
             <DialogHeader>
               <DialogTitle>{t("createDialogTitle", { entity: entityLabel.toLowerCase() })}</DialogTitle>
               <DialogDescription>
@@ -1069,7 +1075,13 @@ export function PhaseECatalogCrudPage({
       {/* Edit dialog */}
       {canEdit && editItem && (
         <Dialog open={!!editItem} onOpenChange={(open) => { if (!open) setEditItem(null); }}>
-          <DialogContent className="max-w-2xl">
+          <DialogContent
+            className={
+              masterHonorsConfig
+                ? "max-h-[calc(100vh-2rem)] w-[calc(100vw-2rem)] overflow-y-auto sm:max-w-5xl xl:max-w-6xl"
+                : "sm:max-w-2xl"
+            }
+          >
             <DialogHeader>
               <DialogTitle>{t("editDialogTitle", { entity: entityLabel.toLowerCase() })}</DialogTitle>
               <DialogDescription>


### PR DESCRIPTION
## Summary
- Stop sending invalid auxiliary query params from the Maestrías admin page.
- Load the main master-honors list independently from editor auxiliary data so an auxiliary endpoint failure does not empty the main table.
- Use `/admin/honors-catalog` for auxiliary honors and `/admin/honor-categories?page=1&limit=100` without `active` for categories.

## Root cause
The page called `listHonorCategoriesAdmin({ limit: 500, active: true })`, but the backend category query DTO does not accept `active` and caps `limit` at 100. That produced: `property active should not exist, limit must not be greater than 100`.

## Validation
- `git diff --check`
- `./node_modules/.bin/eslint src/app/'(dashboard)'/dashboard/catalogs/master-honors/page.tsx`
- `./node_modules/.bin/tsc --noEmit`

No build executed per project rule.
