### PR TITLE
fix(admin): complete v2 studio navigation and union camporee routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,10 @@
     "test:watch": "vitest",
     "test:e2e:smoke": "node scripts/e2e-smoke.mjs",
     "test:e2e:smoke:backlog": "node scripts/smoke-backlog.mjs",
+    "test:smoke:v1-v2": "node scripts/smoke-v1-v2-nav.mjs",
     "audit:design-system": "node scripts/audit-design-system.mjs",
     "scaffold:v2": "node scripts/generate-v2-bridges.mjs",
+    "patch:v2-links": "node scripts/patch-v2-dashboard-links.mjs",
     "analyze": "next experimental-analyze -o"
   },
   "dependencies": {

--- a/scripts/generate-v2-bridges.mjs
+++ b/scripts/generate-v2-bridges.mjs
@@ -56,6 +56,9 @@ const CUSTOM_V2_PAGES = new Set([
   "catalogs",
   "catalogs/honor-categories",
   "catalogs/ecclesiastical-years",
+  "camporees/union/[id]",
+  "camporees/union/[id]/events/new",
+  "camporees/union/[id]/events/[eventId]/edit",
 ]);
 
 function walkPages(dir, base = "") {

--- a/scripts/patch-v2-dashboard-links.mjs
+++ b/scripts/patch-v2-dashboard-links.mjs
@@ -1,0 +1,140 @@
+#!/usr/bin/env node
+/**
+ * Fix hardcoded /dashboard Link hrefs in v2 app routes → PanelDashboardLink.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const V2_APP = path.join(ROOT, "src/app/(dashboard-v2)");
+
+const DASHBOARD_HREF =
+  /href=(?:"(\/dashboard[^"]*)"|'(\/dashboard[^']*)'|(\{`\/dashboard[^`]*`\})|(\{"\/dashboard[^"]*"\}))/;
+
+function walkTsx(dir, acc = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walkTsx(full, acc);
+    else if (entry.name.endsWith(".tsx")) acc.push(full);
+  }
+  return acc;
+}
+
+function injectImport(source) {
+  if (source.includes('from "@/components/shared/panel-dashboard-link"')) return source;
+  const line = 'import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";\n';
+  const useClient = source.match(/^["']use client["'];\n/m);
+  if (useClient) {
+    const at = useClient.index + useClient[0].length;
+    return source.slice(0, at) + "\n" + line + source.slice(at);
+  }
+  const firstImport = source.match(/^import .+;\n/m);
+  if (firstImport) {
+    const at = firstImport.index + firstImport[0].length;
+    return source.slice(0, at) + line + source.slice(at);
+  }
+  return line + source;
+}
+
+function readLinkTag(source, linkStart) {
+  let depth = 0;
+  let inString = false;
+  let stringChar = "";
+  for (let i = linkStart; i < source.length; i++) {
+    const ch = source[i];
+    const prev = source[i - 1];
+
+    if (!inString && (ch === '"' || ch === "'" || ch === "`")) {
+      inString = true;
+      stringChar = ch;
+    } else if (inString && ch === stringChar && prev !== "\\") {
+      inString = false;
+    } else if (!inString && ch === "{") {
+      depth++;
+    } else if (!inString && ch === "}") {
+      depth--;
+    } else if (!inString && depth === 0 && ch === ">") {
+      return source.slice(linkStart, i + 1);
+    }
+  }
+  return null;
+}
+
+function patchLinkTags(source) {
+  let out = "";
+  let i = 0;
+  let changed = 0;
+
+  while (i < source.length) {
+    const linkStart = source.indexOf("<Link", i);
+    if (linkStart === -1) {
+      out += source.slice(i);
+      break;
+    }
+
+    out += source.slice(i, linkStart);
+    const tag = readLinkTag(source, linkStart);
+    if (!tag) {
+      out += source.slice(linkStart);
+      break;
+    }
+
+    const selfClosing = /\/>\s*$/.test(tag);
+
+    if (DASHBOARD_HREF.test(tag)) {
+      const nextTag = tag.replace("<Link", "<PanelDashboardLink");
+      out += nextTag;
+      changed++;
+      if (!selfClosing) {
+        const afterTag = linkStart + tag.length;
+        const closeStart = source.indexOf("</Link>", afterTag);
+        if (closeStart !== -1) {
+          out += source.slice(afterTag, closeStart);
+          out += "</PanelDashboardLink>";
+          i = closeStart + "</Link>".length;
+          continue;
+        }
+      }
+      i = linkStart + tag.length;
+    } else {
+      out += tag;
+      i = linkStart + tag.length;
+    }
+  }
+
+  return { source: out, changed };
+}
+
+function removeUnusedLinkImport(source) {
+  if (!source.includes('from "next/link"')) return source;
+  const stillUsesLink =
+    /<Link[\s>]/.test(source) ||
+    /<\/Link>/.test(source);
+  if (stillUsesLink) return source;
+  return source.replace(/^import Link from "next\/link";\n/m, "");
+}
+
+let patched = 0;
+for (const file of walkTsx(V2_APP)) {
+  let source = fs.readFileSync(file, "utf8");
+  if (!source.includes("/dashboard")) continue;
+
+  const { source: next, changed } = patchLinkTags(source);
+  const needsImport =
+    next.includes("<PanelDashboardLink") &&
+    !next.includes('from "@/components/shared/panel-dashboard-link"');
+
+  if (changed === 0 && !needsImport) continue;
+
+  let out = changed > 0 ? next : source;
+  out = injectImport(out);
+  out = removeUnusedLinkImport(out);
+  fs.writeFileSync(file, out, "utf8");
+  patched++;
+  console.log(
+    `Patched ${path.relative(ROOT, file)}${changed > 0 ? ` (${changed} links)` : " (import)"}`,
+  );
+}
+
+console.log(`Done. Patched ${patched} files.`);

--- a/scripts/smoke-v1-v2-nav.mjs
+++ b/scripts/smoke-v1-v2-nav.mjs
@@ -21,6 +21,7 @@ const KEY_ROUTES = [
   "/dashboard/investiture",
   "/dashboard/rbac/roles",
   "/dashboard/settings",
+  "/dashboard/camporees/union",
 ];
 
 function toV2Path(v1) {

--- a/src/app/(dashboard-v2)/v2/dashboard/achievements/[categoryId]/[achievementId]/edit/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/achievements/[categoryId]/[achievementId]/edit/page.tsx
@@ -13,11 +13,13 @@ import { PageHeader } from "@/components/shared/page-header";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
 import { Skeleton } from "@/components/ui/skeleton";
 
+import { toV2Path } from "@/lib/v2/route-map";
+
 const AchievementForm = dynamic(
   () =>
-    import(
-      "@/app/(dashboard)/dashboard/achievements/_components/achievement-form"
-    ).then((m) => ({ default: m.AchievementForm })),
+    import("../../../_components/achievement-form").then((m) => ({
+      default: m.AchievementForm,
+    })),
   {
     loading: () => (
       <div className="space-y-6">
@@ -154,8 +156,8 @@ export default async function EditAchievementPage({ params }: { params: Params }
         title={t("title")}
         description={achievementName}
         breadcrumbs={[
-          { label: t("breadcrumbRoot"), href: "/dashboard/achievements" },
-          { label: categoryName, href: cancelHref },
+          { label: t("breadcrumbRoot"), href: toV2Path("/dashboard/achievements") },
+          { label: categoryName, href: toV2Path(cancelHref) },
           { label: achievementName },
         ]}
       />

--- a/src/app/(dashboard-v2)/v2/dashboard/achievements/[categoryId]/new/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/achievements/[categoryId]/new/page.tsx
@@ -7,9 +7,10 @@ import {
 } from "@/lib/api/achievements";
 import { requireAdminUser } from "@/lib/auth/session";
 import { createAchievementAction } from "@/lib/achievements/actions";
-import { AchievementForm } from "@/app/(dashboard)/dashboard/achievements/_components/achievement-form";
+import { AchievementForm } from "../../_components/achievement-form";
 import { PageHeader } from "@/components/shared/page-header";
 import { EndpointErrorBanner } from "@/components/shared/endpoint-error-banner";
+import { toV2Path } from "@/lib/v2/route-map";
 
 type Params = Promise<{ categoryId: string }>;
 
@@ -105,8 +106,8 @@ export default async function NewAchievementPage({ params }: { params: Params })
         title={t("title")}
         description={t("descriptionTemplate", { categoryName })}
         breadcrumbs={[
-          { label: t("breadcrumbRoot"), href: "/dashboard/achievements" },
-          { label: categoryName, href: cancelHref },
+          { label: t("breadcrumbRoot"), href: toV2Path("/dashboard/achievements") },
+          { label: categoryName, href: toV2Path(cancelHref) },
           { label: t("breadcrumbNew") },
         ]}
       />

--- a/src/app/(dashboard-v2)/v2/dashboard/achievements/_components/achievement-categories-crud-page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/achievements/_components/achievement-categories-crud-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+
 import { useActionState, useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -297,14 +298,14 @@ export function AchievementCategoriesCrudPage({
                       <TableRow key={rowKey} className="transition-colors hover:bg-muted/30">
                         <TableCell className="font-medium">
                           {categoryId ? (
-                            <Link
+                            <PanelDashboardLink
                               href={`/dashboard/achievements/${categoryId}`}
                               className="flex items-center gap-1.5 text-primary hover:underline"
                               prefetch={false}
                             >
                               {categoryName}
                               <ChevronRight className="size-3.5 text-muted-foreground" />
-                            </Link>
+                            </PanelDashboardLink>
                           ) : (
                             categoryName
                           )}

--- a/src/app/(dashboard-v2)/v2/dashboard/achievements/_components/achievement-form.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/achievements/_components/achievement-form.tsx
@@ -2,7 +2,7 @@
 
 import { useActionState, useState } from "react";
 import { useFormStatus } from "react-dom";
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { Loader2 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -455,7 +455,7 @@ export function AchievementForm({
       {/* Form actions */}
       <div className="flex items-center justify-end gap-3 border-t pt-4">
         <Button type="button" variant="outline" asChild>
-          <Link href={cancelHref}>{t("cancelButton")}</Link>
+          <PanelDashboardLink href={cancelHref}>{t("cancelButton")}</PanelDashboardLink>
         </Button>
         <SubmitButton label={isEdit ? t("submitEdit") : t("submitCreate")} />
       </div>

--- a/src/app/(dashboard-v2)/v2/dashboard/achievements/_components/achievements-crud-page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/achievements/_components/achievements-crud-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+
 import { useActionState, useCallback, useEffect, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -245,7 +246,7 @@ export function AchievementsCrudPage({
         <BreadcrumbList>
           <BreadcrumbItem>
             <BreadcrumbLink asChild>
-              <Link href="/dashboard/achievements">{t("breadcrumbRoot")}</Link>
+              <PanelDashboardLink href="/dashboard/achievements">{t("breadcrumbRoot")}</PanelDashboardLink>
             </BreadcrumbLink>
           </BreadcrumbItem>
           <BreadcrumbSeparator />
@@ -260,10 +261,10 @@ export function AchievementsCrudPage({
         description={t("pageDescription")}
         actions={
           <Button asChild>
-            <Link href={`/dashboard/achievements/${categoryId}/new`}>
+            <PanelDashboardLink href={`/dashboard/achievements/${categoryId}/new`}>
               <Plus className="size-4" />
               {t("newButton")}
-            </Link>
+            </PanelDashboardLink>
           </Button>
         }
       />
@@ -363,10 +364,10 @@ export function AchievementsCrudPage({
           >
             {!hasActiveFilters && (
               <Button asChild>
-                <Link href={`/dashboard/achievements/${categoryId}/new`}>
+                <PanelDashboardLink href={`/dashboard/achievements/${categoryId}/new`}>
                   <Plus className="size-4" />
                   {t("newButton")}
-                </Link>
+                </PanelDashboardLink>
               </Button>
             )}
           </EmptyState>
@@ -476,12 +477,12 @@ export function AchievementsCrudPage({
                                 asChild
                                 title={t("actionEdit")}
                               >
-                                <Link
+                                <PanelDashboardLink
                                   href={`/dashboard/achievements/${categoryId}/${achId}/edit`}
                                   prefetch={false}
                                 >
                                   <Pencil className="size-3.5" />
-                                </Link>
+                                </PanelDashboardLink>
                               </Button>
                             ) : (
                               <Button
@@ -516,13 +517,13 @@ export function AchievementsCrudPage({
                               <DropdownMenuContent align="end">
                                 {achId ? (
                                   <DropdownMenuItem asChild>
-                                    <Link
+                                    <PanelDashboardLink
                                       href={`/dashboard/achievements/${categoryId}/${achId}/edit`}
                                       prefetch={false}
                                     >
                                       <Pencil className="size-4" />
                                       {t("actionEdit")}
-                                    </Link>
+                                    </PanelDashboardLink>
                                   </DropdownMenuItem>
                                 ) : (
                                   <DropdownMenuItem disabled>

--- a/src/app/(dashboard-v2)/v2/dashboard/activities/[id]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/activities/[id]/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft, Calendar, MapPin, Clock, Monitor, Link2 } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Badge } from "@/components/ui/badge";
@@ -172,10 +172,10 @@ export default async function ActivityDetailPage({ params }: { params: Params })
         actions={
           <>
             <Button variant="outline" size="sm" asChild>
-              <Link href="/dashboard/activities">
+              <PanelDashboardLink href="/dashboard/activities">
                 <ArrowLeft className="size-4" />
                 {t("pageDetail.back_link")}
-              </Link>
+              </PanelDashboardLink>
             </Button>
             <ActivityDetailActions activity={activity} />
           </>

--- a/src/app/(dashboard-v2)/v2/dashboard/camporees/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/camporees/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { Tent } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { getTranslations } from "next-intl/server";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
@@ -44,7 +44,7 @@ export default async function CamporeesPage() {
     <div className="space-y-6">
       <PageHeader title={t("title")} description={t("description")}>
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/camporees/union">{t("viewUnion")}</Link>
+          <PanelDashboardLink href="/dashboard/camporees/union">{t("viewUnion")}</PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/camporees/union/[id]/events/[eventId]/edit/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/camporees/union/[id]/events/[eventId]/edit/page.tsx
@@ -1,0 +1,182 @@
+import type { Metadata } from "next";
+import { panelRedirect } from "@/lib/v2/panel-path-server";
+import { redirect, notFound } from "next/navigation";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  CAMPOREE_EVENTS_UPDATE,
+  CAMPOREES_UPDATE,
+} from "@/lib/auth/permissions";
+import { apiRequest } from "@/lib/api/client";
+import {
+  getUnionCamporeeById,
+  getUnionEnrolledClubs,
+  type CamporeeClub,
+} from "@/lib/api/camporees";
+import {
+  listCamporeeEventTypes,
+  type CamporeeEventType,
+} from "@/lib/api/camporee-events";
+import {
+  listUnionCamporeeVenues,
+  type CamporeeVenue,
+} from "@/lib/api/camporee-venues";
+import { updateCamporeeAgendaEventAction } from "@/lib/camporee-events/actions";
+import { getCamporeeEventRubrics } from "@/lib/api/camporee-scoring";
+import {
+  EventFormPage,
+  type UserOption,
+} from "@/components/camporee-events/event-form-page";
+import type { BackendCamporeeEvent } from "@/lib/api/camporee-events";
+import type { CamporeeEventRubric } from "@/lib/api/camporee-scoring";
+import type { Camporee } from "@/lib/api/camporees";
+
+type Params = Promise<{ id: string; eventId: string }>;
+
+export async function generateMetadata(): Promise<Metadata> {
+  return { title: "Editar evento" };
+}
+
+// ─── Normalizers ───────────────────────────────────────────────────────────────
+
+type AnyRecord = Record<string, unknown>;
+
+function toPositiveNumber(v: unknown): number | null {
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function extractCamporee(payload: unknown): AnyRecord | null {
+  if (!payload || typeof payload !== "object") return null;
+  const root = payload as AnyRecord;
+  if (root.data && typeof root.data === "object") {
+    const nested = root.data as AnyRecord;
+    if (nested.union_camporee_id != null || nested.name != null) return nested;
+  }
+  if (root.union_camporee_id != null || root.name != null) return root;
+  return null;
+}
+
+function normalizeCamporee(raw: AnyRecord): Camporee {
+  return {
+    camporee_id: toPositiveNumber(raw.union_camporee_id ?? raw.camporee_id ?? raw.id) ?? undefined,
+    name: String(raw.name ?? ""),
+    start_date: String(raw.start_date ?? ""),
+    end_date: String(raw.end_date ?? ""),
+    includes_adventurers: raw.includes_adventurers === true,
+    includes_pathfinders: raw.includes_pathfinders !== false,
+    includes_master_guides: raw.includes_master_guides === true,
+    active: raw.active !== false,
+  };
+}
+
+function extractList<T>(payload: unknown): T[] {
+  if (Array.isArray(payload)) return payload as T[];
+  if (payload && typeof payload === "object") {
+    const root = payload as AnyRecord;
+    if (Array.isArray(root.data)) return root.data as T[];
+  }
+  return [];
+}
+
+function extractEvent(payload: unknown): BackendCamporeeEvent | null {
+  if (!payload || typeof payload !== "object") return null;
+  const root = payload as AnyRecord;
+  const candidate =
+    root.data && typeof root.data === "object" ? (root.data as AnyRecord) : root;
+  if (typeof candidate.camporee_event_id === "number") {
+    return candidate as unknown as BackendCamporeeEvent;
+  }
+  return null;
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function UnionCamporeeEventEditPage({ params }: { params: Params }) {
+  const user = await requireAdminUser();
+
+  const canEdit = hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE, CAMPOREES_UPDATE]);
+  if (!canEdit) panelRedirect("/dashboard/camporees/union");
+
+  const { id: idParam, eventId: eventIdParam } = await params;
+  const camporeeId = toPositiveNumber(idParam);
+  const eventId = toPositiveNumber(eventIdParam);
+  if (!camporeeId) notFound();
+  if (!eventId) notFound();
+
+  let venues: CamporeeVenue[] = [];
+  let rubrics: CamporeeEventRubric[] = [];
+  let eventTypes: CamporeeEventType[] = [];
+  let camporeeClubs: CamporeeClub[] = [];
+
+  // Fetch all in parallel — best effort for venues
+  const [camporeeRes, eventRes, venuesRes] = await Promise.allSettled([
+    getUnionCamporeeById(camporeeId),
+    apiRequest<unknown>(`/camporee-events/${eventId}`),
+    listUnionCamporeeVenues(camporeeId),
+  ]);
+
+  if (camporeeRes.status !== "fulfilled") notFound();
+  const raw = extractCamporee(camporeeRes.value);
+  if (!raw) notFound();
+  const camporee = normalizeCamporee(raw);
+
+  if (eventRes.status !== "fulfilled") notFound();
+  const extractedEvent = extractEvent(eventRes.value);
+  if (!extractedEvent) notFound();
+  const event = extractedEvent;
+
+  if (venuesRes.status === "fulfilled") {
+    venues = extractList<CamporeeVenue>(venuesRes.value);
+  }
+
+  try {
+    const typesPayload = await listCamporeeEventTypes();
+    eventTypes = extractList<CamporeeEventType>(typesPayload);
+  } catch {
+    eventTypes = [];
+  }
+
+  try {
+    const clubsPayload = await getUnionEnrolledClubs(camporeeId);
+    camporeeClubs = extractList<CamporeeClub>(clubsPayload);
+  } catch {
+    camporeeClubs = [];
+  }
+
+  try {
+    const rubricsPayload = await getCamporeeEventRubrics(eventId);
+    rubrics = extractList<CamporeeEventRubric>(rubricsPayload);
+  } catch {
+    rubrics = [];
+  }
+
+  const users: UserOption[] = [];
+
+  async function boundAction(
+    prev: import("@/lib/camporee-events/actions").CamporeeEventActionState,
+    formData: FormData,
+  ) {
+    "use server";
+    formData.set("id", String(eventId));
+    formData.set("camporee_id", String(camporeeId));
+    formData.set("is_union", "true");
+    return updateCamporeeAgendaEventAction(prev, formData);
+  }
+
+  return (
+    <EventFormPage
+      mode="edit"
+      camporeeId={camporeeId}
+      camporee={camporee}
+      venues={venues}
+      users={users}
+      eventTypes={eventTypes}
+      camporeeClubs={camporeeClubs}
+      isUnionCamporee
+      event={event}
+      rubrics={rubrics}
+      action={boundAction}
+    />
+  );
+}

--- a/src/app/(dashboard-v2)/v2/dashboard/camporees/union/[id]/events/new/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/camporees/union/[id]/events/new/page.tsx
@@ -1,0 +1,153 @@
+import type { Metadata } from "next";
+import { panelRedirect } from "@/lib/v2/panel-path-server";
+import { redirect, notFound } from "next/navigation";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  CAMPOREE_EVENTS_CREATE,
+  CAMPOREES_CREATE,
+} from "@/lib/auth/permissions";
+import {
+  getUnionCamporeeById,
+  getUnionEnrolledClubs,
+  type CamporeeClub,
+} from "@/lib/api/camporees";
+import {
+  listCamporeeEventTypes,
+  type CamporeeEventType,
+} from "@/lib/api/camporee-events";
+import {
+  listUnionCamporeeVenues,
+  type CamporeeVenue,
+} from "@/lib/api/camporee-venues";
+import { createUnionCamporeeAgendaEventAction } from "@/lib/camporee-events/actions";
+import {
+  EventFormPage,
+  type UserOption,
+} from "@/components/camporee-events/event-form-page";
+import type { Camporee } from "@/lib/api/camporees";
+
+type Params = Promise<{ id: string }>;
+
+export async function generateMetadata(): Promise<Metadata> {
+  return { title: "Nuevo evento" };
+}
+
+// ─── Normalizers ───────────────────────────────────────────────────────────────
+
+type AnyRecord = Record<string, unknown>;
+
+function toPositiveNumber(v: unknown): number | null {
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
+function extractCamporee(payload: unknown): AnyRecord | null {
+  if (!payload || typeof payload !== "object") return null;
+  const root = payload as AnyRecord;
+  if (root.data && typeof root.data === "object") {
+    const nested = root.data as AnyRecord;
+    if (nested.union_camporee_id != null || nested.name != null) return nested;
+  }
+  if (root.union_camporee_id != null || root.name != null) return root;
+  return null;
+}
+
+function normalizeCamporee(raw: AnyRecord): Camporee {
+  return {
+    camporee_id: toPositiveNumber(raw.union_camporee_id ?? raw.camporee_id ?? raw.id) ?? undefined,
+    name: String(raw.name ?? ""),
+    start_date: String(raw.start_date ?? ""),
+    end_date: String(raw.end_date ?? ""),
+    includes_adventurers: raw.includes_adventurers === true,
+    includes_pathfinders: raw.includes_pathfinders !== false,
+    includes_master_guides: raw.includes_master_guides === true,
+    active: raw.active !== false,
+  };
+}
+
+function extractList<T>(payload: unknown): T[] {
+  if (Array.isArray(payload)) return payload as T[];
+  if (payload && typeof payload === "object") {
+    const root = payload as AnyRecord;
+    if (Array.isArray(root.data)) return root.data as T[];
+  }
+  return [];
+}
+
+// ─── Page ──────────────────────────────────────────────────────────────────────
+
+export default async function UnionCamporeeEventNewPage({ params }: { params: Params }) {
+  const user = await requireAdminUser();
+
+  const canCreate = hasAnyPermission(user, [CAMPOREE_EVENTS_CREATE, CAMPOREES_CREATE]);
+  if (!canCreate) panelRedirect("/dashboard/camporees/union");
+
+  const { id: idParam } = await params;
+  const camporeeId = toPositiveNumber(idParam);
+  if (!camporeeId) notFound();
+
+  let camporee: Camporee;
+  let venues: CamporeeVenue[] = [];
+  let eventTypes: CamporeeEventType[] = [];
+  let camporeeClubs: CamporeeClub[] = [];
+
+  try {
+    const payload = await getUnionCamporeeById(camporeeId);
+    const raw = extractCamporee(payload);
+    if (!raw) notFound();
+    camporee = normalizeCamporee(raw);
+  } catch {
+    notFound();
+  }
+
+  try {
+    const venuesPayload = await listUnionCamporeeVenues(camporeeId);
+    venues = extractList<CamporeeVenue>(venuesPayload);
+  } catch {
+    // Degrade gracefully — venues not required to create an event
+  }
+
+  try {
+    const typesPayload = await listCamporeeEventTypes();
+    eventTypes = extractList<CamporeeEventType>(typesPayload);
+  } catch {
+    eventTypes = [];
+  }
+
+  try {
+    const clubsPayload = await getUnionEnrolledClubs(camporeeId);
+    camporeeClubs = extractList<CamporeeClub>(clubsPayload);
+  } catch {
+    camporeeClubs = [];
+  }
+
+  // Users list: not fetching from backend in this version — empty list allowed
+  // (the form shows "Sin responsable" as default). A future PR can wire
+  // a member-list endpoint here.
+  const users: UserOption[] = [];
+
+  async function boundAction(
+    prev: import("@/lib/camporee-events/actions").CamporeeEventActionState,
+    formData: FormData,
+  ) {
+    "use server";
+    formData.set("camporee_id", String(camporeeId));
+    formData.set("is_union", "true");
+    return createUnionCamporeeAgendaEventAction(prev, formData);
+  }
+
+  return (
+    <EventFormPage
+      mode="create"
+      camporeeId={camporeeId}
+      camporee={camporee}
+      venues={venues}
+      users={users}
+      eventTypes={eventTypes}
+      camporeeClubs={camporeeClubs}
+      isUnionCamporee
+      action={boundAction}
+    />
+  );
+}

--- a/src/app/(dashboard-v2)/v2/dashboard/camporees/union/[id]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/camporees/union/[id]/page.tsx
@@ -1,5 +1,6 @@
-import { notFound } from "next/navigation";
 import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+import { toV2Path } from "@/lib/v2/route-map";
+import { notFound } from "next/navigation";
 import { ArrowLeft, CalendarRange, MapPin, DollarSign, Building2 } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Badge } from "@/components/ui/badge";
@@ -7,26 +8,39 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { PageHeader } from "@/components/shared/page-header";
 import { CamporeeInfoCard } from "@/components/camporees/camporee-info-card";
-import { CamporeeDetailActions } from "@/components/camporees/camporee-detail-actions";
 import { CamporeeDetailTabs } from "@/components/camporees/camporee-detail-tabs";
 import { ApiError } from "@/lib/api/client";
 import {
-  getCamporeeById,
-  listCamporeeMembers,
-  getEnrolledClubs,
-  getCamporeePayments,
-  getCamporeePendingApprovals,
+  getUnionCamporeeById,
+  listUnionCamporeeMembers,
+  getUnionEnrolledClubs,
+  getUnionCamporeePayments,
+  getUnionCamporeePendingApprovals,
 } from "@/lib/api/camporees";
 import {
-  listLocalCamporeeEvents,
+  listUnionCamporeeEvents,
   listCamporeeEventTemplates,
   type BackendCamporeeEvent,
   type CamporeeEventTemplate,
 } from "@/lib/api/camporee-events";
 import {
-  listLocalCamporeeVenues,
+  listUnionCamporeeVenues,
   type CamporeeVenue,
 } from "@/lib/api/camporee-venues";
+import {
+  getCamporeeEventRubrics,
+  getUnionCamporeeLeaderboard,
+  listUnionCamporeeJudgeCandidates,
+  listCamporeeEventJudgeAssignments,
+  listCamporeeEventScoringTargets,
+  listUnionCamporeeJudges,
+  type CamporeeEventJudgeAssignment,
+  type CamporeeEventRubric,
+  type CamporeeJudge,
+  type CamporeeJudgeCandidate,
+  type CamporeeLeaderboard,
+  type CamporeeScoringTarget,
+} from "@/lib/api/camporee-scoring";
 import { hasAnyPermission } from "@/lib/auth/permission-utils";
 import {
   CAMPOREE_EVENTS_CREATE,
@@ -69,26 +83,25 @@ function extractCamporee(payload: unknown): AnyRecord | null {
   const root = payload as AnyRecord;
   if (root.data && typeof root.data === "object") {
     const nested = root.data as AnyRecord;
-    if (nested.local_camporee_id != null || nested.camporee_id != null || nested.name != null) return nested;
+    if (nested.union_camporee_id != null || nested.camporee_id != null || nested.name != null) return nested;
     if (nested.data && typeof nested.data === "object") return nested.data as AnyRecord;
   }
-  if (root.local_camporee_id != null || root.camporee_id != null || root.name != null) return root;
+  if (root.union_camporee_id != null || root.camporee_id != null || root.name != null) return root;
   return null;
 }
 
 function normalizeCamporee(raw: AnyRecord): Camporee {
   return {
-    camporee_id: toPositiveNumber(raw.local_camporee_id ?? raw.camporee_id ?? raw.id) ?? undefined,
+    camporee_id: toPositiveNumber(raw.union_camporee_id ?? raw.camporee_id ?? raw.id) ?? undefined,
     id: toPositiveNumber(raw.id) ?? undefined,
     name: String(raw.name ?? ""),
     description: toText(raw.description),
     start_date: String(raw.start_date ?? ""),
     end_date: String(raw.end_date ?? ""),
-    local_field_id: toPositiveNumber(raw.local_field_id) ?? undefined,
     includes_adventurers: raw.includes_adventurers === true,
     includes_pathfinders: raw.includes_pathfinders !== false,
     includes_master_guides: raw.includes_master_guides === true,
-    local_camporee_place: toText(raw.local_camporee_place) ?? undefined,
+    local_camporee_place: toText(raw.union_camporee_place) ?? toText(raw.place) ?? undefined,
     registration_cost: (() => {
       const v = raw.registration_cost;
       if (v == null || v === "") return undefined;
@@ -96,15 +109,7 @@ function normalizeCamporee(raw: AnyRecord): Camporee {
       return Number.isFinite(n) ? n : undefined;
     })(),
     active: raw.active !== false,
-    local_field: (() => {
-      const lf = raw.local_fields as AnyRecord | undefined;
-      if (!lf || typeof lf !== "object") return undefined;
-      return {
-        local_field_id: toPositiveNumber(lf.local_field_id) ?? undefined,
-        name: toText(lf.name) ?? undefined,
-        abbreviation: toText(lf.abbreviation) ?? undefined,
-      };
-    })(),
+    local_field: undefined,
   };
 }
 
@@ -115,6 +120,17 @@ function extractList<T>(payload: unknown): T[] {
     if (Array.isArray(root.data)) return root.data as T[];
   }
   return [];
+}
+
+function extractLeaderboard(payload: unknown): CamporeeLeaderboard | null {
+  if (!payload || typeof payload !== "object") return null;
+  const root = payload as AnyRecord;
+  const candidate =
+    root.data && typeof root.data === "object" ? (root.data as AnyRecord) : root;
+  if (Array.isArray(candidate.rows)) {
+    return candidate as unknown as CamporeeLeaderboard;
+  }
+  return null;
 }
 
 // ─── Format helpers ───────────────────────────────────────────────────────────
@@ -154,7 +170,7 @@ function formatCurrencyMXN(value?: number | null): string {
 
 // ─── Page ──────────────────────────────────────────────────────────────────────
 
-export default async function CamporeeDetailPage({
+export default async function UnionCamporeeDetailPage({
   params,
   searchParams,
 }: {
@@ -179,12 +195,21 @@ export default async function CamporeeDetailPage({
   let events: BackendCamporeeEvent[] = [];
   let availableTemplates: CamporeeEventTemplate[] = [];
   let venues: CamporeeVenue[] = [];
+  let judges: CamporeeJudge[] = [];
+  let judgeCandidates: CamporeeJudgeCandidate[] = [];
+  let judgeCandidatesError: string | null = null;
+  let assignmentsByEvent: Record<number, CamporeeEventJudgeAssignment[]> = {};
+  let scoringTargetsByEvent: Record<number, CamporeeScoringTarget[]> = {};
+  let rubricsByEvent: Record<number, CamporeeEventRubric[]> = {};
+  let leaderboard: CamporeeLeaderboard | null = null;
+  let unionName: string | null = null;
 
   // Fetch camporee detail
   try {
-    const payload = await getCamporeeById(camporeeId);
+    const payload = await getUnionCamporeeById(camporeeId);
     const raw = extractCamporee(payload);
     if (!raw) notFound();
+    unionName = toText(raw.union_name) ?? toText((raw.union as AnyRecord | undefined)?.name);
     camporee = normalizeCamporee(raw);
   } catch (error) {
     if (error instanceof ApiError && (error.status === 404 || error.status === 403)) {
@@ -194,10 +219,13 @@ export default async function CamporeeDetailPage({
   }
 
   const t = await getTranslations("camporees.pages.detail");
+  const canCreateEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_CREATE, CAMPOREES_CREATE]);
+  const canEditEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE, CAMPOREES_UPDATE]);
+  const canDeleteEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_DELETE, CAMPOREES_DELETE]);
 
   // Fetch members — best effort
   try {
-    const membersPayload = await listCamporeeMembers(camporeeId, { page: 1, limit: 50 });
+    const membersPayload = await listUnionCamporeeMembers(camporeeId, { page: 1, limit: 100 });
     members = membersPayload.data;
     membersMeta = membersPayload.meta;
   } catch (err) {
@@ -209,7 +237,7 @@ export default async function CamporeeDetailPage({
 
   // Fetch enrolled clubs — best effort
   try {
-    const clubsPayload = await getEnrolledClubs(camporeeId);
+    const clubsPayload = await getUnionEnrolledClubs(camporeeId);
     clubs = extractList<CamporeeClub>(clubsPayload);
   } catch (err) {
     clubsError =
@@ -220,7 +248,7 @@ export default async function CamporeeDetailPage({
 
   // Fetch payments — best effort
   try {
-    const paymentsPayload = await getCamporeePayments(camporeeId);
+    const paymentsPayload = await getUnionCamporeePayments(camporeeId);
     payments = extractList<CamporeePayment>(paymentsPayload);
   } catch (err) {
     paymentsError =
@@ -231,7 +259,7 @@ export default async function CamporeeDetailPage({
 
   // Fetch pending approvals — best effort (non-blocking)
   try {
-    const pendingPayload = await getCamporeePendingApprovals(camporeeId);
+    const pendingPayload = await getUnionCamporeePendingApprovals(camporeeId);
     if (pendingPayload && typeof pendingPayload === "object") {
       pending = pendingPayload as PendingApprovals;
     }
@@ -265,15 +293,14 @@ export default async function CamporeeDetailPage({
 
   // Fetch camporee events (instances) — best effort
   try {
-    const eventsPayload = await listLocalCamporeeEvents(camporeeId, eventsFilter);
+    const eventsPayload = await listUnionCamporeeEvents(camporeeId, eventsFilter);
     const eventsData = extractList<BackendCamporeeEvent>(eventsPayload);
     events = eventsData.sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0));
   } catch {
     // Events are not blocking — tab shows empty state
   }
 
-  // Fetch templates available for this local camporee — best effort
-  // Local camporees can use local_field templates + their union's templates
+  // Fetch templates available for this union camporee — best effort
   try {
     const templatesPayload = await listCamporeeEventTemplates({ limit: 200, active: true });
     availableTemplates = extractList<CamporeeEventTemplate>(templatesPayload);
@@ -281,18 +308,83 @@ export default async function CamporeeDetailPage({
     // silently degrade
   }
 
-  // Fetch venues accessible to this camporee — best effort
-  // listLocalCamporeeVenues returns both local_field-scoped and union-scoped venues
+  // Fetch venues accessible to this union camporee — best effort
   try {
-    const venuesPayload = await listLocalCamporeeVenues(camporeeId);
+    const venuesPayload = await listUnionCamporeeVenues(camporeeId);
     venues = extractList<CamporeeVenue>(venuesPayload);
   } catch {
     // silently degrade — timeline renders without venue names
   }
 
-  const canCreateEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_CREATE, CAMPOREES_CREATE]);
-  const canEditEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE, CAMPOREES_UPDATE]);
-  const canDeleteEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_DELETE, CAMPOREES_DELETE]);
+  // Fetch scoring roster/assignments — best effort
+  try {
+    const judgesPayload = await listUnionCamporeeJudges(camporeeId);
+    judges = extractList<CamporeeJudge>(judgesPayload);
+  } catch {
+    judges = [];
+  }
+
+  // Fetch eligible users for the judge selector — best effort. The form must
+  // never ask operators to paste UUIDs manually.
+  if (canEditEvents) {
+    try {
+      const candidatesPayload = await listUnionCamporeeJudgeCandidates(camporeeId);
+      judgeCandidates = extractList<CamporeeJudgeCandidate>(candidatesPayload);
+    } catch (error) {
+      judgeCandidatesError =
+        error instanceof ApiError
+          ? error.message
+          : "No se pudieron cargar usuarios elegibles para el selector de jueces.";
+    }
+  }
+
+  if (events.length > 0) {
+    const assignmentResults = await Promise.allSettled(
+      events.map(async (event) => {
+        const payload = await listCamporeeEventJudgeAssignments(event.camporee_event_id);
+        return [event.camporee_event_id, extractList<CamporeeEventJudgeAssignment>(payload)] as const;
+      }),
+    );
+    assignmentsByEvent = Object.fromEntries(
+      assignmentResults
+        .filter((result): result is PromiseFulfilledResult<readonly [number, CamporeeEventJudgeAssignment[]]> => result.status === "fulfilled")
+        .map((result) => result.value),
+    );
+
+    const targetResults = await Promise.allSettled(
+      events.map(async (event) => {
+        const payload = await listCamporeeEventScoringTargets(event.camporee_event_id);
+        return [event.camporee_event_id, extractList<CamporeeScoringTarget>(payload)] as const;
+      }),
+    );
+    scoringTargetsByEvent = Object.fromEntries(
+      targetResults
+        .filter((result): result is PromiseFulfilledResult<readonly [number, CamporeeScoringTarget[]]> => result.status === "fulfilled")
+        .map((result) => result.value),
+    );
+
+    const rubricResults = await Promise.allSettled(
+      events
+        .filter((event) => event.scoring_enabled)
+        .map(async (event) => {
+          const payload = await getCamporeeEventRubrics(event.camporee_event_id);
+          return [event.camporee_event_id, extractList<CamporeeEventRubric>(payload)] as const;
+        }),
+    );
+    rubricsByEvent = Object.fromEntries(
+      rubricResults
+        .filter((result): result is PromiseFulfilledResult<readonly [number, CamporeeEventRubric[]]> => result.status === "fulfilled")
+        .map((result) => result.value),
+    );
+  }
+
+  // Fetch camporee leaderboard — best effort
+  try {
+    const leaderboardPayload = await getUnionCamporeeLeaderboard(camporeeId);
+    leaderboard = extractLeaderboard(leaderboardPayload);
+  } catch {
+    leaderboard = null;
+  }
 
   return (
     <div className="space-y-6">
@@ -300,19 +392,16 @@ export default async function CamporeeDetailPage({
         title={camporee.name}
         description={t("description")}
         breadcrumbs={[
-          { label: t("back"), href: "/dashboard/camporees" },
+          { label: "Camporees de unión", href: toV2Path("/dashboard/camporees/union") },
           { label: camporee.name },
         ]}
         actions={
-          <>
-            <Button variant="outline" size="sm" asChild>
-              <PanelDashboardLink href="/dashboard/camporees">
-                <ArrowLeft className="size-4" />
-                {t("back")}
-              </PanelDashboardLink>
-            </Button>
-            <CamporeeDetailActions camporee={camporee} />
-          </>
+          <Button variant="outline" size="sm" asChild>
+            <PanelDashboardLink href="/dashboard/camporees/union">
+              <ArrowLeft className="size-4" />
+              {t("back")}
+            </PanelDashboardLink>
+          </Button>
         }
       />
 
@@ -323,6 +412,7 @@ export default async function CamporeeDetailPage({
       <CamporeeDetailTabs
         camporeeId={camporeeId}
         camporee={camporee}
+        isUnionCamporee
         initialMembers={members}
         initialMembersMeta={membersMeta}
         initialClubs={clubs}
@@ -334,6 +424,13 @@ export default async function CamporeeDetailPage({
         initialEvents={events}
         availableTemplates={availableTemplates}
         initialVenues={venues}
+        initialJudges={judges}
+        judgeCandidates={judgeCandidates}
+        judgeCandidatesError={judgeCandidatesError}
+        initialAssignmentsByEvent={assignmentsByEvent}
+        initialScoringTargetsByEvent={scoringTargetsByEvent}
+        initialRubricsByEvent={rubricsByEvent}
+        initialLeaderboard={leaderboard}
         canCreateEvents={canCreateEvents}
         canEditEvents={canEditEvents}
         canDeleteEvents={canDeleteEvents}
@@ -392,19 +489,11 @@ export default async function CamporeeDetailPage({
               <Card className="rounded-xl border-border/60 bg-card shadow-xs px-4 py-3">
                 <div className="flex items-center gap-1.5 text-[10.5px] uppercase tracking-wider font-semibold text-muted-foreground">
                   <Building2 className="size-3.5" />
-                  Campo local
+                  Unión
                 </div>
                 <div className="mt-1 text-[15px] font-semibold tracking-tight truncate">
-                  {camporee.local_field?.name ??
-                    camporee.local_field?.abbreviation ??
-                    "—"}
+                  {unionName ?? "—"}
                 </div>
-                {camporee.local_field?.name &&
-                  camporee.local_field?.abbreviation && (
-                    <div className="text-[11.5px] text-muted-foreground mt-0.5">
-                      {camporee.local_field.abbreviation}
-                    </div>
-                  )}
               </Card>
             </div>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/catalogs/geography/local-fields/[id]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/catalogs/geography/local-fields/[id]/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
@@ -88,10 +88,10 @@ export default async function LocalFieldDetailPage({
     <div className="space-y-6">
       <PageHeader title={fieldName}>
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/catalogs/geography/local-fields">
+          <PanelDashboardLink href="/dashboard/catalogs/geography/local-fields">
             <ArrowLeft className="size-4" />
             {t("back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/catalogs/geography/unions/[id]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/catalogs/geography/unions/[id]/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
@@ -88,10 +88,10 @@ export default async function UnionDetailPage({
     <div className="space-y-6">
       <PageHeader title={unionName}>
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/catalogs/geography/unions">
+          <PanelDashboardLink href="/dashboard/catalogs/geography/unions">
             <ArrowLeft className="size-4" />
             {t("back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/catalogs/honor-categories/[categoryId]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/catalogs/honor-categories/[categoryId]/page.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft } from "lucide-react";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
@@ -148,10 +148,10 @@ export default async function HonorCategoryDetailPage({ params }: { params: Para
     <div className="space-y-6">
       <PageHeader title={t("pageTitle")}>
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/catalogs/honor-categories">
+          <PanelDashboardLink href="/dashboard/catalogs/honor-categories">
             <ArrowLeft className="size-4" />
             {t("backButton")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/certifications/[id]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/certifications/[id]/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft, ShieldCheck } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Badge } from "@/components/ui/badge";
@@ -219,10 +219,10 @@ export default async function CertificationDetailPage({ params }: { params: Para
         ]}
         actions={
           <Button variant="outline" size="sm" asChild>
-            <Link href="/dashboard/certifications">
+            <PanelDashboardLink href="/dashboard/certifications">
               <ArrowLeft className="size-4" />
               {t("back")}
-            </Link>
+            </PanelDashboardLink>
           </Button>
         }
       />

--- a/src/app/(dashboard-v2)/v2/dashboard/classes/[classId]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/classes/[classId]/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft, GraduationCap } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Badge } from "@/components/ui/badge";
@@ -232,10 +232,10 @@ export default async function ClassDetailPage({ params }: { params: Params }) {
         ]}
         actions={
           <Button variant="outline" size="sm" asChild>
-            <Link href="/dashboard/classes">
+            <PanelDashboardLink href="/dashboard/classes">
               <ArrowLeft className="size-4" />
               {t("back")}
-            </Link>
+            </PanelDashboardLink>
           </Button>
         }
       />

--- a/src/app/(dashboard-v2)/v2/dashboard/clubs/[id]/units/[unitId]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/clubs/[id]/units/[unitId]/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
@@ -89,10 +89,10 @@ export default async function EditUnitPage({ params }: { params: Params }) {
         description={t("descriptionTemplate", { unitName: unit.name, clubName })}
       >
         <Button variant="outline" size="sm" asChild>
-          <Link href={`/dashboard/clubs/${clubId}`}>
+          <PanelDashboardLink href={`/dashboard/clubs/${clubId}`}>
             <ArrowLeft className="size-4" />
             {t("back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/clubs/[id]/units/new/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/clubs/[id]/units/new/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
@@ -59,10 +59,10 @@ export default async function NewUnitPage({ params }: { params: Params }) {
     <div className="space-y-6">
       <PageHeader title={t("title")} description={t("descriptionTemplate", { clubName })}>
         <Button variant="outline" size="sm" asChild>
-          <Link href={`/dashboard/clubs/${clubId}`}>
+          <PanelDashboardLink href={`/dashboard/clubs/${clubId}`}>
             <ArrowLeft className="size-4" />
             {t("back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/clubs/import/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/clubs/import/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { panelRedirect } from "@/lib/v2/panel-path-server";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { redirect } from "next/navigation";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
@@ -163,10 +163,10 @@ export default async function ImportClubsPage() {
     <div className="space-y-6">
       <PageHeader title={t("title")} description={t("description")}>
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/clubs">
+          <PanelDashboardLink href="/dashboard/clubs">
             <ArrowLeft className="size-4" />
             {t("back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/clubs/new/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/clubs/new/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
 import { PageHeader } from "@/components/shared/page-header";
@@ -157,10 +157,10 @@ export default async function NewClubPage() {
     <div className="space-y-6">
       <PageHeader title={t("title")}>
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/clubs" prefetch={false}>
+          <PanelDashboardLink href="/dashboard/clubs" prefetch={false}>
             <ArrowLeft className="size-4" />
             {t("back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/honors/[honorId]/edit/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/honors/[honorId]/edit/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
@@ -71,10 +71,10 @@ export default async function EditHonorPage({ params }: { params: Params }) {
         description={t("description")}
       >
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/honors">
+          <PanelDashboardLink href="/dashboard/honors">
             <ArrowLeft className="size-4" />
             {t("backButton")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/honors/[honorId]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/honors/[honorId]/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Badge } from "@/components/ui/badge";
@@ -326,10 +326,10 @@ export default async function HonorDetailPage({ params }: { params: Params }) {
         ]}
         actions={
           <Button variant="outline" size="sm" asChild>
-            <Link href="/dashboard/honors">
+            <PanelDashboardLink href="/dashboard/honors">
               <ArrowLeft className="size-4" />
               {t("backButton")}
-            </Link>
+            </PanelDashboardLink>
           </Button>
         }
       />

--- a/src/app/(dashboard-v2)/v2/dashboard/honors/[honorId]/requirements/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/honors/[honorId]/requirements/page.tsx
@@ -2,7 +2,7 @@
 
 import dynamic from "next/dynamic";
 import { useCallback, useEffect, useState } from "react";
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { useParams } from "next/navigation";
 import { AlertCircle, ArrowLeft, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
@@ -132,10 +132,10 @@ export default function HonorRequirementsPage() {
         description={status === "ready" ? honorName : undefined}
       >
         <Button variant="outline" size="sm" asChild>
-          <Link href={backHref}>
+          <PanelDashboardLink href={backHref}>
             <ArrowLeft className="size-4" />
             {t("backButton")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
 
         {status === "ready" && (

--- a/src/app/(dashboard-v2)/v2/dashboard/honors/new/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/honors/new/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
@@ -32,10 +32,10 @@ export default async function NewHonorPage() {
         description={t("description")}
       >
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/honors">
+          <PanelDashboardLink href="/dashboard/honors">
             <ArrowLeft className="size-4" />
             {t("backButton")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/insurance/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/insurance/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ShieldCheck, Clock } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { getTranslations } from "next-intl/server";
 import { PageHeader } from "@/components/shared/page-header";
 import { EmptyState } from "@/components/shared/empty-state";
@@ -183,10 +183,10 @@ export default async function InsurancePage() {
         description={t("page.description")}
       >
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/insurance/expiring" prefetch={false}>
+          <PanelDashboardLink href="/dashboard/insurance/expiring" prefetch={false}>
             <Clock className="mr-1.5 size-4" />
             {t("page.button_view_expiring")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/materials/inbox/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/materials/inbox/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { toV2Path } from "@/lib/v2/route-map";
 import { Inbox } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { PageHeader } from "@/components/shared/page-header";
@@ -60,7 +61,7 @@ function resolvePage(raw: unknown): number {
  */
 function resolveDetailHref(orden: OrdenSummary): string {
   const slug = orden.folio_referencia ?? orden.id;
-  return `/dashboard/materials/request/${slug}`;
+  return toV2Path(`/dashboard/materials/request/${slug}`);
 }
 
 function formatDate(iso: string): string {

--- a/src/app/(dashboard-v2)/v2/dashboard/materials/receipts/[folio]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/materials/receipts/[folio]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound, redirect } from "next/navigation";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { panelRedirect } from "@/lib/v2/panel-path-server";
-import Link from "next/link";
 import {
   Building2,
   Banknote,
@@ -69,10 +69,10 @@ export default async function ComprobantesDetailPage({
     <div className="space-y-6">
       {/* Back link */}
       <Button variant="ghost" size="sm" className="-ml-1" asChild>
-        <Link href="/dashboard/materials/receipts">
+        <PanelDashboardLink href="/dashboard/materials/receipts">
           <ChevronLeft className="mr-1 size-4" />
           {t("backLink")}
-        </Link>
+        </PanelDashboardLink>
       </Button>
 
       {/* Page header */}

--- a/src/app/(dashboard-v2)/v2/dashboard/materials/receipts/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/materials/receipts/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { panelRedirect } from "@/lib/v2/panel-path-server";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { redirect } from "next/navigation";
 import { Receipt, ArrowRight } from "lucide-react";
 import { getTranslations } from "next-intl/server";
@@ -190,13 +190,13 @@ export default async function ComprobantesPage({
                     </TableCell>
                     <TableCell className="px-3 py-2.5 align-middle">
                       <Button variant="ghost" size="sm" asChild>
-                        <Link
+                        <PanelDashboardLink
                           href={`/dashboard/materials/receipts/${orden.folio_referencia ?? orden.id}`}
                           prefetch={false}
                         >
                           Revisar comprobantes
                           <ArrowRight className="ml-1.5 size-3.5" />
-                        </Link>
+                        </PanelDashboardLink>
                       </Button>
                     </TableCell>
                   </TableRow>

--- a/src/app/(dashboard-v2)/v2/dashboard/member-ranking-weights/[id]/edit/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/member-ranking-weights/[id]/edit/page.tsx
@@ -1,4 +1,5 @@
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+import { toV2Path } from "@/lib/v2/route-map";
 import { ArrowLeft, Scale } from "lucide-react";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
@@ -50,16 +51,16 @@ export default async function EditWeightsPage({ params }: EditWeightsPageProps) 
         title={pageTitle}
         description={t("description")}
         breadcrumbs={[
-          { label: "Dashboard", href: "/dashboard" },
-          { label: tList("breadcrumbLabel"), href: BACK_HREF },
+          { label: "Dashboard", href: toV2Path("/dashboard") },
+          { label: tList("breadcrumbLabel"), href: toV2Path(BACK_HREF) },
           { label: isDefault ? t("breadcrumbDefault") : t("breadcrumbOverride") },
         ]}
       >
         <Button variant="outline" size="sm" asChild>
-          <Link href={BACK_HREF}>
+          <PanelDashboardLink href={BACK_HREF}>
             <ArrowLeft className="size-4" />
             {t("back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/member-ranking-weights/_components/weights-form.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/member-ranking-weights/_components/weights-form.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { usePanelPath } from "@/lib/v2/panel-path-context";
+
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -113,6 +115,7 @@ export function WeightsForm({
   ecclesiasticalYears,
   backHref = "/dashboard/member-ranking-weights",
 }: WeightsFormProps) {
+  const { toPanelPath } = usePanelPath();
   const isEdit = mode === "edit";
   const t = useTranslations("memberRankingWeights.formDialog");
   const router = useRouter();
@@ -164,7 +167,7 @@ export function WeightsForm({
         toast.success("Sobreescritura de pesos creada");
       }
 
-      router.push(backHref);
+      router.push(toPanelPath(backHref));
       router.refresh();
     } catch (err: unknown) {
       toast.error(mapWeightsErrorMessage(err));
@@ -342,7 +345,7 @@ export function WeightsForm({
               <Button
                 type="button"
                 variant="outline"
-                onClick={() => router.push(backHref)}
+                onClick={() => router.push(toPanelPath(backHref))}
                 disabled={isSubmitting}
               >
                 Cancelar

--- a/src/app/(dashboard-v2)/v2/dashboard/member-ranking-weights/_components/weights-table.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/member-ranking-weights/_components/weights-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+
 import { Pencil, Trash2, Plus } from "lucide-react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
@@ -76,10 +77,10 @@ export function WeightsTable({
                 asChild
                 title={t("editDefaultTitle")}
               >
-                <Link href={`/dashboard/member-ranking-weights/${defaultRow.id}/edit`}>
+                <PanelDashboardLink href={`/dashboard/member-ranking-weights/${defaultRow.id}/edit`}>
                   <Pencil className="size-3.5" />
                   {t("editButton")}
-                </Link>
+                </PanelDashboardLink>
               </Button>
             </div>
           </CardHeader>
@@ -133,10 +134,10 @@ export function WeightsTable({
             <Badge variant="secondary">{overrides.length}</Badge>
           </div>
           <Button size="sm" asChild>
-            <Link href="/dashboard/member-ranking-weights/new">
+            <PanelDashboardLink href="/dashboard/member-ranking-weights/new">
               <Plus className="size-4" />
               {t("createOverride")}
-            </Link>
+            </PanelDashboardLink>
           </Button>
         </div>
 
@@ -147,10 +148,10 @@ export function WeightsTable({
               {t("emptyDescription")}
             </p>
             <Button size="sm" variant="outline" className="mt-4" asChild>
-              <Link href="/dashboard/member-ranking-weights/new">
+              <PanelDashboardLink href="/dashboard/member-ranking-weights/new">
                 <Plus className="size-4" />
                 {t("createOverride")}
-              </Link>
+              </PanelDashboardLink>
             </Button>
           </div>
         ) : (
@@ -208,10 +209,10 @@ export function WeightsTable({
                           asChild
                           title={t("editOverrideTitle")}
                         >
-                          <Link href={`/dashboard/member-ranking-weights/${row.id}/edit`} prefetch={false}>
+                          <PanelDashboardLink href={`/dashboard/member-ranking-weights/${row.id}/edit`} prefetch={false}>
                             <Pencil className="size-3.5" />
                             <span className="sr-only">{t("editButton")}</span>
-                          </Link>
+                          </PanelDashboardLink>
                         </Button>
                         <Button
                           variant="ghost"

--- a/src/app/(dashboard-v2)/v2/dashboard/member-ranking-weights/new/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/member-ranking-weights/new/page.tsx
@@ -1,4 +1,4 @@
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
@@ -6,6 +6,8 @@ import { PageHeader } from "@/components/shared/page-header";
 import { requireAdminUser } from "@/lib/auth/session";
 import { listClubTypes, listEcclesiasticalYears } from "@/lib/api/catalogs";
 import { WeightsForm } from "../_components/weights-form";
+
+import { toV2Path } from "@/lib/v2/route-map";
 
 const BACK_HREF = "/dashboard/member-ranking-weights";
 
@@ -25,16 +27,16 @@ export default async function NewWeightsPage() {
         title={t("title")}
         description={t("description")}
         breadcrumbs={[
-          { label: "Dashboard", href: "/dashboard" },
-          { label: tList("breadcrumbLabel"), href: BACK_HREF },
+          { label: "Dashboard", href: toV2Path("/dashboard") },
+          { label: tList("breadcrumbLabel"), href: toV2Path(BACK_HREF) },
           { label: t("breadcrumbLabel") },
         ]}
       >
         <Button variant="outline" size="sm" asChild>
-          <Link href={BACK_HREF}>
+          <PanelDashboardLink href={BACK_HREF}>
             <ArrowLeft className="size-4" />
             {t("back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/member-rankings/[enrollmentId]/breakdown/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/member-rankings/[enrollmentId]/breakdown/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -89,10 +89,10 @@ export default async function MemberBreakdownPage({
         ]}
       >
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/member-rankings">
+          <PanelDashboardLink href="/dashboard/member-rankings">
             <ArrowLeft className="size-4" />
             {t("pageMemberBreakdown.back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/member-rankings/_components/member-rankings-filters.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/member-rankings/_components/member-rankings-filters.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import Link from "next/link";
 import { EcclesiasticalYearSelect } from "@/components/shared/selectors/ecclesiastical-year-select";
 import { ClubSelect } from "@/components/shared/selectors/club-select";
 import { ClubSectionSelect } from "@/components/shared/selectors/club-section-select";
@@ -113,7 +114,7 @@ export function MemberRankingsFilters({
           {t("apply")}
         </Button>
         <Button variant="ghost" size="sm" asChild>
-          <Link href="/dashboard/member-rankings">{t("clear")}</Link>
+          <PanelDashboardLink href="/dashboard/member-rankings">{t("clear")}</PanelDashboardLink>
         </Button>
       </div>
     </form>

--- a/src/app/(dashboard-v2)/v2/dashboard/member-rankings/_components/member-rankings-table.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/member-rankings/_components/member-rankings-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+
 import { Trophy } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
@@ -176,11 +177,11 @@ export function MemberRankingsTable({
                 {/* Action */}
                 <TableCell className="px-3 py-2.5 align-middle text-right">
                   <Button variant="ghost" size="sm" asChild>
-                    <Link prefetch={false}
+                    <PanelDashboardLink prefetch={false}
                       href={`/dashboard/member-rankings/${item.enrollment_id}/breakdown?year_id=${selectedYearId}`}
                     >
                       {t("viewDetail")}
-                    </Link>
+                    </PanelDashboardLink>
                   </Button>
                 </TableCell>
               </TableRow>

--- a/src/app/(dashboard-v2)/v2/dashboard/rbac/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/rbac/page.tsx
@@ -1,3 +1,4 @@
+import { toV2Path } from "@/lib/v2/route-map";
 import Link from "next/link";
 import { Shield, Key, Users, Grid3X3, ShieldCheck } from "lucide-react";
 import { getTranslations } from "next-intl/server";
@@ -13,25 +14,25 @@ export default async function RbacPage() {
     {
       title: t("sectionPermissions"),
       description: t("sectionPermissionsDesc"),
-      href: "/dashboard/rbac/permissions",
+      href: toV2Path("/dashboard/rbac/permissions"),
       icon: Key,
     },
     {
       title: t("sectionRoles"),
       description: t("sectionRolesDesc"),
-      href: "/dashboard/rbac/roles",
+      href: toV2Path("/dashboard/rbac/roles"),
       icon: Users,
     },
     {
       title: t("sectionUserPermissions"),
       description: t("sectionUserPermissionsDesc"),
-      href: "/dashboard/rbac/user-permissions",
+      href: toV2Path("/dashboard/rbac/user-permissions"),
       icon: ShieldCheck,
     },
     {
       title: t("sectionMatrix"),
       description: t("sectionMatrixDesc"),
-      href: "/dashboard/rbac/matrix",
+      href: toV2Path("/dashboard/rbac/matrix"),
       icon: Grid3X3,
     },
   ];

--- a/src/app/(dashboard-v2)/v2/dashboard/rbac/roles/[roleId]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/rbac/roles/[roleId]/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { panelRedirect } from "@/lib/v2/panel-path-server";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft, ShieldCheck } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { buildRoleTranslator } from "@/lib/auth/role-labels";
@@ -60,9 +60,9 @@ export default async function EditRolePage({ params }: EditRolePageProps) {
     <div className="mx-auto max-w-3xl space-y-6">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/dashboard/rbac/roles" aria-label={t("backAriaLabel")}>
+          <PanelDashboardLink href="/dashboard/rbac/roles" aria-label={t("backAriaLabel")}>
             <ArrowLeft className="size-4" />
-          </Link>
+          </PanelDashboardLink>
         </Button>
         <PageHeader
           title={role ? t("editTitle", { name: translateRole(role.role_name) }) : t("editTitleFallback")}

--- a/src/app/(dashboard-v2)/v2/dashboard/rbac/roles/new/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/rbac/roles/new/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { panelRedirect } from "@/lib/v2/panel-path-server";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
@@ -36,9 +36,9 @@ export default async function NewRolePage() {
     <div className="mx-auto max-w-3xl space-y-6">
       <div className="flex items-center gap-4">
         <Button variant="ghost" size="icon" asChild>
-          <Link href="/dashboard/rbac/roles" aria-label={t("backAriaLabel")}>
+          <PanelDashboardLink href="/dashboard/rbac/roles" aria-label={t("backAriaLabel")}>
             <ArrowLeft className="size-4" />
-          </Link>
+          </PanelDashboardLink>
         </Button>
         <PageHeader
           title={t("title")}

--- a/src/app/(dashboard-v2)/v2/dashboard/rbac/roles/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/rbac/roles/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ShieldCheck, Plus } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { getTranslations } from "next-intl/server";
 import dynamic from "next/dynamic";
 import { Button } from "@/components/ui/button";
@@ -52,10 +52,10 @@ export default async function RolesPage() {
         actions={
           isSuperAdmin ? (
             <Button asChild>
-              <Link href="/dashboard/rbac/roles/new">
+              <PanelDashboardLink href="/dashboard/rbac/roles/new">
                 <Plus className="size-4" />
                 {t("newRole")}
-              </Link>
+              </PanelDashboardLink>
             </Button>
           ) : undefined
         }
@@ -80,10 +80,10 @@ export default async function RolesPage() {
         >
           {isSuperAdmin && (
             <Button asChild>
-              <Link href="/dashboard/rbac/roles/new">
+              <PanelDashboardLink href="/dashboard/rbac/roles/new">
                 <Plus className="size-4" />
                 {t("newRole")}
-              </Link>
+              </PanelDashboardLink>
             </Button>
           )}
         </EmptyState>

--- a/src/app/(dashboard-v2)/v2/dashboard/reports/[reportId]/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/reports/[reportId]/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { notFound } from "next/navigation";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { ArrowLeft } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
@@ -61,10 +61,10 @@ export default async function ReportDetailPage({ params }: { params: Params }) {
     <div className="space-y-6">
       <PageHeader title={pageTitle} description={t("pageDetail.description")}>
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/reports">
+          <PanelDashboardLink href="/dashboard/reports">
             <ArrowLeft className="size-4" />
             {t("pageDetail.back_link")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/reports/supervision/_components/reports-supervision-client.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/reports/supervision/_components/reports-supervision-client.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
 import {
   ChevronLeft,
   ChevronRight,
@@ -350,9 +351,9 @@ export function ReportsSupervisionClient({
                   <TableCell>
                     <div className="flex items-center justify-end gap-2">
                       <Button asChild variant="outline" size="sm">
-                        <Link prefetch={false} href={`/dashboard/reports/${item.monthly_report_id}`}>
+                        <PanelDashboardLink prefetch={false} href={`/dashboard/reports/${item.monthly_report_id}`}>
                           {t("actionView")}
-                        </Link>
+                        </PanelDashboardLink>
                       </Button>
                       {item.status !== "draft" && (
                         <Button

--- a/src/app/(dashboard-v2)/v2/dashboard/section-rankings/[sectionId]/members/_components/section-members-table.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/section-rankings/[sectionId]/members/_components/section-members-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+
 import { Users } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
@@ -164,11 +165,11 @@ export function SectionMembersTable({
               {/* Action — links to existing member breakdown page */}
               <TableCell className="px-3 py-2.5 align-middle text-right">
                 <Button variant="ghost" size="sm" asChild>
-                  <Link prefetch={false}
+                  <PanelDashboardLink prefetch={false}
                     href={`/dashboard/member-rankings/${item.enrollment_id}/breakdown?year_id=${yearId}`}
                   >
                     {t("viewDetail")}
-                  </Link>
+                  </PanelDashboardLink>
                 </Button>
               </TableCell>
             </TableRow>

--- a/src/app/(dashboard-v2)/v2/dashboard/section-rankings/[sectionId]/members/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/section-rankings/[sectionId]/members/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ArrowLeft } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { notFound } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { PageHeader } from "@/components/shared/page-header";
@@ -84,10 +84,10 @@ export default async function SectionMembersPage({
         ]}
       >
         <Button variant="outline" size="sm" asChild>
-          <Link href="/dashboard/section-rankings">
+          <PanelDashboardLink href="/dashboard/section-rankings">
             <ArrowLeft className="size-4" />
             {t("pageSectionMembers.back")}
-          </Link>
+          </PanelDashboardLink>
         </Button>
       </PageHeader>
 

--- a/src/app/(dashboard-v2)/v2/dashboard/section-rankings/_components/section-rankings-filters.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/section-rankings/_components/section-rankings-filters.tsx
@@ -1,10 +1,11 @@
 "use client";
 
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
-import Link from "next/link";
 import { EcclesiasticalYearSelect } from "@/components/shared/selectors/ecclesiastical-year-select";
 import { ClubSelect } from "@/components/shared/selectors/club-select";
 
@@ -81,7 +82,7 @@ export function SectionRankingsFilters({
           {t("apply")}
         </Button>
         <Button variant="ghost" size="sm" asChild>
-          <Link href="/dashboard/section-rankings">{t("clear")}</Link>
+          <PanelDashboardLink href="/dashboard/section-rankings">{t("clear")}</PanelDashboardLink>
         </Button>
       </div>
     </form>

--- a/src/app/(dashboard-v2)/v2/dashboard/section-rankings/_components/section-rankings-table.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/section-rankings/_components/section-rankings-table.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import Link from "next/link";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
+
 import { BarChart3 } from "lucide-react";
 import { useTranslations } from "next-intl";
 import {
@@ -150,11 +151,11 @@ export function SectionRankingsTable({
                   {/* Action */}
                   <TableCell className="px-3 py-2.5 align-middle text-right">
                     <Button variant="ghost" size="sm" asChild>
-                      <Link prefetch={false}
+                      <PanelDashboardLink prefetch={false}
                         href={`/dashboard/section-rankings/${item.club_section_id}/members?year_id=${yearId}`}
                       >
                         {t("viewMembers")}
-                      </Link>
+                      </PanelDashboardLink>
                     </Button>
                   </TableCell>
                 </TableRow>

--- a/src/app/(dashboard-v2)/v2/dashboard/system/jobs/history/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/system/jobs/history/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { ChevronLeft } from "lucide-react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { getTranslations } from "next-intl/server";
 import { requireAdminUser } from "@/lib/auth/session";
 import { getCronRunsHistory } from "@/lib/api/analytics";
@@ -69,10 +69,10 @@ export default async function CronHistoryPage({ searchParams }: PageProps) {
         description={t("pageHistory.description")}
         actions={
           <Button variant="ghost" size="sm" asChild>
-            <Link href="/dashboard/system/jobs">
+            <PanelDashboardLink href="/dashboard/system/jobs">
               <ChevronLeft className="size-4 mr-1" />
               {t("pageHistory.back")}
-            </Link>
+            </PanelDashboardLink>
           </Button>
         }
       />

--- a/src/app/(dashboard-v2)/v2/dashboard/system/jobs/page.tsx
+++ b/src/app/(dashboard-v2)/v2/dashboard/system/jobs/page.tsx
@@ -1,5 +1,5 @@
-import Link from "next/link";
 import { Suspense } from "react";
+import { PanelDashboardLink } from "@/components/shared/panel-dashboard-link";
 import { History } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { requireAdminUser } from "@/lib/auth/session";
@@ -122,10 +122,10 @@ async function JobsContent({ messages }: { messages: JobsMessages }) {
             </p>
           </div>
           <Button variant="outline" size="sm" asChild>
-            <Link href="/dashboard/system/jobs/history">
+            <PanelDashboardLink href="/dashboard/system/jobs/history">
               <History className="size-4 mr-2" />
               {messages.viewHistory}
-            </Link>
+            </PanelDashboardLink>
           </Button>
         </div>
         {cronSection}

--- a/src/components/camporees/union-camporees-view.tsx
+++ b/src/components/camporees/union-camporees-view.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { usePanelPath } from "@/lib/v2/panel-path-context";
+
 import { useState, useCallback } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
@@ -76,6 +78,7 @@ interface UnionCampoReesViewProps {
 // ─── Component ────────────────────────────────────────────────────────────────
 
 export function UnionCampoReesView({ initialCamporees, unions }: UnionCampoReesViewProps) {
+  const { toPanelPath } = usePanelPath();
   const t = useTranslations("camporees");
   const [camporees, setCamporees] = useState<UnionCamporee[]>(initialCamporees);
   const [isLoading, setIsLoading] = useState(false);
@@ -220,7 +223,7 @@ export function UnionCampoReesView({ initialCamporees, unions }: UnionCampoReesV
                           asChild
                           title="Ver detalle"
                         >
-                          <Link href={`/dashboard/camporees/union/${id}`}>
+                          <Link href={toPanelPath(`/dashboard/camporees/union/${id}`)}>
                             <Eye className="size-3.5" />
                             <span className="sr-only">Ver detalle</span>
                           </Link>


### PR DESCRIPTION
## Summary

- Add missing union camporee v2 routes (`/camporees/union/[id]`, events new/edit) with `panelRedirect` / `PanelDashboardLink` / `toV2Path`.
- Batch-fix ~35 scaffolded v2 pages that still linked to `/dashboard/*` and dropped users out of Studio shell.
- Add `scripts/patch-v2-dashboard-links.mjs` + `pnpm patch:v2-links` / `pnpm test:smoke:v1-v2`.

## Test plan

- [x] `pnpm exec tsc --noEmit`
- [ ] `pnpm test:smoke:v1-v2`
- [ ] Manual v2: camporees list → union list → union detail → event create/edit
- [ ] Manual v2: rankings, rbac, achievements, materials inbox — links stay under `/v2/dashboard`


Made with [Cursor](https://cursor.com)