### PR TITLE
feat(camporees): recover operational staff and scoring UI

### DIFF
--- a/src/app/(dashboard)/dashboard/camporees/[id]/events/[eventId]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/camporees/[id]/events/[eventId]/edit/page.tsx
@@ -9,9 +9,15 @@ import {
 import { apiRequest } from "@/lib/api/client";
 import { getCamporeeById, getEnrolledClubs, type CamporeeClub } from "@/lib/api/camporees";
 import {
+  listCamporeeEventStaffAssignments,
   listCamporeeEventTypes,
+  type CamporeeEventStaffAssignment,
   type CamporeeEventType,
 } from "@/lib/api/camporee-events";
+import {
+  listCamporeeStaff,
+  type CamporeeStaffMember,
+} from "@/lib/api/camporee-staff";
 import {
   listLocalCamporeeVenues,
   type CamporeeVenue,
@@ -58,6 +64,14 @@ function normalizeCamporee(raw: AnyRecord): Camporee {
     name: String(raw.name ?? ""),
     start_date: String(raw.start_date ?? ""),
     end_date: String(raw.end_date ?? ""),
+    club_registration_closed_at:
+      typeof raw.club_registration_closed_at === "string"
+        ? raw.club_registration_closed_at
+        : null,
+    club_registration_closed_by:
+      typeof raw.club_registration_closed_by === "string"
+        ? raw.club_registration_closed_by
+        : null,
     local_field_id: toPositiveNumber(raw.local_field_id) ?? undefined,
     includes_adventurers: raw.includes_adventurers === true,
     includes_pathfinders: raw.includes_pathfinders !== false,
@@ -104,6 +118,7 @@ export default async function LocalCamporeeEventEditPage({ params }: { params: P
   let rubrics: CamporeeEventRubric[] = [];
   let eventTypes: CamporeeEventType[] = [];
   let camporeeClubs: CamporeeClub[] = [];
+  let staffRoster: CamporeeStaffMember[] = [];
 
   // Fetch all in parallel — best effort for venues
   const [camporeeRes, eventRes, venuesRes] = await Promise.allSettled([
@@ -141,6 +156,22 @@ export default async function LocalCamporeeEventEditPage({ params }: { params: P
   }
 
   try {
+    const staffPayload = await listCamporeeStaff("local", camporeeId);
+    staffRoster = extractList<CamporeeStaffMember>(staffPayload);
+  } catch {
+    staffRoster = [];
+  }
+
+  try {
+    const staffAssignmentsPayload = await listCamporeeEventStaffAssignments(eventId);
+    event.staff_assignments = extractList<CamporeeEventStaffAssignment>(
+      staffAssignmentsPayload,
+    );
+  } catch {
+    event.staff_assignments = event.staff_assignments ?? [];
+  }
+
+  try {
     const rubricsPayload = await getCamporeeEventRubrics(eventId);
     rubrics = extractList<CamporeeEventRubric>(rubricsPayload);
   } catch {
@@ -168,6 +199,8 @@ export default async function LocalCamporeeEventEditPage({ params }: { params: P
       users={users}
       eventTypes={eventTypes}
       camporeeClubs={camporeeClubs}
+      staffRoster={staffRoster}
+      scoringSetupEnabled={Boolean(camporee.club_registration_closed_at)}
       event={event}
       rubrics={rubrics}
       action={boundAction}

--- a/src/app/(dashboard)/dashboard/camporees/[id]/events/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/camporees/[id]/events/new/page.tsx
@@ -12,6 +12,10 @@ import {
   type CamporeeEventType,
 } from "@/lib/api/camporee-events";
 import {
+  listCamporeeStaff,
+  type CamporeeStaffMember,
+} from "@/lib/api/camporee-staff";
+import {
   listLocalCamporeeVenues,
   type CamporeeVenue,
 } from "@/lib/api/camporee-venues";
@@ -54,6 +58,14 @@ function normalizeCamporee(raw: AnyRecord): Camporee {
     name: String(raw.name ?? ""),
     start_date: String(raw.start_date ?? ""),
     end_date: String(raw.end_date ?? ""),
+    club_registration_closed_at:
+      typeof raw.club_registration_closed_at === "string"
+        ? raw.club_registration_closed_at
+        : null,
+    club_registration_closed_by:
+      typeof raw.club_registration_closed_by === "string"
+        ? raw.club_registration_closed_by
+        : null,
     local_field_id: toPositiveNumber(raw.local_field_id) ?? undefined,
     includes_adventurers: raw.includes_adventurers === true,
     includes_pathfinders: raw.includes_pathfinders !== false,
@@ -87,6 +99,7 @@ export default async function LocalCamporeeEventNewPage({ params }: { params: Pa
   let venues: CamporeeVenue[] = [];
   let eventTypes: CamporeeEventType[] = [];
   let camporeeClubs: CamporeeClub[] = [];
+  let staffRoster: CamporeeStaffMember[] = [];
 
   try {
     const payload = await getCamporeeById(camporeeId);
@@ -118,6 +131,13 @@ export default async function LocalCamporeeEventNewPage({ params }: { params: Pa
     camporeeClubs = [];
   }
 
+  try {
+    const staffPayload = await listCamporeeStaff("local", camporeeId);
+    staffRoster = extractList<CamporeeStaffMember>(staffPayload);
+  } catch {
+    staffRoster = [];
+  }
+
   // Users list: not fetching from backend in this version — empty list allowed
   // (the form shows "Sin responsable" as default). A future PR can wire
   // a member-list endpoint here.
@@ -141,6 +161,8 @@ export default async function LocalCamporeeEventNewPage({ params }: { params: Pa
       users={users}
       eventTypes={eventTypes}
       camporeeClubs={camporeeClubs}
+      staffRoster={staffRoster}
+      scoringSetupEnabled={Boolean(camporee.club_registration_closed_at)}
       action={boundAction}
     />
   );

--- a/src/app/(dashboard)/dashboard/camporees/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/camporees/[id]/page.tsx
@@ -41,6 +41,12 @@ import {
   type CamporeeLeaderboard,
   type CamporeeScoringTarget,
 } from "@/lib/api/camporee-scoring";
+import {
+  listCamporeeStaff,
+  listCamporeeStaffCandidates,
+  type CamporeeStaffCandidate,
+  type CamporeeStaffMember,
+} from "@/lib/api/camporee-staff";
 import { hasAnyPermission } from "@/lib/auth/permission-utils";
 import {
   CAMPOREE_EVENTS_CREATE,
@@ -98,6 +104,14 @@ function normalizeCamporee(raw: AnyRecord): Camporee {
     description: toText(raw.description),
     start_date: String(raw.start_date ?? ""),
     end_date: String(raw.end_date ?? ""),
+    club_registration_closed_at:
+      typeof raw.club_registration_closed_at === "string"
+        ? raw.club_registration_closed_at
+        : null,
+    club_registration_closed_by:
+      typeof raw.club_registration_closed_by === "string"
+        ? raw.club_registration_closed_by
+        : null,
     local_field_id: toPositiveNumber(raw.local_field_id) ?? undefined,
     includes_adventurers: raw.includes_adventurers === true,
     includes_pathfinders: raw.includes_pathfinders !== false,
@@ -211,6 +225,9 @@ export default async function CamporeeDetailPage({
   let scoringTargetsByEvent: Record<number, CamporeeScoringTarget[]> = {};
   let rubricsByEvent: Record<number, CamporeeEventRubric[]> = {};
   let leaderboard: CamporeeLeaderboard | null = null;
+  let staffRoster: CamporeeStaffMember[] = [];
+  let staffCandidates: CamporeeStaffCandidate[] = [];
+  let staffError: string | null = null;
 
   // Fetch camporee detail
   try {
@@ -229,6 +246,7 @@ export default async function CamporeeDetailPage({
   const canCreateEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_CREATE, CAMPOREES_CREATE]);
   const canEditEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE, CAMPOREES_UPDATE]);
   const canDeleteEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_DELETE, CAMPOREES_DELETE]);
+  const canManageClubRegistration = hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE]);
 
   // Fetch members — best effort
   try {
@@ -272,6 +290,26 @@ export default async function CamporeeDetailPage({
     }
   } catch {
     // Silently ignore — pending count is informational only
+  }
+
+  // Fetch operational staff roster — best effort
+  try {
+    const staffPayload = await listCamporeeStaff("local", camporeeId);
+    staffRoster = extractList<CamporeeStaffMember>(staffPayload);
+  } catch (err) {
+    staffError =
+      err instanceof ApiError
+        ? err.message
+        : "No se pudo cargar el personal del camporee.";
+  }
+
+  if (canEditEvents) {
+    try {
+      const candidatesPayload = await listCamporeeStaffCandidates("local", camporeeId);
+      staffCandidates = extractList<CamporeeStaffCandidate>(candidatesPayload);
+    } catch {
+      staffCandidates = [];
+    }
   }
 
   // Resolve URL filter params for the events tab
@@ -432,6 +470,9 @@ export default async function CamporeeDetailPage({
         membersError={membersError}
         clubsError={clubsError}
         paymentsError={paymentsError}
+        initialStaff={staffRoster}
+        staffCandidates={staffCandidates}
+        staffError={staffError}
         initialEvents={events}
         availableTemplates={availableTemplates}
         initialVenues={venues}
@@ -445,6 +486,7 @@ export default async function CamporeeDetailPage({
         canCreateEvents={canCreateEvents}
         canEditEvents={canEditEvents}
         canDeleteEvents={canDeleteEvents}
+        canManageClubRegistration={canManageClubRegistration}
         infoContent={
           <div className="space-y-4">
             {/* KPI strip */}

--- a/src/app/(dashboard)/dashboard/camporees/union/[id]/events/[eventId]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/camporees/union/[id]/events/[eventId]/edit/page.tsx
@@ -13,9 +13,15 @@ import {
   type CamporeeClub,
 } from "@/lib/api/camporees";
 import {
+  listCamporeeEventStaffAssignments,
   listCamporeeEventTypes,
+  type CamporeeEventStaffAssignment,
   type CamporeeEventType,
 } from "@/lib/api/camporee-events";
+import {
+  listCamporeeStaff,
+  type CamporeeStaffMember,
+} from "@/lib/api/camporee-staff";
 import {
   listUnionCamporeeVenues,
   type CamporeeVenue,
@@ -62,6 +68,14 @@ function normalizeCamporee(raw: AnyRecord): Camporee {
     name: String(raw.name ?? ""),
     start_date: String(raw.start_date ?? ""),
     end_date: String(raw.end_date ?? ""),
+    club_registration_closed_at:
+      typeof raw.club_registration_closed_at === "string"
+        ? raw.club_registration_closed_at
+        : null,
+    club_registration_closed_by:
+      typeof raw.club_registration_closed_by === "string"
+        ? raw.club_registration_closed_by
+        : null,
     includes_adventurers: raw.includes_adventurers === true,
     includes_pathfinders: raw.includes_pathfinders !== false,
     includes_master_guides: raw.includes_master_guides === true,
@@ -107,6 +121,7 @@ export default async function UnionCamporeeEventEditPage({ params }: { params: P
   let rubrics: CamporeeEventRubric[] = [];
   let eventTypes: CamporeeEventType[] = [];
   let camporeeClubs: CamporeeClub[] = [];
+  let staffRoster: CamporeeStaffMember[] = [];
 
   // Fetch all in parallel — best effort for venues
   const [camporeeRes, eventRes, venuesRes] = await Promise.allSettled([
@@ -144,6 +159,22 @@ export default async function UnionCamporeeEventEditPage({ params }: { params: P
   }
 
   try {
+    const staffPayload = await listCamporeeStaff("union", camporeeId);
+    staffRoster = extractList<CamporeeStaffMember>(staffPayload);
+  } catch {
+    staffRoster = [];
+  }
+
+  try {
+    const staffAssignmentsPayload = await listCamporeeEventStaffAssignments(eventId);
+    event.staff_assignments = extractList<CamporeeEventStaffAssignment>(
+      staffAssignmentsPayload,
+    );
+  } catch {
+    event.staff_assignments = event.staff_assignments ?? [];
+  }
+
+  try {
     const rubricsPayload = await getCamporeeEventRubrics(eventId);
     rubrics = extractList<CamporeeEventRubric>(rubricsPayload);
   } catch {
@@ -172,6 +203,8 @@ export default async function UnionCamporeeEventEditPage({ params }: { params: P
       users={users}
       eventTypes={eventTypes}
       camporeeClubs={camporeeClubs}
+      staffRoster={staffRoster}
+      scoringSetupEnabled={Boolean(camporee.club_registration_closed_at)}
       isUnionCamporee
       event={event}
       rubrics={rubrics}

--- a/src/app/(dashboard)/dashboard/camporees/union/[id]/events/new/page.tsx
+++ b/src/app/(dashboard)/dashboard/camporees/union/[id]/events/new/page.tsx
@@ -16,6 +16,10 @@ import {
   type CamporeeEventType,
 } from "@/lib/api/camporee-events";
 import {
+  listCamporeeStaff,
+  type CamporeeStaffMember,
+} from "@/lib/api/camporee-staff";
+import {
   listUnionCamporeeVenues,
   type CamporeeVenue,
 } from "@/lib/api/camporee-venues";
@@ -58,6 +62,14 @@ function normalizeCamporee(raw: AnyRecord): Camporee {
     name: String(raw.name ?? ""),
     start_date: String(raw.start_date ?? ""),
     end_date: String(raw.end_date ?? ""),
+    club_registration_closed_at:
+      typeof raw.club_registration_closed_at === "string"
+        ? raw.club_registration_closed_at
+        : null,
+    club_registration_closed_by:
+      typeof raw.club_registration_closed_by === "string"
+        ? raw.club_registration_closed_by
+        : null,
     includes_adventurers: raw.includes_adventurers === true,
     includes_pathfinders: raw.includes_pathfinders !== false,
     includes_master_guides: raw.includes_master_guides === true,
@@ -90,6 +102,7 @@ export default async function UnionCamporeeEventNewPage({ params }: { params: Pa
   let venues: CamporeeVenue[] = [];
   let eventTypes: CamporeeEventType[] = [];
   let camporeeClubs: CamporeeClub[] = [];
+  let staffRoster: CamporeeStaffMember[] = [];
 
   try {
     const payload = await getUnionCamporeeById(camporeeId);
@@ -121,6 +134,13 @@ export default async function UnionCamporeeEventNewPage({ params }: { params: Pa
     camporeeClubs = [];
   }
 
+  try {
+    const staffPayload = await listCamporeeStaff("union", camporeeId);
+    staffRoster = extractList<CamporeeStaffMember>(staffPayload);
+  } catch {
+    staffRoster = [];
+  }
+
   // Users list: not fetching from backend in this version — empty list allowed
   // (the form shows "Sin responsable" as default). A future PR can wire
   // a member-list endpoint here.
@@ -145,6 +165,8 @@ export default async function UnionCamporeeEventNewPage({ params }: { params: Pa
       users={users}
       eventTypes={eventTypes}
       camporeeClubs={camporeeClubs}
+      staffRoster={staffRoster}
+      scoringSetupEnabled={Boolean(camporee.club_registration_closed_at)}
       isUnionCamporee
       action={boundAction}
     />

--- a/src/app/(dashboard)/dashboard/camporees/union/[id]/page.tsx
+++ b/src/app/(dashboard)/dashboard/camporees/union/[id]/page.tsx
@@ -40,6 +40,12 @@ import {
   type CamporeeLeaderboard,
   type CamporeeScoringTarget,
 } from "@/lib/api/camporee-scoring";
+import {
+  listCamporeeStaff,
+  listCamporeeStaffCandidates,
+  type CamporeeStaffCandidate,
+  type CamporeeStaffMember,
+} from "@/lib/api/camporee-staff";
 import { hasAnyPermission } from "@/lib/auth/permission-utils";
 import {
   CAMPOREE_EVENTS_CREATE,
@@ -97,6 +103,14 @@ function normalizeCamporee(raw: AnyRecord): Camporee {
     description: toText(raw.description),
     start_date: String(raw.start_date ?? ""),
     end_date: String(raw.end_date ?? ""),
+    club_registration_closed_at:
+      typeof raw.club_registration_closed_at === "string"
+        ? raw.club_registration_closed_at
+        : null,
+    club_registration_closed_by:
+      typeof raw.club_registration_closed_by === "string"
+        ? raw.club_registration_closed_by
+        : null,
     includes_adventurers: raw.includes_adventurers === true,
     includes_pathfinders: raw.includes_pathfinders !== false,
     includes_master_guides: raw.includes_master_guides === true,
@@ -202,6 +216,9 @@ export default async function UnionCamporeeDetailPage({
   let rubricsByEvent: Record<number, CamporeeEventRubric[]> = {};
   let leaderboard: CamporeeLeaderboard | null = null;
   let unionName: string | null = null;
+  let staffRoster: CamporeeStaffMember[] = [];
+  let staffCandidates: CamporeeStaffCandidate[] = [];
+  let staffError: string | null = null;
 
   // Fetch camporee detail
   try {
@@ -221,6 +238,7 @@ export default async function UnionCamporeeDetailPage({
   const canCreateEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_CREATE, CAMPOREES_CREATE]);
   const canEditEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE, CAMPOREES_UPDATE]);
   const canDeleteEvents = hasAnyPermission(user, [CAMPOREE_EVENTS_DELETE, CAMPOREES_DELETE]);
+  const canManageClubRegistration = hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE]);
 
   // Fetch members — best effort
   try {
@@ -264,6 +282,26 @@ export default async function UnionCamporeeDetailPage({
     }
   } catch {
     // Silently ignore — pending count is informational only
+  }
+
+  // Fetch operational staff roster — best effort
+  try {
+    const staffPayload = await listCamporeeStaff("union", camporeeId);
+    staffRoster = extractList<CamporeeStaffMember>(staffPayload);
+  } catch (err) {
+    staffError =
+      err instanceof ApiError
+        ? err.message
+        : "No se pudo cargar el personal del camporee.";
+  }
+
+  if (canEditEvents) {
+    try {
+      const candidatesPayload = await listCamporeeStaffCandidates("union", camporeeId);
+      staffCandidates = extractList<CamporeeStaffCandidate>(candidatesPayload);
+    } catch {
+      staffCandidates = [];
+    }
   }
 
   // Resolve URL filter params for the events tab
@@ -420,6 +458,9 @@ export default async function UnionCamporeeDetailPage({
         membersError={membersError}
         clubsError={clubsError}
         paymentsError={paymentsError}
+        initialStaff={staffRoster}
+        staffCandidates={staffCandidates}
+        staffError={staffError}
         initialEvents={events}
         availableTemplates={availableTemplates}
         initialVenues={venues}
@@ -433,6 +474,7 @@ export default async function UnionCamporeeDetailPage({
         canCreateEvents={canCreateEvents}
         canEditEvents={canEditEvents}
         canDeleteEvents={canDeleteEvents}
+        canManageClubRegistration={canManageClubRegistration}
         infoContent={
           <div className="space-y-4">
             {/* KPI strip */}

--- a/src/components/camporee-events/camporee-events-tab.tsx
+++ b/src/components/camporee-events/camporee-events-tab.tsx
@@ -68,6 +68,7 @@ export function CamporeeEventsTab({
     includes_pathfinders: true,
     includes_master_guides: false,
   };
+  const clubRegistrationClosed = Boolean(camporeeCtx.club_registration_closed_at);
 
   const data = backendToTimeline(initialEvents, {
     camporee: camporeeCtx,
@@ -88,6 +89,7 @@ export function CamporeeEventsTab({
         judgeCandidates={judgeCandidates}
         judgeCandidatesError={judgeCandidatesError}
         canEdit={canEdit}
+        clubRegistrationClosed={clubRegistrationClosed}
       />
       <EventJudgeAssignmentsPanel
         camporeeId={camporeeId}
@@ -97,6 +99,7 @@ export function CamporeeEventsTab({
         assignmentsByEvent={assignmentsByEvent}
         targetsByEvent={scoringTargetsByEvent}
         canEdit={canEdit}
+        clubRegistrationClosed={clubRegistrationClosed}
       />
       <EventScoreEntryPanel
         camporeeId={camporeeId}
@@ -105,6 +108,7 @@ export function CamporeeEventsTab({
         rubricsByEvent={rubricsByEvent}
         targetsByEvent={scoringTargetsByEvent}
         canEdit={canEdit}
+        clubRegistrationClosed={clubRegistrationClosed}
       />
       <CamporeeLeaderboard leaderboard={leaderboard} />
       <EventsTimelineView

--- a/src/components/camporee-events/event-form-page.tsx
+++ b/src/components/camporee-events/event-form-page.tsx
@@ -40,6 +40,11 @@ import {
 } from "@/components/camporee-events/venue-create-dialog";
 import { RubricsEditor } from "@/components/camporee-events/rubrics-editor";
 import { ScheduleBlocksEditor } from "@/components/camporee-events/schedule-blocks-editor";
+import {
+  EventStaffAssignmentsEditor,
+  normalizeEventStaffAssignments,
+  type EditableEventStaffAssignment,
+} from "@/components/camporee-events/event-staff-assignments-editor";
 import type {
   CamporeeEventStatus,
   CamporeeEventDisplayCategory,
@@ -54,6 +59,7 @@ import type {
 } from "@/lib/api/camporee-scoring";
 import type { CamporeeVenue } from "@/lib/api/camporee-venues";
 import type { Camporee, CamporeeClub } from "@/lib/api/camporees";
+import type { CamporeeStaffMember } from "@/lib/api/camporee-staff";
 import type { CamporeeEventActionState } from "@/lib/camporee-events/actions";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -77,6 +83,8 @@ export interface EventFormPageProps {
   users: UserOption[];
   eventTypes?: CamporeeEventType[];
   camporeeClubs?: CamporeeClub[];
+  staffRoster?: CamporeeStaffMember[];
+  scoringSetupEnabled?: boolean;
   isUnionCamporee?: boolean;
   event?: BackendCamporeeEvent;
   rubrics?: CamporeeEventRubric[];
@@ -132,6 +140,8 @@ export function EventFormPage({
   users,
   eventTypes = [],
   camporeeClubs = [],
+  staffRoster = [],
+  scoringSetupEnabled = true,
   isUnionCamporee = false,
   event,
   rubrics: initialRubrics = [],
@@ -251,6 +261,9 @@ export function EventFormPage({
       notes: block.notes ?? null,
       assignments: block.assignments ?? [],
     })),
+  );
+  const [staffAssignments, setStaffAssignments] = useState<EditableEventStaffAssignment[]>(
+    normalizeEventStaffAssignments(event?.staff_assignments),
   );
 
   function handleEventTypeChange(value: string) {
@@ -667,6 +680,13 @@ export function EventFormPage({
           </section>
         )}
 
+        <EventStaffAssignmentsEditor
+          staff={staffRoster}
+          value={staffAssignments}
+          onChange={setStaffAssignments}
+          publishRequested={status === "publicado"}
+        />
+
         {/* ══ Section 6: Capacidad y puntos ══ (PR6c) */}
         <section className="space-y-6 rounded-xl border p-6">
           <h2 className="text-base font-semibold tracking-tight">Capacidad y puntos</h2>
@@ -714,12 +734,19 @@ export function EventFormPage({
           </div>
         </section>
 
+        {!scoringSetupEnabled && (
+          <div className="rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-warning">
+            Primero cerrá/cierra la inscripción de clubes para congelar las secciones participantes.
+          </div>
+        )}
+
         <RubricsEditor
           enabled={scoringEnabled}
           onEnabledChange={setScoringEnabled}
           value={rubrics}
           onChange={setRubrics}
           maxPoints={maxPoints}
+          disabled={!scoringSetupEnabled}
         />
 
         <ScheduleBlocksEditor

--- a/src/components/camporee-events/event-staff-assignments-editor.tsx
+++ b/src/components/camporee-events/event-staff-assignments-editor.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { Plus, Trash2, UsersRound } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import type {
+  CamporeeEventStaffAssignment,
+  CamporeeEventStaffAssignmentRole,
+  ReplaceCamporeeEventStaffAssignmentsPayload,
+} from "@/lib/api/camporee-events";
+import type { CamporeeStaffMember } from "@/lib/api/camporee-staff";
+
+export type EditableEventStaffAssignment =
+  ReplaceCamporeeEventStaffAssignmentsPayload["assignments"][number];
+
+interface EventStaffAssignmentsEditorProps {
+  staff: CamporeeStaffMember[];
+  value: EditableEventStaffAssignment[];
+  onChange: (value: EditableEventStaffAssignment[]) => void;
+  fieldName?: string;
+  publishRequested?: boolean;
+}
+
+const STAFF_ROLES: Array<{ value: CamporeeEventStaffAssignmentRole; label: string }> = [
+  { value: "responsible", label: "Responsable" },
+  { value: "assistant", label: "Ayudante" },
+  { value: "evaluator", label: "Evaluador" },
+  { value: "support", label: "Apoyo" },
+];
+
+const CATEGORY_LABELS: Record<string, string> = {
+  judge: "Juez",
+  administrative: "Administrativo",
+  kitchen: "Cocina",
+  support: "Apoyo",
+  spiritual: "Espiritual",
+  leadership: "Liderazgo",
+  other: "Otro",
+};
+
+function getStaffName(member: CamporeeStaffMember | CamporeeEventStaffAssignment["staff_member"]) {
+  const user = member?.user;
+  if (!user) return "Personal sin usuario";
+  return (
+    user.full_name ||
+    [user.name, user.paternal_last_name, user.maternal_last_name]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join(" ") ||
+    "Personal sin nombre"
+  );
+}
+
+export function normalizeEventStaffAssignments(
+  assignments: CamporeeEventStaffAssignment[] | undefined,
+): EditableEventStaffAssignment[] {
+  return (assignments ?? [])
+    .filter((assignment) => assignment.active !== false)
+    .sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0))
+    .map((assignment, index) => ({
+      camporee_staff_member_id: assignment.camporee_staff_member_id,
+      assignment_role: assignment.assignment_role,
+      title_override: assignment.title_override ?? null,
+      notes: assignment.notes ?? null,
+      display_order: assignment.display_order ?? index,
+    }));
+}
+
+export function hasResponsibleAssignment(assignments: EditableEventStaffAssignment[]) {
+  return assignments.some(
+    (assignment) =>
+      assignment.camporee_staff_member_id && assignment.assignment_role === "responsible",
+  );
+}
+
+export function EventStaffAssignmentsEditor({
+  staff,
+  value,
+  onChange,
+  fieldName = "staff_assignments",
+  publishRequested = false,
+}: EventStaffAssignmentsEditorProps) {
+  const responsibleMissing = publishRequested && !hasResponsibleAssignment(value);
+
+  function updateAssignment(index: number, patch: Partial<EditableEventStaffAssignment>) {
+    onChange(
+      value.map((assignment, currentIndex) =>
+        currentIndex === index ? { ...assignment, ...patch } : assignment,
+      ),
+    );
+  }
+
+  function addAssignment() {
+    onChange([
+      ...value,
+      {
+        camporee_staff_member_id: "",
+        assignment_role: value.some((assignment) => assignment.assignment_role === "responsible")
+          ? "assistant"
+          : "responsible",
+        title_override: null,
+        notes: null,
+        display_order: value.length,
+      },
+    ]);
+  }
+
+  function removeAssignment(index: number) {
+    onChange(
+      value
+        .filter((_, currentIndex) => currentIndex !== index)
+        .map((assignment, display_order) => ({ ...assignment, display_order })),
+    );
+  }
+
+  return (
+    <section className="space-y-6 rounded-xl border p-6">
+      <input type="hidden" name={fieldName} value={JSON.stringify(value)} />
+      {responsibleMissing && (
+        <input
+          aria-hidden="true"
+          className="sr-only"
+          data-testid="staff-responsible-guard"
+          onChange={() => undefined}
+          required
+          tabIndex={-1}
+          value=""
+        />
+      )}
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <h2 className="flex items-center gap-2 text-base font-semibold tracking-tight">
+            <UsersRound className="size-4" />
+            Personal de la actividad
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Asigná sólo las personas necesarias para esta actividad: responsable,
+            ayudantes, evaluadores o apoyo.
+          </p>
+        </div>
+        <Button type="button" variant="outline" size="sm" onClick={addAssignment}>
+          <Plus className="size-4" />
+          Agregar persona
+        </Button>
+      </div>
+
+      {staff.length === 0 && (
+        <div className="rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground">
+          Primero cargá el roster en la pestaña Personal para poder asignar personas a actividades.
+        </div>
+      )}
+
+      {responsibleMissing && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+          Para publicar el evento necesitás al menos una persona con rol Responsable.
+        </div>
+      )}
+
+      {value.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+          Sin personal asignado a esta actividad todavía.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {value.map((assignment, index) => (
+            <div
+              key={`${assignment.camporee_staff_member_id}-${index}`}
+              className="grid gap-3 rounded-lg border p-3 lg:grid-cols-[minmax(0,1.4fr)_180px_minmax(0,1fr)_minmax(0,1fr)_auto]"
+            >
+              <div className="space-y-2">
+                <Label>Persona</Label>
+                <Select
+                  value={assignment.camporee_staff_member_id || undefined}
+                  onValueChange={(nextValue) =>
+                    updateAssignment(index, { camporee_staff_member_id: nextValue })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Seleccionar persona" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {staff.map((member) => (
+                      <SelectItem
+                        key={member.camporee_staff_member_id}
+                        value={member.camporee_staff_member_id}
+                      >
+                        {getStaffName(member)} · {CATEGORY_LABELS[member.category] ?? member.category}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Rol en actividad</Label>
+                <Select
+                  value={assignment.assignment_role}
+                  onValueChange={(nextValue) =>
+                    updateAssignment(index, {
+                      assignment_role: nextValue as CamporeeEventStaffAssignmentRole,
+                    })
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {STAFF_ROLES.map((role) => (
+                      <SelectItem key={role.value} value={role.value}>
+                        {role.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`staff-title-${index}`}>Etiqueta opcional</Label>
+                <Input
+                  id={`staff-title-${index}`}
+                  value={assignment.title_override ?? ""}
+                  onChange={(event) =>
+                    updateAssignment(index, { title_override: event.target.value || null })
+                  }
+                  maxLength={100}
+                  placeholder="Ej. Estación 1"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor={`staff-notes-${index}`}>Notas</Label>
+                <Textarea
+                  id={`staff-notes-${index}`}
+                  value={assignment.notes ?? ""}
+                  onChange={(event) =>
+                    updateAssignment(index, { notes: event.target.value || null })
+                  }
+                  rows={1}
+                  placeholder="Opcional"
+                />
+              </div>
+
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="self-end text-destructive hover:text-destructive"
+                onClick={() => removeAssignment(index)}
+                aria-label={`Eliminar asignación ${index + 1}`}
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/camporee-events/rubrics-editor.tsx
+++ b/src/components/camporee-events/rubrics-editor.tsx
@@ -17,6 +17,7 @@ export interface RubricsEditorProps {
   maxPoints: number;
   enabledFieldName?: string;
   rubricsFieldName?: string;
+  disabled?: boolean;
 }
 
 function normalizeNumber(value: string): number {
@@ -46,6 +47,7 @@ export function RubricsEditor({
   maxPoints,
   enabledFieldName = "scoring_enabled",
   rubricsFieldName = "rubrics",
+  disabled = false,
 }: RubricsEditorProps) {
   const total = calculateRubricsTotal(value);
   const isValid = areRubricsValid(enabled, value, maxPoints);
@@ -71,9 +73,13 @@ export function RubricsEditor({
 
   return (
     <section className="space-y-6 rounded-xl border p-6">
-      <input type="hidden" name={enabledFieldName} value={enabled ? "on" : ""} />
-      <input type="hidden" name={rubricsFieldName} value={JSON.stringify(value)} />
-      {enabled && !isValid && (
+      {!disabled && (
+        <>
+          <input type="hidden" name={enabledFieldName} value={enabled ? "on" : ""} />
+          <input type="hidden" name={rubricsFieldName} value={JSON.stringify(value)} />
+        </>
+      )}
+      {!disabled && enabled && !isValid && (
         <input
           aria-hidden="true"
           className="sr-only"
@@ -91,12 +97,18 @@ export function RubricsEditor({
           <p className="text-sm text-muted-foreground">
             Activá esta opción cuando el evento/template aporte puntos reales al camporee.
           </p>
+          {disabled && (
+            <p className="text-sm text-warning">
+              Primero cerrá/cierra la inscripción de clubes para congelar las secciones participantes.
+            </p>
+          )}
         </div>
         <div className="flex items-center gap-2">
           <Switch
             aria-label="Habilitar scoring por rúbricas"
             checked={enabled}
             onCheckedChange={onEnabledChange}
+            disabled={disabled}
           />
           <span className="text-sm text-muted-foreground">
             {enabled ? "Puntuable" : "No puntuable"}
@@ -126,6 +138,7 @@ export function RubricsEditor({
                   <Input
                     id={`rubric-title-${index}`}
                     value={rubric.title}
+                    disabled={disabled}
                     maxLength={120}
                     onChange={(event) => updateRubric(index, { title: event.target.value })}
                     placeholder="Ej. Técnica"
@@ -133,6 +146,7 @@ export function RubricsEditor({
                   <Textarea
                     aria-label={`Descripción criterio ${index + 1}`}
                     value={rubric.description ?? ""}
+                    disabled={disabled}
                     rows={2}
                     onChange={(event) =>
                       updateRubric(index, { description: event.target.value || null })
@@ -149,6 +163,7 @@ export function RubricsEditor({
                     min={0}
                     step="0.01"
                     value={rubric.max_points}
+                    disabled={disabled}
                     onChange={(event) =>
                       updateRubric(index, { max_points: normalizeNumber(event.target.value) })
                     }
@@ -161,6 +176,7 @@ export function RubricsEditor({
                   className="self-start md:mt-7"
                   onClick={() => removeRubric(index)}
                   aria-label={`Eliminar criterio ${index + 1}`}
+                  disabled={disabled}
                 >
                   <Trash2 className="size-4" />
                 </Button>
@@ -168,7 +184,13 @@ export function RubricsEditor({
             ))}
           </div>
 
-          <Button type="button" variant="outline" size="sm" onClick={addRubric}>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={addRubric}
+            disabled={disabled}
+          >
             <Plus className="size-4" />
             Agregar criterio
           </Button>

--- a/src/components/camporee-events/timeline/event-row.tsx
+++ b/src/components/camporee-events/timeline/event-row.tsx
@@ -76,6 +76,12 @@ export function EventRow({
   const status = event.status;
   const capPct = event.capacity > 0 ? (event.registered / event.capacity) * 100 : 0;
   const hasCapacity = event.registered > 0;
+  const displayedLeaderName = event.staffResponsibleName || event.leaderName;
+  const displayedLeaderRole =
+    event.staffResponsibleRole || event.leaderRole || "responsable";
+  const helperNames = event.staffHelpers ?? [];
+  const helpersPreview = helperNames.slice(0, 2).join(", ");
+  const extraHelpersCount = Math.max(0, helperNames.length - 2);
 
   const [dialogOpen, setDialogOpen] = React.useState<DialogType>(null);
   const [isPending, startTransition] = React.useTransition();
@@ -230,14 +236,20 @@ export function EventRow({
         <div className="flex items-center gap-2 min-w-0">
           <Avatar className="size-7">
             <AvatarFallback className="text-[10px] bg-primary text-primary-foreground font-bold">
-              {initials(event.leaderName)}
+              {initials(displayedLeaderName)}
             </AvatarFallback>
           </Avatar>
           <div className="min-w-0">
-            <div className="text-[12px] font-medium truncate">{event.leaderName}</div>
+            <div className="text-[12px] font-medium truncate">{displayedLeaderName}</div>
             <div className="text-[10.5px] text-muted-foreground truncate">
-              {event.leaderRole ?? "responsable"}
+              {displayedLeaderRole}
             </div>
+            {helperNames.length > 0 && (
+              <div className="truncate text-[10.5px] text-muted-foreground">
+                Apoyan: {helpersPreview}
+                {extraHelpersCount > 0 ? ` +${extraHelpersCount}` : ""}
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/camporee-scoring/camporee-judges-panel.tsx
+++ b/src/components/camporee-scoring/camporee-judges-panel.tsx
@@ -35,6 +35,7 @@ export interface CamporeeJudgesPanelProps {
   judgeCandidates?: CamporeeJudgeCandidate[];
   judgeCandidatesError?: string | null;
   canEdit?: boolean;
+  clubRegistrationClosed?: boolean;
 }
 
 const CLUB_ROLE_NAMES = new Set([
@@ -224,6 +225,7 @@ export function CamporeeJudgesPanel({
   judgeCandidates = [],
   judgeCandidatesError = null,
   canEdit = false,
+  clubRegistrationClosed = true,
 }: CamporeeJudgesPanelProps) {
   const [state, formAction] = useActionState<CamporeeScoringActionState, FormData>(
     addCamporeeJudgeAction,
@@ -296,7 +298,13 @@ export function CamporeeJudgesPanel({
           </div>
         )}
 
-        {canEdit && (
+        {canEdit && !clubRegistrationClosed && (
+          <p className="rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground">
+            Primero cerrá/cierra la inscripción de clubes para congelar las secciones participantes.
+          </p>
+        )}
+
+        {canEdit && clubRegistrationClosed && (
           <form action={formAction} className="grid gap-3 rounded-lg border p-3 md:grid-cols-[minmax(0,1.3fr)_minmax(0,1fr)_auto]">
             <input type="hidden" name="camporee_id" value={camporeeId} />
             <input type="hidden" name="is_union" value={isUnionCamporee ? "true" : "false"} />

--- a/src/components/camporee-scoring/event-judge-assignments-panel.tsx
+++ b/src/components/camporee-scoring/event-judge-assignments-panel.tsx
@@ -26,6 +26,7 @@ export interface EventJudgeAssignmentsPanelProps {
   assignmentsByEvent: Record<number, CamporeeEventJudgeAssignment[]>;
   targetsByEvent: Record<number, CamporeeScoringTarget[]>;
   canEdit?: boolean;
+  clubRegistrationClosed?: boolean;
 }
 
 export function EventJudgeAssignmentsPanel({
@@ -36,6 +37,7 @@ export function EventJudgeAssignmentsPanel({
   assignmentsByEvent,
   targetsByEvent,
   canEdit = false,
+  clubRegistrationClosed = true,
 }: EventJudgeAssignmentsPanelProps) {
   const scoringEvents = events.filter((event) => event.scoring_enabled);
   const [selectedEventId, setSelectedEventId] = useState<number | null>(
@@ -123,7 +125,13 @@ export function EventJudgeAssignmentsPanel({
           </div>
         )}
 
-        {canEdit && selectedEventId && (
+        {canEdit && selectedEventId && !clubRegistrationClosed && (
+          <p className="rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground">
+            Primero cerrá/cierra la inscripción de clubes para congelar las secciones participantes.
+          </p>
+        )}
+
+        {canEdit && selectedEventId && clubRegistrationClosed && (
           <form action={formAction} className="grid gap-3 rounded-lg border p-3 md:grid-cols-4">
             <input type="hidden" name="camporee_id" value={camporeeId} />
             <input type="hidden" name="is_union" value={isUnionCamporee ? "true" : "false"} />

--- a/src/components/camporee-scoring/event-score-entry-panel.tsx
+++ b/src/components/camporee-scoring/event-score-entry-panel.tsx
@@ -24,6 +24,7 @@ export interface EventScoreEntryPanelProps {
   rubricsByEvent: Record<number, CamporeeEventRubric[]>;
   targetsByEvent: Record<number, CamporeeScoringTarget[]>;
   canEdit?: boolean;
+  clubRegistrationClosed?: boolean;
 }
 
 function toNumber(value: string): number {
@@ -48,6 +49,7 @@ export function EventScoreEntryPanel({
   rubricsByEvent,
   targetsByEvent,
   canEdit = false,
+  clubRegistrationClosed = true,
 }: EventScoreEntryPanelProps) {
   const scoringEvents = useMemo(
     () => events.filter((event) => event.scoring_enabled),
@@ -145,7 +147,13 @@ export function EventScoreEntryPanel({
           </p>
         )}
 
-        {canEdit && selectedEventId && rubrics.length > 0 && (
+        {canEdit && selectedEventId && rubrics.length > 0 && !clubRegistrationClosed && (
+          <p className="rounded-lg border border-warning/30 bg-warning/10 p-3 text-sm text-warning-foreground">
+            Primero cerrá/cierra la inscripción de clubes para congelar las secciones participantes.
+          </p>
+        )}
+
+        {canEdit && selectedEventId && rubrics.length > 0 && clubRegistrationClosed && (
           <form action={formAction} className="space-y-4 rounded-lg border p-4">
             <input type="hidden" name="camporee_id" value={camporeeId} />
             <input type="hidden" name="is_union" value={isUnionCamporee ? "true" : "false"} />

--- a/src/components/camporee-staff/camporee-staff-panel.tsx
+++ b/src/components/camporee-staff/camporee-staff-panel.tsx
@@ -1,0 +1,451 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { Check, ChevronsUpDown, Loader2, UserRoundCheck, UserRoundX } from "lucide-react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { EmptyState } from "@/components/shared/empty-state";
+import { UserAvatar } from "@/components/users/user-avatar";
+import {
+  addCamporeeStaffMemberAction,
+  deleteCamporeeStaffMemberAction,
+} from "@/lib/camporee-staff/actions";
+import {
+  listCamporeeStaff,
+  listCamporeeStaffCandidates,
+  type CamporeeStaffCandidate,
+  type CamporeeStaffCategory,
+  type CamporeeStaffMember,
+  type CamporeeStaffScope,
+} from "@/lib/api/camporee-staff";
+import { cn } from "@/lib/utils";
+
+interface CamporeeStaffPanelProps {
+  camporeeId: number;
+  isUnionCamporee?: boolean;
+  staff: CamporeeStaffMember[];
+  candidates: CamporeeStaffCandidate[];
+  canEdit?: boolean;
+}
+
+const CATEGORY_LABELS: Record<CamporeeStaffCategory, string> = {
+  judge: "Juez",
+  administrative: "Administrativo",
+  kitchen: "Cocina",
+  support: "Apoyo",
+  spiritual: "Espiritual",
+  leadership: "Liderazgo",
+  other: "Otro",
+};
+
+const CATEGORY_ORDER: CamporeeStaffCategory[] = [
+  "leadership",
+  "administrative",
+  "judge",
+  "kitchen",
+  "spiritual",
+  "support",
+  "other",
+];
+
+function extractList<T>(payload: unknown): T[] {
+  if (Array.isArray(payload)) return payload as T[];
+  if (payload && typeof payload === "object") {
+    const root = payload as Record<string, unknown>;
+    if (Array.isArray(root.data)) return root.data as T[];
+  }
+  return [];
+}
+
+function getUserName(user: CamporeeStaffCandidate | CamporeeStaffMember["user"]) {
+  if (!user) return "Usuario sin nombre";
+  return (
+    user.full_name ||
+    [user.name, user.paternal_last_name, user.maternal_last_name]
+      .filter((value): value is string => Boolean(value?.trim()))
+      .join(" ") ||
+    user.email ||
+    "Usuario sin nombre"
+  );
+}
+
+function getCandidateSearchText(candidate: CamporeeStaffCandidate) {
+  return [
+    candidate.user_id,
+    candidate.email,
+    getUserName(candidate),
+    candidate.local_field?.name,
+    candidate.union?.name,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ")
+    .toLowerCase();
+}
+
+function getScope(isUnionCamporee: boolean): CamporeeStaffScope {
+  return isUnionCamporee ? "union" : "local";
+}
+
+function StaffCandidateOption({ candidate }: { candidate: CamporeeStaffCandidate }) {
+  const name = getUserName(candidate);
+  return (
+    <div className="flex min-w-0 items-center gap-3 overflow-hidden">
+      <UserAvatar src={candidate.user_image} name={name} email={candidate.email} size={36} />
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{name}</p>
+        <p className="truncate text-xs text-muted-foreground">
+          {candidate.email ?? "Sin correo"}
+        </p>
+        <p className="truncate text-[11px] text-muted-foreground">
+          {candidate.local_field?.name ?? candidate.union?.name ?? "Sin territorio"}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export function CamporeeStaffPanel({
+  camporeeId,
+  isUnionCamporee = false,
+  staff: initialStaff,
+  candidates: initialCandidates,
+  canEdit = false,
+}: CamporeeStaffPanelProps) {
+  const [staff, setStaff] = useState(initialStaff);
+  const [candidates, setCandidates] = useState(initialCandidates);
+  const [selectedUserId, setSelectedUserId] = useState("");
+  const [selectedCategory, setSelectedCategory] = useState<CamporeeStaffCategory>("support");
+  const [roleLabel, setRoleLabel] = useState("");
+  const [notes, setNotes] = useState("");
+  const [search, setSearch] = useState("");
+  const [open, setOpen] = useState(false);
+  const [pending, startTransition] = useTransition();
+
+  const scope = getScope(isUnionCamporee);
+  const activeStaffUserIds = useMemo(
+    () => new Set(staff.filter((member) => member.active).map((member) => member.user_id)),
+    [staff],
+  );
+
+  const availableCandidates = useMemo(
+    () =>
+      candidates.filter(
+        (candidate) =>
+          !candidate.already_staff_member_id &&
+          !activeStaffUserIds.has(candidate.user_id),
+      ),
+    [activeStaffUserIds, candidates],
+  );
+
+  const filteredCandidates = useMemo(() => {
+    const normalizedSearch = search.trim().toLowerCase();
+    if (!normalizedSearch) return availableCandidates.slice(0, 25);
+    return availableCandidates
+      .filter((candidate) => getCandidateSearchText(candidate).includes(normalizedSearch))
+      .slice(0, 25);
+  }, [availableCandidates, search]);
+
+  const selectedCandidate = useMemo(
+    () => availableCandidates.find((candidate) => candidate.user_id === selectedUserId) ?? null,
+    [availableCandidates, selectedUserId],
+  );
+
+  const staffByCategory = useMemo(() => {
+    const grouped = new Map<CamporeeStaffCategory, CamporeeStaffMember[]>();
+    for (const category of CATEGORY_ORDER) grouped.set(category, []);
+    for (const member of staff.filter((item) => item.active)) {
+      grouped.set(member.category, [...(grouped.get(member.category) ?? []), member]);
+    }
+    return grouped;
+  }, [staff]);
+
+  async function refreshStaff() {
+    const [staffPayload, candidatesPayload] = await Promise.all([
+      listCamporeeStaff(scope, camporeeId),
+      listCamporeeStaffCandidates(scope, camporeeId),
+    ]);
+    setStaff(extractList<CamporeeStaffMember>(staffPayload));
+    setCandidates(extractList<CamporeeStaffCandidate>(candidatesPayload));
+  }
+
+  function handleAddStaff() {
+    if (!selectedUserId || pending) return;
+
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set("camporee_id", String(camporeeId));
+      formData.set("is_union", String(isUnionCamporee));
+      formData.set("user_id", selectedUserId);
+      formData.set("category", selectedCategory);
+      formData.set("role_label", roleLabel);
+      formData.set("notes", notes);
+
+      const result = await addCamporeeStaffMemberAction({}, formData);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success(result.success ?? "Personal agregado.");
+      setSelectedUserId("");
+      setRoleLabel("");
+      setNotes("");
+      await refreshStaff();
+    });
+  }
+
+  function handleDeactivate(member: CamporeeStaffMember) {
+    if (pending) return;
+    startTransition(async () => {
+      const formData = new FormData();
+      formData.set("camporee_id", String(camporeeId));
+      formData.set("is_union", String(isUnionCamporee));
+      formData.set("staff_member_id", member.camporee_staff_member_id);
+
+      const result = await deleteCamporeeStaffMemberAction({}, formData);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+
+      toast.success(result.success ?? "Personal desactivado.");
+      await refreshStaff();
+    });
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{staff.length}</span>{" "}
+            {staff.length === 1 ? "persona asignada" : "personas asignadas"}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Este roster es la base para asignar responsables y apoyos a cada actividad.
+          </p>
+        </div>
+      </div>
+
+      {canEdit && (
+        <div className="grid gap-3 rounded-xl border p-4 lg:grid-cols-[minmax(0,1.5fr)_220px_minmax(0,1fr)_minmax(0,1fr)_auto]">
+          <div className="space-y-2">
+            <Label>Persona</Label>
+            <Popover open={open} onOpenChange={setOpen}>
+              <PopoverTrigger asChild>
+                <Button
+                  type="button"
+                  variant="outline"
+                  role="combobox"
+                  aria-label="Persona del camporee"
+                  aria-expanded={open}
+                  className="h-auto min-h-10 w-full justify-between gap-2 overflow-hidden px-3 py-2 text-left font-normal"
+                  disabled={availableCandidates.length === 0}
+                >
+                  {selectedCandidate ? (
+                    <span className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
+                      <UserAvatar
+                        src={selectedCandidate.user_image}
+                        name={getUserName(selectedCandidate)}
+                        email={selectedCandidate.email}
+                        size={28}
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="block truncate text-sm font-medium">
+                          {getUserName(selectedCandidate)}
+                        </span>
+                        <span className="block truncate text-xs text-muted-foreground">
+                          {selectedCandidate.email ?? "Sin correo"}
+                        </span>
+                      </span>
+                    </span>
+                  ) : (
+                    <span className="min-w-0 truncate text-muted-foreground">
+                      Seleccionar persona del territorio
+                    </span>
+                  )}
+                  <ChevronsUpDown className="size-4 shrink-0 opacity-50" />
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent
+                align="start"
+                className="w-[var(--radix-popover-trigger-width)] max-w-[calc(100vw-2rem)] p-0"
+              >
+                <Command shouldFilter={false}>
+                  <CommandInput
+                    value={search}
+                    onValueChange={setSearch}
+                    placeholder="Buscar por nombre, correo o territorio..."
+                  />
+                  <CommandList className="max-h-80">
+                    <CommandEmpty>No encontramos personas disponibles.</CommandEmpty>
+                    <CommandGroup>
+                      {filteredCandidates.map((candidate) => (
+                        <CommandItem
+                          key={candidate.user_id}
+                          value={candidate.user_id}
+                          onSelect={() => {
+                            setSelectedUserId(candidate.user_id);
+                            setOpen(false);
+                          }}
+                          className="min-w-0 items-start gap-2 py-2"
+                        >
+                          <Check
+                            className={cn(
+                              "mt-2 size-4 shrink-0",
+                              selectedUserId === candidate.user_id ? "opacity-100" : "opacity-0",
+                            )}
+                          />
+                          <StaffCandidateOption candidate={candidate} />
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Categoría</Label>
+            <Select
+              value={selectedCategory}
+              onValueChange={(value) => setSelectedCategory(value as CamporeeStaffCategory)}
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {CATEGORY_ORDER.map((category) => (
+                  <SelectItem key={category} value={category}>
+                    {CATEGORY_LABELS[category]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="staff-role-label">Rol/cargo opcional</Label>
+            <Input
+              id="staff-role-label"
+              value={roleLabel}
+              onChange={(event) => setRoleLabel(event.target.value)}
+              maxLength={100}
+              placeholder="Ej. Cocina turno tarde"
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="staff-notes">Notas</Label>
+            <Textarea
+              id="staff-notes"
+              value={notes}
+              onChange={(event) => setNotes(event.target.value)}
+              rows={1}
+              placeholder="Opcional"
+            />
+          </div>
+
+          <Button
+            type="button"
+            className="self-end"
+            disabled={!selectedUserId || pending}
+            onClick={handleAddStaff}
+          >
+            {pending ? <Loader2 className="size-4 animate-spin" /> : <UserRoundCheck className="size-4" />}
+            Agregar
+          </Button>
+        </div>
+      )}
+
+      {staff.length === 0 ? (
+        <EmptyState
+          icon={UserRoundCheck}
+          title="Aún no hay personal asignado al camporee"
+          description="Agregá primero el roster operativo; después vas a poder asignarlo a actividades específicas."
+        />
+      ) : (
+        <div className="space-y-4">
+          {CATEGORY_ORDER.map((category) => {
+            const members = staffByCategory.get(category) ?? [];
+            if (members.length === 0) return null;
+
+            return (
+              <section key={category} className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <h3 className="text-sm font-semibold">{CATEGORY_LABELS[category]}</h3>
+                  <Badge variant="secondary">{members.length}</Badge>
+                </div>
+                <div className="grid gap-2 md:grid-cols-2 xl:grid-cols-3">
+                  {members.map((member) => {
+                    const name = getUserName(member.user);
+                    return (
+                      <div
+                        key={member.camporee_staff_member_id}
+                        className="flex items-start justify-between gap-3 rounded-xl border p-3"
+                      >
+                        <div className="flex min-w-0 gap-3">
+                          <UserAvatar
+                            src={member.user?.user_image}
+                            name={name}
+                            email={member.user?.email}
+                            size={36}
+                          />
+                          <div className="min-w-0">
+                            <p className="truncate text-sm font-medium">{name}</p>
+                            <p className="truncate text-xs text-muted-foreground">
+                              {member.role_label ?? CATEGORY_LABELS[member.category]}
+                            </p>
+                            {member.notes && (
+                              <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+                                {member.notes}
+                              </p>
+                            )}
+                          </div>
+                        </div>
+                        {canEdit && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon-sm"
+                            className="shrink-0 text-destructive hover:text-destructive"
+                            disabled={pending}
+                            onClick={() => handleDeactivate(member)}
+                            aria-label={`Desactivar ${name}`}
+                          >
+                            <UserRoundX className="size-4" />
+                          </Button>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/camporees/camporee-clubs-panel.tsx
+++ b/src/components/camporees/camporee-clubs-panel.tsx
@@ -96,6 +96,7 @@ interface CamporeeClubsPanelProps {
   clubs: CamporeeClub[];
   onClubsChange: () => void;
   isUnionCamporee?: boolean;
+  clubRegistrationClosed?: boolean;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -105,6 +106,7 @@ export function CamporeeClubsPanel({
   clubs,
   onClubsChange,
   isUnionCamporee = false,
+  clubRegistrationClosed = false,
 }: CamporeeClubsPanelProps) {
   const t = useTranslations("camporees");
   const [cancellingId, setCancellingId] = useState<number | null>(null);
@@ -244,7 +246,7 @@ export function CamporeeClubsPanel({
                                 size="icon-sm"
                                 className="text-success hover:bg-success/10 hover:text-success"
                                 onClick={() => handleApprove(club.camporee_club_id)}
-                                disabled={isApproving}
+                                disabled={isApproving || clubRegistrationClosed}
                                 aria-label={t("clubsPanel.approveLabel")}
                               >
                                 {isApproving ? (
@@ -254,7 +256,11 @@ export function CamporeeClubsPanel({
                                 )}
                               </Button>
                             </TooltipTrigger>
-                            <TooltipContent>{t("clubsPanel.approveLabel")}</TooltipContent>
+                            <TooltipContent>
+                              {clubRegistrationClosed
+                                ? "Inscripción de clubes cerrada"
+                                : t("clubsPanel.approveLabel")}
+                            </TooltipContent>
                           </Tooltip>
 
                           <Tooltip>
@@ -264,12 +270,17 @@ export function CamporeeClubsPanel({
                                 size="icon-sm"
                                 className="text-destructive hover:bg-destructive/10 hover:text-destructive"
                                 onClick={() => setDialog({ club, mode: "reject" })}
+                                disabled={clubRegistrationClosed}
                                 aria-label={t("clubsPanel.rejectLabel")}
                               >
                                 <XCircle className="size-4" />
                               </Button>
                             </TooltipTrigger>
-                            <TooltipContent>{t("clubsPanel.rejectLabel")}</TooltipContent>
+                            <TooltipContent>
+                              {clubRegistrationClosed
+                                ? "Inscripción de clubes cerrada"
+                                : t("clubsPanel.rejectLabel")}
+                            </TooltipContent>
                           </Tooltip>
                         </>
                       )}
@@ -281,7 +292,7 @@ export function CamporeeClubsPanel({
                               variant="ghost"
                               size="icon-sm"
                               onClick={() => handleCancel(club.camporee_club_id, club.section_name)}
-                              disabled={cancellingId === club.camporee_club_id}
+                              disabled={cancellingId === club.camporee_club_id || clubRegistrationClosed}
                               aria-label={t("clubsPanel.cancelLabel")}
                               className="text-destructive hover:text-destructive"
                             >
@@ -289,7 +300,11 @@ export function CamporeeClubsPanel({
                               <span className="sr-only">{t("clubsPanel.cancelLabel")}</span>
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent>{t("clubsPanel.cancelLabel")}</TooltipContent>
+                          <TooltipContent>
+                            {clubRegistrationClosed
+                              ? "Inscripción de clubes cerrada"
+                              : t("clubsPanel.cancelLabel")}
+                          </TooltipContent>
                         </Tooltip>
                       )}
                     </div>

--- a/src/components/camporees/camporee-clubs-tab.tsx
+++ b/src/components/camporees/camporee-clubs-tab.tsx
@@ -1,11 +1,26 @@
 "use client";
 
-import { useState, useCallback } from "react";
-import { PlusCircle, RefreshCw } from "lucide-react";
+import { useCallback, useEffect, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { Lock, LockOpen, PlusCircle, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { CamporeeClubsPanel } from "@/components/camporees/camporee-clubs-panel";
 import { EnrollClubDialog } from "@/components/camporees/enroll-club-dialog";
 import { getEnrolledClubs, getUnionEnrolledClubs } from "@/lib/api/camporees";
+import {
+  closeCamporeeClubRegistrationAction,
+  reopenCamporeeClubRegistrationAction,
+} from "@/lib/camporees/actions";
 import type { CamporeeClub } from "@/lib/api/camporees";
 
 export interface CamporeeClubsTabProps {
@@ -18,7 +33,24 @@ export interface CamporeeClubsTabProps {
   includesAdventurers?: boolean;
   includesPathfinders?: boolean;
   includesMasterGuides?: boolean;
+  clubRegistrationClosedAt?: string | null;
+  canManageClubRegistration?: boolean;
   onAfterChange?: () => void;
+}
+
+type ClosureDialog = "close" | "reopen" | null;
+
+function formatClosedAt(value?: string | null) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString("es-MX", {
+    day: "numeric",
+    month: "short",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
 }
 
 export function CamporeeClubsTab({
@@ -29,12 +61,25 @@ export function CamporeeClubsTab({
   includesAdventurers = false,
   includesPathfinders = false,
   includesMasterGuides = false,
+  clubRegistrationClosedAt = null,
+  canManageClubRegistration = false,
   onAfterChange,
 }: CamporeeClubsTabProps) {
+  const router = useRouter();
   const [clubs, setClubs] = useState<CamporeeClub[]>(initialClubs);
+  const [closedAt, setClosedAt] = useState<string | null>(clubRegistrationClosedAt);
   const [isLoading, setIsLoading] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [enrollOpen, setEnrollOpen] = useState(false);
+  const [closureDialog, setClosureDialog] = useState<ClosureDialog>(null);
+  const [isClosurePending, startClosureTransition] = useTransition();
+
+  const isClosed = Boolean(closedAt);
+  const canCloseRegistration = clubs.length > 0;
+
+  useEffect(() => {
+    setClosedAt(clubRegistrationClosedAt);
+  }, [clubRegistrationClosedAt]);
 
   const refreshClubs = useCallback(async () => {
     setIsLoading(true);
@@ -66,15 +111,58 @@ export function CamporeeClubsTab({
     }
   }, [camporeeId, isUnionCamporee, onAfterChange]);
 
+  function submitClosureAction(next: Exclude<ClosureDialog, null>) {
+    startClosureTransition(async () => {
+      const formData = new FormData();
+      formData.set("camporee_id", String(camporeeId));
+      formData.set("is_union", String(isUnionCamporee));
+
+      const result =
+        next === "close"
+          ? await closeCamporeeClubRegistrationAction({}, formData)
+          : await reopenCamporeeClubRegistrationAction({}, formData);
+
+      if (result.error) {
+        toast.error(result.error);
+        setClosureDialog(null);
+        return;
+      }
+
+      toast.success(result.success ?? "Estado de inscripción actualizado.");
+      setClosedAt(next === "close" ? new Date().toISOString() : null);
+      setClosureDialog(null);
+      router.refresh();
+    });
+  }
+
   return (
     <div className="space-y-4">
       {/* Toolbar */}
-      <div className="flex items-center justify-between">
-        <p className="text-sm text-muted-foreground">
-          <span className="font-medium text-foreground">{clubs.length}</span>{" "}
-          {clubs.length === 1 ? "club inscrito" : "clubes inscritos"}
-        </p>
-        <div className="flex items-center gap-2">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{clubs.length}</span>{" "}
+            {clubs.length === 1 ? "club inscrito" : "clubes inscritos"}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {isClosed
+              ? `Inscripción de clubes cerrada${formatClosedAt(closedAt) ? ` · ${formatClosedAt(closedAt)}` : ""}. Las secciones participantes quedaron congeladas para scoring.`
+              : "Inscripción de clubes abierta. Cerrala antes de configurar o capturar scoring."}
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {canManageClubRegistration && (
+            <Button
+              type="button"
+              variant={isClosed ? "outline" : "secondary"}
+              size="sm"
+              disabled={isClosurePending || (!isClosed && !canCloseRegistration)}
+              onClick={() => setClosureDialog(isClosed ? "reopen" : "close")}
+            >
+              {isClosed ? <LockOpen className="size-4" /> : <Lock className="size-4" />}
+              {isClosed ? "Reabrir inscripción" : "Cerrar inscripción"}
+            </Button>
+          )}
           <Button
             variant="outline"
             size="icon-sm"
@@ -85,12 +173,24 @@ export function CamporeeClubsTab({
             <RefreshCw className={`size-3.5 ${isLoading ? "animate-spin" : ""}`} />
             <span className="sr-only">Actualizar</span>
           </Button>
-          <Button size="sm" onClick={() => setEnrollOpen(true)}>
+          <Button size="sm" onClick={() => setEnrollOpen(true)} disabled={isClosed}>
             <PlusCircle className="size-4" />
             Inscribir club
           </Button>
         </div>
       </div>
+
+      {isClosed && (
+        <div className="rounded-lg border border-warning/30 bg-warning/10 px-4 py-3 text-sm text-warning-foreground">
+          Inscripción de clubes cerrada: las secciones participantes están congeladas para scoring.
+          Reabrila sólo si necesitás corregir la lista de clubes.
+        </div>
+      )}
+      {!isClosed && canManageClubRegistration && !canCloseRegistration && (
+        <div className="rounded-lg border border-muted bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+          Inscribí al menos un club antes de cerrar la inscripción de clubes.
+        </div>
+      )}
 
       {/* Error */}
       {loadError && (
@@ -104,6 +204,7 @@ export function CamporeeClubsTab({
         clubs={clubs}
         onClubsChange={refreshClubs}
         isUnionCamporee={isUnionCamporee}
+        clubRegistrationClosed={isClosed}
       />
 
       <EnrollClubDialog
@@ -117,6 +218,38 @@ export function CamporeeClubsTab({
         includesMasterGuides={includesMasterGuides}
         onSuccess={refreshClubs}
       />
+
+      <AlertDialog
+        open={closureDialog !== null}
+        onOpenChange={(open) => {
+          if (!open) setClosureDialog(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              {closureDialog === "reopen"
+                ? "¿Reabrir inscripción de clubes?"
+                : "¿Cerrar inscripción de clubes?"}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {closureDialog === "reopen"
+                ? "Esto permitirá volver a modificar clubes inscritos. Scoring quedará sujeto a la nueva lista cuando vuelvas a cerrar."
+                : "Esto congela las secciones participantes para configurar jueces, rúbricas y puntajes. La inscripción de miembros no se ve afectada."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isClosurePending}>Volver</AlertDialogCancel>
+            <Button
+              type="button"
+              disabled={isClosurePending || !closureDialog}
+              onClick={() => closureDialog && submitClosureAction(closureDialog)}
+            >
+              {closureDialog === "reopen" ? "Reabrir" : "Cerrar inscripción"}
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/camporees/camporee-detail-tabs.tsx
+++ b/src/components/camporees/camporee-detail-tabs.tsx
@@ -15,8 +15,13 @@ import type { CamporeeMembersTabProps } from "@/components/camporees/camporee-me
 import type { CamporeeClubsTabProps } from "@/components/camporees/camporee-clubs-tab";
 import type { CamporeePaymentsTabProps } from "@/components/camporees/camporee-payments-tab";
 import { CamporeeEventsTab } from "@/components/camporee-events/camporee-events-tab";
+import { CamporeeStaffPanel } from "@/components/camporee-staff/camporee-staff-panel";
 import type { BackendCamporeeEvent, CamporeeEventTemplate } from "@/lib/api/camporee-events";
 import type { CamporeeVenue } from "@/lib/api/camporee-venues";
+import type {
+  CamporeeStaffCandidate,
+  CamporeeStaffMember,
+} from "@/lib/api/camporee-staff";
 import type {
   CamporeeEventJudgeAssignment,
   CamporeeEventRubric,
@@ -75,6 +80,9 @@ interface CamporeeDetailTabsProps {
   membersError: string | null;
   clubsError: string | null;
   paymentsError: string | null;
+  initialStaff?: CamporeeStaffMember[];
+  staffCandidates?: CamporeeStaffCandidate[];
+  staffError?: string | null;
   isUnionCamporee?: boolean;
   /** Server-rendered info tab content passed as a slot */
   infoContent: ReactNode;
@@ -93,6 +101,7 @@ interface CamporeeDetailTabsProps {
   canCreateEvents?: boolean;
   canEditEvents?: boolean;
   canDeleteEvents?: boolean;
+  canManageClubRegistration?: boolean;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -108,6 +117,9 @@ export function CamporeeDetailTabs({
   membersError,
   clubsError,
   paymentsError,
+  initialStaff = [],
+  staffCandidates = [],
+  staffError = null,
   isUnionCamporee = false,
   infoContent,
   initialEvents = [],
@@ -123,6 +135,7 @@ export function CamporeeDetailTabs({
   canCreateEvents = false,
   canEditEvents = false,
   canDeleteEvents = false,
+  canManageClubRegistration = false,
 }: CamporeeDetailTabsProps) {
   const [pending, setPending] = useState<PendingApprovals>(initialPending);
 
@@ -186,6 +199,15 @@ export function CamporeeDetailTabs({
           )}
         </TabsTrigger>
 
+        <TabsTrigger value="staff">
+          Personal
+          {initialStaff.length > 0 && (
+            <Badge variant="secondary" className="ml-2">
+              {initialStaff.length}
+            </Badge>
+          )}
+        </TabsTrigger>
+
         <TabsTrigger value="events">
           Eventos
           {initialEvents.length > 0 && (
@@ -245,6 +267,8 @@ export function CamporeeDetailTabs({
                 includesAdventurers={camporee?.includes_adventurers ?? false}
                 includesPathfinders={camporee?.includes_pathfinders ?? false}
                 includesMasterGuides={camporee?.includes_master_guides ?? false}
+                clubRegistrationClosedAt={camporee?.club_registration_closed_at ?? null}
+                canManageClubRegistration={canManageClubRegistration}
                 onAfterChange={refreshPending}
               />
             )}
@@ -267,6 +291,28 @@ export function CamporeeDetailTabs({
                 initialPayments={initialPayments}
                 isUnionCamporee={isUnionCamporee}
                 onAfterChange={refreshPending}
+              />
+            )}
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      {/* ── Personal ── */}
+      <TabsContent value="staff" className="mt-4">
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Personal del camporee</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {staffError ? (
+              <EndpointErrorBanner state="missing" detail={staffError} />
+            ) : (
+              <CamporeeStaffPanel
+                camporeeId={camporeeId}
+                isUnionCamporee={isUnionCamporee}
+                staff={initialStaff}
+                candidates={staffCandidates}
+                canEdit={canEditEvents}
               />
             )}
           </CardContent>

--- a/src/components/camporees/camporee-info-card.tsx
+++ b/src/components/camporees/camporee-info-card.tsx
@@ -1,4 +1,4 @@
-import { Tent, CalendarRange, MapPin, DollarSign } from "lucide-react";
+import { Tent, CalendarRange, MapPin, DollarSign, Lock } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardContent } from "@/components/ui/card";
 import type { Camporee } from "@/lib/api/camporees";
@@ -93,9 +93,19 @@ export function CamporeeInfoCard({ camporee }: CamporeeInfoCardProps) {
           </div>
 
           {/* Status badge */}
-          <Badge variant={camporee.active !== false ? "soft-success" : "outline"}>
-            {camporee.active !== false ? "Activo" : "Inactivo"}
-          </Badge>
+          <div className="flex flex-col items-end gap-1.5">
+            <Badge variant={camporee.active !== false ? "soft-success" : "outline"}>
+              {camporee.active !== false ? "Activo" : "Inactivo"}
+            </Badge>
+            {camporee.club_registration_closed_at ? (
+              <Badge variant="warning" className="gap-1">
+                <Lock className="size-3" />
+                Clubes cerrados
+              </Badge>
+            ) : (
+              <Badge variant="outline">Clubes abiertos</Badge>
+            )}
+          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/lib/api/camporee-events.ts
+++ b/src/lib/api/camporee-events.ts
@@ -14,6 +14,7 @@ import type {
   CamporeeEventTemplateRubric,
   CamporeeTemplateRubricInput,
 } from "@/lib/api/camporee-scoring";
+import type { CamporeeStaffMember } from "@/lib/api/camporee-staff";
 
 // ─── Shared shapes ─────────────────────────────────────────────────────────────
 
@@ -121,6 +122,46 @@ export type CamporeeEventType = {
   active?: boolean;
 };
 
+export type CamporeeEventStaffAssignmentRole =
+  | "responsible"
+  | "assistant"
+  | "evaluator"
+  | "support";
+
+export type CamporeeEventStaffAssignment = {
+  camporee_event_staff_assignment_id?: string;
+  camporee_event_id?: number;
+  camporee_staff_member_id: string;
+  assignment_role: CamporeeEventStaffAssignmentRole;
+  title_override?: string | null;
+  notes?: string | null;
+  display_order?: number;
+  active?: boolean;
+  staff_member?: Pick<
+    CamporeeStaffMember,
+    "camporee_staff_member_id" | "category" | "role_label" | "user_id"
+  > & {
+    user?: {
+      user_id: string;
+      name?: string | null;
+      paternal_last_name?: string | null;
+      maternal_last_name?: string | null;
+      full_name?: string | null;
+      user_image?: string | null;
+    } | null;
+  } | null;
+};
+
+export type ReplaceCamporeeEventStaffAssignmentsPayload = {
+  assignments: Array<{
+    camporee_staff_member_id: string;
+    assignment_role: CamporeeEventStaffAssignmentRole;
+    title_override?: string | null;
+    notes?: string | null;
+    display_order?: number;
+  }>;
+};
+
 /** Leader info joined from the users table (present when leader_user_id is set) */
 export type CamporeeEventLeader = {
   user_id: string;
@@ -212,6 +253,7 @@ export type BackendCamporeeEvent = {
   registered_count: number;
   agenda_visible?: boolean;
   schedule_blocks?: CamporeeEventScheduleBlock[];
+  staff_assignments?: CamporeeEventStaffAssignment[];
   // ── Joined relations (present when backend includes them) ──────────────────
   leader?: CamporeeEventLeader | null;
   venue?: CamporeeEventVenueRef | null;
@@ -386,6 +428,22 @@ export async function updateCamporeeEvent(
   payload: UpdateCamporeeEventPayload,
 ) {
   return apiRequest(`/camporee-events/${id}`, { method: "PATCH", body: payload });
+}
+
+export async function listCamporeeEventStaffAssignments(eventId: number) {
+  return apiRequest<CamporeeEventStaffAssignment[]>(
+    `/camporee-events/${eventId}/staff-assignments`,
+  );
+}
+
+export async function replaceEventStaffAssignments(
+  eventId: number,
+  payload: ReplaceCamporeeEventStaffAssignmentsPayload,
+) {
+  return apiRequest<CamporeeEventStaffAssignment[]>(
+    `/camporee-events/${eventId}/staff-assignments`,
+    { method: "PUT", body: payload },
+  );
 }
 
 export async function replaceCamporeeEventScheduleBlocks(

--- a/src/lib/api/camporee-staff.ts
+++ b/src/lib/api/camporee-staff.ts
@@ -1,0 +1,122 @@
+import { apiRequest } from "@/lib/api/client";
+
+export type CamporeeStaffScope = "local" | "union";
+
+export type CamporeeStaffCategory =
+  | "judge"
+  | "administrative"
+  | "kitchen"
+  | "support"
+  | "spiritual"
+  | "leadership"
+  | "other";
+
+export const CAMPOREE_STAFF_CATEGORIES: CamporeeStaffCategory[] = [
+  "judge",
+  "administrative",
+  "kitchen",
+  "support",
+  "spiritual",
+  "leadership",
+  "other",
+];
+
+export type CamporeeStaffUserSummary = {
+  user_id: string;
+  email: string | null;
+  name: string | null;
+  paternal_last_name: string | null;
+  maternal_last_name: string | null;
+  full_name: string;
+  user_image: string | null;
+  active: boolean;
+  access_app: boolean;
+  access_panel: boolean;
+  union?: { union_id: number | null; name: string | null } | null;
+  local_field?: {
+    local_field_id: number | null;
+    union_id: number | null;
+    name: string | null;
+  } | null;
+};
+
+export type CamporeeStaffMember = {
+  camporee_staff_member_id: string;
+  local_camporee_id: number | null;
+  union_camporee_id: number | null;
+  user_id: string;
+  category: CamporeeStaffCategory;
+  role_label: string | null;
+  notes: string | null;
+  status: string;
+  active: boolean;
+  user: CamporeeStaffUserSummary | null;
+};
+
+export type CamporeeStaffCandidate = CamporeeStaffUserSummary & {
+  already_staff_member_id: string | null;
+};
+
+export type AddCamporeeStaffMemberPayload = {
+  user_id: string;
+  category: CamporeeStaffCategory;
+  role_label?: string | null;
+  notes?: string | null;
+};
+
+export type UpdateCamporeeStaffMemberPayload = Partial<{
+  category: CamporeeStaffCategory;
+  role_label: string | null;
+  notes: string | null;
+  status: "active" | "inactive";
+  active: boolean;
+}>;
+
+function scopedCamporeePath(scope: CamporeeStaffScope, camporeeId: number) {
+  return scope === "union"
+    ? `/union-camporees/${camporeeId}`
+    : `/local-camporees/${camporeeId}`;
+}
+
+export async function listCamporeeStaff(
+  scope: CamporeeStaffScope,
+  camporeeId: number,
+) {
+  return apiRequest<CamporeeStaffMember[]>(`${scopedCamporeePath(scope, camporeeId)}/staff`);
+}
+
+export async function listCamporeeStaffCandidates(
+  scope: CamporeeStaffScope,
+  camporeeId: number,
+) {
+  return apiRequest<CamporeeStaffCandidate[]>(
+    `${scopedCamporeePath(scope, camporeeId)}/staff-candidates`,
+  );
+}
+
+export async function addCamporeeStaffMember(
+  scope: CamporeeStaffScope,
+  camporeeId: number,
+  payload: AddCamporeeStaffMemberPayload,
+) {
+  return apiRequest<CamporeeStaffMember>(`${scopedCamporeePath(scope, camporeeId)}/staff`, {
+    method: "POST",
+    body: payload,
+  });
+}
+
+export async function updateCamporeeStaffMember(
+  staffMemberId: string,
+  payload: UpdateCamporeeStaffMemberPayload,
+) {
+  return apiRequest<CamporeeStaffMember>(`/camporee-staff/${staffMemberId}`, {
+    method: "PATCH",
+    body: payload,
+  });
+}
+
+export async function deleteCamporeeStaffMember(staffMemberId: string) {
+  return apiRequest<CamporeeStaffMember>(`/camporee-staff/${staffMemberId}`, {
+    method: "DELETE",
+  });
+}

--- a/src/lib/api/camporees.ts
+++ b/src/lib/api/camporees.ts
@@ -81,6 +81,8 @@ export type Camporee = {
   start_date: string;
   end_date: string;
   club_registration_deadline?: string | null;
+  club_registration_closed_at?: string | null;
+  club_registration_closed_by?: string | null;
   member_registration_deadline?: string | null;
   payment_deadline?: string | null;
   agenda_visible_from?: string | null;
@@ -263,6 +265,26 @@ export async function cancelUnionClubEnrollment(camporeeId: number, camporeeClub
   });
 }
 
+export async function closeClubRegistration(
+  scope: "local" | "union",
+  camporeeId: number,
+) {
+  const path = scope === "union"
+    ? `/union-camporees/${camporeeId}/club-registration/close`
+    : `/camporees/${camporeeId}/club-registration/close`;
+  return apiRequest<Camporee | UnionCamporee>(path, { method: "POST" });
+}
+
+export async function reopenClubRegistration(
+  scope: "local" | "union",
+  camporeeId: number,
+) {
+  const path = scope === "union"
+    ? `/union-camporees/${camporeeId}/club-registration/reopen`
+    : `/camporees/${camporeeId}/club-registration/reopen`;
+  return apiRequest<Camporee | UnionCamporee>(path, { method: "POST" });
+}
+
 // ─── Payment functions ────────────────────────────────────────────────────────
 
 export async function createPayment(
@@ -333,6 +355,8 @@ export type UnionCamporee = {
   start_date: string;
   end_date: string;
   club_registration_deadline?: string | null;
+  club_registration_closed_at?: string | null;
+  club_registration_closed_by?: string | null;
   member_registration_deadline?: string | null;
   payment_deadline?: string | null;
   agenda_visible_from?: string | null;

--- a/src/lib/camporee-events/actions.ts
+++ b/src/lib/camporee-events/actions.ts
@@ -43,10 +43,13 @@ import {
   updateCamporeeEvent,
   deleteCamporeeEvent,
   reorderCamporeeEvent,
+  replaceEventStaffAssignments,
   type CreateCamporeeEventTemplatePayload,
   type UpdateCamporeeEventTemplatePayload,
+  type CamporeeEventStaffAssignmentRole,
   type CamporeeEventScheduleBlock,
   type CreateCamporeeEventPayload,
+  type ReplaceCamporeeEventStaffAssignmentsPayload,
   type PenaltyRule,
   type ParticipantsByClass,
   type ParticipantsMode,
@@ -123,6 +126,49 @@ async function syncRubricsFromForm(eventId: number, formData: FormData) {
     scoring_enabled: getBoolean(formData, "scoring_enabled"),
     items: getJson<CamporeeTemplateRubricInput[]>(formData, "rubrics") ?? [],
   });
+}
+
+function getStaffAssignmentsFromForm(
+  formData: FormData,
+): ReplaceCamporeeEventStaffAssignmentsPayload["assignments"] | undefined {
+  if (!formData.has("staff_assignments")) return undefined;
+
+  const assignments =
+    getJson<ReplaceCamporeeEventStaffAssignmentsPayload["assignments"]>(
+      formData,
+      "staff_assignments",
+    ) ?? [];
+
+  return assignments
+    .filter((assignment) => {
+      const role = assignment.assignment_role as CamporeeEventStaffAssignmentRole;
+      return Boolean(assignment.camporee_staff_member_id) &&
+        (role === "responsible" ||
+          role === "assistant" ||
+          role === "evaluator" ||
+          role === "support");
+    })
+    .map((assignment, index) => ({
+      camporee_staff_member_id: assignment.camporee_staff_member_id,
+      assignment_role: assignment.assignment_role,
+      title_override: assignment.title_override?.trim() || null,
+      notes: assignment.notes?.trim() || null,
+      display_order: assignment.display_order ?? index,
+    }));
+}
+
+async function syncStaffAssignmentsFromForm(eventId: number, formData: FormData) {
+  const assignments = getStaffAssignmentsFromForm(formData);
+  if (!assignments) return;
+
+  await replaceEventStaffAssignments(eventId, { assignments });
+}
+
+function hasResponsibleStaffAssignment(formData: FormData) {
+  const assignments = getStaffAssignmentsFromForm(formData) ?? [];
+  return assignments.some(
+    (assignment) => assignment.assignment_role === "responsible",
+  );
 }
 
 /**
@@ -361,6 +407,7 @@ function buildInstancePayload(
   const duration_seconds = getPositiveInt(formData, "duration_seconds");
   const display_order = getNonNegativeInt(formData, "display_order") ?? 0;
   const active = getBoolean(formData, "active");
+  const status = getString(formData, "status") as CreateCamporeeEventPayload["status"];
 
   return {
     event_type_id,
@@ -379,6 +426,7 @@ function buildInstancePayload(
     participants_by_class: participants_mode === "by_class" ? participants_by_class : null,
     duration_seconds,
     display_order,
+    ...(status ? { status } : {}),
     active,
   };
 }
@@ -398,11 +446,27 @@ export async function createLocalCamporeeEventAction(
 
   const payload = buildInstancePayload(formData);
   if ("validationError" in payload) return { error: payload.validationError };
+  if (payload.status === "publicado" && !hasResponsibleStaffAssignment(formData)) {
+    return {
+      error:
+        "Para publicar el evento, asigná primero al menos una persona responsable.",
+    };
+  }
 
   try {
-    const created = await createLocalCamporeeEvent(camporeeId, payload);
+    const targetStatus = payload.status;
+    const created = await createLocalCamporeeEvent(camporeeId, {
+      ...payload,
+      ...(targetStatus === "publicado" ? { status: "programado" } : {}),
+    });
     const eventId = extractCreatedEventId(created);
-    if (eventId) await syncRubricsFromForm(eventId, formData);
+    if (eventId) {
+      await syncStaffAssignmentsFromForm(eventId, formData);
+      await syncRubricsFromForm(eventId, formData);
+      if (targetStatus === "publicado") {
+        await updateCamporeeEvent(eventId, { status: "publicado" });
+      }
+    }
   } catch (error) {
     return {
       error: getActionErrorMessage(error, "No se pudo crear el evento.", {
@@ -430,11 +494,27 @@ export async function createUnionCamporeeEventAction(
 
   const payload = buildInstancePayload(formData);
   if ("validationError" in payload) return { error: payload.validationError };
+  if (payload.status === "publicado" && !hasResponsibleStaffAssignment(formData)) {
+    return {
+      error:
+        "Para publicar el evento, asigná primero al menos una persona responsable.",
+    };
+  }
 
   try {
-    const created = await createUnionCamporeeEvent(camporeeId, payload);
+    const targetStatus = payload.status;
+    const created = await createUnionCamporeeEvent(camporeeId, {
+      ...payload,
+      ...(targetStatus === "publicado" ? { status: "programado" } : {}),
+    });
     const eventId = extractCreatedEventId(created);
-    if (eventId) await syncRubricsFromForm(eventId, formData);
+    if (eventId) {
+      await syncStaffAssignmentsFromForm(eventId, formData);
+      await syncRubricsFromForm(eventId, formData);
+      if (targetStatus === "publicado") {
+        await updateCamporeeEvent(eventId, { status: "publicado" });
+      }
+    }
   } catch (error) {
     return {
       error: getActionErrorMessage(error, "No se pudo crear el evento.", {
@@ -523,9 +603,21 @@ export async function updateCamporeeEventAction(
 
   const payload = buildInstancePayload(formData);
   if ("validationError" in payload) return { error: payload.validationError };
+  if (payload.status === "publicado" && !hasResponsibleStaffAssignment(formData)) {
+    return {
+      error:
+        "Para publicar el evento, asigná primero al menos una persona responsable.",
+    };
+  }
 
   try {
+    if (payload.status === "publicado") {
+      await syncStaffAssignmentsFromForm(id, formData);
+    }
     await updateCamporeeEvent(id, payload);
+    if (payload.status !== "publicado") {
+      await syncStaffAssignmentsFromForm(id, formData);
+    }
     await syncRubricsFromForm(id, formData);
   } catch (error) {
     return {
@@ -678,11 +770,27 @@ export async function createCamporeeAgendaEventAction(
 
   const payload = buildAgendaPayload(formData);
   if ("validationError" in payload) return { error: payload.validationError };
+  if (payload.status === "publicado" && !hasResponsibleStaffAssignment(formData)) {
+    return {
+      error:
+        "Para publicar el evento, asigná primero al menos una persona responsable.",
+    };
+  }
 
   try {
-    const created = await createLocalCamporeeEvent(camporeeId, payload);
+    const targetStatus = payload.status;
+    const created = await createLocalCamporeeEvent(camporeeId, {
+      ...payload,
+      ...(targetStatus === "publicado" ? { status: "programado" } : {}),
+    });
     const eventId = extractCreatedEventId(created);
-    if (eventId) await syncRubricsFromForm(eventId, formData);
+    if (eventId) {
+      await syncStaffAssignmentsFromForm(eventId, formData);
+      await syncRubricsFromForm(eventId, formData);
+      if (targetStatus === "publicado") {
+        await updateCamporeeEvent(eventId, { status: "publicado" });
+      }
+    }
   } catch (error) {
     return {
       error: getActionErrorMessage(error, "No se pudo crear el evento.", {
@@ -710,11 +818,27 @@ export async function createUnionCamporeeAgendaEventAction(
 
   const payload = buildAgendaPayload(formData);
   if ("validationError" in payload) return { error: payload.validationError };
+  if (payload.status === "publicado" && !hasResponsibleStaffAssignment(formData)) {
+    return {
+      error:
+        "Para publicar el evento, asigná primero al menos una persona responsable.",
+    };
+  }
 
   try {
-    const created = await createUnionCamporeeEvent(camporeeId, payload);
+    const targetStatus = payload.status;
+    const created = await createUnionCamporeeEvent(camporeeId, {
+      ...payload,
+      ...(targetStatus === "publicado" ? { status: "programado" } : {}),
+    });
     const eventId = extractCreatedEventId(created);
-    if (eventId) await syncRubricsFromForm(eventId, formData);
+    if (eventId) {
+      await syncStaffAssignmentsFromForm(eventId, formData);
+      await syncRubricsFromForm(eventId, formData);
+      if (targetStatus === "publicado") {
+        await updateCamporeeEvent(eventId, { status: "publicado" });
+      }
+    }
   } catch (error) {
     return {
       error: getActionErrorMessage(error, "No se pudo crear el evento.", {
@@ -745,9 +869,21 @@ export async function updateCamporeeAgendaEventAction(
 
   const payload = buildAgendaPayload(formData);
   if ("validationError" in payload) return { error: payload.validationError };
+  if (payload.status === "publicado" && !hasResponsibleStaffAssignment(formData)) {
+    return {
+      error:
+        "Para publicar el evento, asigná primero al menos una persona responsable.",
+    };
+  }
 
   try {
+    if (payload.status === "publicado") {
+      await syncStaffAssignmentsFromForm(id, formData);
+    }
     await updateCamporeeEvent(id, payload);
+    if (payload.status !== "publicado") {
+      await syncStaffAssignmentsFromForm(id, formData);
+    }
     await syncRubricsFromForm(id, formData);
   } catch (error) {
     return {

--- a/src/lib/camporee-staff/actions.ts
+++ b/src/lib/camporee-staff/actions.ts
@@ -1,0 +1,172 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { getActionErrorMessage } from "@/lib/api/action-error";
+import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import {
+  CAMPOREE_EVENTS_UPDATE,
+} from "@/lib/auth/permissions";
+import {
+  addCamporeeStaffMember,
+  deleteCamporeeStaffMember,
+  updateCamporeeStaffMember,
+  type CamporeeStaffCategory,
+  type CamporeeStaffScope,
+} from "@/lib/api/camporee-staff";
+
+export type CamporeeStaffActionState = {
+  error?: string;
+  success?: string;
+};
+
+const STAFF_CATEGORIES = new Set<CamporeeStaffCategory>([
+  "judge",
+  "administrative",
+  "kitchen",
+  "support",
+  "spiritual",
+  "leadership",
+  "other",
+]);
+
+function readString(formData: FormData, key: string): string {
+  return String(formData.get(key) ?? "").trim();
+}
+
+function readPositiveNumber(formData: FormData, key: string): number | null {
+  const value = Number(readString(formData, key));
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function readBoolean(formData: FormData, key: string): boolean {
+  return formData.get(key) === "on" || formData.get(key) === "true";
+}
+
+function readScope(formData: FormData): CamporeeStaffScope {
+  return readBoolean(formData, "is_union") ? "union" : "local";
+}
+
+function getCamporeePath(camporeeId: number | null, scope: CamporeeStaffScope) {
+  if (!camporeeId) return "/dashboard/camporees";
+  return scope === "union"
+    ? `/dashboard/camporees/union/${camporeeId}`
+    : `/dashboard/camporees/${camporeeId}`;
+}
+
+async function assertCanManageCamporeeStaff() {
+  const user = await requireAdminUser();
+  return hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE])
+    ? null
+    : "Sin permisos para gestionar el personal del camporee.";
+}
+
+export async function addCamporeeStaffMemberAction(
+  _: CamporeeStaffActionState,
+  formData: FormData,
+): Promise<CamporeeStaffActionState> {
+  const permissionError = await assertCanManageCamporeeStaff();
+  if (permissionError) return { error: permissionError };
+
+  const camporeeId = readPositiveNumber(formData, "camporee_id");
+  if (!camporeeId) return { error: "No se pudo identificar el camporee." };
+
+  const userId = readString(formData, "user_id");
+  if (!userId) return { error: "La persona es obligatoria." };
+
+  const category = readString(formData, "category") as CamporeeStaffCategory;
+  if (!STAFF_CATEGORIES.has(category)) {
+    return { error: "La categoría del personal es inválida." };
+  }
+
+  const scope = readScope(formData);
+  const roleLabel = readString(formData, "role_label");
+  const notes = readString(formData, "notes");
+
+  try {
+    await addCamporeeStaffMember(scope, camporeeId, {
+      user_id: userId,
+      category,
+      role_label: roleLabel || null,
+      notes: notes || null,
+    });
+  } catch (error) {
+    return {
+      error: getActionErrorMessage(error, "No se pudo agregar personal al camporee.", {
+        endpointLabel:
+          scope === "union"
+            ? `/union-camporees/${camporeeId}/staff`
+            : `/local-camporees/${camporeeId}/staff`,
+      }),
+    };
+  }
+
+  revalidatePath(getCamporeePath(camporeeId, scope));
+  return { success: "Personal agregado." };
+}
+
+export async function updateCamporeeStaffMemberAction(
+  _: CamporeeStaffActionState,
+  formData: FormData,
+): Promise<CamporeeStaffActionState> {
+  const permissionError = await assertCanManageCamporeeStaff();
+  if (permissionError) return { error: permissionError };
+
+  const staffMemberId = readString(formData, "staff_member_id");
+  if (!staffMemberId) return { error: "No se pudo identificar el registro de personal." };
+
+  const category = readString(formData, "category") as CamporeeStaffCategory;
+  if (category && !STAFF_CATEGORIES.has(category)) {
+    return { error: "La categoría del personal es inválida." };
+  }
+
+  const camporeeId = readPositiveNumber(formData, "camporee_id");
+  const scope = readScope(formData);
+  const roleLabel = readString(formData, "role_label");
+  const notes = readString(formData, "notes");
+
+  try {
+    await updateCamporeeStaffMember(staffMemberId, {
+      ...(category ? { category } : {}),
+      role_label: roleLabel || null,
+      notes: notes || null,
+      ...(formData.has("active") ? { active: readBoolean(formData, "active") } : {}),
+    });
+  } catch (error) {
+    return {
+      error: getActionErrorMessage(error, "No se pudo actualizar el personal.", {
+        endpointLabel: `/camporee-staff/${staffMemberId}`,
+      }),
+    };
+  }
+
+  revalidatePath(getCamporeePath(camporeeId, scope));
+  return { success: "Personal actualizado." };
+}
+
+export async function deleteCamporeeStaffMemberAction(
+  _: CamporeeStaffActionState,
+  formData: FormData,
+): Promise<CamporeeStaffActionState> {
+  const permissionError = await assertCanManageCamporeeStaff();
+  if (permissionError) return { error: permissionError };
+
+  const staffMemberId = readString(formData, "staff_member_id");
+  if (!staffMemberId) return { error: "No se pudo identificar el registro de personal." };
+
+  const camporeeId = readPositiveNumber(formData, "camporee_id");
+  const scope = readScope(formData);
+
+  try {
+    await deleteCamporeeStaffMember(staffMemberId);
+  } catch (error) {
+    return {
+      error: getActionErrorMessage(error, "No se pudo desactivar el personal.", {
+        endpointLabel: `/camporee-staff/${staffMemberId}`,
+      }),
+    };
+  }
+
+  revalidatePath(getCamporeePath(camporeeId, scope));
+  return { success: "Personal desactivado." };
+}

--- a/src/lib/camporee-timeline/mapper.ts
+++ b/src/lib/camporee-timeline/mapper.ts
@@ -14,7 +14,11 @@
  */
 
 import type { Camporee } from "@/lib/api/camporees";
-import type { BackendCamporeeEvent, CamporeeEventTemplate } from "@/lib/api/camporee-events";
+import type {
+  BackendCamporeeEvent,
+  CamporeeEventStaffAssignment,
+  CamporeeEventTemplate,
+} from "@/lib/api/camporee-events";
 import type { CamporeeVenue as BackendCamporeeVenue } from "@/lib/api/camporee-venues";
 import type {
   CamporeeEventsData,
@@ -97,6 +101,44 @@ function resolveLeaderName(event: BackendCamporeeEvent): string {
   }
   if (event.leader_name_override) return event.leader_name_override;
   return "—";
+}
+
+function resolveStaffName(assignment: CamporeeEventStaffAssignment): string | null {
+  const user = assignment.staff_member?.user;
+  if (!user) return null;
+  const joined = [user.name, user.paternal_last_name, user.maternal_last_name]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join(" ");
+  return user.full_name || joined || null;
+}
+
+function staffRoleLabel(assignment: CamporeeEventStaffAssignment): string {
+  if (assignment.title_override) return assignment.title_override;
+  if (assignment.staff_member?.role_label) return assignment.staff_member.role_label;
+  if (assignment.assignment_role === "responsible") return "Responsable";
+  if (assignment.assignment_role === "assistant") return "Ayudante";
+  if (assignment.assignment_role === "evaluator") return "Evaluador";
+  return "Apoyo";
+}
+
+function resolveStaffSummary(event: BackendCamporeeEvent) {
+  const assignments = (event.staff_assignments ?? [])
+    .filter((assignment) => assignment.active !== false)
+    .sort((a, b) => (a.display_order ?? 0) - (b.display_order ?? 0));
+  const responsible = assignments.find(
+    (assignment) => assignment.assignment_role === "responsible",
+  );
+  const helpers = assignments.filter(
+    (assignment) => assignment.assignment_role !== "responsible",
+  );
+
+  return {
+    staffResponsibleName: responsible ? resolveStaffName(responsible) ?? "Personal asignado" : undefined,
+    staffResponsibleRole: responsible ? staffRoleLabel(responsible) : undefined,
+    staffHelpers: helpers
+      .map((assignment) => resolveStaffName(assignment))
+      .filter((value): value is string => Boolean(value)),
+  };
 }
 
 /**
@@ -258,6 +300,7 @@ export function backendToTimeline(
     venueId: e.venue_id ? String(e.venue_id) : "",
     leaderName: resolveLeaderName(e),
     leaderRole: e.leader_role ?? "",
+    ...resolveStaffSummary(e),
     sections: e.sections.length > 0 ? mapSections(e.sections) : allSections,
     capacity: e.capacity ?? 0,
     registered: e.registered_count,

--- a/src/lib/camporee-timeline/types.ts
+++ b/src/lib/camporee-timeline/types.ts
@@ -65,6 +65,9 @@ export interface CamporeeEvent {
   venueId: string;
   leaderName: string;
   leaderRole?: string;
+  staffResponsibleName?: string;
+  staffResponsibleRole?: string;
+  staffHelpers?: string[];
   sections: Section[];
   capacity: number;
   registered: number;

--- a/src/lib/camporees/actions.ts
+++ b/src/lib/camporees/actions.ts
@@ -5,13 +5,17 @@ import { redirect } from "next/navigation";
 import { getTranslations } from "next-intl/server";
 import { getActionErrorMessage } from "@/lib/api/action-error";
 import {
+  closeClubRegistration,
   createCamporee,
   deleteCamporee,
   registerCamporeeMember,
   removeCamporeeMember,
+  reopenClubRegistration,
   updateCamporee,
 } from "@/lib/api/camporees";
 import { requireAdminUser } from "@/lib/auth/session";
+import { hasAnyPermission } from "@/lib/auth/permission-utils";
+import { CAMPOREE_EVENTS_UPDATE } from "@/lib/auth/permissions";
 
 type CamporeesTranslator = Awaited<
   ReturnType<typeof getTranslations<"camporees">>
@@ -65,6 +69,19 @@ function parseOptionalNumber(
 
 function parseBool(formData: FormData, fieldName: string) {
   return formData.get(fieldName) === "on" || formData.get(fieldName) === "true";
+}
+
+function parseOptionalPositiveInt(formData: FormData, fieldName: string) {
+  const value = readString(formData, fieldName);
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : null;
+}
+
+function camporeeDetailPath(camporeeId: number, isUnionCamporee: boolean) {
+  return isUnionCamporee
+    ? `/dashboard/camporees/union/${camporeeId}`
+    : `/dashboard/camporees/${camporeeId}`;
 }
 
 function readOptionalDateTime(formData: FormData, fieldName: string) {
@@ -335,4 +352,76 @@ export async function removeCamporeeMemberAction(
 
   revalidatePath(`/dashboard/camporees/${camporeeId}`);
   return { success: t("success.member_removed") };
+}
+
+export async function closeCamporeeClubRegistrationAction(
+  _: CamporeeActionState,
+  formData: FormData,
+): Promise<CamporeeActionState> {
+  const user = await requireAdminUser();
+  if (!hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE])) {
+    return { error: "Sin permisos para cerrar la inscripción de clubes." };
+  }
+
+  const camporeeId = parseOptionalPositiveInt(formData, "camporee_id");
+  if (!camporeeId) return { error: "No se pudo identificar el camporee." };
+
+  const isUnionCamporee = parseBool(formData, "is_union");
+  const scope = isUnionCamporee ? "union" : "local";
+
+  try {
+    await closeClubRegistration(scope, camporeeId);
+  } catch (error) {
+    return {
+      error: getActionErrorMessage(
+        error,
+        "No se pudo cerrar la inscripción de clubes.",
+        {
+          endpointLabel:
+            scope === "union"
+              ? `/union-camporees/${camporeeId}/club-registration/close`
+              : `/camporees/${camporeeId}/club-registration/close`,
+        },
+      ),
+    };
+  }
+
+  revalidatePath(camporeeDetailPath(camporeeId, isUnionCamporee));
+  return { success: "Inscripción de clubes cerrada." };
+}
+
+export async function reopenCamporeeClubRegistrationAction(
+  _: CamporeeActionState,
+  formData: FormData,
+): Promise<CamporeeActionState> {
+  const user = await requireAdminUser();
+  if (!hasAnyPermission(user, [CAMPOREE_EVENTS_UPDATE])) {
+    return { error: "Sin permisos para reabrir la inscripción de clubes." };
+  }
+
+  const camporeeId = parseOptionalPositiveInt(formData, "camporee_id");
+  if (!camporeeId) return { error: "No se pudo identificar el camporee." };
+
+  const isUnionCamporee = parseBool(formData, "is_union");
+  const scope = isUnionCamporee ? "union" : "local";
+
+  try {
+    await reopenClubRegistration(scope, camporeeId);
+  } catch (error) {
+    return {
+      error: getActionErrorMessage(
+        error,
+        "No se pudo reabrir la inscripción de clubes.",
+        {
+          endpointLabel:
+            scope === "union"
+              ? `/union-camporees/${camporeeId}/club-registration/reopen`
+              : `/camporees/${camporeeId}/club-registration/reopen`,
+        },
+      ),
+    };
+  }
+
+  revalidatePath(camporeeDetailPath(camporeeId, isUnionCamporee));
+  return { success: "Inscripción de clubes reabierta." };
 }


### PR DESCRIPTION
Closes #198\n\n## Estado\nPR de recuperación en borrador para preservar un checkpoint local.\n\n## Alcance\n- Operación de eventos, staff y asignaciones.\n- Integración de scoring y detalle de camporees.\n\n## Validación\n- git diff --check