### PR TITLE
feat(coordination): add coordinator administration panel

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -119,7 +119,8 @@
       "materials_inventory": "Inventory",
       "materials_categories": "Categories",
       "materials_config": "Settings",
-      "certificate_bulk_imports": "Cargas por certificado"
+      "certificate_bulk_imports": "Cargas por certificado",
+      "coordination": "Coordination"
     },
     "breadcrumbs": {
       "dashboard": "Dashboard",
@@ -156,7 +157,8 @@
       "permissions": "Permissions",
       "roles": "Roles",
       "matrix": "Matrix",
-      "support": "Support"
+      "support": "Support",
+      "coordination": "Coordination"
     },
     "themeToggle": {
       "switchToLight": "Switch to light mode",
@@ -209,6 +211,93 @@
       "notifications": "Notifications",
       "resources": "Resources",
       "system": "System"
+    }
+  },
+  "coordinationAdmin": {
+    "page": {
+      "title": "Coordination",
+      "description": "Zones, general coordinators, and direct assignments by section."
+    },
+    "emptyNoLocalField": {
+      "title": "No local field available",
+      "description": "Select or configure a local field before managing coordinators."
+    },
+    "assignmentTypes": {
+      "general": "General",
+      "zone": "Zone + section",
+      "section": "Direct club/section"
+    },
+    "targets": {
+      "allLocalField": "Entire local field",
+      "zoneFallback": "Zone {id}",
+      "clubTypeFallback": "Type {id}",
+      "clubFallback": "Club",
+      "sectionFallback": "Section {id}"
+    },
+    "errors": {
+      "generic": "The operation could not be completed.",
+      "zoneNameRequired": "The zone name is required.",
+      "zoneAndDistrictRequired": "Select a zone and a district.",
+      "coordinatorRequired": "Select a coordinator.",
+      "assignmentScopeRequired": "Complete the assignment scope."
+    },
+    "success": {
+      "zoneCreated": "Zone created.",
+      "districtAssigned": "District assigned to the zone.",
+      "districtRemoved": "District removed from the zone.",
+      "zoneActivated": "Zone activated.",
+      "zoneDeactivated": "Zone deactivated.",
+      "assignmentCreated": "Assignment created.",
+      "assignmentActivated": "Assignment activated.",
+      "assignmentDeactivated": "Assignment deactivated."
+    },
+    "localField": {
+      "title": "Local field",
+      "description": "Zones and assignments are managed inside the selected local field.",
+      "placeholder": "Select local field"
+    },
+    "zones": {
+      "title": "Zones",
+      "description": "Group districts so a zone coordinator sees the corresponding sections.",
+      "namePlaceholder": "Zone 1",
+      "descriptionPlaceholder": "North / Metropolitan",
+      "empty": "There are no zones for this local field yet.",
+      "noDistricts": "No districts"
+    },
+    "assignments": {
+      "newTitle": "New assignment",
+      "newDescription": "Final authority is always resolved to club sections.",
+      "directorConflictRule": "Rule: if the user is already director of a section, the backend rejects assigning them as coordinator of that same section.",
+      "title": "Active assignments",
+      "description": "A coordinator can accumulate several scopes; the app receives the combined scope.",
+      "empty": "No assignments registered."
+    },
+    "fields": {
+      "name": "Name",
+      "description": "Description",
+      "zone": "Zone",
+      "selectZone": "Select zone",
+      "district": "District",
+      "districts": "Districts",
+      "selectDistrict": "Select district",
+      "status": "Status",
+      "actions": "Actions",
+      "coordinator": "Coordinator",
+      "selectUser": "Select user",
+      "type": "Type",
+      "section": "Section",
+      "clubSection": "Club / section",
+      "selectSection": "Select section",
+      "scope": "Scope"
+    },
+    "actions": {
+      "createZone": "Create zone",
+      "assignDistrict": "Assign district",
+      "createAssignment": "Create assignment"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
     }
   },
   "catalogs": {
@@ -1791,6 +1880,10 @@
       "club_roles:read": "View club roles",
       "club_roles:assign": "Assign club role",
       "club_roles:revoke": "Revoke club role",
+      "coordination": {
+        "manage": "Manage coordination"
+      },
+      "coordination:manage": "Manage coordination",
       "club_members:approve": "Approve membership",
       "club_members:reject": "Reject membership",
       "club_members:list_pending": "View pending requests",

--- a/messages/es.json
+++ b/messages/es.json
@@ -119,7 +119,8 @@
       "materials_inventory": "Inventario",
       "materials_categories": "Categorías",
       "materials_config": "Configuración",
-      "certificate_bulk_imports": "Cargas por certificado"
+      "certificate_bulk_imports": "Cargas por certificado",
+      "coordination": "Coordinación"
     },
     "breadcrumbs": {
       "dashboard": "Dashboard",
@@ -156,7 +157,8 @@
       "permissions": "Permisos",
       "roles": "Roles",
       "matrix": "Matriz",
-      "support": "Soporte"
+      "support": "Soporte",
+      "coordination": "Coordinación"
     },
     "themeToggle": {
       "switchToLight": "Cambiar a modo claro",
@@ -209,6 +211,93 @@
       "notifications": "Notificaciones",
       "resources": "Recursos",
       "system": "Sistema"
+    }
+  },
+  "coordinationAdmin": {
+    "page": {
+      "title": "Coordinación",
+      "description": "Zonas, coordinadores generales y asignaciones directas por sección."
+    },
+    "emptyNoLocalField": {
+      "title": "No hay campo local disponible",
+      "description": "Selecciona o configura un campo local antes de administrar coordinadores."
+    },
+    "assignmentTypes": {
+      "general": "General",
+      "zone": "Zona + sección",
+      "section": "Club/sección directa"
+    },
+    "targets": {
+      "allLocalField": "Todo el campo local",
+      "zoneFallback": "Zona {id}",
+      "clubTypeFallback": "Tipo {id}",
+      "clubFallback": "Club",
+      "sectionFallback": "Sección {id}"
+    },
+    "errors": {
+      "generic": "No se pudo completar la operación.",
+      "zoneNameRequired": "El nombre de la zona es obligatorio.",
+      "zoneAndDistrictRequired": "Selecciona una zona y un distrito.",
+      "coordinatorRequired": "Selecciona un coordinador.",
+      "assignmentScopeRequired": "Completa el alcance de la asignación."
+    },
+    "success": {
+      "zoneCreated": "Zona creada.",
+      "districtAssigned": "Distrito asignado a la zona.",
+      "districtRemoved": "Distrito removido de la zona.",
+      "zoneActivated": "Zona activada.",
+      "zoneDeactivated": "Zona desactivada.",
+      "assignmentCreated": "Asignación creada.",
+      "assignmentActivated": "Asignación activada.",
+      "assignmentDeactivated": "Asignación desactivada."
+    },
+    "localField": {
+      "title": "Campo local",
+      "description": "Las zonas y asignaciones se administran dentro del campo local seleccionado.",
+      "placeholder": "Seleccionar campo local"
+    },
+    "zones": {
+      "title": "Zonas",
+      "description": "Agrupa distritos para que un coordinador de zona vea las secciones correspondientes.",
+      "namePlaceholder": "Zona 1",
+      "descriptionPlaceholder": "Norte / Metropolitana",
+      "empty": "Todavía no hay zonas para este campo local.",
+      "noDistricts": "Sin distritos"
+    },
+    "assignments": {
+      "newTitle": "Nueva asignación",
+      "newDescription": "La autoridad final siempre se resuelve a secciones de club.",
+      "directorConflictRule": "Regla: si el usuario ya es director de una sección, el backend rechaza asignarlo como coordinador de esa misma sección.",
+      "title": "Asignaciones activas",
+      "description": "Un coordinador puede acumular varios alcances; la app recibirá el scope combinado.",
+      "empty": "No hay asignaciones registradas."
+    },
+    "fields": {
+      "name": "Nombre",
+      "description": "Descripción",
+      "zone": "Zona",
+      "selectZone": "Seleccionar zona",
+      "district": "Distrito",
+      "districts": "Distritos",
+      "selectDistrict": "Seleccionar distrito",
+      "status": "Estado",
+      "actions": "Acciones",
+      "coordinator": "Coordinador",
+      "selectUser": "Seleccionar usuario",
+      "type": "Tipo",
+      "section": "Sección",
+      "clubSection": "Club / sección",
+      "selectSection": "Seleccionar sección",
+      "scope": "Alcance"
+    },
+    "actions": {
+      "createZone": "Crear zona",
+      "assignDistrict": "Asignar distrito",
+      "createAssignment": "Crear asignación"
+    },
+    "status": {
+      "active": "Activa",
+      "inactive": "Inactiva"
     }
   },
   "catalogs": {
@@ -1791,6 +1880,10 @@
       "club_roles:read": "Ver roles de club",
       "club_roles:assign": "Asignar rol de club",
       "club_roles:revoke": "Revocar rol de club",
+      "coordination": {
+        "manage": "Administrar coordinación"
+      },
+      "coordination:manage": "Administrar coordinación",
       "club_members:approve": "Aprobar membresía",
       "club_members:reject": "Rechazar membresía",
       "club_members:list_pending": "Ver solicitudes pendientes",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -119,7 +119,8 @@
       "materials_inventory": "Inventaire",
       "materials_categories": "Catégories",
       "materials_config": "Paramètres",
-      "certificate_bulk_imports": "Cargas por certificado"
+      "certificate_bulk_imports": "Cargas por certificado",
+      "coordination": "Coordination"
     },
     "breadcrumbs": {
       "dashboard": "Tableau de bord",
@@ -156,7 +157,8 @@
       "permissions": "Permissions",
       "roles": "Rôles",
       "matrix": "Matrice",
-      "support": "Support"
+      "support": "Support",
+      "coordination": "Coordination"
     },
     "themeToggle": {
       "switchToLight": "Passer en mode clair",
@@ -209,6 +211,93 @@
       "notifications": "Notifications",
       "resources": "Ressources",
       "system": "Système"
+    }
+  },
+  "coordinationAdmin": {
+    "page": {
+      "title": "Coordination",
+      "description": "Zones, coordinateurs généraux et assignations directes par section."
+    },
+    "emptyNoLocalField": {
+      "title": "Aucun champ local disponible",
+      "description": "Sélectionnez ou configurez un champ local avant de gérer les coordinateurs."
+    },
+    "assignmentTypes": {
+      "general": "Général",
+      "zone": "Zone + section",
+      "section": "Club/section direct"
+    },
+    "targets": {
+      "allLocalField": "Tout le champ local",
+      "zoneFallback": "Zone {id}",
+      "clubTypeFallback": "Type {id}",
+      "clubFallback": "Club",
+      "sectionFallback": "Section {id}"
+    },
+    "errors": {
+      "generic": "L'opération n'a pas pu être terminée.",
+      "zoneNameRequired": "Le nom de la zone est obligatoire.",
+      "zoneAndDistrictRequired": "Sélectionnez une zone et un district.",
+      "coordinatorRequired": "Sélectionnez un coordinateur.",
+      "assignmentScopeRequired": "Complétez le périmètre de l'assignation."
+    },
+    "success": {
+      "zoneCreated": "Zone créée.",
+      "districtAssigned": "District assigné à la zone.",
+      "districtRemoved": "District retiré de la zone.",
+      "zoneActivated": "Zone activée.",
+      "zoneDeactivated": "Zone désactivée.",
+      "assignmentCreated": "Assignation créée.",
+      "assignmentActivated": "Assignation activée.",
+      "assignmentDeactivated": "Assignation désactivée."
+    },
+    "localField": {
+      "title": "Champ local",
+      "description": "Les zones et assignations sont administrées dans le champ local sélectionné.",
+      "placeholder": "Sélectionner un champ local"
+    },
+    "zones": {
+      "title": "Zones",
+      "description": "Regroupez des districts afin qu'un coordinateur de zone voie les sections correspondantes.",
+      "namePlaceholder": "Zone 1",
+      "descriptionPlaceholder": "Nord / Métropolitaine",
+      "empty": "Il n'y a pas encore de zones pour ce champ local.",
+      "noDistricts": "Aucun district"
+    },
+    "assignments": {
+      "newTitle": "Nouvelle assignation",
+      "newDescription": "L'autorité finale est toujours résolue en sections de club.",
+      "directorConflictRule": "Règle : si l'utilisateur est déjà directeur d'une section, le backend refuse de l'assigner comme coordinateur de cette même section.",
+      "title": "Assignations actives",
+      "description": "Un coordinateur peut cumuler plusieurs périmètres ; l'app recevra le périmètre combiné.",
+      "empty": "Aucune assignation enregistrée."
+    },
+    "fields": {
+      "name": "Nom",
+      "description": "Description",
+      "zone": "Zone",
+      "selectZone": "Sélectionner une zone",
+      "district": "District",
+      "districts": "Districts",
+      "selectDistrict": "Sélectionner un district",
+      "status": "État",
+      "actions": "Actions",
+      "coordinator": "Coordinateur",
+      "selectUser": "Sélectionner un utilisateur",
+      "type": "Type",
+      "section": "Section",
+      "clubSection": "Club / section",
+      "selectSection": "Sélectionner une section",
+      "scope": "Périmètre"
+    },
+    "actions": {
+      "createZone": "Créer une zone",
+      "assignDistrict": "Assigner le district",
+      "createAssignment": "Créer l'assignation"
+    },
+    "status": {
+      "active": "Active",
+      "inactive": "Inactive"
     }
   },
   "catalogs": {
@@ -1790,6 +1879,10 @@
       "club_roles:read": "Voir les rôles de club",
       "club_roles:assign": "Assigner un rôle de club",
       "club_roles:revoke": "Révoquer un rôle de club",
+      "coordination": {
+        "manage": "Gérer la coordination"
+      },
+      "coordination:manage": "Gérer la coordination",
       "club_members:approve": "Approuver une adhésion",
       "club_members:reject": "Rejeter une adhésion",
       "club_members:list_pending": "Voir les demandes en attente",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -119,7 +119,8 @@
       "materials_inventory": "Inventário",
       "materials_categories": "Categorias",
       "materials_config": "Configurações",
-      "certificate_bulk_imports": "Cargas por certificado"
+      "certificate_bulk_imports": "Cargas por certificado",
+      "coordination": "Coordenação"
     },
     "breadcrumbs": {
       "dashboard": "Painel",
@@ -156,7 +157,8 @@
       "permissions": "Permissões",
       "roles": "Funções",
       "matrix": "Matriz",
-      "support": "Suporte"
+      "support": "Suporte",
+      "coordination": "Coordenação"
     },
     "themeToggle": {
       "switchToLight": "Mudar para modo claro",
@@ -209,6 +211,93 @@
       "notifications": "Notificações",
       "resources": "Recursos",
       "system": "Sistema"
+    }
+  },
+  "coordinationAdmin": {
+    "page": {
+      "title": "Coordenação",
+      "description": "Zonas, coordenadores gerais e atribuições diretas por seção."
+    },
+    "emptyNoLocalField": {
+      "title": "Nenhum campo local disponível",
+      "description": "Selecione ou configure um campo local antes de administrar coordenadores."
+    },
+    "assignmentTypes": {
+      "general": "Geral",
+      "zone": "Zona + seção",
+      "section": "Clube/seção direta"
+    },
+    "targets": {
+      "allLocalField": "Todo o campo local",
+      "zoneFallback": "Zona {id}",
+      "clubTypeFallback": "Tipo {id}",
+      "clubFallback": "Clube",
+      "sectionFallback": "Seção {id}"
+    },
+    "errors": {
+      "generic": "Não foi possível concluir a operação.",
+      "zoneNameRequired": "O nome da zona é obrigatório.",
+      "zoneAndDistrictRequired": "Selecione uma zona e um distrito.",
+      "coordinatorRequired": "Selecione um coordenador.",
+      "assignmentScopeRequired": "Complete o escopo da atribuição."
+    },
+    "success": {
+      "zoneCreated": "Zona criada.",
+      "districtAssigned": "Distrito atribuído à zona.",
+      "districtRemoved": "Distrito removido da zona.",
+      "zoneActivated": "Zona ativada.",
+      "zoneDeactivated": "Zona desativada.",
+      "assignmentCreated": "Atribuição criada.",
+      "assignmentActivated": "Atribuição ativada.",
+      "assignmentDeactivated": "Atribuição desativada."
+    },
+    "localField": {
+      "title": "Campo local",
+      "description": "As zonas e atribuições são administradas dentro do campo local selecionado.",
+      "placeholder": "Selecionar campo local"
+    },
+    "zones": {
+      "title": "Zonas",
+      "description": "Agrupe distritos para que um coordenador de zona veja as seções correspondentes.",
+      "namePlaceholder": "Zona 1",
+      "descriptionPlaceholder": "Norte / Metropolitana",
+      "empty": "Ainda não há zonas para este campo local.",
+      "noDistricts": "Sem distritos"
+    },
+    "assignments": {
+      "newTitle": "Nova atribuição",
+      "newDescription": "A autoridade final sempre é resolvida para seções de clube.",
+      "directorConflictRule": "Regra: se o usuário já é diretor de uma seção, o backend rejeita atribuí-lo como coordenador dessa mesma seção.",
+      "title": "Atribuições ativas",
+      "description": "Um coordenador pode acumular vários escopos; o app receberá o escopo combinado.",
+      "empty": "Não há atribuições registradas."
+    },
+    "fields": {
+      "name": "Nome",
+      "description": "Descrição",
+      "zone": "Zona",
+      "selectZone": "Selecionar zona",
+      "district": "Distrito",
+      "districts": "Distritos",
+      "selectDistrict": "Selecionar distrito",
+      "status": "Status",
+      "actions": "Ações",
+      "coordinator": "Coordenador",
+      "selectUser": "Selecionar usuário",
+      "type": "Tipo",
+      "section": "Seção",
+      "clubSection": "Clube / seção",
+      "selectSection": "Selecionar seção",
+      "scope": "Escopo"
+    },
+    "actions": {
+      "createZone": "Criar zona",
+      "assignDistrict": "Atribuir distrito",
+      "createAssignment": "Criar atribuição"
+    },
+    "status": {
+      "active": "Ativa",
+      "inactive": "Inativa"
     }
   },
   "catalogs": {
@@ -1790,6 +1879,10 @@
       "club_roles:read": "Ver funções do clube",
       "club_roles:assign": "Atribuir função ao clube",
       "club_roles:revoke": "Revogar função do clube",
+      "coordination": {
+        "manage": "Administrar coordenação"
+      },
+      "coordination:manage": "Administrar coordenação",
       "club_members:approve": "Aprovar adesão",
       "club_members:reject": "Rejeitar adesão",
       "club_members:list_pending": "Ver solicitações pendentes",

--- a/src/app/(dashboard)/dashboard/coordination/page.tsx
+++ b/src/app/(dashboard)/dashboard/coordination/page.tsx
@@ -1,0 +1,202 @@
+import { Network } from "lucide-react";
+import { getTranslations } from "next-intl/server";
+import { notFound } from "next/navigation";
+import { PageHeader } from "@/components/shared/page-header";
+import { EmptyState } from "@/components/shared/empty-state";
+import { CoordinationAdminClient } from "@/components/coordination/coordination-admin-client";
+import { apiRequest } from "@/lib/api/client";
+import { listAdminUsers } from "@/lib/api/admin-users";
+import { listClubTypes, type ClubType } from "@/lib/api/catalogs";
+import { listDistricts, listLocalFields, type LocalField } from "@/lib/api/geography";
+import {
+  listCoordinationZones,
+  listCoordinatorAssignments,
+} from "@/lib/api/coordination";
+import { COORDINATION_MANAGE } from "@/lib/auth/permissions";
+import { hasPermission } from "@/lib/auth/permission-utils";
+import { requireAdminUser } from "@/lib/auth/session";
+import { resolveUserLocalField } from "@/lib/auth/user-local-field";
+
+type SearchParams = Promise<Record<string, string | string[] | undefined>>;
+
+type RawClubSection = {
+  club_section_id: number;
+  name?: string | null;
+  active?: boolean;
+  club_type_id?: number | null;
+  club_types?: { club_type_id?: number; name?: string | null } | null;
+};
+
+type RawClub = {
+  club_id?: number;
+  id?: number;
+  name?: string | null;
+  club_sections?: RawClubSection[];
+};
+
+type ClubSectionOption = {
+  club_section_id: number;
+  name?: string | null;
+  active?: boolean;
+  club_id: number;
+  club_name: string;
+  club_type_id?: number | null;
+  club_type_name?: string | null;
+};
+
+function getRequestedLocalFieldId(raw: Record<string, string | string[] | undefined>) {
+  const value = raw.localFieldId;
+  if (typeof value !== "string") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
+}
+
+async function safeListLocalFields() {
+  try {
+    return await listLocalFields();
+  } catch {
+    return [] as LocalField[];
+  }
+}
+
+async function safeListDistricts(localFieldId: number) {
+  try {
+    return await listDistricts(localFieldId);
+  } catch {
+    return [];
+  }
+}
+
+async function safeListClubTypes() {
+  try {
+    return await listClubTypes();
+  } catch {
+    return [] as ClubType[];
+  }
+}
+
+async function safeListCoordinatorUsers(localFieldId: number) {
+  try {
+    const result = await listAdminUsers({ localFieldId, active: true, limit: 100 });
+    const coordinatorRoles = new Set([
+      "coordinator",
+      "zone-coordinator",
+      "general-coordinator",
+    ]);
+    return result.items.filter((user) =>
+      (user.roles ?? []).some((role) => coordinatorRoles.has(role.toLowerCase())),
+    );
+  } catch {
+    return [];
+  }
+}
+
+function unwrapClubs(payload: unknown): RawClub[] {
+  if (Array.isArray(payload)) return payload as RawClub[];
+  if (payload && typeof payload === "object") {
+    const record = payload as { data?: unknown };
+    if (Array.isArray(record.data)) return record.data as RawClub[];
+  }
+  return [];
+}
+
+async function safeListClubSections(localFieldId: number): Promise<ClubSectionOption[]> {
+  try {
+    const payload = await apiRequest<unknown>("/clubs", {
+      params: { localFieldId, limit: 500, page: 1, active: true },
+    });
+    return unwrapClubs(payload).flatMap((club) => {
+      const clubId = club.club_id ?? club.id;
+      if (!clubId) return [];
+      const clubName = club.name ?? `Club ${clubId}`;
+      return (club.club_sections ?? [])
+        .filter((section) => section.active !== false)
+        .map((section) => ({
+          club_section_id: section.club_section_id,
+          name: section.name,
+          active: section.active,
+          club_id: clubId,
+          club_name: clubName,
+          club_type_id: section.club_type_id ?? section.club_types?.club_type_id ?? null,
+          club_type_name: section.club_types?.name ?? null,
+        }));
+    });
+  } catch {
+    return [];
+  }
+}
+
+export default async function CoordinationPage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const user = await requireAdminUser();
+  if (!hasPermission(user, COORDINATION_MANAGE)) {
+    notFound();
+  }
+
+  const t = await getTranslations("coordinationAdmin");
+  const rawParams = await searchParams;
+  const userLocalFieldScope = resolveUserLocalField(user);
+  const localFields = await safeListLocalFields();
+
+  const requestedLocalFieldId = getRequestedLocalFieldId(rawParams);
+  const selectedLocalFieldId =
+    userLocalFieldScope.scope === "single"
+      ? userLocalFieldScope.localFieldId
+      : requestedLocalFieldId ?? localFields[0]?.local_field_id ?? null;
+
+  if (!selectedLocalFieldId) {
+    return (
+      <div className="space-y-6">
+        <PageHeader
+          title={t("page.title")}
+          description={t("page.description")}
+        />
+        <EmptyState
+          icon={Network}
+          title={t("emptyNoLocalField.title")}
+          description={t("emptyNoLocalField.description")}
+        />
+      </div>
+    );
+  }
+
+  const [zones, assignments, districts, clubTypes, coordinatorUsers, clubSections] =
+    await Promise.all([
+      listCoordinationZones(selectedLocalFieldId).catch(() => []),
+      listCoordinatorAssignments(selectedLocalFieldId).catch(() => []),
+      safeListDistricts(selectedLocalFieldId),
+      safeListClubTypes(),
+      safeListCoordinatorUsers(selectedLocalFieldId),
+      safeListClubSections(selectedLocalFieldId),
+    ]);
+
+  const visibleLocalFields =
+    userLocalFieldScope.scope === "single"
+      ? localFields.filter(
+          (localField) => localField.local_field_id === selectedLocalFieldId,
+        )
+      : localFields;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title={t("page.title")}
+        description={t("page.description")}
+      />
+      <CoordinationAdminClient
+        localFields={visibleLocalFields.length > 0 ? visibleLocalFields : localFields}
+        selectedLocalFieldId={selectedLocalFieldId}
+        zones={zones}
+        assignments={assignments}
+        districts={districts}
+        clubTypes={clubTypes}
+        coordinatorUsers={coordinatorUsers}
+        clubSections={clubSections}
+        canChangeLocalField={userLocalFieldScope.scope === "all"}
+      />
+    </div>
+  );
+}

--- a/src/components/coordination/coordination-admin-client.tsx
+++ b/src/components/coordination/coordination-admin-client.tsx
@@ -1,0 +1,638 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Plus, Power, PowerOff, Route, Users } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Textarea } from "@/components/ui/textarea";
+import { ApiError } from "@/lib/api/client";
+import {
+  assignDistrictToCoordinationZone,
+  createCoordinationZone,
+  createCoordinatorAssignment,
+  removeDistrictFromCoordinationZone,
+  updateCoordinationZone,
+  updateCoordinatorAssignment,
+  type CoordinationZone,
+  type CoordinatorAssignment,
+  type CoordinatorAssignmentType,
+} from "@/lib/api/coordination";
+import { cn } from "@/lib/utils";
+
+type LocalFieldOption = { local_field_id: number; name: string };
+type DistrictOption = {
+  district_id?: number;
+  districlub_type_id?: number;
+  name: string;
+  active?: boolean;
+};
+type ClubTypeOption = { club_type_id: number; name: string };
+type CoordinatorUserOption = {
+  user_id: string;
+  full_name?: string | null;
+  name?: string | null;
+  paternal_last_name?: string | null;
+  maternal_last_name?: string | null;
+  email?: string | null;
+};
+type ClubSectionOption = {
+  club_section_id: number;
+  name?: string | null;
+  active?: boolean;
+  club_id: number;
+  club_name: string;
+  club_type_id?: number | null;
+  club_type_name?: string | null;
+};
+
+type Props = {
+  localFields: LocalFieldOption[];
+  selectedLocalFieldId: number;
+  zones: CoordinationZone[];
+  assignments: CoordinatorAssignment[];
+  districts: DistrictOption[];
+  clubTypes: ClubTypeOption[];
+  coordinatorUsers: CoordinatorUserOption[];
+  clubSections: ClubSectionOption[];
+  canChangeLocalField: boolean;
+};
+
+function getErrorMessage(error: unknown, fallback: string) {
+  if (error instanceof ApiError) return error.message;
+  if (error instanceof Error) return error.message;
+  return fallback;
+}
+
+function getDistrictId(district: DistrictOption) {
+  return district.district_id ?? district.districlub_type_id ?? 0;
+}
+
+function userLabel(user: CoordinatorUserOption) {
+  const fullName =
+    user.full_name ??
+    [user.name, user.paternal_last_name, user.maternal_last_name]
+      .filter(Boolean)
+      .join(" ");
+  return fullName || user.email || user.user_id;
+}
+
+type AssignmentTargetLabels = {
+  allLocalField: string;
+  zoneFallback: (id: number | null | undefined) => string;
+  clubTypeFallback: (id: number | null | undefined) => string;
+  clubFallback: string;
+  sectionFallback: (id: number | null | undefined) => string;
+};
+
+function assignmentTarget(
+  assignment: CoordinatorAssignment,
+  labels: AssignmentTargetLabels,
+) {
+  if (assignment.assignment_type === "GENERAL") return labels.allLocalField;
+  if (assignment.assignment_type === "ZONE") {
+    return `${assignment.coordination_zones?.name ?? labels.zoneFallback(assignment.zone_id)} · ${assignment.club_types?.name ?? labels.clubTypeFallback(assignment.club_type_id)}`;
+  }
+  const section = assignment.club_sections;
+  return `${section?.clubs?.name ?? labels.clubFallback} · ${section?.name ?? section?.club_types?.name ?? labels.sectionFallback(assignment.club_section_id)}`;
+}
+
+export function CoordinationAdminClient({
+  localFields,
+  selectedLocalFieldId,
+  zones,
+  assignments,
+  districts,
+  clubTypes,
+  coordinatorUsers,
+  clubSections,
+  canChangeLocalField,
+}: Props) {
+  const router = useRouter();
+  const t = useTranslations("coordinationAdmin");
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const [zoneName, setZoneName] = useState("");
+  const [zoneDescription, setZoneDescription] = useState("");
+  const [districtZoneId, setDistrictZoneId] = useState<string>("");
+  const [districtId, setDistrictId] = useState<string>("");
+
+  const [assignmentType, setAssignmentType] =
+    useState<CoordinatorAssignmentType>("ZONE");
+  const [assignmentUserId, setAssignmentUserId] = useState("");
+  const [assignmentZoneId, setAssignmentZoneId] = useState("");
+  const [assignmentClubTypeId, setAssignmentClubTypeId] = useState("");
+  const [assignmentSectionId, setAssignmentSectionId] = useState("");
+
+  const activeZones = useMemo(
+    () => zones.filter((zone) => zone.active),
+    [zones],
+  );
+
+  const assignmentLabels = useMemo<Record<CoordinatorAssignmentType, string>>(
+    () => ({
+      GENERAL: t("assignmentTypes.general"),
+      ZONE: t("assignmentTypes.zone"),
+      SECTION: t("assignmentTypes.section"),
+    }),
+    [t],
+  );
+
+  const targetLabels = useMemo<AssignmentTargetLabels>(
+    () => ({
+      allLocalField: t("targets.allLocalField"),
+      zoneFallback: (id) => t("targets.zoneFallback", { id: id ?? "—" }),
+      clubTypeFallback: (id) =>
+        t("targets.clubTypeFallback", { id: id ?? "—" }),
+      clubFallback: t("targets.clubFallback"),
+      sectionFallback: (id) => t("targets.sectionFallback", { id: id ?? "—" }),
+    }),
+    [t],
+  );
+
+  const runMutation = (fn: () => Promise<unknown>, successMessage: string) => {
+    setError(null);
+    setMessage(null);
+    startTransition(async () => {
+      try {
+        await fn();
+        setMessage(successMessage);
+        router.refresh();
+      } catch (err) {
+        setError(getErrorMessage(err, t("errors.generic")));
+      }
+    });
+  };
+
+  const handleCreateZone = () => {
+    const name = zoneName.trim();
+    if (!name) {
+      setError(t("errors.zoneNameRequired"));
+      return;
+    }
+
+    runMutation(
+      async () => {
+        await createCoordinationZone(selectedLocalFieldId, {
+          name,
+          description: zoneDescription.trim() || undefined,
+        });
+        setZoneName("");
+        setZoneDescription("");
+      },
+      t("success.zoneCreated"),
+    );
+  };
+
+  const handleAssignDistrict = () => {
+    if (!districtZoneId || !districtId) {
+      setError(t("errors.zoneAndDistrictRequired"));
+      return;
+    }
+
+    runMutation(
+      () => assignDistrictToCoordinationZone(Number(districtZoneId), Number(districtId)),
+      t("success.districtAssigned"),
+    );
+  };
+
+  const handleCreateAssignment = () => {
+    if (!assignmentUserId) {
+      setError(t("errors.coordinatorRequired"));
+      return;
+    }
+
+    const payload = {
+      user_id: assignmentUserId,
+      assignment_type: assignmentType,
+      ...(assignmentType === "ZONE"
+        ? {
+            zone_id: Number(assignmentZoneId),
+            club_type_id: Number(assignmentClubTypeId),
+          }
+        : {}),
+      ...(assignmentType === "SECTION"
+        ? { club_section_id: Number(assignmentSectionId) }
+        : {}),
+    };
+
+    if (
+      (assignmentType === "ZONE" && (!assignmentZoneId || !assignmentClubTypeId)) ||
+      (assignmentType === "SECTION" && !assignmentSectionId)
+    ) {
+      setError(t("errors.assignmentScopeRequired"));
+      return;
+    }
+
+    runMutation(
+      async () => {
+        await createCoordinatorAssignment(selectedLocalFieldId, payload);
+        setAssignmentUserId("");
+        setAssignmentZoneId("");
+        setAssignmentClubTypeId("");
+        setAssignmentSectionId("");
+      },
+      t("success.assignmentCreated"),
+    );
+  };
+
+  return (
+    <div className="space-y-6">
+      {(error || message) && (
+        <div
+          className={cn(
+            "rounded-lg border px-4 py-3 text-sm",
+            error
+              ? "border-destructive/30 bg-destructive/10 text-destructive"
+              : "border-success/30 bg-success/10 text-success-foreground",
+          )}
+        >
+          {error ?? message}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("localField.title")}</CardTitle>
+          <CardDescription>
+            {t("localField.description")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Select
+            value={String(selectedLocalFieldId)}
+            disabled={!canChangeLocalField || isPending}
+            onValueChange={(value) => {
+              router.push(`/dashboard/coordination?localFieldId=${value}`);
+            }}
+          >
+            <SelectTrigger className="w-full sm:w-80">
+              <SelectValue placeholder={t("localField.placeholder")} />
+            </SelectTrigger>
+            <SelectContent>
+              {localFields.map((localField) => (
+                <SelectItem
+                  key={localField.local_field_id}
+                  value={String(localField.local_field_id)}
+                >
+                  {localField.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_420px]">
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Route className="size-5" /> {t("zones.title")}
+            </CardTitle>
+            <CardDescription>
+              {t("zones.description")}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-3 md:grid-cols-[1fr_1fr_auto]">
+              <div className="space-y-2">
+                <Label htmlFor="zone-name">{t("fields.name")}</Label>
+                <Input
+                  id="zone-name"
+                  value={zoneName}
+                  onChange={(event) => setZoneName(event.target.value)}
+                  placeholder={t("zones.namePlaceholder")}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="zone-description">{t("fields.description")}</Label>
+                <Input
+                  id="zone-description"
+                  value={zoneDescription}
+                  onChange={(event) => setZoneDescription(event.target.value)}
+                  placeholder={t("zones.descriptionPlaceholder")}
+                />
+              </div>
+              <div className="flex items-end">
+                <Button onClick={handleCreateZone} disabled={isPending}>
+                  <Plus className="size-4" /> {t("actions.createZone")}
+                </Button>
+              </div>
+            </div>
+
+            <div className="grid gap-3 rounded-lg border p-3 md:grid-cols-[1fr_1fr_auto]">
+              <div className="space-y-2">
+                <Label>{t("fields.zone")}</Label>
+                <Select value={districtZoneId} onValueChange={setDistrictZoneId}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t("fields.selectZone")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {activeZones.map((zone) => (
+                      <SelectItem key={zone.zone_id} value={String(zone.zone_id)}>
+                        {zone.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>{t("fields.district")}</Label>
+                <Select value={districtId} onValueChange={setDistrictId}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t("fields.selectDistrict")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {districts.map((district) => (
+                      <SelectItem
+                        key={getDistrictId(district)}
+                        value={String(getDistrictId(district))}
+                      >
+                        {district.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="flex items-end">
+                <Button variant="secondary" onClick={handleAssignDistrict} disabled={isPending}>
+                  {t("actions.assignDistrict")}
+                </Button>
+              </div>
+            </div>
+
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("fields.zone")}</TableHead>
+                  <TableHead>{t("fields.districts")}</TableHead>
+                  <TableHead>{t("fields.status")}</TableHead>
+                  <TableHead className="text-right">{t("fields.actions")}</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {zones.length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={4} className="py-8 text-center text-muted-foreground">
+                      {t("zones.empty")}
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  zones.map((zone) => (
+                    <TableRow key={zone.zone_id}>
+                      <TableCell className="font-medium">{zone.name}</TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {(zone.districts ?? []).filter((item) => item.active).length === 0 ? (
+                            <span className="text-muted-foreground">{t("zones.noDistricts")}</span>
+                          ) : (
+                            (zone.districts ?? [])
+                              .filter((item) => item.active)
+                              .map((item) => (
+                                <Badge key={item.zone_district_id} variant="secondary" className="gap-1">
+                                  {item.districts?.name ?? item.districlub_type_id}
+                                  <button
+                                    type="button"
+                                    className="ml-1 text-muted-foreground hover:text-destructive"
+                                    onClick={() =>
+                                      runMutation(
+                                        () => removeDistrictFromCoordinationZone(zone.zone_id, item.districlub_type_id),
+                                        t("success.districtRemoved"),
+                                      )
+                                    }
+                                  >
+                                    ×
+                                  </button>
+                                </Badge>
+                              ))
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant={zone.active ? "default" : "secondary"}>
+                          {zone.active ? t("status.active") : t("status.inactive")}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          size="sm"
+                          variant="ghost"
+                          onClick={() =>
+                            runMutation(
+                              () => updateCoordinationZone(zone.zone_id, { active: !zone.active }),
+                              zone.active ? t("success.zoneDeactivated") : t("success.zoneActivated"),
+                            )
+                          }
+                          disabled={isPending}
+                        >
+                          {zone.active ? <PowerOff className="size-4" /> : <Power className="size-4" />}
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="size-5" /> {t("assignments.newTitle")}
+            </CardTitle>
+            <CardDescription>
+              {t("assignments.newDescription")}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label>{t("fields.coordinator")}</Label>
+              <Select value={assignmentUserId} onValueChange={setAssignmentUserId}>
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder={t("fields.selectUser")} />
+                </SelectTrigger>
+                <SelectContent>
+                  {coordinatorUsers.map((user) => (
+                    <SelectItem key={user.user_id} value={user.user_id}>
+                      {userLabel(user)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label>{t("fields.type")}</Label>
+              <Select
+                value={assignmentType}
+                onValueChange={(value) => setAssignmentType(value as CoordinatorAssignmentType)}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(assignmentLabels).map(([value, label]) => (
+                    <SelectItem key={value} value={value}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {assignmentType === "ZONE" && (
+              <div className="grid gap-3 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>{t("fields.zone")}</Label>
+                  <Select value={assignmentZoneId} onValueChange={setAssignmentZoneId}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder={t("fields.zone")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {activeZones.map((zone) => (
+                        <SelectItem key={zone.zone_id} value={String(zone.zone_id)}>
+                          {zone.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label>{t("fields.section")}</Label>
+                  <Select value={assignmentClubTypeId} onValueChange={setAssignmentClubTypeId}>
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder={t("fields.type")} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {clubTypes.map((clubType) => (
+                        <SelectItem key={clubType.club_type_id} value={String(clubType.club_type_id)}>
+                          {clubType.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+            )}
+
+            {assignmentType === "SECTION" && (
+              <div className="space-y-2">
+                <Label>{t("fields.clubSection")}</Label>
+                <Select value={assignmentSectionId} onValueChange={setAssignmentSectionId}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder={t("fields.selectSection")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {clubSections.map((section) => (
+                      <SelectItem key={section.club_section_id} value={String(section.club_section_id)}>
+                        {section.club_name} · {section.name ?? section.club_type_name ?? section.club_section_id}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+
+            <Button className="w-full" onClick={handleCreateAssignment} disabled={isPending}>
+              {t("actions.createAssignment")}
+            </Button>
+            <Textarea
+              readOnly
+              value={t("assignments.directorConflictRule")}
+              className="min-h-20 resize-none text-xs text-muted-foreground"
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t("assignments.title")}</CardTitle>
+          <CardDescription>
+            {t("assignments.description")}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t("fields.coordinator")}</TableHead>
+                <TableHead>{t("fields.type")}</TableHead>
+                <TableHead>{t("fields.scope")}</TableHead>
+                <TableHead>{t("fields.status")}</TableHead>
+                <TableHead className="text-right">{t("fields.actions")}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {assignments.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={5} className="py-8 text-center text-muted-foreground">
+                    {t("assignments.empty")}
+                  </TableCell>
+                </TableRow>
+              ) : (
+                assignments.map((assignment) => (
+                  <TableRow key={assignment.assignment_id}>
+                    <TableCell className="font-medium">
+                      {assignment.users ? userLabel(assignment.users) : assignment.user_id}
+                    </TableCell>
+                    <TableCell>{assignmentLabels[assignment.assignment_type]}</TableCell>
+                    <TableCell>{assignmentTarget(assignment, targetLabels)}</TableCell>
+                    <TableCell>
+                      <Badge variant={assignment.active ? "default" : "secondary"}>
+                        {assignment.active ? t("status.active") : t("status.inactive")}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() =>
+                          runMutation(
+                            () => updateCoordinatorAssignment(assignment.assignment_id, { active: !assignment.active }),
+                            assignment.active ? t("success.assignmentDeactivated") : t("success.assignmentActivated"),
+                          )
+                        }
+                        disabled={isPending}
+                      >
+                        {assignment.active ? <PowerOff className="size-4" /> : <Power className="size-4" />}
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/components/layout/nav-config.ts
+++ b/src/components/layout/nav-config.ts
@@ -30,9 +30,11 @@ import {
   ShoppingBag,
   Tag,
   Headset,
+  Network,
   type LucideIcon,
 } from "lucide-react";
 import {
+  COORDINATION_MANAGE,
   USER_HONORS_VALIDATE,
   RANKINGS_READ,
   RANKING_WEIGHTS_READ,
@@ -187,6 +189,7 @@ export const navConfig: NavGroup[] = [
     label: "sections.clubs",
     items: [
       { title: "items.clubs", url: "/dashboard/clubs", icon: Building2, permission: "clubs:read" },
+      { title: "items.coordination", url: "/dashboard/coordination", icon: Network, permission: COORDINATION_MANAGE },
       {
         title: "items.camporees",
         url: "/dashboard/camporees",

--- a/src/i18n/messages.d.ts
+++ b/src/i18n/messages.d.ts
@@ -149,6 +149,7 @@ export interface IntlMessages {
       materials_categories: string;
       materials_config: string;
       certificate_bulk_imports: string;
+      coordination: string;
     };
     breadcrumbs: {
       dashboard: string;
@@ -186,6 +187,7 @@ export interface IntlMessages {
       roles: string;
       matrix: string;
       support: string;
+      coordination: string;
     };
     themeToggle: {
       switchToLight: string;
@@ -238,6 +240,93 @@ export interface IntlMessages {
       notifications: string;
       resources: string;
       system: string;
+    };
+  };
+  coordinationAdmin: {
+    page: {
+      title: string;
+      description: string;
+    };
+    emptyNoLocalField: {
+      title: string;
+      description: string;
+    };
+    assignmentTypes: {
+      general: string;
+      zone: string;
+      section: string;
+    };
+    targets: {
+      allLocalField: string;
+      zoneFallback: string;
+      clubTypeFallback: string;
+      clubFallback: string;
+      sectionFallback: string;
+    };
+    errors: {
+      generic: string;
+      zoneNameRequired: string;
+      zoneAndDistrictRequired: string;
+      coordinatorRequired: string;
+      assignmentScopeRequired: string;
+    };
+    success: {
+      zoneCreated: string;
+      districtAssigned: string;
+      districtRemoved: string;
+      zoneActivated: string;
+      zoneDeactivated: string;
+      assignmentCreated: string;
+      assignmentActivated: string;
+      assignmentDeactivated: string;
+    };
+    localField: {
+      title: string;
+      description: string;
+      placeholder: string;
+    };
+    zones: {
+      title: string;
+      description: string;
+      namePlaceholder: string;
+      descriptionPlaceholder: string;
+      empty: string;
+      noDistricts: string;
+    };
+    assignments: {
+      newTitle: string;
+      newDescription: string;
+      directorConflictRule: string;
+      title: string;
+      description: string;
+      empty: string;
+    };
+    fields: {
+      name: string;
+      description: string;
+      zone: string;
+      selectZone: string;
+      district: string;
+      districts: string;
+      selectDistrict: string;
+      status: string;
+      actions: string;
+      coordinator: string;
+      selectUser: string;
+      type: string;
+      section: string;
+      clubSection: string;
+      selectSection: string;
+      scope: string;
+    };
+    actions: {
+      createZone: string;
+      assignDistrict: string;
+      createAssignment: string;
+    };
+    status: {
+      active: string;
+      inactive: string;
     };
   };
   catalogs: {
@@ -1820,6 +1909,10 @@ export interface IntlMessages {
       "club_roles:read": string;
       "club_roles:assign": string;
       "club_roles:revoke": string;
+      coordination: {
+        manage: string;
+      };
+      "coordination:manage": string;
       "club_members:approve": string;
       "club_members:reject": string;
       "club_members:list_pending": string;
@@ -2789,12 +2882,12 @@ export interface IntlMessages {
     };
     client: {
       allYears: string;
-      selectYear: string;
       yearActive: string;
       countSingular: string;
       countPlural: string;
       refresh: string;
       errorRefresh: string;
+      selectYear: string;
     };
     pipeline: {
       refresh: string;
@@ -2832,10 +2925,7 @@ export interface IntlMessages {
       emptyDescription: string;
       colMember: string;
       colClass: string;
-      colClassYear: string;
       colClub: string;
-      colClubSection: string;
-      colSubmittedBy: string;
       colSubmitted: string;
       colStatus: string;
       colActions: string;
@@ -2847,6 +2937,12 @@ export interface IntlMessages {
       tooltipApprove: string;
       tooltipReject: string;
       tooltipMarkInvested: string;
+      historyTitle: string;
+      errorLoadHistory: string;
+      enrollmentFallback: string;
+      colClassYear: string;
+      colClubSection: string;
+      colSubmittedBy: string;
       viewDetail: string;
       detailTitle: string;
       detailMember: string;
@@ -2871,9 +2967,6 @@ export interface IntlMessages {
       progressPendingReview: string;
       progressPending: string;
       progressUnavailable: string;
-      historyTitle: string;
-      errorLoadHistory: string;
-      enrollmentFallback: string;
     };
     statusBadge: {
       inProgress: string;

--- a/src/lib/api/coordination.ts
+++ b/src/lib/api/coordination.ts
@@ -1,0 +1,173 @@
+import { apiRequest } from "@/lib/api/client";
+
+export type CoordinatorAssignmentType = "GENERAL" | "ZONE" | "SECTION";
+
+export type CoordinationZoneDistrict = {
+  zone_district_id: number;
+  zone_id: number;
+  districlub_type_id: number;
+  active: boolean;
+  districts?: {
+    districlub_type_id: number;
+    name: string;
+    active?: boolean;
+    local_field_id?: number | null;
+  } | null;
+};
+
+export type CoordinationZone = {
+  zone_id: number;
+  local_field_id: number;
+  name: string;
+  description?: string | null;
+  active: boolean;
+  districts?: CoordinationZoneDistrict[];
+};
+
+export type CoordinatorAssignment = {
+  assignment_id: string;
+  user_id: string;
+  local_field_id: number;
+  assignment_type: CoordinatorAssignmentType;
+  zone_id?: number | null;
+  club_type_id?: number | null;
+  club_section_id?: number | null;
+  active: boolean;
+  start_date?: string | null;
+  end_date?: string | null;
+  users?: {
+    user_id: string;
+    email?: string | null;
+    name?: string | null;
+    paternal_last_name?: string | null;
+    maternal_last_name?: string | null;
+  } | null;
+  coordination_zones?: { zone_id: number; name: string; active?: boolean } | null;
+  club_types?: { club_type_id: number; name: string; active?: boolean } | null;
+  club_sections?: {
+    club_section_id: number;
+    name?: string | null;
+    active?: boolean;
+    club_type_id: number;
+    clubs?: { club_id: number; name: string } | null;
+    club_types?: { club_type_id: number; name: string } | null;
+  } | null;
+};
+
+export type CreateCoordinationZonePayload = {
+  name: string;
+  description?: string;
+  active?: boolean;
+};
+
+export type CreateCoordinatorAssignmentPayload = {
+  user_id: string;
+  assignment_type: CoordinatorAssignmentType;
+  zone_id?: number;
+  club_type_id?: number;
+  club_section_id?: number;
+  active?: boolean;
+  start_date?: string;
+  end_date?: string;
+};
+
+export type UpdateCoordinatorAssignmentPayload = Partial<CreateCoordinatorAssignmentPayload>;
+
+type ApiEnvelope<T> = { status?: string; data?: T };
+
+function unwrap<T>(payload: T | ApiEnvelope<T>): T {
+  if (
+    payload &&
+    typeof payload === "object" &&
+    !Array.isArray(payload) &&
+    "data" in payload
+  ) {
+    return (payload as ApiEnvelope<T>).data as T;
+  }
+
+  return payload as T;
+}
+
+export async function listCoordinationZones(localFieldId: number) {
+  const payload = await apiRequest<ApiEnvelope<CoordinationZone[]>>(
+    `/admin/coordination/local-fields/${localFieldId}/zones`,
+  );
+  return unwrap(payload) ?? [];
+}
+
+export async function createCoordinationZone(
+  localFieldId: number,
+  payload: CreateCoordinationZonePayload,
+) {
+  const response = await apiRequest<ApiEnvelope<CoordinationZone>>(
+    `/admin/coordination/local-fields/${localFieldId}/zones`,
+    { method: "POST", body: payload },
+  );
+  return unwrap(response);
+}
+
+export async function updateCoordinationZone(
+  zoneId: number,
+  payload: Partial<CreateCoordinationZonePayload>,
+) {
+  const response = await apiRequest<ApiEnvelope<CoordinationZone>>(
+    `/admin/coordination/zones/${zoneId}`,
+    { method: "PATCH", body: payload },
+  );
+  return unwrap(response);
+}
+
+export async function assignDistrictToCoordinationZone(
+  zoneId: number,
+  districtId: number,
+) {
+  const response = await apiRequest<ApiEnvelope<CoordinationZoneDistrict>>(
+    `/admin/coordination/zones/${zoneId}/districts/${districtId}`,
+    { method: "POST" },
+  );
+  return unwrap(response);
+}
+
+export async function removeDistrictFromCoordinationZone(
+  zoneId: number,
+  districtId: number,
+) {
+  const response = await apiRequest<ApiEnvelope<CoordinationZoneDistrict>>(
+    `/admin/coordination/zones/${zoneId}/districts/${districtId}`,
+    { method: "DELETE" },
+  );
+  return unwrap(response);
+}
+
+export async function listCoordinatorAssignments(
+  localFieldId: number,
+  active?: boolean,
+) {
+  const payload = await apiRequest<ApiEnvelope<CoordinatorAssignment[]>>(
+    `/admin/coordination/local-fields/${localFieldId}/assignments`,
+    { params: { active } },
+  );
+  return unwrap(payload) ?? [];
+}
+
+export async function createCoordinatorAssignment(
+  localFieldId: number,
+  payload: CreateCoordinatorAssignmentPayload,
+) {
+  const response = await apiRequest<ApiEnvelope<CoordinatorAssignment>>(
+    `/admin/coordination/local-fields/${localFieldId}/assignments`,
+    { method: "POST", body: payload },
+  );
+  return unwrap(response);
+}
+
+export async function updateCoordinatorAssignment(
+  assignmentId: string,
+  payload: UpdateCoordinatorAssignmentPayload,
+) {
+  const response = await apiRequest<ApiEnvelope<CoordinatorAssignment>>(
+    `/admin/coordination/assignments/${assignmentId}`,
+    { method: "PATCH", body: payload },
+  );
+  return unwrap(response);
+}

--- a/src/lib/auth/permissions.ts
+++ b/src/lib/auth/permissions.ts
@@ -44,6 +44,7 @@ export const CLUB_SECTIONS_UPDATE = "club_sections:update";
 export const CLUB_ROLES_READ = "club_roles:read";
 export const CLUB_ROLES_ASSIGN = "club_roles:assign";
 export const CLUB_ROLES_REVOKE = "club_roles:revoke";
+export const COORDINATION_MANAGE = "coordination:manage";
 // Club membership approval
 export const CLUB_MEMBERS_APPROVE = "club_members:approve";
 export const CLUB_MEMBERS_REJECT = "club_members:reject";
@@ -289,6 +290,7 @@ export const PERMISSION_GROUPS = {
       { key: CLUB_ROLES_READ },
       { key: CLUB_ROLES_ASSIGN },
       { key: CLUB_ROLES_REVOKE },
+      { key: COORDINATION_MANAGE },
       { key: CLUB_MEMBERS_APPROVE },
       { key: CLUB_MEMBERS_REJECT },
       { key: CLUB_MEMBERS_LIST_PENDING },

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -1,4 +1,9 @@
-export type AdminRole = "super-admin" | "admin" | "coordinator";
+export type AdminRole =
+  | "super-admin"
+  | "admin"
+  | "coordinator"
+  | "zone-coordinator"
+  | "general-coordinator";
 
 export type AuthorizationGrant = {
   assignment_id?: string | null;


### PR DESCRIPTION
## Summary
- Adds `/dashboard/coordination` admin panel for local-field zones and coordinator assignments.
- Adds coordination API client, RBAC nav/page gate via `coordination:manage`, and localized UI copy in all admin locales.
- Regenerates strict `next-intl` message types.

## Verification
- `node scripts/generate-messages-types.mjs`
- `pnpm exec tsc --noEmit --pretty false`
- `python3 -m json.tool messages/{es,en,fr,pt-BR}.json`
- `git diff --check`

## Notes
- No build executed per project instruction.
- Read-only API smoke was attempted, but configured E2E admin credentials returned HTTP 401; live endpoint smoke needs valid credentials/token.
